### PR TITLE
Add default limit to query_nodes_simple

### DIFF
--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -33,7 +33,7 @@ pub use embedding_service::{NodeEmbeddingService, EMBEDDING_DIMENSION};
 pub use error::NodeServiceError;
 pub use mcp_server_service::{default_mcp_port, McpResponseCallback, McpServerService};
 pub use migration_registry::{MigrationRegistry, MigrationTransform};
-pub use node_service::{CreateNodeParams, NodeService, SubtreeData};
+pub use node_service::{CreateNodeParams, NodeService, SubtreeData, DEFAULT_QUERY_LIMIT};
 pub use query_service::{
     FilterOperator, FilterType, QueryDefinition, QueryFilter, QueryService, RelationshipType,
     SortConfig, SortDirection,


### PR DESCRIPTION
## Summary
- Add default limit (100) to `query_nodes_simple` to prevent unbounded queries and potential performance issues
- Callers can still override by explicitly setting a limit via `query.with_limit(n)`
- Export `DEFAULT_QUERY_LIMIT` constant for external callers

## Test plan
- [x] Verify compilation passes (`cargo check`)
- [x] Run existing node_query_tests - all 7 tests pass
- [x] Add new test: `default_limit_applied` - verifies default limit is applied
- [x] Add new test: `explicit_limit_respected` - verifies explicit limits override default
- [x] Run full Rust test suite - 139 tests pass (same as baseline)
- [x] Run cargo clippy - no warnings
- [x] Pre-commit hooks pass

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)