### PR TITLE
Enhancement: Immediate backlinks reactivity on mention creation

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -2291,6 +2291,9 @@ export class SharedNodeStore {
 
     // Update mentionedIn for added mentions
     for (const targetId of added) {
+      // Skip self-mentions - a node shouldn't appear in its own backlinks
+      if (targetId === sourceContainer.id) continue;
+
       const targetNode = this.nodes.get(targetId);
       if (targetNode) {
         const mentionedIn = [...(targetNode.mentionedIn ?? [])];
@@ -2307,6 +2310,9 @@ export class SharedNodeStore {
 
     // Update mentionedIn for removed mentions
     for (const targetId of removed) {
+      // Skip self-mentions - consistency with added mentions handling
+      if (targetId === sourceContainer.id) continue;
+
       const targetNode = this.nodes.get(targetId);
       if (targetNode?.mentionedIn) {
         const mentionedIn = targetNode.mentionedIn.filter(ref => ref.id !== containerRef.id);

--- a/packages/desktop-app/src/tests/services/shared-node-store-extended.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-extended.test.ts
@@ -930,5 +930,28 @@ describe('SharedNodeStore - Extended Coverage', () => {
         storeAny.updateMentionedInOnContentChange(sourceNode.id, 'same', 'same');
       }).not.toThrow();
     });
+
+    it('should skip self-mentions (node mentioning itself)', () => {
+      const storeAny = store as unknown as {
+        updateMentionedInOnContentChange: (
+          sourceNodeId: string,
+          oldContent: string | undefined,
+          newContent: string | undefined
+        ) => void;
+      };
+
+      // Source node mentions itself
+      const contentWithSelfMention = `Check out [@Self](nodespace://${sourceNode.id})`;
+
+      storeAny.updateMentionedInOnContentChange(
+        sourceNode.id,
+        '', // old content without mention
+        contentWithSelfMention // new content with self-mention
+      );
+
+      // Source node's mentionedIn should NOT include itself
+      const updatedSource = store.getNode(sourceNode.id);
+      expect(updatedSource?.mentionedIn ?? []).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

When a user creates or removes a mention (e.g., typing `[@Node](nodespace://target-id)`), the target node's backlinks panel now updates immediately without requiring navigation away and back.

Closes #880

## Changes

### SharedNodeStore (`shared-node-store.svelte.ts`)

- **New helper method `updateMentionedInOnContentChange()`**: Diffs old vs new content to detect added/removed mentions using `contentProcessor.detectNodespaceURIs()`, then updates the `mentionedIn` array on target nodes directly in the store.

- **New helper method `findContainer()`**: Walks the node hierarchy to find the "container" (root node or task node) that should appear in backlinks. Task nodes are their own container regardless of hierarchy position.

- **Normal update flow integration**: Captures old content before optimistic update and calls the helper after successful persistence.

- **Batch update flow integration**: Extended `ActiveBatch` interface to track `originalContent` at batch start, and updated `persistBatchedChanges()` to call the helper after successful persistence.

### Tests (`shared-node-store-extended.test.ts`)

Added comprehensive tests for Issue #880:
- Adding mentions updates target's `mentionedIn`
- Removing mentions removes from target's `mentionedIn`
- Duplicate prevention (same container mentioning multiple times)
- Subscriber notification when `mentionedIn` changes
- Container finding logic for child and task nodes
- Edge cases: undefined content, no mention changes

## Technical Details

**Root cause addressed**: Domain events are filtered by `source_client_id` to prevent feedback loops. When the Tauri frontend creates a mention, the `RelationshipCreated` event is filtered out, so the target node's view never gets notified. This solution bypasses that by updating the store directly on the frontend after persistence succeeds.

**Key design decisions**:
- Updates happen after successful persistence (not optimistically) to ensure consistency
- Container concept matches backend behavior (root nodes and tasks appear in backlinks)
- No duplicate entries allowed (same container can mention via multiple child nodes)

## Test Plan

- [x] Run `bun run test` - All 3554 tests pass (8 new tests added)
- [x] Run `bun run rust:test` - All 777 tests pass
- [x] Run `bun run quality:fix` - No linting/formatting issues
- [x] Type checking passes with `svelte-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)