### PR TITLE
Refactor outdentNode() with validation and rollback helpers

### DIFF
--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -715,7 +715,6 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
    * Returned by validateOutdent() to provide type-safe access to validated data.
    */
   type OutdentValidationResult = {
-    node: Node;
     oldParentId: string;
     newParentId: string | null;
     siblingsBelow: string[];
@@ -766,7 +765,6 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     const newDepth = newParentId ? (_uiState[newParentId]?.depth || 0) + 1 : 0;
 
     return {
-      node,
       oldParentId,
       newParentId,
       siblingsBelow,


### PR DESCRIPTION
## Summary

Light refactoring of `outdentNode()` to improve maintainability without over-engineering.

### Changes
- **New `OutdentValidationResult` type** - Type-safe container for validated data
- **New `validateOutdent()` helper** - Consolidates validation and data gathering
- **New `rollbackOutdentChanges()` helper** - Isolates rollback logic
- **Reduced `outdentNode()` from 183 to 152 lines** - Better separation of concerns

### Why Light Refactoring?
The original issue proposed aggressive extraction (target: 50 lines). After analysis, we determined:
- The function was already working correctly with all tests passing
- Over-extraction would add indirection without clear benefit
- A targeted approach extracts only meaningful, reusable pieces

### Testing
- ✅ All 1569 frontend tests pass (baseline: 1569)
- ✅ All 15 outdent-specific tests pass
- ✅ No functional changes - pure refactoring

## Test plan
- [x] Run `bun run test` - all tests pass
- [x] Run `bun run quality:fix` - no lint/type errors
- [x] Verify outdent-specific tests: `bun run test src/tests/unit/indent-outdent-race-condition.test.ts src/tests/commands/keyboard/outdent-node.command.test.ts`

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)