### PR TITLE
Horizontal lines imported as children of surrounding content instead of root-level nodes

### DIFF
--- a/packages/core/src/mcp/handlers/markdown.rs
+++ b/packages/core/src/mcp/handlers/markdown.rs
@@ -125,6 +125,11 @@ impl PrepareContext {
         self.heading_stack.last().map(|(id, _)| id.clone())
     }
 
+    /// Get the root-level parent ID (bottom of heading stack = document root)
+    fn root_parent_id(&self) -> Option<String> {
+        self.heading_stack.first().map(|(id, _)| id.clone())
+    }
+
     /// Pop headings at same or higher level for new heading insertion
     fn pop_headings_for_level(&mut self, level: usize) {
         while let Some((_, stack_level)) = self.heading_stack.last() {
@@ -645,11 +650,10 @@ pub fn prepare_nodes_from_markdown(
         }
 
         // Determine parent based on hierarchy rules
-        let parent_id = if node_type == "code-block"
-            || node_type == "quote-block"
-            || node_type == "table"
-            || node_type == "horizontal-line"
-        {
+        let parent_id = if node_type == "horizontal-line" {
+            // Horizontal rules are document-level dividers — always place at root level
+            context.root_parent_id()
+        } else if node_type == "code-block" || node_type == "quote-block" || node_type == "table" {
             last_content_node
                 .clone()
                 .or_else(|| context.current_parent_id())

--- a/packages/core/src/mcp/handlers/markdown_test.rs
+++ b/packages/core/src/mcp/handlers/markdown_test.rs
@@ -2942,4 +2942,66 @@ ___
         // 1. Container + 1 horizontal-line
         assert_eq!(result["nodes_created"], 2);
     }
+
+    #[tokio::test]
+    async fn test_horizontal_rule_placed_at_root_level_inside_heading() {
+        let (node_service, _temp_dir) = setup_test_service().await;
+
+        // Regression test for issue #948: HR inside a heading section should be
+        // placed as a direct child of root, not nested under the heading.
+        let markdown = r#"# Section One
+
+Some text here.
+
+---
+
+# Section Two"#;
+
+        let params = json!({
+            "markdown_content": markdown,
+            "sync_import": true,
+            "title": "HR Placement Test"
+        });
+
+        let result = handle_create_nodes_from_markdown(&node_service, params)
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        // Container + Section One (header) + Some text here. (text) + --- (hr) + Section Two (header)
+        assert_eq!(result["nodes_created"], 5);
+
+        let root_id = result["root_id"].as_str().unwrap();
+
+        // Root should have 3 direct children: Section One, ---, Section Two
+        let root_children = node_service.get_children(root_id).await.unwrap();
+        assert_eq!(
+            root_children.len(),
+            3,
+            "Root should have 3 direct children: Section One, HR, Section Two"
+        );
+
+        let types: Vec<&str> = root_children.iter().map(|n| n.node_type.as_str()).collect();
+        assert!(
+            types.contains(&"header"),
+            "Root children should include header nodes"
+        );
+        assert!(
+            types.contains(&"horizontal-line"),
+            "Root children should include the horizontal-line"
+        );
+
+        // Section One should have exactly 1 child: "Some text here."
+        let section_one = root_children
+            .iter()
+            .find(|n| n.node_type == "header" && n.content.contains("Section One"))
+            .expect("Section One header not found");
+        let section_one_children = node_service.get_children(&section_one.id).await.unwrap();
+        assert_eq!(
+            section_one_children.len(),
+            1,
+            "Section One should have exactly 1 child (the text node), not the HR"
+        );
+        assert_eq!(section_one_children[0].node_type, "text");
+    }
 }


### PR DESCRIPTION
Closes #948