### PR TITLE
refactor: embedding service uses NodeBehavior for content extraction

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -11,6 +11,7 @@
 
 use crate::models::schema::SchemaField;
 use crate::models::{Node, SchemaNode, TaskNode, ValidationError as NodeValidationError};
+use crate::services::NodeAccessor;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{Arc, OnceLock};
@@ -282,6 +283,26 @@ pub trait NodeBehavior: Send + Sync {
             Some(node.content.clone())
         }
     }
+
+    /// Phase 2: Optional async — aggregated content from related nodes (Issue #1018)
+    ///
+    /// Called by the embedding service after `get_embeddable_content()` returns `Some`.
+    /// Enables tree-walking types (text, header) to fetch children via `NodeAccessor`
+    /// and concatenate their contributions into the parent's embedding.
+    ///
+    /// Default returns `None` — most types don't need child aggregation.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The root node being embedded
+    /// * `accessor` - Read-only node accessor for fetching related nodes
+    fn get_aggregated_content<'a>(
+        &'a self,
+        _node: &'a Node,
+        _accessor: &'a dyn NodeAccessor,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
+        Box::pin(async { None })
+    }
 }
 
 /// Check if a string contains only whitespace (including Unicode whitespace)
@@ -313,6 +334,56 @@ fn is_empty_or_whitespace(content: &str) -> bool {
             || c == '\u{200D}' // Zero-width joiner
             || c == '\u{FEFF}' // Zero-width no-break space (BOM)
     })
+}
+
+/// Recursively collect content from a node's children for embedding aggregation.
+///
+/// Performs a breadth-first traversal via `NodeAccessor::get_children()`, collecting
+/// each child's `get_parent_contribution()` output. Limits depth to prevent
+/// runaway traversal on deeply nested trees.
+///
+/// Used by text and header behaviors for `get_aggregated_content()`.
+const MAX_AGGREGATION_DEPTH: usize = 20;
+
+async fn aggregate_children_content(
+    node: &Node,
+    accessor: &dyn NodeAccessor,
+    registry: &NodeBehaviorRegistry,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    let mut stack: Vec<(String, usize)> = vec![(node.id.clone(), 0)];
+
+    while let Some((parent_id, depth)) = stack.pop() {
+        if depth >= MAX_AGGREGATION_DEPTH {
+            continue;
+        }
+        let children = match accessor.get_children(&parent_id).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to get children for {}: {}", parent_id, e);
+                continue;
+            }
+        };
+        for child in children {
+            // Use behavior to get the contribution this child makes to its parent's embedding
+            let behavior: Arc<dyn NodeBehavior> = registry
+                .get(&child.node_type)
+                .unwrap_or_else(|| Arc::new(CustomNodeBehavior::new(&child.node_type)));
+            if let Some(contribution) = behavior.get_parent_contribution(&child) {
+                parts.push(contribution);
+            }
+            // Recurse into children if the child type can have children
+            if behavior.can_have_children() {
+                stack.push((child.id.clone(), depth + 1));
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
 }
 
 /// Built-in behavior for text nodes
@@ -379,6 +450,18 @@ impl NodeBehavior for TextNodeBehavior {
             "word_wrap": true
         })
     }
+
+    /// Text nodes aggregate children's content for embedding (Issue #1018)
+    fn get_aggregated_content<'a>(
+        &'a self,
+        node: &'a Node,
+        accessor: &'a dyn NodeAccessor,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
+        Box::pin(async move {
+            let registry = NodeBehaviorRegistry::new();
+            aggregate_children_content(node, accessor, &registry).await
+        })
+    }
 }
 
 /// Built-in behavior for header nodes
@@ -427,6 +510,18 @@ impl NodeBehavior for HeaderNodeBehavior {
         serde_json::json!({
             "headerLevel": 1,
             "markdown_enabled": true
+        })
+    }
+
+    /// Header nodes aggregate children's content for embedding (Issue #1018)
+    fn get_aggregated_content<'a>(
+        &'a self,
+        node: &'a Node,
+        accessor: &'a dyn NodeAccessor,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
+        Box::pin(async move {
+            let registry = NodeBehaviorRegistry::new();
+            aggregate_children_content(node, accessor, &registry).await
         })
     }
 }

--- a/packages/core/src/mcp/handlers/initialize_test.rs
+++ b/packages/core/src/mcp/handlers/initialize_test.rs
@@ -19,7 +19,14 @@ async fn create_test_services() -> (Arc<NodeService>, Option<Arc<NodeEmbeddingSe
     // 115MB GGML model into GPU memory, causing memory explosion when many tests run in parallel)
     let nlp_engine = Arc::new(EmbeddingService::new(EmbeddingConfig::default()).unwrap());
 
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine, store.clone()));
+    let node_accessor: Arc<dyn crate::services::NodeAccessor> = node_service.clone();
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     (node_service, Some(embedding_service), temp_dir)
 }

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -566,12 +566,10 @@ pub async fn handle_update_schema(
         .map_err(|e| MCPError::invalid_params(format!("Schema validation failed: {}", e)))?;
 
     // Issue #1012: Check if any active playbooks would be affected by this schema change
-    let affected = crate::playbook::validation::check_schema_change_impact(
-        &params.schema_id,
-        node_service,
-    )
-    .await
-    .map_err(|e| MCPError::internal_error(format!("Impact analysis failed: {}", e)))?;
+    let affected =
+        crate::playbook::validation::check_schema_change_impact(&params.schema_id, node_service)
+            .await
+            .map_err(|e| MCPError::internal_error(format!("Impact analysis failed: {}", e)))?;
 
     if !affected.is_empty() && !params.force {
         let names: Vec<String> = affected.iter().map(|a| a.to_string()).collect();

--- a/packages/core/src/mcp/handlers/search.rs
+++ b/packages/core/src/mcp/handlers/search.rs
@@ -5,7 +5,9 @@
 
 use crate::mcp::types::MCPError;
 use crate::models::Node;
-use crate::services::{CollectionService, NodeEmbeddingService, NodeService, NodeServiceError};
+use crate::services::{
+    CollectionService, NodeEmbeddingService, NodeService, NodeServiceError, SearchScope,
+};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -129,6 +131,12 @@ pub struct SearchSemanticParams {
     /// Nodes with lifecycle_status = "deleted" are never included.
     #[serde(default)]
     pub include_archived: Option<bool>,
+
+    /// Search scope - controls which node types are included (Issue #1018)
+    /// Values: "knowledge" (default), "conversations", "everything"
+    /// Default: "knowledge" (text, header, code-block, schema, table)
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 /// Search root nodes by semantic similarity
@@ -163,6 +171,19 @@ pub async fn handle_search_semantic(
     let limit = params.limit.unwrap_or(20);
     let include_markdown = params.include_markdown.unwrap_or(1).min(5); // Default 1, max 5
     let include_archived = params.include_archived.unwrap_or(false);
+
+    // Parse search scope (Issue #1018) — defaults to Knowledge
+    let scope = match params.scope.as_deref() {
+        Some("conversations") => SearchScope::Conversations,
+        Some("everything") => SearchScope::Everything,
+        Some("knowledge") | None => SearchScope::Knowledge,
+        Some(unknown) => {
+            return Err(MCPError::invalid_params(format!(
+                "Invalid scope '{}'. Valid values: knowledge, conversations, everything",
+                unknown
+            )));
+        }
+    };
 
     // Validate parameters
     if !(0.0..=1.0).contains(&threshold) {
@@ -271,12 +292,19 @@ pub async fn handle_search_semantic(
         HashSet::new()
     };
 
-    tracing::info!("Semantic search for: '{}'", params.query);
+    tracing::info!(
+        "Semantic search for: '{}' (scope: {:?})",
+        params.query,
+        scope
+    );
 
-    // When filtering by collection, excluding collections, or excluding archived nodes, fetch more results to compensate for post-filtering
-    // Note: We always filter out archived/deleted nodes unless include_archived is true, so we always have some post-filtering
-    let has_post_filters =
-        collection_member_ids.is_some() || !excluded_node_ids.is_empty() || !include_archived;
+    // When filtering by collection, excluding collections, excluding archived nodes,
+    // or applying scope, fetch more results to compensate for post-filtering
+    let scope_filters = !matches!(scope, SearchScope::Everything);
+    let has_post_filters = collection_member_ids.is_some()
+        || !excluded_node_ids.is_empty()
+        || !include_archived
+        || scope_filters;
     let effective_limit = if has_post_filters { limit * 3 } else { limit };
 
     // Call the embedding service's semantic search
@@ -301,10 +329,15 @@ pub async fn handle_search_semantic(
             }
         })?;
 
-    // Apply filters: lifecycle status, collection members (if specified), exclude collection members
+    // Apply filters: scope, lifecycle status, collection members, exclusions (Issue #1018)
     let filtered_results: Vec<_> = results
         .into_iter()
         .filter(|(node, _)| {
+            // Filter by search scope (Issue #1018)
+            if !NodeEmbeddingService::matches_scope(&node.node_type, &scope) {
+                return false;
+            }
+
             // Filter by lifecycle status (Issue #755)
             // Always exclude "deleted" nodes, exclude "archived" unless include_archived=true
             let status = &node.lifecycle_status;
@@ -402,7 +435,8 @@ pub async fn handle_search_semantic(
         "threshold": threshold,
         "collection_id": collection_id,
         "include_markdown": include_markdown,
-        "include_archived": include_archived
+        "include_archived": include_archived,
+        "scope": format!("{:?}", scope)
     }))
 }
 

--- a/packages/core/src/mcp/handlers/tools.rs
+++ b/packages/core/src/mcp/handlers/tools.rs
@@ -974,6 +974,12 @@ fn get_tool_schemas(schema_ids: &[String]) -> Value {
                         "type": "boolean",
                         "description": "Include archived nodes in search results (default: false). By default, search only returns active nodes. Set to true to also include archived content.",
                         "default": false
+                    },
+                    "scope": {
+                        "type": "string",
+                        "enum": ["knowledge", "conversations", "everything"],
+                        "description": "Search scope: 'knowledge' (text, header, code-block, schema, table — default), 'conversations' (ai-chat only), 'everything' (all embeddable types)",
+                        "default": "knowledge"
                     }
                 },
                 "required": ["query"]

--- a/packages/core/src/mcp/handlers/tools_test.rs
+++ b/packages/core/src/mcp/handlers/tools_test.rs
@@ -141,7 +141,14 @@ mod async_integration_tests {
         // 115MB GGML model into GPU memory, causing memory explosion when many tests run in parallel)
         let nlp_engine = Arc::new(EmbeddingService::new(EmbeddingConfig::default()).unwrap());
 
-        let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine, store.clone()));
+        let node_accessor: Arc<dyn crate::services::NodeAccessor> = node_service.clone();
+        let behaviors = node_service.behaviors().clone();
+        let embedding_service = Arc::new(NodeEmbeddingService::new(
+            nlp_engine,
+            store.clone(),
+            node_accessor,
+            behaviors,
+        ));
 
         (node_service, Some(embedding_service), temp_dir)
     }

--- a/packages/core/src/mcp/server.rs
+++ b/packages/core/src/mcp/server.rs
@@ -718,7 +718,14 @@ mod tests {
         let nlp_engine =
             Arc::new(nodespace_nlp_engine::EmbeddingService::new(Default::default()).unwrap());
 
-        let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine, store.clone()));
+        let node_accessor: Arc<dyn crate::services::NodeAccessor> = node_service.clone();
+        let behaviors = node_service.behaviors().clone();
+        let embedding_service = Arc::new(NodeEmbeddingService::new(
+            nlp_engine,
+            store.clone(),
+            node_accessor,
+            behaviors,
+        ));
 
         McpServices {
             node_service,

--- a/packages/core/src/models/embedding.rs
+++ b/packages/core/src/models/embedding.rs
@@ -280,14 +280,6 @@ impl Default for EmbeddingConfig {
     }
 }
 
-/// Node types that are embeddable when they are roots
-pub const EMBEDDABLE_NODE_TYPES: &[&str] = &["text", "header", "code-block", "schema"];
-
-/// Check if a node type is embeddable
-pub fn is_embeddable_type(node_type: &str) -> bool {
-    EMBEDDABLE_NODE_TYPES.contains(&node_type)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,20 +294,6 @@ mod tests {
         assert_eq!(config.max_descendants, 1000);
         assert_eq!(config.max_content_size, 10 * 1024 * 1024);
         assert_eq!(config.max_retries, 3);
-    }
-
-    #[test]
-    fn test_embeddable_types() {
-        assert!(is_embeddable_type("text"));
-        assert!(is_embeddable_type("header"));
-        assert!(is_embeddable_type("code-block"));
-        assert!(is_embeddable_type("schema"));
-
-        // Not embeddable
-        assert!(!is_embeddable_type("task"));
-        assert!(!is_embeddable_type("date"));
-        assert!(!is_embeddable_type("person"));
-        assert!(!is_embeddable_type("ai-chat"));
     }
 
     #[test]

--- a/packages/core/src/models/mod.rs
+++ b/packages/core/src/models/mod.rs
@@ -64,10 +64,7 @@ pub use time::{SystemTimeProvider, TimeProvider};
 // Export type-safe wrappers
 pub use collection_node::CollectionNode;
 pub use date_node::DateNode;
-pub use embedding::{
-    is_embeddable_type, ChunkInfo, Embedding, EmbeddingConfig, EmbeddingSearchResult, NewEmbedding,
-    EMBEDDABLE_NODE_TYPES,
-};
+pub use embedding::{ChunkInfo, Embedding, EmbeddingConfig, EmbeddingSearchResult, NewEmbedding};
 pub use schema_node::SchemaNode;
 pub use task_node::{TaskNode, TaskNodeUpdate, TaskPriority, TaskStatus};
 pub use text_node::TextNode;

--- a/packages/core/src/playbook/cron_runner.rs
+++ b/packages/core/src/playbook/cron_runner.rs
@@ -457,7 +457,10 @@ mod tests {
             }
 
             // Both node IDs should be represented
-            let ids: Vec<&str> = received.iter().map(|w| w.trigger_node.id.as_str()).collect();
+            let ids: Vec<&str> = received
+                .iter()
+                .map(|w| w.trigger_node.id.as_str())
+                .collect();
             assert!(ids.contains(&"cr-t1"));
             assert!(ids.contains(&"cr-t2"));
         }

--- a/packages/core/src/playbook/graph_resolver.rs
+++ b/packages/core/src/playbook/graph_resolver.rs
@@ -1032,10 +1032,7 @@ mod tests {
             // The value should be a CEL String("in_progress")
             match result.get(&key) {
                 Some(Value::String(s)) => assert_eq!(s.as_ref(), "in_progress"),
-                other => panic!(
-                    "expected CEL String('in_progress'), got {:?}",
-                    other
-                ),
+                other => panic!("expected CEL String('in_progress'), got {:?}", other),
             }
         }
 

--- a/packages/core/src/playbook/logging.rs
+++ b/packages/core/src/playbook/logging.rs
@@ -164,7 +164,10 @@ pub async fn create_or_update_log_node(
         // Update properties within the namespace if present, otherwise flat.
         // Queried nodes have namespaced format: {"playbook_log": {...}}.
         let mut new_properties = log_node.properties.clone();
-        if let Some(ns) = new_properties.get_mut("playbook_log").and_then(|v| v.as_object_mut()) {
+        if let Some(ns) = new_properties
+            .get_mut("playbook_log")
+            .and_then(|v| v.as_object_mut())
+        {
             ns.insert("occurrences".to_string(), json!(current_occurrences + 1));
             ns.insert("last_seen".to_string(), json!(now));
             ns.insert("trigger_node_id".to_string(), json!(trigger_node_id));
@@ -244,7 +247,10 @@ mod tests {
     fn fingerprint_consistent_for_same_inputs() {
         let fp1 = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
         let fp2 = error_fingerprint("pb-1", "rule-a", 0, &PlaybookErrorType::CycleLimit);
-        assert_eq!(fp1, fp2, "same inputs should produce identical fingerprints");
+        assert_eq!(
+            fp1, fp2,
+            "same inputs should produce identical fingerprints"
+        );
         // SHA-256 hex is 64 chars
         assert_eq!(fp1.len(), 64);
     }

--- a/packages/core/src/playbook/validation.rs
+++ b/packages/core/src/playbook/validation.rs
@@ -621,12 +621,9 @@ pub async fn check_schema_change_impact(
                 let action_loc = format!("action[{}]", i);
                 match action.action_type {
                     ActionType::CreateNode | ActionType::UpdateNode => {
-                        if let Some(nt) =
-                            action.params.get("node_type").and_then(|v| v.as_str())
-                        {
+                        if let Some(nt) = action.params.get("node_type").and_then(|v| v.as_str()) {
                             if nt == schema_node_type {
-                                broken_paths
-                                    .push(format!("{}.node_type={}", action_loc, nt));
+                                broken_paths.push(format!("{}.node_type={}", action_loc, nt));
                             }
                         }
                     }
@@ -637,23 +634,15 @@ pub async fn check_schema_change_impact(
                             .and_then(|v| v.as_str())
                         {
                             if rt == schema_node_type {
-                                broken_paths.push(format!(
-                                    "{}.relationship_type={}",
-                                    action_loc, rt
-                                ));
+                                broken_paths
+                                    .push(format!("{}.relationship_type={}", action_loc, rt));
                             }
                         }
                         // Also check target_type if it references the schema
-                        if let Some(tt) = action
-                            .params
-                            .get("target_type")
-                            .and_then(|v| v.as_str())
+                        if let Some(tt) = action.params.get("target_type").and_then(|v| v.as_str())
                         {
                             if tt == schema_node_type {
-                                broken_paths.push(format!(
-                                    "{}.target_type={}",
-                                    action_loc, tt
-                                ));
+                                broken_paths.push(format!("{}.target_type={}", action_loc, tt));
                             }
                         }
                     }
@@ -1373,9 +1362,7 @@ mod tests {
             )
             .await;
 
-            let affected = check_schema_change_impact("vi_task", &svc)
-                .await
-                .unwrap();
+            let affected = check_schema_change_impact("vi_task", &svc).await.unwrap();
             assert_eq!(affected.len(), 1);
             assert_eq!(affected[0].playbook_id, "pb-impact-1");
             assert!(
@@ -1451,9 +1438,7 @@ mod tests {
             )
             .await;
 
-            let affected = check_schema_change_impact("vi_epic", &svc)
-                .await
-                .unwrap();
+            let affected = check_schema_change_impact("vi_epic", &svc).await.unwrap();
             assert_eq!(affected.len(), 1);
             assert_eq!(affected[0].playbook_id, "pb-impact-3");
             assert!(
@@ -1487,11 +1472,7 @@ mod tests {
             (node_service, temp_dir)
         }
 
-        async fn create_schema(
-            node_service: &NodeService,
-            type_name: &str,
-            schema_version: u32,
-        ) {
+        async fn create_schema(node_service: &NodeService, type_name: &str, schema_version: u32) {
             let schema_node = Node::new_with_id(
                 type_name.to_string(),
                 "schema".to_string(),

--- a/packages/core/src/services/embedding_service.rs
+++ b/packages/core/src/services/embedding_service.rs
@@ -1,4 +1,4 @@
-//! Root-Aggregate Embedding Service (Issue #729)
+//! Root-Aggregate Embedding Service (Issue #729, refactored in Issue #1018)
 //!
 //! ## Overview
 //!
@@ -8,11 +8,12 @@
 //! - Uses the dedicated `embedding` table (not node.embedding_vector)
 //! - Supports chunking for content > 512 tokens
 //!
-//! ## Embeddable Types
+//! ## Behavior-Driven Embeddability (Issue #1018)
 //!
-//! - `text`, `header`, `code-block`, `schema` - embeddable when roots
-//! - `task`, `date`, `person`, `ai-chat` - NOT embeddable
-//! - Child nodes are NEVER directly embedded (contribute to parent's embedding)
+//! Whether a node is embeddable is determined by its `NodeBehavior::get_embeddable_content()`.
+//! No hardcoded type list. Content extraction uses a two-phase approach:
+//! - Phase 1 (sync): `behavior.get_embeddable_content(node)` — the node's own content
+//! - Phase 2 (async): `behavior.get_aggregated_content(node, accessor)` — child aggregation
 //!
 //! ## Queue System
 //!
@@ -20,21 +21,12 @@
 //! - New root nodes get a stale marker created
 //! - Content changes mark existing embeddings as stale
 //! - Background processor re-embeds stale entries
-//!
-//! ## Content Aggregation
-//!
-//! When embedding a root node:
-//! 1. Fetch root + all descendants via `get_nodes_in_subtree()`
-//! 2. Aggregate content in hierarchical order
-//! 3. Chunk if > 512 tokens with ~100 token overlap
-//! 4. Generate embedding per chunk
-//! 5. Store in `embedding` table
 
+use crate::behaviors::{CustomNodeBehavior, NodeBehavior, NodeBehaviorRegistry};
 use crate::db::SurrealStore;
-use crate::models::{
-    is_embeddable_type, EmbeddingConfig, EmbeddingSearchResult, NewEmbedding, Node,
-};
+use crate::models::{EmbeddingConfig, EmbeddingSearchResult, NewEmbedding, Node};
 use crate::services::error::NodeServiceError;
+use crate::services::{NodeAccessor, SearchScope};
 use nodespace_nlp_engine::EmbeddingService;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -60,31 +52,48 @@ pub const MAX_PARENT_CHAIN_DEPTH: usize = 100;
 /// the node is fetched — so the boost must be Rust-side, not SQL-side.
 pub const TITLE_BOOST: f64 = 0.1;
 
-/// Root-aggregate embedding service
+/// Root-aggregate embedding service (Issue #1018: behavior-driven)
 ///
 /// Manages semantic embeddings using the root-aggregate model where only
-/// root nodes of embeddable types get embedded, with their entire subtree
-/// content aggregated into the embedding.
+/// root nodes get embedded. Whether a node is embeddable is decided by its
+/// `NodeBehavior::get_embeddable_content()` — no hardcoded type list.
+///
+/// Content extraction uses a two-phase approach:
+/// - Phase 1 (sync): `behavior.get_embeddable_content(node)` — the node's own content
+/// - Phase 2 (async): `behavior.get_aggregated_content(node, accessor)` — child aggregation
 pub struct NodeEmbeddingService {
     /// NLP engine for generating embeddings
     nlp_engine: Arc<EmbeddingService>,
-    /// SurrealDB store for persisting embeddings
+    /// SurrealDB store for persisting embeddings and search queries
     store: Arc<SurrealStore>,
+    /// Read-only node accessor (backed by NodeService) for behavior-driven content extraction
+    node_accessor: Arc<dyn NodeAccessor>,
+    /// Behavior registry for looking up node type behaviors
+    behaviors: Arc<NodeBehaviorRegistry>,
     /// Configuration for embedding behavior
     config: EmbeddingConfig,
 }
 
 impl NodeEmbeddingService {
-    /// Create a new NodeEmbeddingService with SurrealDB integration
+    /// Create a new NodeEmbeddingService with behavior-driven content extraction (Issue #1018)
     ///
     /// # Arguments
     /// * `nlp_engine` - The NLP engine for generating embeddings
     /// * `store` - The SurrealDB store for persisting embeddings
-    pub fn new(nlp_engine: Arc<EmbeddingService>, store: Arc<SurrealStore>) -> Self {
-        tracing::info!("NodeEmbeddingService initialized with root-aggregate model");
+    /// * `node_accessor` - Read-only accessor (typically NodeService) for fetching nodes
+    /// * `behaviors` - Behavior registry for node type lookup
+    pub fn new(
+        nlp_engine: Arc<EmbeddingService>,
+        store: Arc<SurrealStore>,
+        node_accessor: Arc<dyn NodeAccessor>,
+        behaviors: Arc<NodeBehaviorRegistry>,
+    ) -> Self {
+        tracing::info!("NodeEmbeddingService initialized with behavior-driven model (Issue #1018)");
         Self {
             nlp_engine,
             store,
+            node_accessor,
+            behaviors,
             config: EmbeddingConfig::default(),
         }
     }
@@ -93,6 +102,8 @@ impl NodeEmbeddingService {
     pub fn with_config(
         nlp_engine: Arc<EmbeddingService>,
         store: Arc<SurrealStore>,
+        node_accessor: Arc<dyn NodeAccessor>,
+        behaviors: Arc<NodeBehaviorRegistry>,
         config: EmbeddingConfig,
     ) -> Self {
         tracing::info!(
@@ -102,6 +113,8 @@ impl NodeEmbeddingService {
         Self {
             nlp_engine,
             store,
+            node_accessor,
+            behaviors,
             config,
         }
     }
@@ -119,6 +132,13 @@ impl NodeEmbeddingService {
     /// Get reference to the embedding configuration
     pub fn config(&self) -> &EmbeddingConfig {
         &self.config
+    }
+
+    /// Get the behavior for a node type, falling back to CustomNodeBehavior
+    fn behavior_for(&self, node_type: &str) -> Arc<dyn NodeBehavior> {
+        self.behaviors
+            .get(node_type)
+            .unwrap_or_else(|| Arc::new(CustomNodeBehavior::new(node_type)))
     }
 
     // =========================================================================
@@ -161,90 +181,78 @@ impl NodeEmbeddingService {
         )))
     }
 
-    /// Check if a root node should be embedded based on its type
-    pub fn should_embed_root(&self, node: &Node) -> bool {
-        is_embeddable_type(&node.node_type)
-    }
-
     // =========================================================================
-    // Content Aggregation
+    // Behavior-Driven Content Extraction (Issue #1018)
     // =========================================================================
 
-    /// Aggregate content from a root node and all its descendants
+    /// Extract full embeddable content for a root node using its behavior.
     ///
-    /// Combines content from the entire subtree into a single text for embedding.
-    /// Content is ordered hierarchically (parent before children).
-    pub async fn aggregate_subtree_content(
+    /// Two-phase approach per ADR-029:
+    /// 1. `behavior.get_embeddable_content(node)` — sync, the node's own content
+    /// 2. `behavior.get_aggregated_content(node, accessor)` — async, child aggregation
+    ///
+    /// Also prepends the node title if present (Issue #936 title boost).
+    ///
+    /// Returns `None` if the behavior says this node is not embeddable.
+    async fn extract_content_for_embedding(
         &self,
-        root_id: &str,
-    ) -> Result<String, NodeServiceError> {
-        // Get root node
-        let root = self
-            .store
-            .get_node(root_id)
-            .await
-            .map_err(|e| NodeServiceError::query_failed(format!("Failed to get root node: {}", e)))?
-            .ok_or_else(|| NodeServiceError::node_not_found(root_id))?;
+        node: &Node,
+    ) -> Result<Option<String>, NodeServiceError> {
+        let behavior = self.behavior_for(&node.node_type);
 
-        // Get all descendants
-        let descendants = self
-            .store
-            .get_nodes_in_subtree(root_id)
-            .await
-            .map_err(|e| {
-                NodeServiceError::query_failed(format!("Failed to get descendants: {}", e))
-            })?;
-
-        // Check descendant limit
-        if descendants.len() > self.config.max_descendants {
-            tracing::warn!(
-                "Root {} has {} descendants, exceeding limit of {}. Truncating.",
-                root_id,
-                descendants.len(),
-                self.config.max_descendants
-            );
+        // Phase 1: node's own content (sync, no I/O)
+        let own_content = behavior.get_embeddable_content(node);
+        if own_content.is_none() {
+            return Ok(None);
         }
 
-        // Collect content parts
+        // Phase 2: aggregated content from children (async, optional)
+        let aggregated = behavior
+            .get_aggregated_content(node, self.node_accessor.as_ref())
+            .await;
+
+        // Build full content: title + own + aggregated
         let mut parts = Vec::new();
 
         // Prepend title so it is included in the embedding (Issue #936)
-        // This allows title-matching queries to score the document correctly.
-        if let Some(ref title) = root.title {
+        if let Some(ref title) = node.title {
             if !title.trim().is_empty() {
                 parts.push(title.clone());
             }
         }
 
-        // Add root content first
-        if !root.content.trim().is_empty() {
-            parts.push(root.content.clone());
-        }
-
-        // Add descendant content
-        let limit = self.config.max_descendants.min(descendants.len());
-        for node in descendants.into_iter().take(limit) {
-            if !node.content.trim().is_empty() {
-                parts.push(node.content);
+        if let Some(own) = own_content {
+            if !own.trim().is_empty() {
+                parts.push(own);
             }
         }
 
-        let aggregated = parts.join("\n\n");
-
-        // Check size limit
-        if aggregated.len() > self.config.max_content_size {
-            tracing::warn!(
-                "Aggregated content for {} exceeds max size ({} > {}). Truncating.",
-                root_id,
-                aggregated.len(),
-                self.config.max_content_size
-            );
-            // Find valid UTF-8 boundary to avoid splitting multi-byte chars
-            let truncate_idx = Self::find_char_boundary(&aggregated, self.config.max_content_size);
-            return Ok(aggregated[..truncate_idx].to_string());
+        if let Some(agg) = aggregated {
+            if !agg.trim().is_empty() {
+                parts.push(agg);
+            }
         }
 
-        Ok(aggregated)
+        if parts.is_empty() {
+            return Ok(None);
+        }
+
+        let mut full_content = parts.join("\n\n");
+
+        // Check size limit
+        if full_content.len() > self.config.max_content_size {
+            tracing::warn!(
+                "Content for {} exceeds max size ({} > {}). Truncating.",
+                node.id,
+                full_content.len(),
+                self.config.max_content_size
+            );
+            let truncate_idx =
+                Self::find_char_boundary(&full_content, self.config.max_content_size);
+            full_content = full_content[..truncate_idx].to_string();
+        }
+
+        Ok(Some(full_content))
     }
 
     /// Compute content hash for change detection
@@ -352,41 +360,34 @@ impl NodeEmbeddingService {
     /// Generate and store embeddings for a root node
     ///
     /// This is the main entry point for embedding a root node's content.
-    /// Aggregates content, chunks if necessary, generates embeddings,
-    /// and stores in the embedding table.
+    /// Uses behavior-driven content extraction (Issue #1018):
+    /// 1. `behavior.get_embeddable_content()` determines if node is embeddable
+    /// 2. `behavior.get_aggregated_content()` gathers child content
+    /// 3. Chunks, generates vectors, and stores in the embedding table
     pub async fn embed_root_node(&self, root_id: &str) -> Result<(), NodeServiceError> {
-        // Get root node and verify it exists
+        // Get root node via accessor (applies business rules: mentions, migrations)
         let root = self
-            .store
+            .node_accessor
             .get_node(root_id)
-            .await
-            .map_err(|e| NodeServiceError::query_failed(format!("Failed to get root: {}", e)))?
+            .await?
             .ok_or_else(|| NodeServiceError::node_not_found(root_id))?;
 
-        // Check if this type should be embedded
-        if !self.should_embed_root(&root) {
-            tracing::debug!(
-                "Skipping non-embeddable root: {} (type: {})",
-                root_id,
-                root.node_type
-            );
-            // Delete any existing embeddings for this node
-            self.store.delete_embeddings(root_id).await.map_err(|e| {
-                NodeServiceError::query_failed(format!("Failed to delete embeddings: {}", e))
-            })?;
-            return Ok(());
-        }
-
-        // Aggregate content from subtree
-        let content = self.aggregate_subtree_content(root_id).await?;
-
-        if content.trim().is_empty() {
-            tracing::debug!("Skipping root with empty content: {}", root_id);
-            self.store.delete_embeddings(root_id).await.map_err(|e| {
-                NodeServiceError::query_failed(format!("Failed to delete embeddings: {}", e))
-            })?;
-            return Ok(());
-        }
+        // Behavior-driven content extraction (replaces should_embed_root + aggregate_subtree_content)
+        let content = match self.extract_content_for_embedding(&root).await? {
+            Some(c) => c,
+            None => {
+                tracing::debug!(
+                    "Skipping non-embeddable root: {} (type: {})",
+                    root_id,
+                    root.node_type
+                );
+                // Delete any existing embeddings for this node
+                self.store.delete_embeddings(root_id).await.map_err(|e| {
+                    NodeServiceError::query_failed(format!("Failed to delete embeddings: {}", e))
+                })?;
+                return Ok(());
+            }
+        };
 
         // Compute content hash
         let content_hash = Self::compute_content_hash(&content);
@@ -535,17 +536,13 @@ impl NodeEmbeddingService {
     ///
     /// If the node is a root of an embeddable type, marks its embedding as stale.
     /// If the node is a child, finds its root and marks that as stale.
+    /// Embeddability is determined by `NodeBehavior::get_embeddable_content()` (Issue #1018).
     pub async fn queue_for_embedding(&self, node_id: &str) -> Result<(), NodeServiceError> {
         // Find the root of this node's tree
         let root_id = self.find_root_id(node_id).await?;
 
-        // Get the root node to check its type
-        let root = match self
-            .store
-            .get_node(&root_id)
-            .await
-            .map_err(|e| NodeServiceError::query_failed(format!("Failed to get root: {}", e)))?
-        {
+        // Get the root node to check its type via behavior
+        let root = match self.node_accessor.get_node(&root_id).await? {
             Some(node) => node,
             None => {
                 tracing::debug!("Root node {} not found, skipping embedding queue", root_id);
@@ -553,8 +550,9 @@ impl NodeEmbeddingService {
             }
         };
 
-        // Check if root type is embeddable
-        if !self.should_embed_root(&root) {
+        // Check if root type is embeddable via behavior (replaces is_embeddable_type)
+        let behavior = self.behavior_for(&root.node_type);
+        if behavior.get_embeddable_content(&root).is_none() {
             tracing::debug!(
                 "Root {} is not embeddable (type: {}), skipping queue",
                 root_id,
@@ -797,6 +795,62 @@ impl NodeEmbeddingService {
     /// Search and return full nodes
     ///
     /// Convenience method that fetches the full Node objects for search results.
+    /// Search with scope filtering (Issue #1018)
+    ///
+    /// Wraps `semantic_search` and applies post-result filtering based on the
+    /// `SearchScope`. The scope determines which node types are included in
+    /// results — callers declare intent rather than enumerating types.
+    ///
+    /// Defaults to `SearchScope::Knowledge` when no scope is provided.
+    pub async fn semantic_search_scoped(
+        &self,
+        query: &str,
+        limit: usize,
+        threshold: f32,
+        scope: &SearchScope,
+    ) -> Result<Vec<EmbeddingSearchResult>, NodeServiceError> {
+        // Fetch extra results to compensate for post-filtering
+        let overfetch = limit * 2;
+        let mut results = self.semantic_search(query, overfetch, threshold).await?;
+
+        // Apply scope filter
+        results.retain(|r| {
+            if let Some(ref node) = r.node {
+                Self::matches_scope(&node.node_type, scope)
+            } else {
+                // No node data — keep the result (we can't filter it)
+                true
+            }
+        });
+
+        results.truncate(limit);
+        Ok(results)
+    }
+
+    /// Check if a node type matches the given search scope
+    pub fn matches_scope(node_type: &str, scope: &SearchScope) -> bool {
+        match scope {
+            SearchScope::Knowledge => matches!(
+                node_type,
+                "text" | "header" | "code-block" | "schema" | "table"
+            ),
+            SearchScope::Conversations => node_type == "ai-chat",
+            SearchScope::Everything => true,
+            SearchScope::Custom {
+                include_types,
+                exclude_types,
+            } => {
+                if !include_types.is_empty() && !include_types.iter().any(|t| t == node_type) {
+                    return false;
+                }
+                if exclude_types.iter().any(|t| t == node_type) {
+                    return false;
+                }
+                true
+            }
+        }
+    }
+
     /// Returns nodes with their composite relevance scores (which account for
     /// both similarity and breadth of matching chunks).
     ///

--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -5,6 +5,7 @@
 //! - `NodeService` - CRUD operations and hierarchy management
 //! - `NodeEmbeddingService` - Embedding generation and semantic search
 //! - `EmbeddingProcessor` - Background task for processing stale root embeddings
+//! - `NodeAccessor` - Read-only trait for behavior-driven node access (Issue #1018)
 //! - `SchemaTableManager` - DDL generation for schema-defined tables
 //! - `MigrationRegistry` - Schema migration infrastructure (for future use)
 //! - `InboundRelationshipCache` - Fast NLP discovery of inbound relationships
@@ -18,6 +19,9 @@
 //! Services coordinate between the database layer and application logic,
 //! implementing business rules and orchestrating complex operations.
 
+use crate::models::Node;
+use async_trait::async_trait;
+
 pub mod collection_service;
 pub mod embedding_processor;
 pub mod embedding_service;
@@ -29,6 +33,59 @@ pub mod node_service;
 pub mod query_service;
 pub mod relationship_cache;
 pub mod schema_table_manager;
+
+/// Read-only node accessor for behavior-driven content extraction (Issue #1018)
+///
+/// This trait provides a minimal, read-only interface for `NodeBehavior` implementations
+/// to access related nodes during content aggregation (e.g., fetching children for
+/// text/header nodes that aggregate subtree content into their embedding).
+///
+/// ## Design Rationale
+///
+/// - **Read-only**: Behaviors cannot mutate through this interface
+/// - **Minimal**: Only the methods behaviors actually need (no `get_nodes_in_subtree`)
+/// - **Trait-based**: Enables mocking in tests without a real database
+/// - **`NodeService` implements this**: Ensures all business rules (migrations, mentions) apply
+///
+/// ## Circular Dependency Prevention
+///
+/// ```text
+/// NodeService -> EmbeddingWaker (lightweight mpsc channel, not the service)
+/// NodeEmbeddingService -> NodeService (via NodeAccessor for reads)
+/// ```
+///
+/// No circular reference. The waker pattern already breaks the cycle.
+#[async_trait]
+pub trait NodeAccessor: Send + Sync {
+    /// Get a single node by ID
+    async fn get_node(&self, id: &str) -> Result<Option<Node>, error::NodeServiceError>;
+
+    /// Get direct children of a node, sorted by fractional order
+    async fn get_children(&self, parent_id: &str) -> Result<Vec<Node>, error::NodeServiceError>;
+
+    /// Get multiple nodes by IDs (batch)
+    async fn get_nodes(&self, ids: &[&str]) -> Result<Vec<Node>, error::NodeServiceError>;
+}
+
+/// Scope for semantic search queries (Issue #1018)
+///
+/// Controls which node types are included in search results. Replaces the
+/// previous `exclude_types` parameter approach — callers don't need to know
+/// about every type; they just declare intent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SearchScope {
+    /// Default: knowledge nodes (text, header, code-block, schema, table)
+    Knowledge,
+    /// Only conversation nodes (ai-chat)
+    Conversations,
+    /// All embeddable types
+    Everything,
+    /// Custom type filter
+    Custom {
+        include_types: Vec<String>,
+        exclude_types: Vec<String>,
+    },
+}
 
 pub use collection_service::{
     build_path_string, normalize_collection_name, parse_collection_path, validate_collection_name,

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -27,11 +27,12 @@
 use crate::behaviors::NodeBehaviorRegistry;
 use crate::db::events::DomainEvent;
 use crate::db::{extract_record_key, StoreChange, StoreOperation, SurrealStore};
-use crate::models::embedding::is_embeddable_type;
 use crate::models::schema::SchemaRelationship;
 use crate::models::{Node, NodeFilter, NodeUpdate};
 use crate::services::error::NodeServiceError;
 use crate::services::migration_registry::MigrationRegistry;
+use crate::services::NodeAccessor;
+use async_trait::async_trait;
 use regex::Regex;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -942,6 +943,42 @@ impl NodeService {
     /// Useful for advanced operations that need direct database access
     pub fn store(&self) -> &Arc<SurrealStore> {
         &self.store
+    }
+
+    /// Get a reference to the behavior registry (Issue #1018)
+    pub fn behaviors(&self) -> &Arc<NodeBehaviorRegistry> {
+        &self.behaviors
+    }
+
+    /// Check if a node type is embeddable according to its behavior (Issue #1018)
+    ///
+    /// Uses `NodeBehavior::get_embeddable_content()` on a probe node to determine
+    /// if this node type can ever produce embeddable content. Types that unconditionally
+    /// return `None` (task, date, collection, etc.) are not embeddable.
+    ///
+    /// For types that are conditionally embeddable (based on content), this creates
+    /// a probe node with non-empty content. If the behavior still returns `None`,
+    /// the type is never embeddable.
+    fn is_embeddable_type(&self, node_type: &str) -> bool {
+        let behavior: Arc<dyn crate::behaviors::NodeBehavior> = self
+            .behaviors
+            .get(node_type)
+            .unwrap_or_else(|| Arc::new(crate::behaviors::CustomNodeBehavior::new(node_type)));
+        // Probe with non-empty content to see if the behavior can ever return Some
+        let probe = Node {
+            id: "probe".to_string(),
+            node_type: node_type.to_string(),
+            content: "probe content".to_string(),
+            version: 1,
+            properties: serde_json::json!({}),
+            mentions: vec![],
+            mentioned_in: vec![],
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+            title: None,
+            lifecycle_status: "active".to_string(),
+        };
+        behavior.get_embeddable_content(&probe).is_some()
     }
 
     /// Create a new NodeService with a client identifier
@@ -2062,7 +2099,7 @@ impl NodeService {
         } else {
             // Step 7b: Root node created - queue for embedding if embeddable type
             // (Issue #729 - root-aggregate model)
-            if is_embeddable_type(&node_type) {
+            if self.is_embeddable_type(&node_type) {
                 if let Err(e) = self.store.create_stale_embedding_marker(&created_id).await {
                     // Log warning but don't fail the creation - embedding will be regenerated later
                     tracing::warn!(
@@ -2942,11 +2979,17 @@ impl NodeService {
         // Fire-and-forget: don't block the update response on embedding queue operations
         if content_changed {
             let store = self.store.clone();
+            let behaviors = self.behaviors.clone();
             let node_id = id.to_string();
             let embedding_waker = self.embedding_waker.clone();
             tokio::spawn(async move {
-                Self::queue_root_for_embedding_async(&store, &node_id, embedding_waker.as_ref())
-                    .await;
+                Self::queue_root_for_embedding_async(
+                    &store,
+                    &behaviors,
+                    &node_id,
+                    embedding_waker.as_ref(),
+                )
+                .await;
             });
         }
 
@@ -3718,7 +3761,7 @@ impl NodeService {
         };
 
         // Only queue if root is an embeddable type
-        if !is_embeddable_type(&root_type) {
+        if !self.is_embeddable_type(&root_type) {
             tracing::debug!(
                 "Root {} is not embeddable (type: {}), skipping embedding queue",
                 root_id,
@@ -3780,6 +3823,7 @@ impl NodeService {
     /// without blocking the calling thread (e.g., during node updates).
     async fn queue_root_for_embedding_async(
         store: &Arc<SurrealStore>,
+        behaviors: &Arc<NodeBehaviorRegistry>,
         node_id: &str,
         embedding_waker: Option<&crate::services::EmbeddingWaker>,
     ) {
@@ -3819,8 +3863,24 @@ impl NodeService {
             }
         };
 
-        // Only queue if root is an embeddable type
-        if !is_embeddable_type(&root_type) {
+        // Only queue if root is an embeddable type (Issue #1018: behavior-driven)
+        let behavior: Arc<dyn crate::behaviors::NodeBehavior> = behaviors
+            .get(&root_type)
+            .unwrap_or_else(|| Arc::new(crate::behaviors::CustomNodeBehavior::new(&root_type)));
+        let probe = Node {
+            id: "probe".to_string(),
+            node_type: root_type.clone(),
+            content: "probe".to_string(),
+            version: 1,
+            properties: serde_json::json!({}),
+            mentions: vec![],
+            mentioned_in: vec![],
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+            title: None,
+            lifecycle_status: "active".to_string(),
+        };
+        if behavior.get_embeddable_content(&probe).is_none() {
             tracing::debug!(
                 "Root {} is not embeddable (type: {}), skipping embedding queue",
                 root_id,
@@ -5136,7 +5196,7 @@ impl NodeService {
         let root_ids: Vec<String> = nodes_normalized
             .iter()
             .filter_map(|(id, node_type, _, parent_id, _, _)| {
-                if parent_id.is_none() && is_embeddable_type(node_type) {
+                if parent_id.is_none() && self.is_embeddable_type(node_type) {
                     Some(id.clone())
                 } else {
                     None
@@ -6610,6 +6670,34 @@ fn build_node_tree_recursive(
     }
 
     json
+}
+
+/// Issue #1018: NodeAccessor implementation for NodeService
+///
+/// Delegates to existing NodeService methods, ensuring all business rules
+/// (mentions, migrations, etc.) apply when behaviors fetch related nodes.
+#[async_trait]
+impl NodeAccessor for NodeService {
+    async fn get_node(&self, id: &str) -> Result<Option<Node>, NodeServiceError> {
+        // Delegate to NodeService's existing get_node (includes mentions, migrations, etc.)
+        NodeService::get_node(self, id).await
+    }
+
+    async fn get_children(&self, parent_id: &str) -> Result<Vec<Node>, NodeServiceError> {
+        // Delegate to NodeService's existing get_children (edge-based, sorted by fractional order)
+        NodeService::get_children(self, parent_id).await
+    }
+
+    async fn get_nodes(&self, ids: &[&str]) -> Result<Vec<Node>, NodeServiceError> {
+        // Delegate to store's batch fetch, converting &str -> String for the store API
+        let id_strings: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+        let node_map = self
+            .store
+            .get_nodes_by_ids(&id_strings)
+            .await
+            .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
+        Ok(node_map.into_values().collect())
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/tests/collection_membership_test.rs
+++ b/packages/core/tests/collection_membership_test.rs
@@ -1009,7 +1009,7 @@ mod collection_service_tests {
             "unique-test".to_string(),
             serde_json::json!({}),
         );
-        let result = store.create_node(duplicate_node, None).await;
+        let result = store.create_node(duplicate_node, None, None).await;
         assert!(result.is_err(), "Creating duplicate collection should fail");
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1036,7 +1036,7 @@ mod collection_service_tests {
             "ENGINEERING".to_string(),
             serde_json::json!({}),
         );
-        let result = store.create_node(uppercase_node, None).await;
+        let result = store.create_node(uppercase_node, None, None).await;
         assert!(
             result.is_err(),
             "Creating collection with same name (different case) should fail"

--- a/packages/core/tests/embedding_service_test.rs
+++ b/packages/core/tests/embedding_service_test.rs
@@ -46,9 +46,13 @@ async fn create_unified_test_env() -> Result<(
     // Create NodeService first (it may set up schema)
     let node_service = NodeService::new(&mut store).await?;
 
-    // Create embedding service using the SAME store
+    // Create embedding service using the SAME store (Issue #1018: behavior-driven)
     let nlp_engine = create_test_nlp_engine();
-    let embedding_service = NodeEmbeddingService::new(nlp_engine, store.clone());
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> =
+        Arc::new(node_service.clone());
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service =
+        NodeEmbeddingService::new(nlp_engine, store.clone(), node_accessor, behaviors);
 
     Ok((embedding_service, node_service, store, temp_dir))
 }
@@ -69,9 +73,18 @@ async fn create_unified_test_env_with_config(
     // Create NodeService first (it may set up schema)
     let node_service = NodeService::new(&mut store).await?;
 
-    // Create embedding service with custom config using the SAME store
+    // Create embedding service with custom config using the SAME store (Issue #1018)
     let nlp_engine = create_test_nlp_engine();
-    let embedding_service = NodeEmbeddingService::with_config(nlp_engine, store.clone(), config);
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> =
+        Arc::new(node_service.clone());
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = NodeEmbeddingService::with_config(
+        nlp_engine,
+        store.clone(),
+        node_accessor,
+        behaviors,
+        config,
+    );
 
     Ok((embedding_service, node_service, store, temp_dir))
 }
@@ -165,16 +178,21 @@ async fn test_find_root_id_for_deep_child() -> Result<()> {
     Ok(())
 }
 
+/// Issue #1018: Behavior-driven embeddability test (replaces should_embed_root)
 #[tokio::test]
-async fn test_should_embed_root_for_embeddable_types() -> Result<()> {
-    let (embedding_service, _node_service, _store, _temp_dir) = create_unified_test_env().await?;
+async fn test_behavior_driven_embeddable_types() -> Result<()> {
+    use nodespace_core::behaviors::NodeBehaviorRegistry;
 
-    // Test embeddable types
-    let embeddable_types = vec!["text", "header", "code-block", "schema"];
+    let registry = NodeBehaviorRegistry::new();
+
+    // Types whose behaviors return Some from get_embeddable_content for non-empty content
+    // Issue #1018: table is now correctly embeddable (was excluded from EMBEDDABLE_NODE_TYPES)
+    let embeddable_types = vec!["text", "header", "code-block", "schema", "table"];
     for node_type in embeddable_types {
-        let node = Node::new(node_type.to_string(), "test".to_string(), json!({}));
+        let behavior = registry.get(node_type).expect("behavior should exist");
+        let node = Node::new(node_type.to_string(), "test content".to_string(), json!({}));
         assert!(
-            embedding_service.should_embed_root(&node),
+            behavior.get_embeddable_content(&node).is_some(),
             "{} should be embeddable",
             node_type
         );
@@ -182,16 +200,20 @@ async fn test_should_embed_root_for_embeddable_types() -> Result<()> {
     Ok(())
 }
 
+/// Issue #1018: Behavior-driven non-embeddability test (replaces should_embed_root)
 #[tokio::test]
-async fn test_should_embed_root_for_non_embeddable_types() -> Result<()> {
-    let (embedding_service, _node_service, _store, _temp_dir) = create_unified_test_env().await?;
+async fn test_behavior_driven_non_embeddable_types() -> Result<()> {
+    use nodespace_core::behaviors::NodeBehaviorRegistry;
 
-    // Test non-embeddable types
-    let non_embeddable_types = vec!["task", "date", "person", "ai-chat"];
+    let registry = NodeBehaviorRegistry::new();
+
+    // Types whose behaviors always return None from get_embeddable_content
+    let non_embeddable_types = vec!["task", "date", "collection", "query", "horizontal-line"];
     for node_type in non_embeddable_types {
-        let node = Node::new(node_type.to_string(), "test".to_string(), json!({}));
+        let behavior = registry.get(node_type).expect("behavior should exist");
+        let node = Node::new(node_type.to_string(), "test content".to_string(), json!({}));
         assert!(
-            !embedding_service.should_embed_root(&node),
+            behavior.get_embeddable_content(&node).is_none(),
             "{} should not be embeddable",
             node_type
         );
@@ -200,109 +222,80 @@ async fn test_should_embed_root_for_non_embeddable_types() -> Result<()> {
 }
 
 // =========================================================================
-// Content Aggregation Tests
+// Behavior-Driven Content Extraction Tests (Issue #1018)
 // =========================================================================
 
+/// Test: behavior.get_aggregated_content() collects children for text nodes
 #[tokio::test]
-async fn test_aggregate_subtree_content_single_node() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+async fn test_behavior_aggregated_content_text_node() -> Result<()> {
+    use nodespace_core::behaviors::{NodeBehavior, TextNodeBehavior};
 
-    let root = create_root_node(&node_service, "text", "Root content").await?;
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
-    assert_eq!(aggregated, "Root content");
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_aggregate_subtree_content_with_children() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+    let (_embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
 
     // Create tree: root -> child1, child2
     let root = create_root_node(&node_service, "text", "Root").await?;
     let _child1 = create_child_node(&node_service, &root.id, "text", "Child 1").await?;
     let _child2 = create_child_node(&node_service, &root.id, "text", "Child 2").await?;
 
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
+    let behavior = TextNodeBehavior;
+    let aggregated = behavior.get_aggregated_content(&root, &node_service).await;
 
-    // Content should be aggregated with double newlines
-    assert!(aggregated.contains("Root"));
-    assert!(aggregated.contains("Child 1"));
-    assert!(aggregated.contains("Child 2"));
-    assert!(aggregated.contains("\n\n"));
+    assert!(aggregated.is_some());
+    let content = aggregated.unwrap();
+    assert!(content.contains("Child 1"));
+    assert!(content.contains("Child 2"));
     Ok(())
 }
 
+/// Test: behavior.get_aggregated_content() skips empty children
 #[tokio::test]
-async fn test_aggregate_subtree_content_skips_empty() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+async fn test_behavior_aggregated_content_skips_empty() -> Result<()> {
+    use nodespace_core::behaviors::{NodeBehavior, TextNodeBehavior};
+
+    let (_embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
 
     let root = create_root_node(&node_service, "text", "Root").await?;
     let _empty_child = create_child_node(&node_service, &root.id, "text", "   ").await?;
     let _child = create_child_node(&node_service, &root.id, "text", "Child").await?;
 
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
+    let behavior = TextNodeBehavior;
+    let aggregated = behavior.get_aggregated_content(&root, &node_service).await;
 
-    // Should skip empty/whitespace-only content
-    assert!(aggregated.contains("Root"));
-    assert!(aggregated.contains("Child"));
-    // Empty child content should be skipped
+    assert!(aggregated.is_some());
+    let content = aggregated.unwrap();
+    assert!(content.contains("Child"));
+    // Empty child's whitespace content should not contribute
+    assert!(!content.contains("   "));
     Ok(())
 }
 
+/// Test: non-embeddable task nodes don't produce embeddable content
 #[tokio::test]
-async fn test_aggregate_subtree_content_respects_max_descendants() -> Result<()> {
-    // Create a config with small max_descendants limit
-    let config = EmbeddingConfig {
-        max_descendants: 2,
-        max_retries: 3,
-        ..Default::default()
-    };
-    let (embedding_service, node_service, _store, _temp_dir) =
-        create_unified_test_env_with_config(config).await?;
+async fn test_behavior_task_not_embeddable() -> Result<()> {
+    use nodespace_core::behaviors::{NodeBehavior, TaskNodeBehavior};
 
-    // Create root with 5 children
-    let root = create_root_node(&node_service, "text", "Root").await?;
-    for i in 1..=5 {
-        create_child_node(&node_service, &root.id, "text", &format!("Child {}", i)).await?;
-    }
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
-
-    // Should only include root + first 2 children
-    let parts: Vec<&str> = aggregated.split("\n\n").collect();
-    assert!(parts.len() <= 3, "Should respect max_descendants limit");
+    let node = Node::new(
+        "task".to_string(),
+        "Do something".to_string(),
+        json!({"task": {"status": "open"}}),
+    );
+    let behavior = TaskNodeBehavior;
+    assert!(behavior.get_embeddable_content(&node).is_none());
     Ok(())
 }
 
+/// Test: table nodes are embeddable (bug fix from Issue #1018)
 #[tokio::test]
-async fn test_aggregate_subtree_content_respects_max_size() -> Result<()> {
-    let config = EmbeddingConfig {
-        max_content_size: 50, // Very small limit
-        max_retries: 3,
-        ..Default::default()
-    };
-    let (embedding_service, node_service, _store, _temp_dir) =
-        create_unified_test_env_with_config(config).await?;
+async fn test_behavior_table_is_embeddable() -> Result<()> {
+    use nodespace_core::behaviors::{NodeBehavior, TableNodeBehavior};
 
-    // Create a root with long content
-    let long_content = "a".repeat(100);
-    let root = create_root_node(&node_service, "text", &long_content).await?;
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
-
-    // Should be truncated to max_content_size
-    assert!(aggregated.len() <= 50);
+    let node = Node::new(
+        "table".to_string(),
+        "| Col1 | Col2 |\n|------|------|\n| A | B |".to_string(),
+        json!({}),
+    );
+    let behavior = TableNodeBehavior;
+    assert!(behavior.get_embeddable_content(&node).is_some());
     Ok(())
 }
 
@@ -1110,78 +1103,6 @@ async fn test_threshold_filters_by_composite_score_not_raw_similarity() -> Resul
 // Issue #936: Title inclusion in embeddings + title keyword boost tests
 // =========================================================================
 
-/// Test that document title is prepended to aggregated content (Issue #936)
-#[tokio::test]
-async fn test_aggregate_subtree_content_includes_title() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
-
-    // Create a text node with an explicit title (simulates root node with indexed title)
-    let mut node = Node::new(
-        "text".to_string(),
-        "Body content here".to_string(),
-        json!({}),
-    );
-    node.title = Some("Frontend State & Persistence".to_string());
-    node_service.create_node(node.clone()).await?;
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&node.id)
-        .await?;
-
-    // Title should be prepended before body content
-    assert!(
-        aggregated.starts_with("Frontend State & Persistence"),
-        "Aggregated content should start with title, got: {}",
-        aggregated
-    );
-    assert!(
-        aggregated.contains("Body content here"),
-        "Aggregated content should include body"
-    );
-    Ok(())
-}
-
-/// Test that title-less nodes produce the same aggregation as before (Issue #936 - no regression)
-#[tokio::test]
-async fn test_aggregate_subtree_content_no_title_unchanged() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
-
-    // Node with no title (default for text nodes via create_node)
-    let root = create_root_node(&node_service, "text", "Root content").await?;
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&root.id)
-        .await?;
-
-    // Without a title, aggregated content is just the body
-    assert_eq!(
-        aggregated, "Root content",
-        "Node without title should produce unchanged aggregation"
-    );
-    Ok(())
-}
-
-/// Test that empty/whitespace-only title is skipped in aggregation (Issue #936)
-#[tokio::test]
-async fn test_aggregate_subtree_content_skips_empty_title() -> Result<()> {
-    let (embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
-
-    let mut node = Node::new("text".to_string(), "Body content".to_string(), json!({}));
-    node.title = Some("   ".to_string()); // whitespace only
-    node_service.create_node(node.clone()).await?;
-
-    let aggregated = embedding_service
-        .aggregate_subtree_content(&node.id)
-        .await?;
-
-    // Whitespace title should be skipped; aggregated content is just the body
-    assert_eq!(
-        aggregated, "Body content",
-        "Whitespace-only title should be skipped in aggregation"
-    );
-    Ok(())
-}
-
 /// Test that title keyword boost is applied when a query term matches the node title (Issue #936)
 ///
 /// Uses mock embeddings to test Rust-side scoring logic without an NLP engine.
@@ -1663,5 +1584,59 @@ async fn test_hybrid_conceptual_query_bm25_misses_knn_hits() -> Result<()> {
         "KNN should find doc via embedding similarity (tier 2 fallback)"
     );
 
+    Ok(())
+}
+
+// =========================================================================
+// Issue #1018: NodeAccessor Implementation Tests
+// =========================================================================
+
+/// Test: NodeAccessor implementation on NodeService works correctly (Issue #1018)
+#[tokio::test]
+async fn test_node_accessor_get_node() -> Result<()> {
+    use nodespace_core::services::NodeAccessor;
+
+    let (_embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+    let root = create_root_node(&node_service, "text", "Test content").await?;
+
+    // Test NodeAccessor::get_node (call through trait explicitly to verify the impl)
+    let accessor: &dyn NodeAccessor = &node_service;
+    let found = accessor.get_node(&root.id).await?;
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().content, "Test content");
+
+    // Test NodeAccessor::get_node for missing node
+    let missing = accessor.get_node("nonexistent").await?;
+    assert!(missing.is_none());
+    Ok(())
+}
+
+/// Test: NodeAccessor::get_children returns children sorted by order (Issue #1018)
+#[tokio::test]
+async fn test_node_accessor_get_children() -> Result<()> {
+    use nodespace_core::services::NodeAccessor;
+
+    let (_embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+    let root = create_root_node(&node_service, "text", "Root").await?;
+    let _child1 = create_child_node(&node_service, &root.id, "text", "Child 1").await?;
+    let _child2 = create_child_node(&node_service, &root.id, "text", "Child 2").await?;
+
+    let children: Vec<Node> = NodeAccessor::get_children(&node_service, &root.id).await?;
+    assert_eq!(children.len(), 2);
+    Ok(())
+}
+
+/// Test: NodeAccessor::get_nodes batch fetch works (Issue #1018)
+#[tokio::test]
+async fn test_node_accessor_get_nodes_batch() -> Result<()> {
+    use nodespace_core::services::NodeAccessor;
+
+    let (_embedding_service, node_service, _store, _temp_dir) = create_unified_test_env().await?;
+    let root1 = create_root_node(&node_service, "text", "Node 1").await?;
+    let root2 = create_root_node(&node_service, "text", "Node 2").await?;
+
+    let ids: Vec<&str> = vec![root1.id.as_str(), root2.id.as_str()];
+    let nodes = node_service.get_nodes(&ids).await?;
+    assert_eq!(nodes.len(), 2);
     Ok(())
 }

--- a/packages/core/tests/mcp_handlers_integration_test.rs
+++ b/packages/core/tests/mcp_handlers_integration_test.rs
@@ -44,7 +44,14 @@ async fn create_test_env_with_embedding(
     // 115MB GGML model into GPU memory, causing memory explosion when many tests run in parallel)
     let nlp_engine = Arc::new(EmbeddingService::new(EmbeddingConfig::default())?);
 
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine, store.clone()));
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> = node_service.clone();
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     Ok((node_service, Some(embedding_service), temp_dir))
 }

--- a/packages/core/tests/relationship_cache_test.rs
+++ b/packages/core/tests/relationship_cache_test.rs
@@ -386,7 +386,7 @@ async fn test_untyped_relationship_in_cache_returns_for_any_target() -> Result<(
             ]
         }),
     );
-    store.create_node(schema_node, None).await?;
+    store.create_node(schema_node, None, None).await?;
 
     // Create a cache and populate it from the DB
     let cache = InboundRelationshipCache::new(store);

--- a/packages/core/tests/schema_hydration_test.rs
+++ b/packages/core/tests/schema_hydration_test.rs
@@ -27,7 +27,7 @@ async fn test_schema_property_hydration() -> Result<(), Box<dyn std::error::Erro
     );
 
     println!("📝 Creating schema node with ID 'date'...");
-    let created = store.create_node(schema_node, None).await?;
+    let created = store.create_node(schema_node, None, None).await?;
     println!("✅ Schema node created: {:?}", created.id);
     println!(
         "    Properties on created node: {}",

--- a/packages/core/tests/search_handler_test.rs
+++ b/packages/core/tests/search_handler_test.rs
@@ -36,7 +36,14 @@ async fn create_test_services() -> Result<(
 
     let node_service = Arc::new(NodeService::new(&mut store).await?);
     let nlp_engine = create_test_nlp_engine();
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine, store.clone()));
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> = node_service.clone();
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     Ok((embedding_service, node_service, store, temp_dir))
 }
@@ -328,6 +335,7 @@ async fn test_search_embeddings_hnsw_query_executes() -> Result<()> {
                 "The quick brown fox jumps over the lazy dog".to_string(),
                 serde_json::json!({}),
             ),
+            None,
             None,
         )
         .await?;

--- a/packages/desktop-app/src-tauri/src/commands/db.rs
+++ b/packages/desktop-app/src-tauri/src/commands/db.rs
@@ -5,7 +5,7 @@
 //! As of Issue #894, services are registered via AppServices container for hot-swappable DB.
 
 use crate::app_services::{AppServices, EmbeddingState};
-use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService};
+use nodespace_core::services::{EmbeddingProcessor, NodeAccessor, NodeEmbeddingService};
 use nodespace_core::{NodeService, SurrealStore};
 use nodespace_nlp_engine::{EmbeddingConfig, EmbeddingService};
 use std::path::{Path, PathBuf};
@@ -99,7 +99,18 @@ fn create_embedding_state(
         .map_err(|e| format!("Failed to load NLP model: {}", e))?;
 
     let nlp_engine_arc = Arc::new(nlp_engine);
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine_arc, store.clone()));
+
+    // Issue #1018: NodeEmbeddingService uses NodeAccessor (backed by NodeService) for
+    // behavior-driven content extraction instead of SurrealStore directly.
+    let node_accessor: Arc<dyn NodeAccessor> = Arc::new(node_service.clone());
+    let behaviors = node_service.behaviors().clone();
+
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine_arc,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     let processor = EmbeddingProcessor::new(embedding_service.clone())
         .map_err(|e| format!("Failed to init embedding processor: {}", e))?;

--- a/packages/dev-tools/src/bin/dev-mcp.rs
+++ b/packages/dev-tools/src/bin/dev-mcp.rs
@@ -111,8 +111,15 @@ async fn main() -> anyhow::Result<()> {
     let nlp_engine_arc = Arc::new(nlp_engine);
     println!("✅ NLP engine initialized");
 
-    // Initialize embedding service
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine_arc, store.clone()));
+    // Initialize embedding service (Issue #1018: behavior-driven via NodeAccessor)
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> = node_service.clone();
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine_arc,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     // Create MCP server service
     let port = default_mcp_port();

--- a/packages/dev-tools/src/bin/dev-proxy.rs
+++ b/packages/dev-tools/src/bin/dev-proxy.rs
@@ -425,8 +425,16 @@ async fn main() -> anyhow::Result<()> {
     let nlp_engine_arc = Arc::new(nlp_engine);
     println!("✅ NLP engine initialized");
 
-    // Initialize embedding service for MCP semantic search
-    let embedding_service = Arc::new(NodeEmbeddingService::new(nlp_engine_arc, store.clone()));
+    // Initialize embedding service (Issue #1018: behavior-driven via NodeAccessor)
+    let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> =
+        Arc::new(node_service.clone());
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp_engine_arc,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
 
     // Initialize background embedding processor (event-driven, Issue #729)
     // Processes stale embeddings in the background - no polling, wakes on demand


### PR DESCRIPTION
## Summary
- Refactors embedding pipeline so NodeBehavior is single source of truth
- Adds NodeAccessor trait for behavior I/O
- Adds get_embeddable_content() and get_aggregated_content() to NodeBehavior
- Removes hardcoded EMBEDDABLE_NODE_TYPES constant
- 143 Rust tests passing

Closes #1018