### PR TITLE
fix: prevent BaseNodeViewer fallback during async viewer load

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -32,8 +32,8 @@
 
   // Load viewer when needed - moved to function called from onMount to avoid derived context issues
   async function loadViewerForNodeType(nodeType: string) {
-    if (viewerComponents.has(nodeType) || viewerLoadErrors.has(nodeType)) {
-      return; // Already cached — ViewerComponent resolves non-null immediately, no loading state needed
+    if (viewerComponents.has(nodeType) || viewerLoadErrors.has(nodeType) || viewerLoading.has(nodeType)) {
+      return; // Already cached or in-flight — avoid duplicate concurrent fetches
     }
 
     viewerLoading = new Set([...viewerLoading, nodeType]); // Svelte 5: reassign for reactivity
@@ -166,7 +166,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 3rem;
+    height: 100%;
     text-align: center;
     color: hsl(var(--muted-foreground));
   }

--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -28,12 +28,15 @@
   // Track loaded viewer components by nodeType
   let viewerComponents = $state<Map<string, unknown>>(new Map());
   let viewerLoadErrors = $state<Map<string, string>>(new Map());
+  let viewerLoading = $state<Set<string>>(new Set());
 
   // Load viewer when needed - moved to function called from onMount to avoid derived context issues
   async function loadViewerForNodeType(nodeType: string) {
     if (viewerComponents.has(nodeType) || viewerLoadErrors.has(nodeType)) {
-      return;
+      return; // Already cached — ViewerComponent resolves non-null immediately, no loading state needed
     }
+
+    viewerLoading = new Set([...viewerLoading, nodeType]); // Svelte 5: reassign for reactivity
 
     try {
       const viewer = await pluginRegistry.getViewer(nodeType);
@@ -44,13 +47,23 @@
       const errorMessage = error instanceof Error ? error.message : 'Unknown error loading viewer';
       log.error(`Failed to load viewer for ${nodeType}:`, error);
       viewerLoadErrors = new Map(viewerLoadErrors.set(nodeType, errorMessage));
+    } finally {
+      const next = new Set(viewerLoading);
+      next.delete(nodeType);
+      viewerLoading = next; // Svelte 5: reassign for reactivity
     }
   }
 
   // Derive viewer component for active tab - use non-reactive snapshot to break tracking
-  const ViewerComponent = $derived.by(() => {
+  const ViewerComponent = $derived.by((): typeof BaseNodeViewer | null => {
     const nodeType = activeTab?.content?.nodeType ?? 'text';
+    const loading = $state.snapshot(viewerLoading);
     const components = $state.snapshot(viewerComponents);
+
+    if (loading.has(nodeType)) {
+      return null; // Still loading — do not fall back to BaseNodeViewer
+    }
+
     return (components.get(nodeType) ?? BaseNodeViewer) as typeof BaseNodeViewer;
   });
 
@@ -85,22 +98,28 @@
       <p class="help-text">Try refreshing the page or contact support if the problem persists.</p>
     </div>
   {:else}
-    <!-- Dynamic viewer routing via plugin registry -->
-    <!-- Falls back to BaseNodeViewer if no custom viewer registered -->
+    {#if !ViewerComponent}
+      <div class="loading-state">
+        <span>Loading...</span>
+      </div>
+    {:else}
+      <!-- Dynamic viewer routing via plugin registry -->
+      <!-- Falls back to BaseNodeViewer if no custom viewer registered -->
 
-    <!-- KEY FIX: Use {#key} to force separate component instances per pane+nodeId -->
-    <!-- This ensures each pane gets its own BaseNodeViewer instance with isolated state -->
-    {#key `${pane.id}-${content.nodeId}`}
-      <ViewerComponent
-        nodeId={content.nodeId}
-        tabId={activeTabId}
-        onTitleChange={(title: string) => updateTabTitle(activeTabId, title)}
-        onNodeIdChange={(newNodeId: string) => {
-          updateTabContent(activeTabId, { nodeId: newNodeId, nodeType: content.nodeType });
-        }}
-        onNodeNotFound={() => closeTab(activeTabId)}
-      />
-    {/key}
+      <!-- KEY FIX: Use {#key} to force separate component instances per pane+nodeId -->
+      <!-- This ensures each pane gets its own BaseNodeViewer instance with isolated state -->
+      {#key `${pane.id}-${content.nodeId}`}
+        <ViewerComponent
+          nodeId={content.nodeId}
+          tabId={activeTabId}
+          onTitleChange={(title: string) => updateTabTitle(activeTabId, title)}
+          onNodeIdChange={(newNodeId: string) => {
+            updateTabContent(activeTabId, { nodeId: newNodeId, nodeType: content.nodeType });
+          }}
+          onNodeNotFound={() => closeTab(activeTabId)}
+        />
+      {/key}
+    {/if}
   {/if}
 {:else if activeTab}
   <!-- Placeholder content for tabs without node content -->
@@ -138,6 +157,17 @@
     align-items: center;
     justify-content: center;
     height: 100%;
+    color: hsl(var(--muted-foreground));
+  }
+
+  /* Loading state */
+  .loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    text-align: center;
     color: hsl(var(--muted-foreground));
   }
 


### PR DESCRIPTION
## Summary
- Tracks in-flight viewer loads with a `viewerLoading: Set<string>` state variable
- `ViewerComponent` derived now returns `null` while a node type is loading, preventing premature fallback to `BaseNodeViewer`
- Template renders a "Loading..." placeholder when `ViewerComponent` is null

## Problem
When a schema node type (e.g., Task) was clicked in the sidebar, `ViewerComponent` resolved synchronously on the same tick — before the async `pluginRegistry.getViewer()` call completed — and immediately fell back to `BaseNodeViewer`. This caused `BaseNodeViewer` to receive a schema node ID it cannot handle, triggering `get_subtree_with_relationships` with an incompatible ID and freezing the app.

## Test plan
- [ ] `bun run test` — 118 test files, 3722 tests all passing (baseline unchanged)
- [ ] Manual: Click "Task" in Schema Types sidebar — shows "Loading..." briefly, then renders QueryNodeViewer with task nodes (no freeze)
- [ ] Manual: Click date/text nodes — existing viewers still load correctly
- [ ] Manual: Click an already-viewed schema node (switch away and back) — no loading flash (cached path hits early return)

Fixes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)