### PR TITLE
Fix local agent document reading (get_node markdown, search_semantic, prompt tuning)

### DIFF
--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -133,17 +133,21 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             prompt_templates::fallback_system_prompt(dynamic_ctx)
         };
 
-        let (system_content, tools) = if let Some(ref pipeline) = self.skill_pipeline {
+        let (system_content, tools, effective_max_iterations) = if let Some(ref pipeline) =
+            self.skill_pipeline
+        {
             if let Some(skill_match) = pipeline.find_skill(user_message).await {
                 tracing::info!(
                     skill = %skill_match.skill.content,
                     confidence = skill_match.confidence,
                     intent = %skill_match.intent.query,
+                    max_iterations = skill_match.max_iterations,
                     "Skill matched via push pipeline"
                 );
 
                 // Scope tools to skill's whitelist
                 let scoped_tools = pipeline.scope_tools(&all_tools, &skill_match);
+                let skill_max_iter = skill_match.max_iterations;
 
                 let skill_name = &skill_match.skill.content;
                 let skill_desc = crate::props::get_prop_str(
@@ -154,16 +158,16 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 .unwrap_or("");
 
                 let system = format!(
-                    "{}\n\nACTIVE SKILL: {}\n{}\nFocus on this skill's capabilities. Use only the tools provided.",
-                    base_prompt, skill_name, skill_desc
-                );
+                        "{}\n\nACTIVE SKILL: {}\n{}\nFocus on this skill's capabilities. Use only the tools provided.",
+                        base_prompt, skill_name, skill_desc
+                    );
 
-                (system, scoped_tools)
+                (system, scoped_tools, skill_max_iter)
             } else {
-                (base_prompt, all_tools)
+                (base_prompt, all_tools, MAX_TOOL_ITERATIONS)
             }
         } else {
-            (base_prompt, all_tools)
+            (base_prompt, all_tools, MAX_TOOL_ITERATIONS)
         };
 
         tracing::info!(
@@ -179,8 +183,8 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             completion_tokens: 0,
         };
 
-        // ReAct loop: iterate up to MAX_TOOL_ITERATIONS
-        for iteration in 0..MAX_TOOL_ITERATIONS {
+        // ReAct loop: iterate up to effective_max_iterations (skill-specific or global fallback)
+        for iteration in 0..effective_max_iterations {
             if cancel.is_cancelled() {
                 return Err(InferenceError::Engine("cancelled".into()));
             }
@@ -358,7 +362,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
 
             // If this was the last allowed iteration, do one final inference
             // WITHOUT tools so the model must produce a text response.
-            if iteration == MAX_TOOL_ITERATIONS - 1 {
+            if iteration == effective_max_iterations - 1 {
                 tracing::info!(
                     "Agent loop: max iterations reached, running final inference without tools"
                 );

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -27,7 +27,7 @@ use crate::prompt_assembler::{PromptAssembler, TemplateContext};
 // ---------------------------------------------------------------------------
 
 /// Maximum number of tool-call iterations per turn.
-const MAX_TOOL_ITERATIONS: usize = 2;
+const MAX_TOOL_ITERATIONS: usize = 5;
 
 /// Total token budget for the context window.
 const TOTAL_TOKEN_BUDGET: u32 = 32_000;

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -187,7 +187,7 @@ fn def_search_nodes() -> ToolDefinition {
 fn def_search_semantic() -> ToolDefinition {
     ToolDefinition {
         name: "search_semantic".into(),
-        description: "Find nodes semantically related to a natural-language query".into(),
+        description: "Find nodes semantically related to a natural-language query. By default returns IDs and snippets only. Set include_markdown=1 to get full content for the top result, saving a separate get_node call.".into(),
         parameters_schema: json!({
             "type": "object",
             "properties": {
@@ -198,6 +198,14 @@ fn def_search_semantic() -> ToolDefinition {
                 "limit": {
                     "type": "integer",
                     "description": "Max results to return (default 5)"
+                },
+                "include_markdown": {
+                    "type": "integer",
+                    "description": "Number of top results to include full markdown content for (0-5, default 0). Set to 1 to get full content for the top result without a separate get_node call."
+                },
+                "collection": {
+                    "type": "string",
+                    "description": "Filter results to a specific collection path (e.g. 'Architecture', 'Development')"
                 }
             },
             "required": ["query"]
@@ -628,6 +636,8 @@ impl GraphToolExecutor {
             })?;
         let query = params.query;
         let limit = params.limit.unwrap_or(DEFAULT_SEMANTIC_LIMIT);
+        let include_markdown = params.include_markdown;
+        let collection = params.collection;
 
         let ns = self.node_service()?;
         let emb = self.embedding_service()?;
@@ -637,9 +647,9 @@ impl GraphToolExecutor {
             threshold: Some(SEMANTIC_THRESHOLD),
             limit: Some(limit),
             collection_id: None,
-            collection: None,
+            collection,
             exclude_collections: None,
-            include_markdown: None,
+            include_markdown,
             include_archived: None,
             scope: None,
         };
@@ -653,7 +663,7 @@ impl GraphToolExecutor {
             .nodes
             .iter()
             .map(|v| {
-                json!({
+                let mut item = json!({
                     "id": v.get("id").and_then(|v| v.as_str()).unwrap_or(""),
                     "title": truncate(
                         v.get("title").and_then(|v| v.as_str()).unwrap_or(""),
@@ -665,7 +675,14 @@ impl GraphToolExecutor {
                         v.get("content").and_then(|v| v.as_str()).unwrap_or(""),
                         BODY_TRUNCATE_SUMMARY
                     ),
-                })
+                });
+                // Include full markdown content if the ops layer returned it
+                if let Some(md) = v.get("markdown").and_then(|v| v.as_str()) {
+                    if !md.is_empty() {
+                        item["markdown"] = json!(truncate(md, BODY_TRUNCATE_FULL));
+                    }
+                }
+                item
             })
             .collect();
 
@@ -703,10 +720,7 @@ impl GraphToolExecutor {
             match handle_get_markdown_from_node_id(&ns, params).await {
                 Ok(result) => {
                     let md = result
-                        .get("content")
-                        .and_then(|c| c.as_array())
-                        .and_then(|arr| arr.first())
-                        .and_then(|item| item.get("text"))
+                        .get("markdown")
                         .and_then(|t| t.as_str())
                         .unwrap_or("");
                     let truncated = truncate(md, BODY_TRUNCATE_FULL);

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -100,7 +100,6 @@ struct DeleteNodeParams {
     pub id: String,
 }
 
-
 /// Maximum characters for node body in full node results.
 const BODY_TRUNCATE_FULL: usize = 2000;
 
@@ -187,7 +186,7 @@ fn def_search_nodes() -> ToolDefinition {
 fn def_search_semantic() -> ToolDefinition {
     ToolDefinition {
         name: "search_semantic".into(),
-        description: "Find nodes semantically related to a natural-language query. By default returns IDs and snippets only. Set include_markdown=1 to get full content for the top result, saving a separate get_node call.".into(),
+        description: "Find nodes semantically related to a natural-language query. By default returns full content for the top result (include_markdown=1). Increase include_markdown to get full content for more results, or set to 0 for IDs and snippets only.".into(),
         parameters_schema: json!({
             "type": "object",
             "properties": {
@@ -201,7 +200,7 @@ fn def_search_semantic() -> ToolDefinition {
                 },
                 "include_markdown": {
                     "type": "integer",
-                    "description": "Number of top results to include full markdown content for (0-5, default 0). Set to 1 to get full content for the top result without a separate get_node call."
+                    "description": "Number of top results to include full markdown content for (0-5, default 1). Set to 0 for IDs and snippets only, or increase to get full content for multiple results."
                 },
                 "collection": {
                     "type": "string",

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -255,8 +255,10 @@ impl PromptAssembler {
                 content: "TOOL STRATEGY:\n\
                     - ALWAYS search first before updating or getting a node. NEVER use placeholder IDs like \"abc-123\".\n\
                     - To find nodes by meaning/topic: use search_semantic (natural language query)\n\
+                    - search_semantic results are ordered by relevance — the first result is the best match. Each result has: id, title, score (0-1 similarity), snippet (short preview), and optionally markdown (full content).\n\
+                    - search_semantic includes full markdown content for the top result by default. If the top result has a non-empty 'markdown' field, that IS the full document — use it directly to answer. Do NOT call get_node or search_nodes afterward.\n\
+                    - Only call get_node if you need full content for a result that did NOT include markdown (e.g. results 2-5). Use get_node with format=markdown and the ID.\n\
                     - To find nodes by exact fields: use search_nodes (keyword + type filter)\n\
-                    - To get full node details: use get_node with the ID from search results\n\
                     - To update a task status: search for the task first, then use update_task_status with the real ID\n\
                     - To create a new entity type: use create_schema (not create_node)\n\
                     - To create an instance of an existing type: use create_node with node_type matching the schema ID\n\

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -222,7 +222,7 @@ RESULT STRUCTURE: Each result contains:
 - title: document title
 - score: similarity score (0-1, higher = more relevant)
 - snippet: short content preview
-- markdown: full document content (only present for top result)
+- markdown: full document content (present for top N results based on include_markdown, default 1)
 
 USE MARKDOWN DIRECTLY: If the top result has a non-empty 'markdown' field, that is the complete document. Summarize or answer from it immediately — do NOT call get_node or search_nodes again.
 

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -208,9 +208,30 @@ impl SkillPipeline {
                     "search_nodes".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 4,
                 output_format: "text".to_string(),
-                guidance_prompts: vec![],
+                guidance_prompts: vec![
+                    SeedGuidancePrompt {
+                        title: "Research & Search Guidance".to_string(),
+                        content: r#"When answering questions about stored knowledge:
+
+SEARCH FIRST: Always call search_semantic with a natural language query. Results are ordered by relevance — the first result is the best match.
+
+RESULT STRUCTURE: Each result contains:
+- id: node ID (use this for follow-up get_node calls)
+- title: document title
+- score: similarity score (0-1, higher = more relevant)
+- snippet: short content preview
+- markdown: full document content (only present for top result)
+
+USE MARKDOWN DIRECTLY: If the top result has a non-empty 'markdown' field, that is the complete document. Summarize or answer from it immediately — do NOT call get_node or search_nodes again.
+
+FETCH ADDITIONAL CONTENT: Only call get_node with format=markdown if you need full content for a lower-ranked result that did not include markdown.
+
+MULTIPLE DOCUMENTS: If the user asks about multiple topics, call search_semantic once per topic rather than searching broadly and fetching each result individually."#.to_string(),
+                        priority: 1,
+                    },
+                ],
             },
             SeedSkill {
                 name: "Node Creation".to_string(),
@@ -219,7 +240,7 @@ impl SkillPipeline {
                     "create_node".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![],
             },
@@ -230,7 +251,7 @@ impl SkillPipeline {
                     "create_schema".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![
                     SeedGuidancePrompt {
@@ -307,7 +328,7 @@ EXAMPLE — Project schema:
                     "get_node".to_string(),
                     "search_nodes".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![],
             },
@@ -319,7 +340,7 @@ EXAMPLE — Project schema:
                     "get_related_nodes".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![],
             },
@@ -330,7 +351,7 @@ EXAMPLE — Project schema:
                     "delete_node".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![],
             },
@@ -351,7 +372,7 @@ EXAMPLE — Project schema:
                     "create_relationship".to_string(),
                     "get_node".to_string(),
                 ],
-                max_iterations: 2,
+                max_iterations: 3,
                 output_format: "text".to_string(),
                 guidance_prompts: vec![],
             },


### PR DESCRIPTION
## Summary

Fixes the local agent's inability to read document content when asked questions about stored knowledge. Root cause was a chain of three issues discovered through live terminal log analysis.

## Bug Fixes

### 1. `get_node` format=markdown always returned empty
`exec_get_node` was parsing the response as MCP wire format (`content[0].text`) but `handle_get_markdown_from_node_id` returns a plain object (`{markdown: "..."}`). The `unwrap_or("")` fallback silently swallowed every result.

### 2. `search_semantic` `include_markdown` was hardcoded to `None`
The ops layer defaults `include_markdown` to 1 (return full markdown for top result), but the agent executor always passed `None`, overriding it. The parameter also wasn't in the tool schema so the model couldn't request it.

### 3. Prompt didn't explain search result structure
The Tool Strategy Guide told the model to call `get_node` after searching, even when `search_semantic` already returned the full document. The model had no way to know the result contained a `markdown` field or that results were ordered by relevance.

## Improvements

- `search_semantic` tool definition: expose `include_markdown` and `collection` params
- Tool Strategy Guide: explain result ordering, result shape, and that `markdown` field = full document
- Research & Search skill: add guidance prompt with explicit decision rules
- `MAX_TOOL_ITERATIONS`: 2 → 5 (2 was insufficient for search+fetch+respond)
- Skill `max_iterations`: Research & Search 2→4, others 2→3

## Result

Before: agent looped on empty `search_nodes` calls, hit iteration limit, apologized.
After: search → markdown in result → immediate substantive response. One tool call.

## Related

- Follow-up to #1060 (unify MCP/agent tool schemas) — tool schema drift was still causing silent failures
- See also #1080 (skill node property normalization bug — `max_iterations` DB update blocked)

## Test Plan

- [x] Verified live via terminal logs: `search_semantic` returns `markdown` field, model uses it directly, `tool_calls=0` on iteration 1
- [ ] Unit test for `exec_get_node` with `format=markdown` asserting non-empty response
- [ ] Unit test for `exec_search_semantic` asserting `include_markdown` is wired through