### PR TITLE
Fix horizontal-line nodes placed at root level during markdown import (closes #948)

### DIFF
--- a/packages/core/src/mcp/handlers/markdown.rs
+++ b/packages/core/src/mcp/handlers/markdown.rs
@@ -125,7 +125,7 @@ impl PrepareContext {
         self.heading_stack.last().map(|(id, _)| id.clone())
     }
 
-    /// Get the root-level parent ID (bottom of heading stack = document root)
+    /// Get the root-level parent ID (first element at index 0 = document root)
     fn root_parent_id(&self) -> Option<String> {
         self.heading_stack.first().map(|(id, _)| id.clone())
     }

--- a/packages/core/src/mcp/handlers/markdown_test.rs
+++ b/packages/core/src/mcp/handlers/markdown_test.rs
@@ -2981,14 +2981,26 @@ Some text here.
             "Root should have 3 direct children: Section One, HR, Section Two"
         );
 
-        let types: Vec<&str> = root_children.iter().map(|n| n.node_type.as_str()).collect();
-        assert!(
-            types.contains(&"header"),
-            "Root children should include header nodes"
+        // Assert ordering: Section One → HR → Section Two
+        assert_eq!(
+            root_children[0].node_type, "header",
+            "First root child should be Section One header"
+        );
+        assert_eq!(
+            root_children[1].node_type, "horizontal-line",
+            "Second root child should be the horizontal-line"
+        );
+        assert_eq!(
+            root_children[2].node_type, "header",
+            "Third root child should be Section Two header"
         );
         assert!(
-            types.contains(&"horizontal-line"),
-            "Root children should include the horizontal-line"
+            root_children[0].content.contains("Section One"),
+            "First header should be Section One"
+        );
+        assert!(
+            root_children[2].content.contains("Section Two"),
+            "Third header should be Section Two"
         );
 
         // Section One should have exactly 1 child: "Some text here."


### PR DESCRIPTION
## Summary
- Horizontal rules (`---`, `***`, `___`) were being nested under the current heading during markdown import instead of placed at the document root level
- Add `root_parent_id()` to `PrepareContext` and use it for `horizontal-line` parent resolution, separating it from the `code-block`/`quote-block`/`table` group
- Add regression test verifying HR inside a heading section lands as a direct root child with correct ordering

## Test plan
- [ ] `cargo test test_horizontal` — all horizontal rule tests pass
- [ ] `bun run test:all` — 3704 frontend tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)