### PR TITLE
Fix: retroactive review findings for #1063 Metal crash fix

### DIFF
--- a/packages/agent/src/acp/context_assembly.rs
+++ b/packages/agent/src/acp/context_assembly.rs
@@ -215,7 +215,7 @@ impl GraphContextAssembler {
             }
 
             match embedding_service
-                .semantic_search_nodes(query, NEIGHBORS_PER_SEED, SEMANTIC_THRESHOLD)
+                .semantic_search_nodes(query, NEIGHBORS_PER_SEED, SEMANTIC_THRESHOLD, None)
                 .await
             {
                 Ok(results) => {

--- a/packages/core/src/mcp/handlers/tools.rs
+++ b/packages/core/src/mcp/handlers/tools.rs
@@ -521,8 +521,8 @@ pub async fn handle_tools_call(
 ///
 /// Consider auto-generating schemas from Rust types with proc macros,
 /// while preserving ability to override descriptions (see Issue #312).
-fn get_tool_schemas(schema_ids: &[String]) -> Value {
-    // Build the node_type enum: core types + "schema" + all user-defined schema IDs
+fn get_tool_schemas(schemas: &[SchemaNode]) -> Value {
+    // Build the node_type enum: core types + all user-defined schema IDs
     let mut seen: HashSet<&str> = HashSet::new();
     let core_types: &[&str] = &[
         "text",
@@ -544,12 +544,44 @@ fn get_tool_schemas(schema_ids: &[String]) -> Value {
             t.to_string()
         })
         .collect();
-    for id in schema_ids {
-        if seen.insert(id.as_str()) {
-            node_types.push(id.clone());
+    for schema in schemas {
+        if seen.insert(schema.id.as_str()) {
+            node_types.push(schema.id.clone());
         }
     }
     let node_type_enum = json!(node_types);
+
+    // Build dynamic descriptions that include user-defined schema names when present
+    let user_schemas: Vec<&SchemaNode> = schemas.iter().filter(|s| !s.is_core).collect();
+
+    let tool_desc = if user_schemas.is_empty() {
+        "Create a new node in NodeSpace".to_string()
+    } else {
+        let names: Vec<String> = user_schemas
+            .iter()
+            .map(|s| {
+                if s.description.is_empty() {
+                    s.id.clone()
+                } else {
+                    format!("{} ({})", s.id, s.description)
+                }
+            })
+            .collect();
+        format!(
+            "Create a new node in NodeSpace. User-defined schemas available: {}",
+            names.join(", ")
+        )
+    };
+
+    let node_type_desc = if user_schemas.is_empty() {
+        "Type of node to create".to_string()
+    } else {
+        let ids: Vec<&str> = user_schemas.iter().map(|s| s.id.as_str()).collect();
+        format!(
+            "Type of node to create. Core types: text, header, task, date, etc. User-defined schemas: {}",
+            ids.join(", ")
+        )
+    };
 
     json!([
         {

--- a/packages/core/src/mcp/handlers/tools_test.rs
+++ b/packages/core/src/mcp/handlers/tools_test.rs
@@ -31,8 +31,27 @@ fn test_tool_schemas_include_core_and_schema_type() {
 
 #[test]
 fn test_tool_schemas_include_custom_schema_ids() {
-    let custom_ids = vec!["customer".to_string(), "invoice".to_string()];
-    let schemas = get_tool_schemas(&custom_ids);
+    use crate::models::SchemaNode;
+    use chrono::Utc;
+    let now = Utc::now();
+    let custom_schemas: Vec<SchemaNode> = vec!["customer", "invoice"]
+        .into_iter()
+        .map(|id| SchemaNode {
+            id: id.to_string(),
+            content: id.to_string(),
+            version: 1,
+            created_at: now,
+            modified_at: now,
+            is_core: false,
+            schema_version: 1,
+            description: String::new(),
+            fields: vec![],
+            relationships: vec![],
+            title_template: None,
+            properties_header_summary_template: None,
+        })
+        .collect();
+    let schemas = get_tool_schemas(&custom_schemas);
     let tools = schemas.as_array().unwrap();
 
     let create_node = tools.iter().find(|t| t["name"] == "create_node").unwrap();
@@ -48,9 +67,28 @@ fn test_tool_schemas_include_custom_schema_ids() {
 
 #[test]
 fn test_tool_schemas_no_duplicate_types() {
-    // schema is in core list; passing it again via schema_ids should not duplicate
-    let schema_ids = vec!["schema".to_string(), "text".to_string()];
-    let schemas = get_tool_schemas(&schema_ids);
+    use crate::models::SchemaNode;
+    use chrono::Utc;
+    let now = Utc::now();
+    // schema and text are in the core list; passing them again via custom schemas should not duplicate
+    let custom_schemas: Vec<SchemaNode> = vec!["schema", "text"]
+        .into_iter()
+        .map(|id| SchemaNode {
+            id: id.to_string(),
+            content: id.to_string(),
+            version: 1,
+            created_at: now,
+            modified_at: now,
+            is_core: false,
+            schema_version: 1,
+            description: String::new(),
+            fields: vec![],
+            relationships: vec![],
+            title_template: None,
+            properties_header_summary_template: None,
+        })
+        .collect();
+    let schemas = get_tool_schemas(&custom_schemas);
     let tools = schemas.as_array().unwrap();
 
     let create_node = tools.iter().find(|t| t["name"] == "create_node").unwrap();


### PR DESCRIPTION
## Retroactive Review — PR #1065 (merged without review)

This PR addresses findings from a retroactive code review of #1065 (Fix ggml_metal crash on app exit).

## Critical Findings

### 1. Compile error: incomplete `get_tool_schemas` refactor

PR #1065 changed callers of `get_tool_schemas` to pass `Vec<SchemaNode>` instead of extracting just IDs, and referenced `tool_desc`/`node_type_desc` variables inside the function body — but the function signature was never updated and those variables were never defined.

**Result:** 4 compile errors on main after merge:
- `E0425: cannot find value 'tool_desc' in this scope`
- `E0425: cannot find value 'node_type_desc' in this scope`
- `E0308: mismatched types — expected &[String], found &Vec<SchemaNode>` (×2)

**Fix:** Complete the refactor — update signature to `&[SchemaNode]`, build dynamic descriptions from schema data.

### 2. Compile error: `semantic_search_nodes` missing 4th argument

`context_assembly.rs` wasn't updated when `semantic_search_nodes` gained a `filters: Option<&SearchNodeFilters>` parameter.

**Fix:** Pass `None` (no filter needed for context-assembly queries).

### 3. Test failure: `tools_test.rs` uses `Vec<String>` after signature change

Two unit tests for `get_tool_schemas` still passed `Vec<String>` after the function signature changed to `&[SchemaNode]`.

**Fix:** Construct minimal `SchemaNode` instances in the tests.

## What was correct in PR #1065

- Shutdown sequence ordering (engine reset → model unload → GPU release → backend release): ✅ Correct
- `reset_to_noop_engine()` and `reset_engine_sync()` methods: ✅ Correct, well-documented
- Tracing logs at each shutdown step: ✅ Present throughout
- No `.unwrap()` in shutdown paths: ✅ Using `try_state()` + `warn!` instead
- No `println!` or `#[allow(...)]`: ✅ Clean

## Test Results

- 103 tests pass
- 1 pre-existing failure (`test_handle_query_nodes_filters_unsupported_operator_ignored`) — unrelated to this change, was broken before PR #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)