### PR TITLE
Fix TableNode display overlay: replace absolute positioning with customViewContent snippet

### DIFF
--- a/.claude/hooks/check-feature-branch.ts
+++ b/.claude/hooks/check-feature-branch.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+/**
+ * PreToolUse hook: warns when editing files on the main branch.
+ *
+ * The startup sequence requires creating a feature branch before modifying
+ * any files. Being on `main` is a reliable signal that the sequence was skipped.
+ *
+ * Exits 0 in all cases (never blocks), but prints a warning to stderr when on
+ * `main` so Claude Code surfaces it as a message to the agent — prompting
+ * self-correction without hard-blocking legitimate operations.
+ */
+
+import { execSync } from 'child_process';
+
+function getCurrentBranch(): string {
+  try {
+    return execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+  } catch {
+    // Not a git repo or git not available — allow through
+    return '';
+  }
+}
+
+const branch = getCurrentBranch();
+
+if (branch === 'main') {
+  process.stderr.write(`
+⚠️  WARNING: You are on the \`main\` branch.
+
+Have you completed the startup sequence before editing files?
+
+  1. git fetch origin && git pull origin main
+  2. bun install
+  3. bun run test  (record baseline)
+  4. bun run gh:comment <N> "Frontend: X passed"
+  5. git checkout -b feature/issue-<N>-description
+  6. bun run gh:assign <N> "@me"
+  7. bun run gh:status <N> "In Progress"
+
+If not, STOP and complete the sequence first, then create a feature branch.
+`);
+}
+
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,19 @@
       "Bash(gh:*)",
       "Bash(bun:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run .claude/hooks/check-feature-branch.ts",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   }
 }

--- a/packages/desktop-app/src/lib/design/components/table-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/table-node.svelte
@@ -10,7 +10,7 @@
 -->
 
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, tick } from 'svelte';
   import BaseNode from './base-node.svelte';
   import ViewModeRenderer from './view-mode-renderer.svelte';
   import { focusManager } from '$lib/services/focus-manager.svelte';
@@ -86,8 +86,28 @@
   // Parse the table reactively
   let parsedTable = $derived(parseTable(content));
 
-  // Display content: empty in view mode (we render the table overlay)
-  let displayContent = $derived(isEditing ? content : '');
+  // Pass real content so adjustHeight() has multiline text to measure on edit entry.
+  // customViewContent overrides view rendering entirely — raw markdown is never shown.
+  let displayContent = $derived(content);
+
+  // Measured height of rendered table — updated reactively via bind:clientHeight
+  let tableViewHeight = $state(0);
+
+  // Ref to wrapper div for scoping DOM queries in the $effect
+  let wrapperElement = $state<HTMLDivElement | undefined>(undefined);
+
+  // When entering edit mode, apply the last-known table height to the textarea
+  // so there is no layout shift. After this, adjustHeight() takes over on each keystroke.
+  $effect(() => {
+    if (isEditing && tableViewHeight > 0) {
+      tick().then(() => {
+        const textarea = wrapperElement?.querySelector<HTMLTextAreaElement>('textarea');
+        if (textarea) {
+          textarea.style.height = `${tableViewHeight}px`;
+        }
+      });
+    }
+  });
 
   function handleContentChange(event: CustomEvent<{ content: string }>) {
     content = event.detail.content;
@@ -107,7 +127,34 @@
   }
 </script>
 
-<div class="table-node-wrapper" class:viewing={!isEditing}>
+{#snippet tableViewContent()}
+  {#if parsedTable}
+    <table bind:clientHeight={tableViewHeight}>
+        <thead>
+          <tr>
+            {#each parsedTable.headers as header, i}
+              <th style="text-align: {parsedTable.alignments[i] || 'left'}">
+                <ViewModeRenderer content={header} />
+              </th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each parsedTable.rows as row}
+            <tr>
+              {#each row as cell, i}
+                <td style="text-align: {parsedTable.alignments[i] || 'left'}">
+                  <ViewModeRenderer content={cell} />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+    </table>
+  {/if}
+{/snippet}
+
+<div class="table-node-wrapper" bind:this={wrapperElement}>
   <BaseNode
     {nodeId}
     {nodeType}
@@ -117,6 +164,7 @@
     {children}
     {editableConfig}
     metadata={tableMetadata}
+    customViewContent={tableViewContent}
     on:createNewNode={handleCreateNewNode}
     on:contentChanged={handleContentChange}
     on:indentNode={forwardEvent('indentNode')}
@@ -131,53 +179,16 @@
     on:nodeTypeChanged={handleNodeTypeChanged}
     on:iconClick={forwardEvent('iconClick')}
   />
-
-  <!-- Rendered table overlay (view mode only) -->
-  {#if !isEditing && parsedTable}
-    <div class="table-overlay">
-      <table>
-        <thead>
-          <tr>
-            {#each parsedTable.headers as header, i}
-              <th style="text-align: {parsedTable.alignments[i] || 'left'}"><ViewModeRenderer content={header} /></th>
-            {/each}
-          </tr>
-        </thead>
-        <tbody>
-          {#each parsedTable.rows as row}
-            <tr>
-              {#each row as cell, i}
-                <td style="text-align: {parsedTable.alignments[i] || 'left'}"><ViewModeRenderer content={cell} /></td>
-              {/each}
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
-  {/if}
 </div>
 
 <style>
   .table-node-wrapper {
-    position: relative;
+    width: 100%;
   }
 
-  /* In view mode, hide the raw text content */
-  .table-node-wrapper.viewing :global(.node__content) {
-    color: transparent;
-    position: relative;
-    min-height: 1.5rem;
-    user-select: none;
-  }
-
-  /* Table overlay - positioned over the content area */
-  .table-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    pointer-events: none;
-    padding: 0.25rem 0;
+  /* Padding inside view content area to preserve visual spacing */
+  .table-node-wrapper :global(.node__content--view) {
+    padding-block: 0.25rem;
   }
 
   table {


### PR DESCRIPTION
Fixes #931

## Problem

In view mode, `TableNode` rendered the HTML table as an absolutely-positioned overlay on top of a hidden (transparent) raw text content area. Because `position: absolute` removes the overlay from normal document flow, the wrapper's height was determined only by the hidden text content — not by the actual rendered table. Multi-row tables extended beyond the wrapper bounds and visually covered nodes below them.

## Solution

Replaced the overlay approach with the `customViewContent` snippet prop that `BaseNode` already supports. The rendered table now lives inside the `.node__content--view` div in normal document flow, so the wrapper naturally sizes to the table's height.

Key changes in `table-node.svelte`:
- Removed `.table-overlay` div and its `{#if !isEditing}` conditional
- Removed `position: absolute` CSS for `.table-overlay`
- Removed `.table-node-wrapper.viewing :global(.node__content)` transparency hack
- Added `{#snippet tableViewContent()}` that renders the `<table>` inline
- Passed snippet as `customViewContent` to `BaseNode`
- Added `bind:clientHeight={tableViewHeight}` on the `<table>` element to measure rendered height
- Added `$effect` to apply the last-known table height to the textarea on edit-mode entry, preventing layout shift

### Also addressed (code review feedback from PR #918 review)

- `bind:clientHeight` placed directly on `<table>` element (no wrapper div)
- Restored `/* No outer borders, no vertical lines - clean minimal design */` comment above `tr:last-child td`

### Hook improvements (`.claude/settings.json` + `.claude/hooks/check-feature-branch.ts`)

Added a `PreToolUse` hook that warns (not blocks) when editing files while on `main` branch:
- Hook path uses portable relative path `.claude/hooks/check-feature-branch.ts`
- Exits 0 in all cases — surfaces a warning to the agent via stderr without hard-blocking

## Acceptance Criteria

- [x] Table node in display mode does not overlap or cover nodes below it
- [x] The document layout correctly reserves space for the full rendered table height
- [x] Clicking the table enters edit mode and shows raw GFM markdown
- [x] Switching back from edit mode re-renders the table correctly in its natural position
- [x] Column alignment (left/center/right), table styling, and cell content rendering are unchanged
- [x] No other node type is affected by the change
- [x] Tests pass (`bun run test`) — 3704 passed, 0 failures
- [x] Code passes `bun run quality:fix` — 0 errors, 0 warnings

## Skipped items (with reasoning)

**`isEditing` predicate — add `paneId` check**: `paneId` is obtained via `getContext()` inside `BaseNode` and is not propagated as a prop to wrapper nodes. `code-block-node.svelte` (the reference pattern) also only checks `editingNodeId`. This is an existing accepted pattern at the wrapper level. Track as a separate issue if stricter per-pane isolation is desired.

**Cross-component DOM query — use stable textarea ID**: The stable `textarea__{paneId}__{nodeId}` ID requires `paneId`, which is unavailable in `TableNode` for the same reason. The `wrapperElement` binding already scopes the query to this node's subtree. Track as a follow-up improvement.

## Test Results

- Frontend: 3704 passed (0 failures) — up from 3676 baseline at time of PR #918
- Quality: 0 ESLint errors, 0 svelte-check warnings, 0 Clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)