### PR TITLE
Fix: New tab opens with scroll position at top

### DIFF
--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -849,7 +849,9 @@
           range.collapse(true);
           selection.removeAllRanges();
           selection.addRange(range);
-          element.focus();
+          // Use preventScroll to avoid browser auto-scrolling when focusing
+          // This preserves scroll state during tab switching and cursor restoration
+          element.focus({ preventScroll: true });
           return;
         }
         currentOffset += nodeLength;
@@ -862,7 +864,9 @@
         range.collapse(true);
         selection.removeAllRanges();
         selection.addRange(range);
-        element.focus();
+        // Use preventScroll to avoid browser auto-scrolling when focusing
+        // This preserves scroll state during tab switching and cursor restoration
+        element.focus({ preventScroll: true });
       }
     } catch {
       // Silently handle cursor restoration errors

--- a/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
+++ b/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
@@ -431,7 +431,12 @@ export class TextareaController {
     }
 
     public focus(): void {
-      this.element.focus();
+      // Use preventScroll to avoid browser auto-scrolling when focusing
+      // This is critical for:
+      // 1. New tab opening - scroll should start at top, not at first focused node
+      // 2. Tab switching - scroll position should be restored, not overridden by focus
+      // 3. Arrow navigation - maintains scroll state during node-to-node navigation
+      this.element.focus({ preventScroll: true });
 
       if (this.pendingCursorPosition !== null) {
         this.setCursorPosition(this.pendingCursorPosition);

--- a/packages/desktop-app/src/lib/services/cursor-positioning-service.ts
+++ b/packages/desktop-app/src/lib/services/cursor-positioning-service.ts
@@ -96,8 +96,10 @@ export class CursorPositioningService {
       }
 
       // Focus if requested
+      // Use preventScroll to avoid browser auto-scrolling when focusing
+      // This preserves scroll state during tab switching and new tab opening
       if (focus) {
-        textarea.focus();
+        textarea.focus({ preventScroll: true });
       }
 
       // Set cursor position
@@ -132,8 +134,10 @@ export class CursorPositioningService {
       const clampedPosition = Math.max(0, Math.min(position, maxPosition));
 
       // Focus if requested
+      // Use preventScroll to avoid browser auto-scrolling when focusing
+      // This preserves scroll state during tab switching and new tab opening
       if (focus) {
-        textarea.focus();
+        textarea.focus({ preventScroll: true });
       }
 
       // Set cursor position
@@ -187,8 +191,10 @@ export class CursorPositioningService {
       absolutePosition += column;
 
       // Focus if requested
+      // Use preventScroll to avoid browser auto-scrolling when focusing
+      // This preserves scroll state during tab switching and new tab opening
       if (focus) {
-        textarea.focus();
+        textarea.focus({ preventScroll: true });
       }
 
       // Set cursor position


### PR DESCRIPTION
## Summary
- Adds `{ preventScroll: true }` to all `focus()` calls in the cursor positioning system
- Prevents browser auto-scrolling behavior when focusing textarea elements
- Ensures new tabs open with scroll position at top

## Changes
- **textarea-controller.svelte.ts**: Updated `TextareaController.focus()` method (main entry point)
- **cursor-positioning-service.ts**: Updated all direct `textarea.focus()` calls
- **base-node-viewer.svelte**: Updated cursor restoration focus calls

## Test plan
- [ ] Enter key creates new node - cursor should be in new node
- [ ] Arrow up/down navigation between nodes
- [ ] Clicking on a node to edit
- [ ] Creating a node via slash command
- [ ] Tab switching preserves scroll position
- [ ] New tab opens at scroll top
- [ ] Indent/outdent operations
- [ ] Node type conversion (text → task, etc.)

**Note**: Unit tests pass but manual testing is required as mocked DOM doesn't detect real browser focus/scroll behavior.

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)