### PR TITLE
Add SurrealDB dev server scripts

### DIFF
--- a/packages/desktop-app/.gitignore
+++ b/packages/desktop-app/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.nodespace/

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "preinstall": "node ../../enforce-bun.js",
+    "dev:db": "surreal start --bind 127.0.0.1:8000 --user root --pass root --log info file://.nodespace/dev.db",
+    "dev:db:memory": "surreal start --bind 127.0.0.1:8000 --user root --pass root --log info memory",
     "dev": "bunx vite dev",
     "dev:web": "bunx vite dev --port 1421",
     "build": "bunx vite build",


### PR DESCRIPTION
Quick fix to add SurrealDB server scripts to package.json for browser dev mode.

## Changes

- Added `dev:db` script (persistent mode with file://.nodespace/dev.db)
- Added `dev:db:memory` script (in-memory mode for testing)  
- Added .nodespace/ to .gitignore

## Why

Other worktrees need these scripts to run SurrealDB server for development.

## Testing

```bash
bun run dev:db
# Server should start on port 8000
```

Related to #490