### PR TITLE
test: fill playbook engine test coverage gaps

### DIFF
--- a/packages/core/src/playbook/cron_runner.rs
+++ b/packages/core/src/playbook/cron_runner.rs
@@ -69,7 +69,7 @@ pub async fn cron_runner_loop(
 }
 
 /// Check all cron entries and enqueue work items for matching nodes.
-async fn check_and_enqueue(
+pub(crate) async fn check_and_enqueue(
     lifecycle: &Arc<RwLock<PlaybookLifecycleManager>>,
     node_service: &Arc<NodeService>,
     queue_tx: &mpsc::Sender<ExecutionWorkItem>,
@@ -334,5 +334,172 @@ mod tests {
         assert_eq!(entry.node_type, "invoice");
         assert_eq!(entry.rules.len(), 1);
         assert_eq!(entry.rules[0].playbook_id, "playbook-1");
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests — check_and_enqueue with real NodeService + lifecycle
+    // -----------------------------------------------------------------------
+
+    mod integration {
+        use super::*;
+        use crate::db::SurrealStore;
+        use crate::models::Node;
+        use crate::playbook::lifecycle::PlaybookLifecycleManager;
+        use crate::services::NodeService;
+        use serde_json::json;
+        use std::sync::{Arc, RwLock};
+        use tempfile::TempDir;
+        use tokio::sync::mpsc;
+
+        async fn create_test_service() -> (Arc<NodeService>, TempDir) {
+            let temp_dir = TempDir::new().unwrap();
+            let db_path = temp_dir.path().join("test.db");
+            let mut store: Arc<SurrealStore> = Arc::new(SurrealStore::new(db_path).await.unwrap());
+            let node_service = Arc::new(NodeService::new(&mut store).await.unwrap());
+            (node_service, temp_dir)
+        }
+
+        fn make_lifecycle_with_cron(
+            cron_expr: &str,
+            node_type: &str,
+        ) -> Arc<RwLock<PlaybookLifecycleManager>> {
+            let mut lm = PlaybookLifecycleManager::new();
+
+            // Manually create a playbook node with a scheduled trigger and activate it
+            let playbook_node = Node {
+                id: "pb-cron-1".to_string(),
+                node_type: "playbook".to_string(),
+                content: "cron playbook".to_string(),
+                version: 1,
+                created_at: chrono::Utc::now(),
+                modified_at: chrono::Utc::now(),
+                properties: json!({
+                    "rules": [{
+                        "name": "cron-rule-1",
+                        "trigger": {
+                            "type": "scheduled",
+                            "cron": cron_expr,
+                            "node_type": node_type
+                        },
+                        "conditions": [],
+                        "actions": [{
+                            "action_type": "update_node",
+                            "params": {"target": "trigger.node"}
+                        }]
+                    }]
+                }),
+                mentions: vec![],
+                mentioned_in: vec![],
+                title: Some("Cron Playbook".to_string()),
+                lifecycle_status: "active".to_string(),
+            };
+            lm.activate_playbook(&playbook_node).unwrap();
+
+            Arc::new(RwLock::new(lm))
+        }
+
+        #[tokio::test]
+        async fn check_and_enqueue_enqueues_for_matching_cron() {
+            let (svc, _tmp) = create_test_service().await;
+
+            // Create schema for the node type
+            let schema = Node::new_with_id(
+                "cr_task".to_string(),
+                "schema".to_string(),
+                "cr_task".to_string(),
+                json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "cr_task schema",
+                    "fields": [{"name": "status", "type": "string"}],
+                    "relationships": []
+                }),
+            );
+            svc.create_node(schema).await.unwrap();
+
+            // Create active nodes of type "cr_task"
+            let node1 = Node::new_with_id(
+                "cr-t1".to_string(),
+                "cr_task".to_string(),
+                "task 1".to_string(),
+                json!({"status": "open"}),
+            );
+            let node2 = Node::new_with_id(
+                "cr-t2".to_string(),
+                "cr_task".to_string(),
+                "task 2".to_string(),
+                json!({"status": "open"}),
+            );
+            svc.create_node(node1).await.unwrap();
+            svc.create_node(node2).await.unwrap();
+
+            // Use "every minute" cron — guaranteed to match in any 60s window
+            let lifecycle = make_lifecycle_with_cron("0 * * * * * *", "cr_task");
+
+            let (tx, mut rx) = mpsc::channel::<ExecutionWorkItem>(100);
+            check_and_enqueue(&lifecycle, &svc, &tx).await;
+
+            // Should have enqueued work items for both nodes
+            let mut received = vec![];
+            while let Ok(item) = rx.try_recv() {
+                received.push(item);
+            }
+            assert_eq!(
+                received.len(),
+                2,
+                "should enqueue one work item per matching node"
+            );
+
+            // Each work item should carry the cron rule
+            for item in &received {
+                assert_eq!(item.rules.len(), 1);
+                assert_eq!(item.rules[0].rule.name, "cron-rule-1");
+            }
+
+            // Both node IDs should be represented
+            let ids: Vec<&str> = received.iter().map(|w| w.trigger_node.id.as_str()).collect();
+            assert!(ids.contains(&"cr-t1"));
+            assert!(ids.contains(&"cr-t2"));
+        }
+
+        #[tokio::test]
+        async fn check_and_enqueue_skips_non_matching_cron() {
+            let (svc, _tmp) = create_test_service().await;
+
+            // Create schema
+            let schema = Node::new_with_id(
+                "cr_task2".to_string(),
+                "schema".to_string(),
+                "cr_task2".to_string(),
+                json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "cr_task2 schema",
+                    "fields": [],
+                    "relationships": []
+                }),
+            );
+            svc.create_node(schema).await.unwrap();
+
+            let node = Node::new_with_id(
+                "cr-t3".to_string(),
+                "cr_task2".to_string(),
+                "task 3".to_string(),
+                json!({}),
+            );
+            svc.create_node(node).await.unwrap();
+
+            // Far-future cron expression — should NOT match current window
+            let lifecycle = make_lifecycle_with_cron("0 0 0 29 2 * 2099", "cr_task2");
+
+            let (tx, mut rx) = mpsc::channel::<ExecutionWorkItem>(100);
+            check_and_enqueue(&lifecycle, &svc, &tx).await;
+
+            // Should not enqueue anything
+            assert!(
+                rx.try_recv().is_err(),
+                "non-matching cron should not enqueue any work items"
+            );
+        }
     }
 }

--- a/packages/core/src/playbook/graph_resolver.rs
+++ b/packages/core/src/playbook/graph_resolver.rs
@@ -954,5 +954,203 @@ mod tests {
                 resolver.resolve_path(&node, &["status".to_string(), "deeper".to_string()]);
             assert!(matches!(result, ResolvedValue::Missing));
         }
+
+        // -------------------------------------------------------------------
+        // enrich_context and resolve_collection — direct integration tests
+        // -------------------------------------------------------------------
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn enrich_context_resolves_multi_hop_path() {
+            let (svc, _tmp) = create_test_service().await;
+
+            // Chain: gr_task8 -> story8 -> epic8
+            create_schema(&svc, "gr_epic8", json!([])).await;
+            create_schema(
+                &svc,
+                "gr_story8",
+                json!([{
+                    "name": "epic",
+                    "target_type": "gr_epic8",
+                    "direction": "out",
+                    "cardinality": "one"
+                }]),
+            )
+            .await;
+            create_schema(
+                &svc,
+                "gr_task8",
+                json!([{
+                    "name": "story",
+                    "target_type": "gr_story8",
+                    "direction": "out",
+                    "cardinality": "one"
+                }]),
+            )
+            .await;
+
+            let epic = make_node("gr-e8", "gr_epic8", json!({"status": "in_progress"}));
+            svc.create_node(epic).await.unwrap();
+            let story = make_node("gr-s8", "gr_story8", json!({"status": "active"}));
+            svc.create_node(story).await.unwrap();
+            let task = make_node("gr-t8", "gr_task8", json!({"status": "open"}));
+            svc.create_node(task.clone()).await.unwrap();
+
+            svc.create_relationship("gr-t8", "story", "gr-s8", json!({}))
+                .await
+                .unwrap();
+            svc.create_relationship("gr-s8", "epic", "gr-e8", json!({}))
+                .await
+                .unwrap();
+
+            let mut resolver = GraphResolver::new(Arc::clone(&svc));
+
+            use crate::playbook::path_extractor::ExtractedPath;
+
+            // Multi-hop path: node.story.epic.status (3+ segments, root="node")
+            let paths = vec![ExtractedPath {
+                segments: vec![
+                    "node".to_string(),
+                    "story".to_string(),
+                    "epic".to_string(),
+                    "status".to_string(),
+                ],
+                root: "node".to_string(),
+            }];
+
+            let result = resolver.enrich_context(&task, &paths, &[]);
+
+            let key = vec![
+                "node".to_string(),
+                "story".to_string(),
+                "epic".to_string(),
+                "status".to_string(),
+            ];
+            assert!(
+                result.contains_key(&key),
+                "enrich_context should resolve multi-hop path node.story.epic.status"
+            );
+            // The value should be a CEL String("in_progress")
+            match result.get(&key) {
+                Some(Value::String(s)) => assert_eq!(s.as_ref(), "in_progress"),
+                other => panic!(
+                    "expected CEL String('in_progress'), got {:?}",
+                    other
+                ),
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn resolve_collection_with_collection_path() {
+            let (svc, _tmp) = create_test_service().await;
+
+            create_schema(&svc, "gr_item9", json!([])).await;
+            create_schema(
+                &svc,
+                "gr_parent9",
+                json!([{
+                    "name": "items",
+                    "target_type": "gr_item9",
+                    "direction": "out",
+                    "cardinality": "many"
+                }]),
+            )
+            .await;
+
+            let item1 = make_node("gr-i9a", "gr_item9", json!({"status": "done"}));
+            let item2 = make_node("gr-i9b", "gr_item9", json!({"status": "open"}));
+            svc.create_node(item1).await.unwrap();
+            svc.create_node(item2).await.unwrap();
+
+            let parent = make_node("gr-p9", "gr_parent9", json!({}));
+            svc.create_node(parent.clone()).await.unwrap();
+
+            svc.create_relationship("gr-p9", "items", "gr-i9a", json!({}))
+                .await
+                .unwrap();
+            svc.create_relationship("gr-p9", "items", "gr-i9b", json!({}))
+                .await
+                .unwrap();
+
+            let mut resolver = GraphResolver::new(Arc::clone(&svc));
+
+            use crate::playbook::path_extractor::ExtractedPath;
+
+            // resolve_collection expects segments like ["node", "items"]
+            let collection_path = ExtractedPath {
+                segments: vec!["node".to_string(), "items".to_string()],
+                root: "node".to_string(),
+            };
+
+            let nodes = resolver.resolve_collection(&parent, &collection_path);
+            assert_eq!(nodes.len(), 2, "should resolve 2 collection nodes");
+            let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+            assert!(ids.contains(&"gr-i9a"));
+            assert!(ids.contains(&"gr-i9b"));
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn enrich_context_with_collection() {
+            let (svc, _tmp) = create_test_service().await;
+
+            create_schema(&svc, "gr_sub10", json!([])).await;
+            create_schema(
+                &svc,
+                "gr_parent10",
+                json!([{
+                    "name": "tasks",
+                    "target_type": "gr_sub10",
+                    "direction": "out",
+                    "cardinality": "many"
+                }]),
+            )
+            .await;
+
+            let sub1 = make_node("gr-s10a", "gr_sub10", json!({"status": "done"}));
+            let sub2 = make_node("gr-s10b", "gr_sub10", json!({"status": "open"}));
+            svc.create_node(sub1).await.unwrap();
+            svc.create_node(sub2).await.unwrap();
+
+            let parent = make_node("gr-p10", "gr_parent10", json!({}));
+            svc.create_node(parent.clone()).await.unwrap();
+
+            svc.create_relationship("gr-p10", "tasks", "gr-s10a", json!({}))
+                .await
+                .unwrap();
+            svc.create_relationship("gr-p10", "tasks", "gr-s10b", json!({}))
+                .await
+                .unwrap();
+
+            let mut resolver = GraphResolver::new(Arc::clone(&svc));
+
+            use crate::playbook::path_extractor::{CollectionPath, ExtractedPath};
+
+            let collections = vec![CollectionPath {
+                collection: ExtractedPath {
+                    segments: vec!["node".to_string(), "tasks".to_string()],
+                    root: "node".to_string(),
+                },
+                iter_var: "t".to_string(),
+                item_paths: vec![ExtractedPath {
+                    segments: vec!["t".to_string(), "status".to_string()],
+                    root: "t".to_string(),
+                }],
+            }];
+
+            let result = resolver.enrich_context(&parent, &[], &collections);
+
+            let key = vec!["node".to_string(), "tasks".to_string()];
+            assert!(
+                result.contains_key(&key),
+                "enrich_context should resolve collection path node.tasks"
+            );
+
+            // The value should be a CEL List with 2 elements
+            match result.get(&key) {
+                Some(Value::List(list)) => {
+                    assert_eq!(list.len(), 2, "collection should have 2 nodes");
+                }
+                other => panic!("expected CEL List, got {:?}", other),
+            }
+        }
     }
 }

--- a/packages/core/src/playbook/logging.rs
+++ b/packages/core/src/playbook/logging.rs
@@ -130,10 +130,20 @@ pub async fn create_or_update_log_node(
         .await?;
 
     let existing = existing_logs.iter().find(|n| {
-        n.properties
+        // Check both flat and namespaced property formats.
+        // NodeService normalizes flat properties under the node_type namespace
+        // on storage, so queried nodes have {"playbook_log": {"error_fingerprint": "..."}}.
+        let fp = n
+            .properties
             .get("error_fingerprint")
             .and_then(|v| v.as_str())
-            == Some(&fingerprint)
+            .or_else(|| {
+                n.properties
+                    .get("playbook_log")
+                    .and_then(|ns| ns.get("error_fingerprint"))
+                    .and_then(|v| v.as_str())
+            });
+        fp == Some(&fingerprint)
     });
 
     if let Some(log_node) = existing {
@@ -142,13 +152,27 @@ pub async fn create_or_update_log_node(
             .properties
             .get("occurrences")
             .and_then(|v| v.as_u64())
+            .or_else(|| {
+                log_node
+                    .properties
+                    .get("playbook_log")
+                    .and_then(|ns| ns.get("occurrences"))
+                    .and_then(|v| v.as_u64())
+            })
             .unwrap_or(1);
 
+        // Update properties within the namespace if present, otherwise flat.
+        // Queried nodes have namespaced format: {"playbook_log": {...}}.
         let mut new_properties = log_node.properties.clone();
-        new_properties["occurrences"] = json!(current_occurrences + 1);
-        new_properties["last_seen"] = json!(now);
-        // Update the latest trigger_node_id for debugging context
-        new_properties["trigger_node_id"] = json!(trigger_node_id);
+        if let Some(ns) = new_properties.get_mut("playbook_log").and_then(|v| v.as_object_mut()) {
+            ns.insert("occurrences".to_string(), json!(current_occurrences + 1));
+            ns.insert("last_seen".to_string(), json!(now));
+            ns.insert("trigger_node_id".to_string(), json!(trigger_node_id));
+        } else {
+            new_properties["occurrences"] = json!(current_occurrences + 1);
+            new_properties["last_seen"] = json!(now);
+            new_properties["trigger_node_id"] = json!(trigger_node_id);
+        }
 
         let update = crate::models::NodeUpdate::new().with_properties(new_properties);
 
@@ -202,4 +226,241 @@ pub async fn create_or_update_log_node(
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // error_fingerprint — pure unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fingerprint_consistent_for_same_inputs() {
+        let fp1 = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
+        let fp2 = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
+        assert_eq!(fp1, fp2, "same inputs should produce identical fingerprints");
+        // SHA-256 hex is 64 chars
+        assert_eq!(fp1.len(), 64);
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_inputs() {
+        let fp1 = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
+        let fp2 = error_fingerprint("pb-2", "rule-a", 0, &PlaybookErrorType::CycleLimit);
+        let fp3 = error_fingerprint("pb-1", "rule-b", 0, &PlaybookErrorType::CycleLimit);
+        let fp4 = error_fingerprint("pb-1", "rule-a", 1, &PlaybookErrorType::CycleLimit);
+        assert_ne!(fp1, fp2, "different playbook_id should differ");
+        assert_ne!(fp1, fp3, "different rule_name should differ");
+        assert_ne!(fp1, fp4, "different error_location_index should differ");
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_error_types() {
+        let fp_cycle = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
+        let fp_missing = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::MissingPath);
+        let fp_type = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::TypeMismatch);
+        let fp_compile = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CompileError);
+        assert_ne!(fp_cycle, fp_missing);
+        assert_ne!(fp_cycle, fp_type);
+        assert_ne!(fp_cycle, fp_compile);
+        assert_ne!(fp_missing, fp_type);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests — create_or_update_log_node with real NodeService
+    // -----------------------------------------------------------------------
+
+    mod integration {
+        use super::*;
+        use crate::db::SurrealStore;
+        use crate::services::NodeService;
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        async fn create_test_service() -> (Arc<NodeService>, TempDir) {
+            let temp_dir = TempDir::new().unwrap();
+            let db_path = temp_dir.path().join("test.db");
+            let mut store: Arc<SurrealStore> = Arc::new(SurrealStore::new(db_path).await.unwrap());
+            let node_service = Arc::new(NodeService::new(&mut store).await.unwrap());
+            (node_service, temp_dir)
+        }
+
+        #[tokio::test]
+        async fn create_log_node_creates_new_node() {
+            let (svc, _tmp) = create_test_service().await;
+
+            // Create a schema for playbook_log so NodeService accepts it
+            let schema = crate::models::Node::new_with_id(
+                "playbook_log".to_string(),
+                "schema".to_string(),
+                "playbook_log".to_string(),
+                serde_json::json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "playbook log schema",
+                    "fields": [],
+                    "relationships": []
+                }),
+            );
+            svc.create_node(schema).await.unwrap();
+
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::CycleLimit,
+                "Cycle limit exceeded",
+                "trigger-node-1",
+            )
+            .await
+            .unwrap();
+
+            // Verify a playbook_log node was created
+            let logs = svc
+                .query_nodes_by_type("playbook_log", Some("active"))
+                .await
+                .unwrap();
+            assert_eq!(logs.len(), 1);
+            // Properties are stored under the "playbook_log" namespace by NodeService
+            let props = &logs[0].properties["playbook_log"];
+            assert_eq!(props["occurrences"], 1);
+            assert_eq!(props["error_type"], "cycle_limit");
+            assert_eq!(props["playbook_id"], "pb-1");
+            assert_eq!(props["rule_name"], "rule-a");
+            assert_eq!(props["trigger_node_id"], "trigger-node-1");
+        }
+
+        #[tokio::test]
+        async fn create_log_node_deduplicates_same_fingerprint() {
+            let (svc, _tmp) = create_test_service().await;
+
+            let schema = crate::models::Node::new_with_id(
+                "playbook_log".to_string(),
+                "schema".to_string(),
+                "playbook_log".to_string(),
+                serde_json::json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "playbook log schema",
+                    "fields": [],
+                    "relationships": []
+                }),
+            );
+            svc.create_node(schema).await.unwrap();
+
+            // First call — creates node
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::MissingPath,
+                "Path not found",
+                "trigger-node-1",
+            )
+            .await
+            .unwrap();
+
+            // Second call with same structural params — should deduplicate
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::MissingPath,
+                "Path not found (again)",
+                "trigger-node-2",
+            )
+            .await
+            .unwrap();
+
+            let logs = svc
+                .query_nodes_by_type("playbook_log", Some("active"))
+                .await
+                .unwrap();
+            assert_eq!(
+                logs.len(),
+                1,
+                "should still have only 1 log node after dedup"
+            );
+        }
+
+        #[tokio::test]
+        async fn create_log_node_increments_occurrences_on_dedup() {
+            let (svc, _tmp) = create_test_service().await;
+
+            let schema = crate::models::Node::new_with_id(
+                "playbook_log".to_string(),
+                "schema".to_string(),
+                "playbook_log".to_string(),
+                serde_json::json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "playbook log schema",
+                    "fields": [],
+                    "relationships": []
+                }),
+            );
+            svc.create_node(schema).await.unwrap();
+
+            // Create initial log
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::ActionError,
+                "Action failed",
+                "trigger-1",
+            )
+            .await
+            .unwrap();
+
+            // Dedup — occurrences should go to 2
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::ActionError,
+                "Action failed again",
+                "trigger-2",
+            )
+            .await
+            .unwrap();
+
+            // Dedup again — occurrences should go to 3
+            create_or_update_log_node(
+                &svc,
+                "pb-1",
+                "rule-a",
+                0,
+                PlaybookErrorType::ActionError,
+                "Action failed yet again",
+                "trigger-3",
+            )
+            .await
+            .unwrap();
+
+            let logs = svc
+                .query_nodes_by_type("playbook_log", Some("active"))
+                .await
+                .unwrap();
+            assert_eq!(logs.len(), 1);
+            let props = &logs[0].properties["playbook_log"];
+            assert_eq!(
+                props["occurrences"], 3,
+                "occurrences should be 3 after initial + 2 dedup calls"
+            );
+            // Latest trigger_node_id should be updated
+            assert_eq!(props["trigger_node_id"], "trigger-3");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **logging.rs** (0 tests → 6): Unit tests for `error_fingerprint` consistency/uniqueness, integration tests for `create_or_update_log_node` (creation, deduplication, occurrence counting)
- **graph_resolver.rs** (11+8 → 11+11): Integration tests for `enrich_context` multi-hop path resolution, `resolve_collection` with `ExtractedPath`, and `enrich_context` with collection paths
- **cron_runner.rs** (7 → 7+2): Integration tests for `check_and_enqueue` with matching and non-matching cron expressions (made `pub(crate)` for testability)

Also fixes a bug in `create_or_update_log_node` where fingerprint dedup and occurrence increment were broken by NodeService's property namespace normalization — the function was looking for `error_fingerprint` and `occurrences` at the top level of properties, but NodeService stores them under `{"playbook_log": {...}}`.

## Test plan

- [x] All 1088 lib tests pass (`cargo test -p nodespace-core --lib`)
- [x] `cargo check -p nodespace-core` compiles cleanly
- [x] New logging tests: 3 unit + 3 integration
- [x] New graph_resolver tests: 3 integration
- [x] New cron_runner tests: 2 integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)