### PR TITLE
Eliminate config sync $effect in textarea-controller (#695)

### DIFF
--- a/packages/desktop-app/src/tests/components/textarea-controller.test.ts
+++ b/packages/desktop-app/src/tests/components/textarea-controller.test.ts
@@ -525,16 +525,14 @@ describe('TextareaController', () => {
       // Replace the navigateArrow handler with our spy
       mockEvents.navigateArrow = navigateArrowSpy;
 
-      // Create controller with multiline enabled
+      // Create controller with multiline enabled (config as getter - Issue #695)
       controller = new TextareaController(
         element,
         'test-node',
         'text',
         DEFAULT_PANE_ID,
         mockEvents,
-        {
-          allowMultiline: true
-        }
+        () => ({ allowMultiline: true })
       );
     });
 
@@ -604,16 +602,14 @@ describe('TextareaController', () => {
         controller.destroy();
       }
 
-      // Create controller with multiline enabled
+      // Create controller with multiline enabled (config as getter - Issue #695)
       controller = new TextareaController(
         element,
         'test-node',
         'text',
         DEFAULT_PANE_ID,
         mockEvents,
-        {
-          allowMultiline: true
-        }
+        () => ({ allowMultiline: true })
       );
     });
 
@@ -646,16 +642,14 @@ describe('TextareaController', () => {
         controller.destroy();
       }
 
-      // Create controller with multiline disabled
+      // Create controller with multiline disabled (config as getter - Issue #695)
       controller = new TextareaController(
         element,
         'task-node',
         'task',
         DEFAULT_PANE_ID,
         mockEvents,
-        {
-          allowMultiline: false
-        }
+        () => ({ allowMultiline: false })
       );
     });
 
@@ -990,16 +984,35 @@ describe('TextareaController', () => {
     });
   });
 
-  describe('Config updates', () => {
-    it('should update config dynamically', () => {
+  describe('Config getter pattern (Issue #695)', () => {
+    it('should read config through getter on-demand', () => {
+      // Destroy default controller
+      if (controller) {
+        controller.destroy();
+      }
+
+      // Create mutable config that the getter will read
+      let currentConfig = { allowMultiline: false };
+      const getConfig = () => currentConfig;
+
+      controller = new TextareaController(
+        element,
+        'test-node',
+        'text',
+        DEFAULT_PANE_ID,
+        mockEvents,
+        getConfig
+      );
+
       controller.initialize('test', true);
 
       // Initially single-line
       expect(controller['config'].allowMultiline).toBe(false);
 
-      // Update to multiline
-      controller.updateConfig({ allowMultiline: true });
+      // Update the external config (simulates reactive state change)
+      currentConfig = { allowMultiline: true };
 
+      // Controller reads config on-demand, so it sees the new value
       expect(controller['config'].allowMultiline).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- **Eliminates config sync `$effect`** by storing a config getter instead of a config value
- Controller reads config on-demand via `private get config()` property
- **Keeps content sync `$effect`** - architecturally necessary for external updates (SSE, undo/redo)

## Changes

**textarea-controller.svelte.ts:**
- Changed constructor to accept `getConfig: () => TextareaControllerConfig` instead of `config: TextareaControllerConfig`
- Added `private get config()` getter that reads from `this.getConfig()` on-demand
- Removed `updateConfig()` method (no longer needed with getter pattern)
- Factory passes `getEditableConfig` directly as getter
- Removed config sync effect (replaced with architecture documentation)

**textarea-controller.test.ts:**
- Updated tests to use getter pattern: `() => ({ allowMultiline: true })`
- New test verifies getter reads config changes reactively

## Architecture Decision

After frontend-architect analysis, the **content sync effect is kept** because:
1. Controller needs imperative DOM control (`element.value` writes in 7+ places)
2. `bind:value` would conflict with cursor preservation logic
3. No benefit over current approach - doesn't eliminate events, just shifts complexity
4. Test isolation: controller should remain pure TypeScript

The content sync effect is the **minimal coupling point** between reactive (Svelte) and imperative (controller) systems.

## Test plan

- [x] All 1469 frontend tests pass
- [x] Verified in Chrome DevTools - no console errors
- [x] Config changes reflect immediately (getter pattern works)
- [x] Content sync still works for external updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)