### PR TITLE
Update child node components to use reactive stores directly

### DIFF
--- a/packages/desktop-app/src/lib/components/text-node.svelte
+++ b/packages/desktop-app/src/lib/components/text-node.svelte
@@ -9,14 +9,16 @@
 
 <script lang="ts">
   import BaseNode from '$lib/design/components/base-node.svelte';
+  import { nodeData } from '$lib/stores/reactive-node-data.svelte';
+  import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 
   // Props
   let {
     nodeId,
     autoFocus = false,
-    content = '',
-    nodeType = 'text',
-    children = []
+    content: propsContent = '',
+    nodeType: propsNodeType = 'text',
+    children: propsChildren = []
   }: {
     nodeId: string;
     autoFocus?: boolean;
@@ -24,6 +26,16 @@
     nodeType?: string;
     children?: string[];
   } = $props();
+
+  // Use reactive stores directly instead of relying on props
+  // Components query the stores for current data and re-render automatically when data changes
+  let node = $derived(nodeData.getNode(nodeId));
+  let childIds = $derived(structureTree.getChildren(nodeId));
+
+  // Derive props from stores with fallback to passed props for backward compatibility
+  let content = $derived(node?.content ?? propsContent);
+  let nodeType = $derived(node?.nodeType ?? propsNodeType);
+  let children = $derived(childIds ?? propsChildren);
 
   // Text nodes always allow multiline editing
   const editableConfig = {

--- a/packages/desktop-app/src/lib/design/components/date-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/date-node.svelte
@@ -12,17 +12,29 @@
   import BaseNode from '$lib/design/components/base-node.svelte';
   import Icon from '$lib/design/icons/icon.svelte';
   import type { NodeComponentProps } from '$lib/types/node-viewers.js';
+  import { nodeData } from '$lib/stores/reactive-node-data.svelte';
+  import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 
   // Props following the NodeComponentProps interface (for individual node components)
   let {
     nodeId,
-    content = '',
+    content: propsContent = '',
     autoFocus = false,
-    nodeType = 'date',
-    children = []
+    nodeType: propsNodeType = 'date',
+    children: propsChildren = []
   }: NodeComponentProps = $props();
 
   const dispatch = createEventDispatcher();
+
+  // Use reactive stores directly instead of relying on props
+  // Components query the stores for current data and re-render automatically when data changes
+  let node = $derived(nodeData.getNode(nodeId));
+  let childIds = $derived(structureTree.getChildren(nodeId));
+
+  // Derive props from stores with fallback to passed props for backward compatibility
+  let content = $derived(node?.content ?? propsContent);
+  let nodeType = $derived(node?.nodeType ?? propsNodeType);
+  let children = $derived(childIds ?? propsChildren);
 
   // Parse date from content - expects YYYY-MM-DD format or similar
   function parseDate(content: string): Date | null {

--- a/packages/desktop-app/src/lib/design/components/task-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/task-node.svelte
@@ -19,6 +19,8 @@
   import type { NodeState } from '$lib/design/icons/registry';
   import { getNavigationService } from '$lib/services/navigation-service';
   import { DEFAULT_PANE_ID } from '$lib/stores/navigation';
+  import { nodeData } from '$lib/stores/reactive-node-data.svelte';
+  import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 
   // Get paneId from context (set by PaneContent) - identifies which pane this node is in
   const sourcePaneId = getContext<string>('paneId') ?? DEFAULT_PANE_ID;
@@ -26,10 +28,10 @@
   // Props using Svelte 5 runes mode - same interface as BaseNode
   let {
     nodeId,
-    nodeType = 'task',
+    nodeType: propsNodeType = 'task',
     autoFocus = false,
-    content = '',
-    children = [],
+    content: propsContent = '',
+    children: propsChildren = [],
     metadata = {}
   }: {
     nodeId: string;
@@ -41,6 +43,16 @@
   } = $props();
 
   const dispatch = createEventDispatcher();
+
+  // Use reactive stores directly instead of relying on props
+  // Components query the stores for current data and re-render automatically when data changes
+  let node = $derived(nodeData.getNode(nodeId));
+  let childIds = $derived(structureTree.getChildren(nodeId));
+
+  // Derive props from stores with fallback to passed props for backward compatibility
+  let content = $derived(node?.content ?? propsContent);
+  let nodeType = $derived(node?.nodeType ?? propsNodeType);
+  let children = $derived(childIds ?? propsChildren);
 
   // Track if user is actively typing (hide button during typing)
   let isTyping = $state(false);


### PR DESCRIPTION
## Summary

Updates child node components (TextNode, TaskNode, DateNode) to directly use ReactiveNodeData and ReactiveStructureTree stores instead of relying on props passed from parent components.

## Changes

- All three components now import and query reactive stores directly
- Components derive content, nodeType, and children from stores with prop fallbacks
- Uses nullish coalescing (`??`) for children fallback to preserve distinction between "store not initialized" (undefined) and "no children" (empty array)
- Follows established pattern from BaseNodeViewer (PR #572)

## Acceptance Criteria (Issue #579)

- ✅ All child components import reactive stores directly
- ✅ No calls to legacy service methods  
- ✅ All reactivity uses `$derived` (no `$effect` blocks)
- ✅ Components render correctly with reactive updates
- ✅ All tests pass (1690 passing, 102 skipped)

## Test Plan

- [x] Unit tests pass
- [x] Quality checks pass (eslint, svelte-check, clippy)
- [x] Pattern follows established architecture

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)