### PR TITLE
Eliminate all $effect blocks from base-node-viewer.svelte

### DIFF
--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -582,64 +582,6 @@
     }, 10);
   }
 
-  // OLD IMPLEMENTATION - REPLACED BY FOCUSMANAGER
-  // function requestNodeFocus(nodeId: string, position: number) {
-  //   // Find the target node
-  //   const node = nodeManager.findNode(nodeId);
-  //   if (!node) {
-  //     console.error(`Node ${nodeId} not found for focus request`);
-  //     return;
-  //   }
-  //
-  //   // Use DOM API to focus the node directly with cursor positioning
-  //   setTimeout(() => {
-  //     const nodeElement = document.querySelector(
-  //       `[data-node-id="${nodeId}"] [contenteditable]`
-  //     ) as HTMLElement;
-  //     if (nodeElement) {
-  //       nodeElement.focus();
-  //
-  //       // Set cursor position using tree walker (same approach as controller)
-  //       if (position >= 0) {
-  //         const selection = window.getSelection();
-  //         if (!selection) return;
-  //
-  //         // Use tree walker to find the correct text node and offset
-  //         const walker = document.createTreeWalker(nodeElement, NodeFilter.SHOW_TEXT, null);
-  //
-  //         let currentOffset = 0;
-  //         let currentNode;
-  //
-  //         while ((currentNode = walker.nextNode())) {
-  //           const nodeLength = currentNode.textContent?.length || 0;
-  //
-  //           if (currentOffset + nodeLength >= position) {
-  //             const range = document.createRange();
-  //             const offsetInNode = position - currentOffset;
-  //             range.setStart(currentNode, Math.min(offsetInNode, nodeLength));
-  //             range.setEnd(currentNode, Math.min(offsetInNode, nodeLength));
-  //
-  //             selection.removeAllRanges();
-  //             selection.addRange(range);
-  //             return;
-  //           }
-  //
-  //           currentOffset += nodeLength;
-  //         }
-  //
-  //         // If we didn't find the position, position at the end
-  //         const range = document.createRange();
-  //         range.selectNodeContents(nodeElement);
-  //         range.collapse(false);
-  //         selection.removeAllRanges();
-  //         selection.addRange(range);
-  //       }
-  //     } else {
-  //       console.error(`Could not find contenteditable element for node ${nodeId}`);
-  //     }
-  //   }, 10);
-  // }
-
   /**
    * Add appropriate formatting syntax to content based on node type
    * Used when creating new nodes from splits to preserve formatting


### PR DESCRIPTION
## Summary

- Complete removal of all reactive `$effect` blocks from `BaseNodeViewer`
- Replaced effect-based patterns with event-driven architecture and lazy initialization
- Removed ~307 lines of effect-related code
- File now has **zero** `$effect` blocks (down from 4, originally 8)

Closes #653

## Changes

**Removed effect-related infrastructure:**
- `VIEWER_SOURCE` constant
- `lastSavedContent` Map
- `isLoadingInitialNodes` flag
- `pendingContentSavePromises` Map
- `ensureAncestorsPersisted` function (was already a no-op)
- `UpdateSource` import

**Why this works without effects:**
1. Content changes trigger persistence via `on:contentChanged` → `nodeManager.updateNodeContent()` → `sharedNodeStore.updateNode()` → `PersistenceCoordinator`
2. New nodes persist via `sharedNodeStore.setNode()` which handles new nodes immediately
3. Deletions handled explicitly via `combineNodes()` → `deleteNode()`

## Test plan

- [x] Type content in a node - verify it persists after reload
- [x] Create new nodes (press Enter) - verify they persist
- [x] Delete nodes (backspace to combine) - verify deletion works
- [x] Navigate between nodes - verify focus works
- [x] All quality checks pass (svelte-check, eslint, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)