### PR TITLE
Fix: retroactive review findings for #1062 workspace context refresh

### DIFF
--- a/packages/core/src/mcp/handlers/initialize.rs
+++ b/packages/core/src/mcp/handlers/initialize.rs
@@ -14,39 +14,6 @@ use crate::services::{NodeEmbeddingService, NodeService};
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-/// Build workspace context string for injection into system prompts.
-///
-/// Fetches available schemas, collections, and playbooks and formats them
-/// as a compact string suitable for inclusion in AI agent system prompts.
-/// Respects a token budget by truncating if necessary.
-///
-/// # Arguments
-///
-/// * `node_service` - NodeService for querying available schemas
-/// * `max_chars` - Maximum character budget for the output (e.g., 1000 for token efficiency)
-///
-/// # Returns
-///
-/// A formatted string suitable for injection into a system prompt, or empty string
-/// if no context is available or on error.
-pub async fn build_workspace_context_for_prompt(
-    node_service: &Arc<NodeService>,
-    max_chars: usize,
-) -> String {
-    let ws_ctx = context_ops::build_workspace_context(node_service)
-        .await
-        .unwrap_or_else(|e| {
-            tracing::warn!("Failed to build workspace context for prompt: {}", e);
-            context_ops::WorkspaceContext {
-                entity_types: vec![],
-                collections: vec![],
-                active_playbooks: vec![],
-            }
-        });
-
-    ws_ctx.format_for_prompt(max_chars)
-}
-
 /// Handle MCP initialize request
 ///
 /// This is the FIRST method called when a client connects.

--- a/packages/desktop-app/src-tauri/tests/agent_e2e.rs
+++ b/packages/desktop-app/src-tauri/tests/agent_e2e.rs
@@ -2055,55 +2055,54 @@ async fn multi_turn_mixed_tool_calls() {
 ///
 /// Skipped if the model file doesn't exist (CI-safe).
 #[tokio::test]
-#[ignore]  // Only run locally with models downloaded
+#[ignore] // Only run locally with models downloaded
 async fn test_real_inference_loads_and_runs() {
     use nodespace_agent::local_agent::inference::LlamaChatInferenceEngine;
     use nodespace_nlp_engine::chat::ChatConfig;
     use std::path::PathBuf;
 
     // Check if model exists (skip if not)
-    let model_path = PathBuf::from(
-        std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
-    )
-    .join(".nodespace/models/Ministral-3-3B-Instruct-2512-Q4_K_M.gguf");
+    let model_path = PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/root".to_string()))
+        .join(".nodespace/models/Ministral-3-3B-Instruct-2512-Q4_K_M.gguf");
 
     if !model_path.exists() {
-        eprintln!("⏭️  Skipping real inference test: model not found at {:?}", model_path);
+        eprintln!(
+            "Skipping real inference test: model not found at {:?}",
+            model_path
+        );
         return;
     }
 
-    // Create inference engine with the real model
+    // LlamaChatInferenceEngine::load takes model path separately from ChatConfig.
     let config = ChatConfig {
-        model_path: model_path.to_string_lossy().to_string(),
         n_ctx: 4096,
         ..Default::default()
     };
 
-    let engine = LlamaChatInferenceEngine::new(config)
+    let engine = LlamaChatInferenceEngine::load(&model_path.to_string_lossy(), config)
         .expect("Failed to initialize Llama inference engine with Ministral-3");
 
     // Verify model info is available
-    let model_info = engine
-        .model_info()
-        .await
-        .expect("Failed to get model info");
+    let model_info = engine.model_info().await.expect("Failed to get model info");
     assert!(
         model_info.is_some(),
         "Model should report its information after loading"
     );
-    println!("✅ Loaded model: {:?}", model_info);
+    println!("Loaded model: {:?}", model_info);
 
-    // Create a mock executor that records tool calls
-    let executor = MockExecutor::new();
+    // Create a mock executor for tool dispatch
+    let executor = MockToolExecutor::new();
 
     let service = LocalAgentService::new(
         Arc::new(engine) as Arc<dyn ChatInferenceEngine>,
-        Arc::new(executor.clone()) as Arc<dyn AgentToolExecutor>,
+        Arc::new(executor) as Arc<dyn AgentToolExecutor>,
         None,
     );
 
     // Create session
-    let session_id = service.create_session(Some("real_inference_test".into())).await;
+    let session_id = service
+        .create_session(Some("real_inference_test".into()))
+        .await;
 
     // Send a simple message to validate inference works
     let result = service
@@ -2118,13 +2117,13 @@ async fn test_real_inference_loads_and_runs() {
 
     // Verify we got a response (either text or tool calls)
     assert!(
-        !result.final_response.is_empty() || !result.tool_calls_made.is_empty(),
+        !result.response.is_empty() || !result.tool_calls_made.is_empty(),
         "Should receive either a text response or tool calls"
     );
 
     println!(
-        "✅ Real inference test passed: model responded with {} characters or {} tool calls",
-        result.final_response.len(),
+        "Real inference test passed: model responded with {} characters or {} tool calls",
+        result.response.len(),
         result.tool_calls_made.len()
     );
 


### PR DESCRIPTION
## Summary

Retroactive review of PR #1069 (Refresh workspace context per turn, closes #1062), which was merged without a review cycle.

**3 findings identified and fixed:**

- **Dead code** (`initialize.rs`): `build_workspace_context_for_prompt()` was added but never called — CLAUDE.md requires deleting unused code immediately
- **5 compile errors** in `#[ignore]` test (`agent_e2e.rs`): wrong type name (`MockExecutor` → `MockToolExecutor`), non-existent `ChatConfig.model_path` field, `LlamaChatInferenceEngine::new()` (doesn't exist, should be `::load(path, config)`), `result.final_response` (should be `result.response`), and `executor.clone()` on a non-Clone type
- **Emoji in test output**: violates CLAUDE.md style standards

## Test plan

- [x] `cargo check -p nodespace-app --test agent_e2e` — compiles cleanly (pre-existing `tools.rs` errors are unrelated to this PR)
- [x] `bun run test` — 3918 frontend tests pass (1 pre-existing flaky timing test in `shared-node-store-coverage.test.ts`)
- [x] `build_workspace_context_for_prompt` is no longer present in `initialize.rs`
- [x] `test_real_inference_loads_and_runs` uses `MockToolExecutor`, `result.response`, `LlamaChatInferenceEngine::load`, correct `ChatConfig` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)