### PR TITLE
Fix: Database locking race condition on node deletion with mentions (closes #190)

### DIFF
--- a/packages/desktop-app/src/tests/integration/node-deletion-with-mentions.test.ts
+++ b/packages/desktop-app/src/tests/integration/node-deletion-with-mentions.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Node Deletion with Mentions Integration Test
+ *
+ * Tests that deleting nodes with @mention references doesn't cause
+ * database locking errors. This verifies the fix for issue #190.
+ *
+ * Key behaviors tested:
+ * 1. Node deletion with mentions completes without errors
+ * 2. Cleanup doesn't race with database CASCADE deletes
+ * 3. Cache invalidation happens correctly
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { NodeReferenceService } from '$lib/services/node-reference-service';
+import { TauriNodeService } from '$lib/services/tauri-node-service';
+import { HierarchyService } from '$lib/services/hierarchy-service';
+import { eventBus } from '$lib/services/event-bus';
+import type { Node } from '$lib/types';
+import type { NodeDeletedEvent } from '$lib/services/event-types';
+
+describe('Node Deletion with Mentions (Issue #190)', () => {
+  let nodeReferenceService: NodeReferenceService;
+  let mockTauriService: {
+    queryNodes: ReturnType<typeof vi.fn>;
+    createNode: ReturnType<typeof vi.fn>;
+    getNode: ReturnType<typeof vi.fn>;
+    updateNode: ReturnType<typeof vi.fn>;
+    deleteNode: ReturnType<typeof vi.fn>;
+    initializeDatabase: ReturnType<typeof vi.fn>;
+    isInitialized: ReturnType<typeof vi.fn>;
+  };
+  let mockNodeManager: {
+    findNode: ReturnType<typeof vi.fn>;
+    nodes: Node[];
+  };
+  let mockHierarchyService: HierarchyService;
+  let mockNodeOperationsService: {
+    updateNodeMentions: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Clear all event bus listeners (recreate eventBus if needed)
+    // eventBus doesn't have a clear() method, but tests use isolated instances
+
+    // Setup mock Tauri service
+    mockTauriService = {
+      queryNodes: vi.fn().mockResolvedValue([]),
+      createNode: vi.fn().mockResolvedValue('new-node-id'),
+      getNode: vi.fn().mockResolvedValue(null),
+      updateNode: vi.fn().mockResolvedValue(undefined),
+      deleteNode: vi.fn().mockResolvedValue(undefined),
+      initializeDatabase: vi.fn().mockResolvedValue('/mock/path/db.sqlite'),
+      isInitialized: vi.fn().mockReturnValue(true)
+    };
+
+    // Setup mock node manager
+    mockNodeManager = {
+      findNode: vi.fn().mockReturnValue(null),
+      nodes: []
+    };
+
+    // Setup mock hierarchy service
+    mockHierarchyService = {
+      getNodePath: vi.fn().mockReturnValue({ nodeIds: [], depth: 0 })
+    } as unknown as HierarchyService;
+
+    // Setup mock node operations service
+    mockNodeOperationsService = {
+      updateNodeMentions: vi.fn().mockResolvedValue(undefined)
+    };
+
+    // Create NodeReferenceService with mocks
+    nodeReferenceService = new NodeReferenceService(
+      mockNodeManager as unknown as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      mockHierarchyService,
+      mockNodeOperationsService as unknown as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      mockTauriService as unknown as TauriNodeService
+    );
+  });
+
+  afterEach(() => {
+    // Cleanup after each test
+  });
+
+  describe('Deletion without Database Locking', () => {
+    it('should not call queryNodes when node is deleted', async () => {
+      // Create nodes with mention relationship
+      const sourceNode: Node = {
+        id: 'source-node',
+        nodeType: 'text',
+        content: 'Text with @target-node mention',
+        parentId: null,
+        originNodeId: 'source-node',
+        beforeSiblingId: null,
+        mentions: ['target-node'],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      const targetNode: Node = {
+        id: 'target-node',
+        nodeType: 'text',
+        content: 'Target node',
+        parentId: null,
+        originNodeId: 'target-node',
+        beforeSiblingId: null,
+        mentions: [],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      // Setup mock responses
+      mockNodeManager.findNode.mockImplementation((id: string) => {
+        if (id === 'source-node') return sourceNode;
+        if (id === 'target-node') return targetNode;
+        return null;
+      });
+
+      // Emit node:deleted event (simulating delete operation)
+      const deleteEvent: NodeDeletedEvent = {
+        type: 'node:deleted',
+        namespace: 'lifecycle',
+        source: 'test',
+        timestamp: Date.now(),
+        nodeId: 'target-node',
+        parentId: undefined
+      };
+
+      eventBus.emit(deleteEvent);
+
+      // Wait for any async operations
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // CRITICAL: queryNodes should NOT be called
+      // The fix prevents the race condition by not querying during deletion
+      expect(mockTauriService.queryNodes).not.toHaveBeenCalledWith({
+        mentionedBy: 'target-node'
+      });
+
+      // updateNodeMentions should also NOT be called
+      // Database CASCADE handles cleanup automatically
+      expect(mockNodeOperationsService.updateNodeMentions).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate caches when node is deleted', async () => {
+      const nodeId = 'deleted-node';
+
+      // Spy on private methods through the service
+      const clearCachesSpy = vi.spyOn(
+        nodeReferenceService as unknown as any,
+        'invalidateNodeCaches'
+      );
+
+      // Emit deletion event
+      const deleteEvent: NodeDeletedEvent = {
+        type: 'node:deleted',
+        namespace: 'lifecycle',
+        source: 'test',
+        timestamp: Date.now(),
+        nodeId,
+        parentId: undefined
+      };
+
+      eventBus.emit(deleteEvent);
+
+      // Wait for event processing
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Cache invalidation should have been called
+      expect(clearCachesSpy).toHaveBeenCalledWith(nodeId);
+    });
+
+    it('should handle deletion of node with multiple mentions', async () => {
+      // Create multiple nodes mentioning the target
+      const targetNode: Node = {
+        id: 'target',
+        nodeType: 'text',
+        content: 'Target',
+        parentId: null,
+        originNodeId: 'target',
+        beforeSiblingId: null,
+        mentions: [],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      const mentioningNode1: Node = {
+        id: 'mention-1',
+        nodeType: 'text',
+        content: 'Mentions @target',
+        parentId: null,
+        originNodeId: 'mention-1',
+        beforeSiblingId: null,
+        mentions: ['target'],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      const mentioningNode2: Node = {
+        id: 'mention-2',
+        nodeType: 'text',
+        content: 'Also mentions @target',
+        parentId: null,
+        originNodeId: 'mention-2',
+        beforeSiblingId: null,
+        mentions: ['target'],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      mockNodeManager.findNode.mockImplementation((id: string) => {
+        if (id === 'target') return targetNode;
+        if (id === 'mention-1') return mentioningNode1;
+        if (id === 'mention-2') return mentioningNode2;
+        return null;
+      });
+
+      // Delete target node
+      const deleteEvent: NodeDeletedEvent = {
+        type: 'node:deleted',
+        namespace: 'lifecycle',
+        source: 'test',
+        timestamp: Date.now(),
+        nodeId: 'target',
+        parentId: undefined
+      };
+
+      eventBus.emit(deleteEvent);
+
+      // Wait for processing
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should NOT query for nodes that mention the target
+      expect(mockTauriService.queryNodes).not.toHaveBeenCalledWith({
+        mentionedBy: 'target'
+      });
+
+      // Should NOT update mentions arrays
+      // Database CASCADE handles this automatically
+      expect(mockNodeOperationsService.updateNodeMentions).not.toHaveBeenCalled();
+    });
+
+    it('should not cause errors when deleting node without mentions', async () => {
+      const simpleNode: Node = {
+        id: 'simple-node',
+        nodeType: 'text',
+        content: 'Simple text without mentions',
+        parentId: null,
+        originNodeId: 'simple-node',
+        beforeSiblingId: null,
+        mentions: [],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        properties: {}
+      };
+
+      mockNodeManager.findNode.mockReturnValue(simpleNode);
+
+      // Delete simple node
+      const deleteEvent: NodeDeletedEvent = {
+        type: 'node:deleted',
+        namespace: 'lifecycle',
+        source: 'test',
+        timestamp: Date.now(),
+        nodeId: 'simple-node',
+        parentId: undefined
+      };
+
+      // Should not throw any errors
+      expect(() => eventBus.emit(deleteEvent)).not.toThrow();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // No database operations should have been triggered
+      expect(mockTauriService.queryNodes).not.toHaveBeenCalled();
+      expect(mockNodeOperationsService.updateNodeMentions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupDeletedNodeReferences deprecation', () => {
+    it('cleanupDeletedNodeReferences should not be called automatically', async () => {
+      // Spy on the deprecated method
+      const cleanupSpy = vi.spyOn(
+        nodeReferenceService as unknown as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        'cleanupDeletedNodeReferences'
+      );
+
+      // Emit deletion event
+      const deleteEvent: NodeDeletedEvent = {
+        type: 'node:deleted',
+        namespace: 'lifecycle',
+        source: 'test',
+        timestamp: Date.now(),
+        nodeId: 'some-node',
+        parentId: undefined
+      };
+
+      eventBus.emit(deleteEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // The deprecated cleanup function should NOT be called
+      expect(cleanupSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When deleting nodes with @mention references, a database locking error occurred:

```
[Error] [TauriNodeService] Failed to query nodes: {mentionedBy: "a3def39f-98bf-441e-920f-1f96752107ea"}
Error: Node operation failed: Query failed: Failed to prepare mentioned_by query: SQLite failure: `database is locked`
```

This was caused by a race condition where `NodeReferenceService.cleanupDeletedNodeReferences()` tried to query the database while the delete transaction was still active.

## Solution

### Part A: Remove Redundant Cleanup (Primary Fix)

The cleanup function was unnecessary because:
- Database CASCADE deletes already handle `node_mentions` table cleanup automatically
- Frontend doesn't need to query and update - database handles it

**Changes:**
- Removed automatic call to `cleanupDeletedNodeReferences()` in `node:deleted` event handler
- Event handler now only invalidates caches (lightweight operation)
- Marked `cleanupDeletedNodeReferences()` as `@deprecated` for future reference

**Files changed:**
- `packages/desktop-app/src/lib/services/node-reference-service.ts`

### Part B: Add Query Timeout Protection (Defense in Depth)

Updated Rust backend to use connections with busy timeout:
- `query_nodes()` now uses `connect_with_timeout()` instead of `connect()`
- `query_nodes_simple()` now uses `connect_with_timeout()` instead of `connect()`
- Operations now wait up to 5 seconds instead of failing immediately on lock contention

**Files changed:**
- `packages/core/src/services/node_service.rs`

### Part C: Comprehensive Test Coverage

Created integration test that verifies:
- ✅ Cleanup is not called automatically on deletion
- ✅ Cache invalidation happens correctly
- ✅ No database operations race with deletion
- ✅ Multiple mentions scenarios handled properly
- ✅ Nodes without mentions delete cleanly

**Files changed:**
- `packages/desktop-app/src/tests/integration/node-deletion-with-mentions.test.ts` (new)

## Testing

- ✅ All 5 new integration tests pass
- ✅ All existing tests pass
- ✅ Code passes `bun run quality:fix` checks:
  - oxlint ✅
  - eslint ✅
  - prettier ✅
  - svelte-check ✅
  - cargo clippy ✅

## Root Cause Analysis

**The Race Condition:**

1. **Backend Delete Operation:**
   - Executes: `DELETE FROM nodes WHERE id = ?`
   - CASCADE deletes `node_mentions` entries
   - Transaction holds locks on both tables

2. **Frontend Cleanup (Races):**
   - Subscribes to `node:deleted` events
   - Calls `cleanupDeletedNodeReferences()` via `setTimeout(..., 0)`
   - Queries: `SELECT ... FROM nodes n INNER JOIN node_mentions nm ...`
   - **Fails**: "database is locked"

**Why It Only Happened with Mentions:**
- Text nodes without mentions didn't trigger cleanup query
- Nodes with mentions triggered both CASCADE + cleanup query simultaneously

## Impact

- ✅ Fixes #190
- ✅ Eliminates database locking errors during node deletion
- ✅ Improves overall database concurrency handling
- ✅ No breaking changes - fully backward compatible
- ✅ Better performance (one less database query per deletion)

## Review Notes

The fix is straightforward:
1. Primary fix removes the redundant cleanup (the race condition source)
2. Timeout protection adds resilience for future edge cases
3. Tests ensure the fix works and prevent regressions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>