### PR TITLE
test: add transport robustness and embedding behavior tests

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -3819,4 +3819,187 @@ mod tests {
         assert!(behavior.is_some(), "ai-chat should be registered");
         assert_eq!(behavior.unwrap().type_name(), "ai-chat");
     }
+
+    // =========================================================================
+    // Comprehensive: Every behavior's get_embeddable_content() (Issue #1018)
+    // =========================================================================
+
+    /// Verify the embeddable content decision for every registered behavior type.
+    /// Types that return Some(...) are embedded as roots; types that return None are not.
+    #[test]
+    fn test_all_behaviors_embeddable_content_decision() {
+        let registry = NodeBehaviorRegistry::new();
+
+        // --- Types that SHOULD be embeddable (return Some for non-empty content) ---
+
+        // text: primary knowledge content
+        let text_node = Node::new("text".to_string(), "Some knowledge".to_string(), json!({}));
+        assert!(
+            registry.get("text").unwrap().get_embeddable_content(&text_node).is_some(),
+            "text nodes with content should be embeddable"
+        );
+
+        // header: section titles carry semantic value
+        let header_node = Node::new(
+            "header".to_string(),
+            "## Architecture".to_string(),
+            json!({"headerLevel": 2}),
+        );
+        assert!(
+            registry.get("header").unwrap().get_embeddable_content(&header_node).is_some(),
+            "header nodes with content should be embeddable"
+        );
+
+        // code-block: code snippets are searchable (uses default trait impl)
+        let code_node = Node::new(
+            "code-block".to_string(),
+            "```rust\nfn main() {}".to_string(),
+            json!({"language": "rust"}),
+        );
+        assert!(
+            registry.get("code-block").unwrap().get_embeddable_content(&code_node).is_some(),
+            "code-block nodes with content should be embeddable"
+        );
+
+        // quote-block: quoted text is searchable (uses default trait impl)
+        let quote_node = Node::new(
+            "quote-block".to_string(),
+            "> Important quote".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("quote-block").unwrap().get_embeddable_content(&quote_node).is_some(),
+            "quote-block nodes with content should be embeddable"
+        );
+
+        // ordered-list: list content is searchable (uses default trait impl)
+        let list_node = Node::new(
+            "ordered-list".to_string(),
+            "1. First step".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("ordered-list").unwrap().get_embeddable_content(&list_node).is_some(),
+            "ordered-list nodes with content should be embeddable"
+        );
+
+        // table: table data is searchable
+        let table_node = Node::new(
+            "table".to_string(),
+            "| A | B |\n| 1 | 2 |".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("table").unwrap().get_embeddable_content(&table_node).is_some(),
+            "table nodes with content should be embeddable"
+        );
+
+        // schema: schema name is content (uses default trait impl)
+        let schema_node = Node::new(
+            "schema".to_string(),
+            "task".to_string(),
+            json!({"is_core": true, "fields": []}),
+        );
+        assert!(
+            registry.get("schema").unwrap().get_embeddable_content(&schema_node).is_some(),
+            "schema nodes with content should be embeddable"
+        );
+
+        // ai-chat: extracts user/assistant messages from properties
+        let chat_node = Node::new(
+            "ai-chat".to_string(),
+            "Chat about webhooks".to_string(),
+            json!({
+                "messages": [
+                    {"role": "user", "content": "How do I implement webhooks?"},
+                    {"role": "assistant", "content": "Here is an approach..."}
+                ]
+            }),
+        );
+        let chat_content = registry.get("ai-chat").unwrap().get_embeddable_content(&chat_node);
+        assert!(chat_content.is_some(), "ai-chat with messages should be embeddable");
+        let chat_text = chat_content.unwrap();
+        assert!(chat_text.contains("How do I implement webhooks?"));
+        assert!(chat_text.contains("Here is an approach..."));
+
+        // --- Types that should NOT be embeddable (return None) ---
+
+        // task: action items, not semantic knowledge
+        let task_node = Node::new(
+            "task".to_string(),
+            "Buy groceries".to_string(),
+            json!({"task": {"status": "open"}}),
+        );
+        assert!(
+            registry.get("task").unwrap().get_embeddable_content(&task_node).is_none(),
+            "task nodes should NOT be embeddable"
+        );
+
+        // date: organizational containers
+        let date_node = Node::new_with_id(
+            "2025-06-15".to_string(),
+            "date".to_string(),
+            "2025-06-15".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("date").unwrap().get_embeddable_content(&date_node).is_none(),
+            "date nodes should NOT be embeddable"
+        );
+
+        // horizontal-line: decorative, no semantic content
+        let hr_node = Node::new("horizontal-line".to_string(), "---".to_string(), json!({}));
+        assert!(
+            registry.get("horizontal-line").unwrap().get_embeddable_content(&hr_node).is_none(),
+            "horizontal-line nodes should NOT be embeddable"
+        );
+
+        // query: operational/structural, not semantic
+        let query_node = Node::new(
+            "query".to_string(),
+            "Find open tasks".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("query").unwrap().get_embeddable_content(&query_node).is_none(),
+            "query nodes should NOT be embeddable"
+        );
+
+        // collection: organizational labels
+        let coll_node = Node::new(
+            "collection".to_string(),
+            "Engineering".to_string(),
+            json!({}),
+        );
+        assert!(
+            registry.get("collection").unwrap().get_embeddable_content(&coll_node).is_none(),
+            "collection nodes should NOT be embeddable"
+        );
+
+        // --- Edge case: ai-chat with no messages returns None ---
+        let empty_chat = Node::new("ai-chat".to_string(), "Empty".to_string(), json!({}));
+        assert!(
+            registry.get("ai-chat").unwrap().get_embeddable_content(&empty_chat).is_none(),
+            "ai-chat without messages property should NOT be embeddable"
+        );
+    }
+
+    /// Verify that CustomNodeBehavior (fallback for schema-defined types) uses the
+    /// default trait implementation for embeddable content (embeddable if non-empty).
+    #[test]
+    fn test_custom_behavior_uses_default_embeddability() {
+        let behavior = CustomNodeBehavior::new("invoice");
+
+        let node = Node::new("invoice".to_string(), "INV-001".to_string(), json!({}));
+        assert!(
+            behavior.get_embeddable_content(&node).is_some(),
+            "Custom type with content should be embeddable (default trait impl)"
+        );
+
+        let empty = Node::new("invoice".to_string(), "".to_string(), json!({}));
+        assert!(
+            behavior.get_embeddable_content(&empty).is_none(),
+            "Custom type with empty content should NOT be embeddable"
+        );
+    }
 }

--- a/packages/core/src/services/embedding_service.rs
+++ b/packages/core/src/services/embedding_service.rs
@@ -900,6 +900,7 @@ impl NodeEmbeddingService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_chunk_content_single() {
@@ -1109,6 +1110,275 @@ mod tests {
         assert!(
             chunks[0].2.ends_with(". "),
             "First chunk should end at sentence boundary"
+        );
+    }
+
+    // =========================================================================
+    // Behavior-Driven Embedding Decision Tests (Issue #1018)
+    // =========================================================================
+
+    /// Mock NodeAccessor for testing extract_content_for_embedding without a database.
+    struct MockNodeAccessor {
+        nodes: std::collections::HashMap<String, Node>,
+        children: std::collections::HashMap<String, Vec<Node>>,
+    }
+
+    impl MockNodeAccessor {
+        fn new() -> Self {
+            Self {
+                nodes: std::collections::HashMap::new(),
+                children: std::collections::HashMap::new(),
+            }
+        }
+
+        fn add_node(&mut self, node: Node) {
+            self.nodes.insert(node.id.clone(), node);
+        }
+
+        fn set_children(&mut self, parent_id: &str, kids: Vec<Node>) {
+            self.children.insert(parent_id.to_string(), kids);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl NodeAccessor for MockNodeAccessor {
+        async fn get_node(
+            &self,
+            id: &str,
+        ) -> Result<Option<Node>, crate::services::error::NodeServiceError> {
+            Ok(self.nodes.get(id).cloned())
+        }
+
+        async fn get_children(
+            &self,
+            parent_id: &str,
+        ) -> Result<Vec<Node>, crate::services::error::NodeServiceError> {
+            Ok(self.children.get(parent_id).cloned().unwrap_or_default())
+        }
+
+        async fn get_nodes(
+            &self,
+            ids: &[&str],
+        ) -> Result<Vec<Node>, crate::services::error::NodeServiceError> {
+            Ok(ids.iter().filter_map(|id| self.nodes.get(*id).cloned()).collect())
+        }
+    }
+
+    /// Verify that extract_content_for_embedding respects behavior decisions:
+    /// - Embeddable types (text, header, code-block) return Some
+    /// - Non-embeddable types (task, date, collection) return None
+    /// - ai-chat extracts messages, not node content
+    #[tokio::test]
+    async fn test_behavior_driven_embedding_decision() {
+        let accessor = Arc::new(MockNodeAccessor::new());
+        let behaviors = Arc::new(NodeBehaviorRegistry::new());
+
+        // We cannot construct a full NodeEmbeddingService without a real NLP engine
+        // and SurrealStore, so we test the behavior dispatch logic directly by
+        // calling behavior.get_embeddable_content() through the registry,
+        // which is exactly what extract_content_for_embedding delegates to.
+
+        // --- Embeddable types ---
+
+        let text_node = Node::new("text".to_string(), "Knowledge content".to_string(), json!({}));
+        let text_behavior = behaviors.get("text").unwrap();
+        assert!(
+            text_behavior.get_embeddable_content(&text_node).is_some(),
+            "text should be embeddable via behavior"
+        );
+
+        let header_node = Node::new(
+            "header".to_string(),
+            "## Architecture Overview".to_string(),
+            json!({"headerLevel": 2}),
+        );
+        let header_behavior = behaviors.get("header").unwrap();
+        assert!(
+            header_behavior.get_embeddable_content(&header_node).is_some(),
+            "header should be embeddable via behavior"
+        );
+
+        let code_node = Node::new(
+            "code-block".to_string(),
+            "```python\nprint('hello')".to_string(),
+            json!({"language": "python"}),
+        );
+        let code_behavior = behaviors.get("code-block").unwrap();
+        assert!(
+            code_behavior.get_embeddable_content(&code_node).is_some(),
+            "code-block should be embeddable via behavior"
+        );
+
+        // --- Non-embeddable types ---
+
+        let task_node = Node::new(
+            "task".to_string(),
+            "Fix the bug".to_string(),
+            json!({"task": {"status": "open"}}),
+        );
+        let task_behavior = behaviors.get("task").unwrap();
+        assert!(
+            task_behavior.get_embeddable_content(&task_node).is_none(),
+            "task should NOT be embeddable — behavior returns None"
+        );
+
+        let date_node = Node::new_with_id(
+            "2025-03-01".to_string(),
+            "date".to_string(),
+            "2025-03-01".to_string(),
+            json!({}),
+        );
+        let date_behavior = behaviors.get("date").unwrap();
+        assert!(
+            date_behavior.get_embeddable_content(&date_node).is_none(),
+            "date should NOT be embeddable — behavior returns None"
+        );
+
+        let coll_node = Node::new(
+            "collection".to_string(),
+            "Engineering".to_string(),
+            json!({}),
+        );
+        let coll_behavior = behaviors.get("collection").unwrap();
+        assert!(
+            coll_behavior.get_embeddable_content(&coll_node).is_none(),
+            "collection should NOT be embeddable — behavior returns None"
+        );
+
+        // --- ai-chat: message-based extraction ---
+
+        let chat_node = Node::new(
+            "ai-chat".to_string(),
+            "Chat about testing".to_string(),
+            json!({
+                "messages": [
+                    {"role": "user", "content": "How do I write tests?"},
+                    {"role": "tool_call", "tool": "search", "result_summary": "3 results"},
+                    {"role": "assistant", "content": "Here is a testing guide."}
+                ]
+            }),
+        );
+        let chat_behavior = behaviors.get("ai-chat").unwrap();
+        let chat_content = chat_behavior.get_embeddable_content(&chat_node);
+        assert!(chat_content.is_some(), "ai-chat with messages should be embeddable");
+        let text = chat_content.unwrap();
+        assert!(text.contains("How do I write tests?"), "Should include user message");
+        assert!(text.contains("Here is a testing guide."), "Should include assistant message");
+        assert!(!text.contains("search"), "Should exclude tool_call messages");
+
+        // --- CustomNodeBehavior fallback ---
+
+        let custom_behavior = CustomNodeBehavior::new("invoice");
+        let custom_node = Node::new("invoice".to_string(), "INV-2025-001".to_string(), json!({}));
+        assert!(
+            custom_behavior.get_embeddable_content(&custom_node).is_some(),
+            "Custom types use default trait impl — embeddable if non-empty"
+        );
+
+        // Verify the behavior_for() fallback logic: unknown types get CustomNodeBehavior
+        assert!(
+            behaviors.get("nonexistent_type").is_none(),
+            "Registry should not have a behavior for unknown types"
+        );
+        // The embedding service uses behavior_for() which falls back to CustomNodeBehavior
+        let fallback = CustomNodeBehavior::new("nonexistent_type");
+        let unknown_node = Node::new(
+            "nonexistent_type".to_string(),
+            "Some content".to_string(),
+            json!({}),
+        );
+        assert!(
+            fallback.get_embeddable_content(&unknown_node).is_some(),
+            "Fallback CustomNodeBehavior should make unknown types embeddable if non-empty"
+        );
+    }
+
+    /// Verify the MockNodeAccessor works correctly (validates test infrastructure).
+    #[tokio::test]
+    async fn test_mock_node_accessor() {
+        let mut accessor = MockNodeAccessor::new();
+
+        let node = Node::new("text".to_string(), "Test content".to_string(), json!({}));
+        let node_id = node.id.clone();
+        accessor.add_node(node.clone());
+
+        let child1 = Node::new("text".to_string(), "Child 1".to_string(), json!({}));
+        let child2 = Node::new("text".to_string(), "Child 2".to_string(), json!({}));
+        accessor.set_children(&node_id, vec![child1.clone(), child2.clone()]);
+
+        // get_node
+        let retrieved = accessor.get_node(&node_id).await.unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().content, "Test content");
+
+        // get_node for unknown ID
+        let unknown = accessor.get_node("no-such-id").await.unwrap();
+        assert!(unknown.is_none());
+
+        // get_children
+        let children = accessor.get_children(&node_id).await.unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].content, "Child 1");
+        assert_eq!(children[1].content, "Child 2");
+
+        // get_children for node with no children
+        let empty_children = accessor.get_children("no-children").await.unwrap();
+        assert!(empty_children.is_empty());
+
+        // get_nodes (batch)
+        let id1 = child1.id.clone();
+        let id2 = child2.id.clone();
+        accessor.add_node(child1);
+        accessor.add_node(child2);
+        let batch = accessor.get_nodes(&[&id1, &id2, "nonexistent"]).await.unwrap();
+        assert_eq!(batch.len(), 2, "Should return only existing nodes");
+    }
+
+    /// Verify that text behavior's get_aggregated_content() collects children
+    /// via the NodeAccessor interface (the Phase 2 async aggregation).
+    #[tokio::test]
+    async fn test_text_behavior_aggregated_content_via_accessor() {
+        let mut accessor = MockNodeAccessor::new();
+
+        let parent = Node::new("text".to_string(), "Parent note".to_string(), json!({}));
+        let parent_id = parent.id.clone();
+        accessor.add_node(parent.clone());
+
+        let child_text = Node::new("text".to_string(), "Child paragraph".to_string(), json!({}));
+        let child_code = Node::new(
+            "code-block".to_string(),
+            "```rust\nlet x = 1;".to_string(),
+            json!({"language": "rust"}),
+        );
+        // Task child should NOT contribute (task behavior returns None)
+        let child_task = Node::new(
+            "task".to_string(),
+            "Buy milk".to_string(),
+            json!({"task": {"status": "open"}}),
+        );
+
+        accessor.set_children(&parent_id, vec![
+            child_text.clone(),
+            child_code.clone(),
+            child_task.clone(),
+        ]);
+
+        let behavior = crate::behaviors::TextNodeBehavior;
+        let aggregated = behavior.get_aggregated_content(&parent, &accessor).await;
+
+        assert!(aggregated.is_some(), "Should have aggregated content from children");
+        let text = aggregated.unwrap();
+        assert!(
+            text.contains("Child paragraph"),
+            "Should include text child contribution"
+        );
+        assert!(
+            text.contains("let x = 1"),
+            "Should include code-block child contribution"
+        );
+        assert!(
+            !text.contains("Buy milk"),
+            "Should NOT include task child (task returns None for parent contribution)"
         );
     }
 }

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -11319,5 +11319,91 @@ mod tests {
                 "Missing fields should produce empty strings, not errors"
             );
         }
+
+        // =====================================================================
+        // NodeAccessor Implementation Tests (Issue #1018)
+        // =====================================================================
+
+        #[tokio::test]
+        async fn test_node_accessor_get_node() {
+            let (service, _temp) = create_test_service().await;
+
+            let node = Node::new("text".to_string(), "Accessor test".to_string(), json!({}));
+            let node_id = node.id.clone();
+            service.create_node(node).await.unwrap();
+
+            // Use NodeAccessor trait method (not NodeService method directly)
+            let accessor: &dyn NodeAccessor = &service;
+            let retrieved = accessor.get_node(&node_id).await.unwrap();
+            assert!(retrieved.is_some(), "NodeAccessor::get_node should find existing node");
+            assert_eq!(retrieved.unwrap().content, "Accessor test");
+
+            // Unknown ID returns None
+            let missing = accessor.get_node("nonexistent-id").await.unwrap();
+            assert!(missing.is_none(), "NodeAccessor::get_node should return None for unknown ID");
+        }
+
+        #[tokio::test]
+        async fn test_node_accessor_get_children() {
+            let (service, _temp) = create_test_service().await;
+
+            let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
+            let parent_id = parent.id.clone();
+            service.create_node(parent).await.unwrap();
+
+            let child1 = Node::new("text".to_string(), "Child 1".to_string(), json!({}));
+            let child2 = Node::new("text".to_string(), "Child 2".to_string(), json!({}));
+            let child1_id = child1.id.clone();
+            let child2_id = child2.id.clone();
+            service.create_node(child1).await.unwrap();
+            service.create_node(child2).await.unwrap();
+            service
+                .move_node_unchecked(&child1_id, Some(&parent_id), None)
+                .await
+                .unwrap();
+            service
+                .move_node_unchecked(&child2_id, Some(&parent_id), Some(&child1_id))
+                .await
+                .unwrap();
+
+            let accessor: &dyn NodeAccessor = &service;
+            let children = accessor.get_children(&parent_id).await.unwrap();
+            assert_eq!(children.len(), 2, "NodeAccessor::get_children should return 2 children");
+
+            // Node with no children returns empty vec
+            let empty = accessor.get_children(&child1_id).await.unwrap();
+            assert!(empty.is_empty(), "NodeAccessor::get_children for leaf node should be empty");
+        }
+
+        #[tokio::test]
+        async fn test_node_accessor_get_nodes_batch() {
+            let (service, _temp) = create_test_service().await;
+
+            let n1 = Node::new("text".to_string(), "Batch 1".to_string(), json!({}));
+            let n2 = Node::new("text".to_string(), "Batch 2".to_string(), json!({}));
+            let n3 = Node::new("text".to_string(), "Batch 3".to_string(), json!({}));
+            let id1 = n1.id.clone();
+            let id2 = n2.id.clone();
+            let id3 = n3.id.clone();
+            service.create_node(n1).await.unwrap();
+            service.create_node(n2).await.unwrap();
+            service.create_node(n3).await.unwrap();
+
+            let accessor: &dyn NodeAccessor = &service;
+            let batch = accessor
+                .get_nodes(&[&id1, &id2, &id3, "nonexistent"])
+                .await
+                .unwrap();
+            assert_eq!(
+                batch.len(),
+                3,
+                "NodeAccessor::get_nodes should return only existing nodes"
+            );
+
+            let contents: HashSet<String> = batch.into_iter().map(|n| n.content).collect();
+            assert!(contents.contains("Batch 1"));
+            assert!(contents.contains("Batch 2"));
+            assert!(contents.contains("Batch 3"));
+        }
     }
 }

--- a/packages/desktop-app/src-tauri/src/acp/transport.rs
+++ b/packages/desktop-app/src-tauri/src/acp/transport.rs
@@ -704,4 +704,143 @@ mod tests {
 
         transport.shutdown().await.unwrap();
     }
+
+    #[tokio::test]
+    async fn test_concurrent_send_receive() {
+        // Verify that sending multiple messages while receiving works without deadlock.
+        // Uses an echo agent so every send produces a corresponding receive.
+        let transport = Arc::new(StdioTransport::spawn(echo_config()).await.unwrap());
+
+        let sender = Arc::clone(&transport);
+        let send_handle = tokio::spawn(async move {
+            for i in 1..=10u64 {
+                let msg = AcpMessage {
+                    jsonrpc: "2.0".to_string(),
+                    method: Some(format!("test/concurrent_{i}")),
+                    params: Some(serde_json::json!({})),
+                    id: Some(serde_json::json!(i)),
+                    result: None,
+                    error: None,
+                };
+                sender.send(msg).await.unwrap();
+            }
+        });
+
+        let receiver = Arc::clone(&transport);
+        let recv_handle = tokio::spawn(async move {
+            let mut received = Vec::new();
+            for _ in 0..10 {
+                let msg = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    receiver.receive(),
+                )
+                .await
+                .expect("receive timed out")
+                .expect("receive failed");
+                received.push(msg);
+            }
+            received
+        });
+
+        send_handle.await.unwrap();
+        let received = recv_handle.await.unwrap();
+
+        assert_eq!(received.len(), 10);
+        // Verify all IDs are present (order preserved by echo agent)
+        for (i, msg) in received.iter().enumerate() {
+            assert_eq!(msg.id, Some(serde_json::json!((i + 1) as u64)));
+        }
+
+        transport.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_large_message_handling() {
+        // Verify that a message with a large params payload (>10KB) round-trips correctly.
+        let transport = StdioTransport::spawn(echo_config()).await.unwrap();
+
+        // Build a ~15KB payload string
+        let large_value = "x".repeat(15_000);
+        let msg = AcpMessage {
+            jsonrpc: "2.0".to_string(),
+            method: Some("test/large_payload".to_string()),
+            params: Some(serde_json::json!({ "data": large_value })),
+            id: Some(serde_json::json!(1)),
+            result: None,
+            error: None,
+        };
+
+        transport.send(msg).await.unwrap();
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), transport.receive())
+            .await
+            .expect("receive timed out")
+            .expect("receive failed");
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, Some(serde_json::json!(1)));
+        assert_eq!(response.method.as_deref(), Some("test/large_payload"));
+        // Verify the large payload survived the round-trip
+        let data = response.params.unwrap()["data"].as_str().unwrap().to_string();
+        assert_eq!(data.len(), 15_000);
+
+        transport.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_rapid_sequential_sends() {
+        // Send 25 messages rapidly and verify all are received in order.
+        let transport = StdioTransport::spawn(echo_config()).await.unwrap();
+        let count = 25u64;
+
+        // Send all messages without waiting for responses
+        for i in 1..=count {
+            let msg = test_request(i, &format!("test/rapid_{i}"));
+            transport.send(msg).await.unwrap();
+        }
+
+        // Receive all and verify order
+        for i in 1..=count {
+            let response =
+                tokio::time::timeout(std::time::Duration::from_secs(10), transport.receive())
+                    .await
+                    .expect("receive timed out")
+                    .expect("receive failed");
+
+            assert_eq!(
+                response.id,
+                Some(serde_json::json!(i)),
+                "Message {i} received out of order"
+            );
+            assert_eq!(
+                response.method.as_deref(),
+                Some(format!("test/rapid_{i}").as_str()),
+            );
+        }
+
+        transport.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_idempotency_with_state_checks() {
+        // Calling shutdown() multiple times should not panic, error, or corrupt state.
+        let transport = StdioTransport::spawn(echo_config()).await.unwrap();
+        assert!(transport.is_alive().await);
+
+        // First shutdown
+        transport.shutdown().await.unwrap();
+        assert!(!transport.is_alive().await);
+
+        // Second shutdown (idempotent)
+        transport.shutdown().await.unwrap();
+        assert!(!transport.is_alive().await);
+
+        // Third shutdown (still idempotent)
+        transport.shutdown().await.unwrap();
+        assert!(!transport.is_alive().await);
+
+        // Operations after shutdown still fail gracefully
+        assert!(transport.send(test_request(1, "test")).await.is_err());
+        assert!(transport.receive().await.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- **Transport** (4 new tests): concurrent send/receive, large message (>10KB) round-trip, rapid sequential sends (25 messages), shutdown idempotency with state verification
- **Embedding behaviors** (2 new tests): comprehensive embeddable content decision for all 13 registered behavior types, custom behavior fallback verification
- **NodeAccessor** (3 new tests): `get_node`, `get_children`, `get_nodes` implementation verification against a real SurrealDB test database
- **Behavior-driven embedding** (3 new tests): mock NodeAccessor for behavior dispatch testing, text behavior aggregated content via accessor, mock infrastructure validation

Total: 12 new tests across 4 files (678 lines added)

## Test plan
- [x] `cargo test -p nodespace-app -- transport` — 17 passed (was 13)
- [x] `cargo test -p nodespace-core` — 144 passed, 0 failed
- [x] `cargo check -p nodespace-app` — clean
- [x] `cargo check -p nodespace-core` — clean

Generated with [Claude Code](https://claude.com/claude-code)