### PR TITLE
Refactor: Rename test to better reflect blank content acceptance

### DIFF
--- a/packages/core/src/models/node.rs
+++ b/packages/core/src/models/node.rs
@@ -1223,7 +1223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_node_validation_empty_content() {
+    fn test_node_validation_accepts_blank_content() {
         // Issue #484: Blank content is now allowed (supports ephemeral node elimination from #479)
         let mut node = Node::new(
             "text".to_string(),


### PR DESCRIPTION
## Summary

Renames `test_node_validation_empty_content` → `test_node_validation_accepts_blank_content` for clarity.

## Problem

The original test name was ambiguous after Issue #484 changed the behavior:
- Could imply: "test that empty content validation **fails**" (old behavior)
- Actually means: "test that empty content validation **succeeds**" (current behavior)

## Solution

Renamed to `test_node_validation_accepts_blank_content` which clearly communicates:
- Blank content **is accepted**
- Validation **passes** for blank nodes
- This is the expected behavior (not a bug)

## Changes

- `packages/core/src/models/node.rs`: Renamed test function only
- Test logic unchanged (still validates blank content passes)
- All tests passing ✅

## Related

- Issue #484: Backend: Allow blank text nodes in validation
- PR #502: Original implementation

## Test Results

```
running 1 test
test models::node::tests::test_node_validation_accepts_blank_content ... ok

test result: ok. 1 passed; 0 failed
```

---

**Type**: Refactor (test naming only, no behavior change)  
**Risk**: Minimal - test logic unchanged, only name changed