### PR TITLE
Fix: address PR #1098 review findings and e2e test compilation (#1082)

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands/local_agent.rs
+++ b/packages/desktop-app/src-tauri/src/commands/local_agent.rs
@@ -77,25 +77,28 @@ pub struct ManagedAgentState {
 }
 
 impl ManagedAgentState {
+    /// Build a `LocalAgentService` with the no-op inference engine and no services.
+    ///
+    /// Used at startup (before real services exist) and during shutdown/reset.
+    fn build_noop_service() -> LocalAgentService<dyn ChatInferenceEngine, dyn AgentToolExecutor> {
+        use nodespace_agent::local_agent::tools::GraphToolExecutor;
+
+        let engine: Arc<dyn ChatInferenceEngine> = Arc::new(NoOpInferenceEngine);
+        let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
+            node_service: None,
+            embedding_service: None,
+        });
+        LocalAgentService::new(engine, executor, None)
+    }
+
     /// Create with a no-op inference engine.
     ///
     /// The `app_services` parameter is used to resolve NodeService and
     /// NodeEmbeddingService when constructing the tool executor. At startup,
     /// services may not be initialized yet, so the executor starts without them.
     pub fn new(app_services: crate::app_services::AppServices) -> Self {
-        use nodespace_agent::local_agent::tools::GraphToolExecutor;
-
-        let engine: Arc<dyn ChatInferenceEngine> = Arc::new(NoOpInferenceEngine);
-        // At startup, services aren't initialized yet. The executor handles
-        // None gracefully (returns "service unavailable" errors).
-        let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
-            node_service: None,
-            embedding_service: None,
-        });
-        let service = LocalAgentService::new(engine, executor, None);
-
         Self {
-            inner: RwLock::new(service),
+            inner: RwLock::new(Self::build_noop_service()),
             app_services,
             active_model_id: tokio::sync::Mutex::new(None),
         }
@@ -194,17 +197,10 @@ impl ManagedAgentState {
     /// This must be called BEFORE `release_llama_backend()` to ensure
     /// proper cleanup order and avoid use-after-free crashes in Metal.
     pub async fn reset_to_noop_engine(&self) {
-        use nodespace_agent::local_agent::tools::GraphToolExecutor;
-
-        let engine: Arc<dyn ChatInferenceEngine> = Arc::new(NoOpInferenceEngine);
-        let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
-            node_service: None,
-            embedding_service: None,
-        });
-        let service = LocalAgentService::new(engine, executor, None);
-
         let mut guard = self.inner.write().await;
-        *guard = service;
+        *guard = Self::build_noop_service();
+        // Explicitly release write lock before calling clear_active_model which
+        // acquires the active_model_id Mutex, to avoid lock ordering issues.
         drop(guard);
 
         // Clear active model so the next ensure_model_ready always re-installs
@@ -251,10 +247,11 @@ struct ModelStatusEvent {
 ///
 /// Emits `model://status` events for each phase transition so the frontend
 /// can update the status bar.
-#[tauri::command]
+///
 /// Returns `true` if the inference engine was (re-)installed, meaning existing
 /// sessions were dropped and the caller must create a new session.
 /// Returns `false` if the model was already loaded and the engine is unchanged.
+#[tauri::command]
 pub async fn ensure_model_ready(
     model_id: String,
     app: AppHandle,

--- a/packages/desktop-app/src-tauri/src/tests.rs
+++ b/packages/desktop-app/src-tauri/src/tests.rs
@@ -301,6 +301,13 @@ mod nodespace_tests {
 
     /// Verify that reset_to_noop_engine called from a dedicated thread (the pattern
     /// used in release_gpu_resources) works correctly without panicking.
+    ///
+    /// This test uses `new_current_thread` to build a throwaway Tokio runtime on a
+    /// spawned OS thread, mirroring the production `release_gpu_resources` path which
+    /// calls `tauri::async_runtime::block_on` from a dedicated thread. Both drive a
+    /// single-threaded executor; the only difference is who owns the runtime. The
+    /// behaviour under test (no nested-runtime panic, correct lock ordering) is
+    /// identical in both cases.
     #[test]
     fn test_reset_to_noop_engine_from_dedicated_thread() {
         use crate::app_services::AppServices;

--- a/packages/desktop-app/src-tauri/tests/agent_e2e.rs
+++ b/packages/desktop-app/src-tauri/tests/agent_e2e.rs
@@ -2253,6 +2253,44 @@ fn skill_test_executor() -> MockToolExecutor {
     MockToolExecutor { tools, results }
 }
 
+/// Extract tool_whitelist from a skill NodeTemplate's root_properties.
+fn tmpl_tool_whitelist(
+    tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
+) -> Vec<String> {
+    tmpl.root_properties
+        .get("tool_whitelist")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Extract max_iterations from a skill NodeTemplate's root_properties.
+fn tmpl_max_iterations(
+    tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
+) -> usize {
+    tmpl.root_properties
+        .get("max_iterations")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize
+}
+
+/// Build a Node from a NodeTemplate using prepare_nodes_from_template.
+fn tmpl_to_node(
+    tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
+) -> nodespace_core::Node {
+    let nodes =
+        nodespace_core::mcp::handlers::markdown::prepare_nodes_from_template(tmpl).unwrap();
+    nodespace_core::Node::new(
+        nodes[0].node_type.clone(),
+        nodes[0].content.clone(),
+        nodes[0].properties.clone(),
+    )
+}
+
 /// Skill pipeline: Research & Search skill scopes to only search tools via MockEngine.
 #[tokio::test]
 async fn skill_pipeline_research_search_scoping() {
@@ -2264,21 +2302,21 @@ async fn skill_pipeline_research_search_scoping() {
     let seeds = SkillPipeline::seed_skill_nodes();
     let skill = seeds
         .iter()
-        .find(|s| s.name == "Research & Search")
+        .find(|s| s.title == "Research & Search")
         .unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "search".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2306,20 +2344,20 @@ async fn skill_pipeline_node_creation_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Node Creation").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Node Creation").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "create".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2347,20 +2385,20 @@ async fn skill_pipeline_schema_creation_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Schema Creation").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Schema Creation").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "create schema".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2384,20 +2422,20 @@ async fn skill_pipeline_graph_editing_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Graph Editing").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Graph Editing").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "update".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2427,21 +2465,21 @@ async fn skill_pipeline_relationship_management_scoping() {
     let seeds = SkillPipeline::seed_skill_nodes();
     let skill = seeds
         .iter()
-        .find(|s| s.name == "Relationship Management")
+        .find(|s| s.title == "Relationship Management")
         .unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "relate".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2469,20 +2507,20 @@ async fn skill_pipeline_node_deletion_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Node Deletion").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Node Deletion").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "delete".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2521,20 +2559,20 @@ async fn skill_pipeline_bulk_import_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Bulk Import").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Bulk Import").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "import".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);
@@ -2565,20 +2603,20 @@ async fn skill_pipeline_organization_scoping() {
 
     let pipeline = Arc::new(SkillPipeline::new(None));
     let seeds = SkillPipeline::seed_skill_nodes();
-    let skill = seeds.iter().find(|s| s.name == "Organization").unwrap();
+    let skill = seeds.iter().find(|s| s.title == "Organization").unwrap();
 
     let executor = Arc::new(skill_test_executor());
     let all_tools = executor.available_tools().await.unwrap();
 
     let skill_match = SkillMatch {
-        skill: skill.to_node(),
+        skill: tmpl_to_node(skill),
         confidence: 0.9,
         intent: ExtractedIntent {
             query: "organize".to_string(),
             from_pattern: true,
         },
-        tool_whitelist: skill.tool_whitelist.clone(),
-        max_iterations: skill.max_iterations,
+        tool_whitelist: tmpl_tool_whitelist(skill),
+        max_iterations: tmpl_max_iterations(skill),
     };
 
     let scoped = pipeline.scope_tools(&all_tools, &skill_match);


### PR DESCRIPTION
## Summary
Addresses retroactive review findings from PR #1098 (issue #1082) and fixes pre-existing e2e test compilation errors:

- **Fix split doc comment on `ensure_model_ready`** — merged both `///` blocks into one contiguous block before `#[tauri::command]` so rustdoc sees the full documentation
- **Add clarifying comment on explicit `drop(guard)`** — explains lock ordering: write lock released before `clear_active_model` acquires the `active_model_id` Mutex
- **Extract `build_noop_service()` helper** — deduplicates no-op `LocalAgentService` construction used in both `ManagedAgentState::new` and `reset_to_noop_engine`
- **Add test runtime doc comment** — explains why the test uses `new_current_thread` while production uses `tauri::async_runtime::block_on`, and why both validate the same behavior
- **Fix agent_e2e skill pipeline tests** — updates 8 tests to use the new `NodeTemplate` API after #1096 refactored the struct (`.name` → `.title`, `.to_node()` → `prepare_nodes_from_template`, whitelist/iterations extracted from `root_properties`)

## Test plan
- [x] `cargo build -p nodespace-app` compiles clean
- [x] `cargo clippy -p nodespace-app --all-targets` passes (was failing on main due to e2e breakage)
- [x] `cargo test -p nodespace-app` — 79 tests pass (25 lib + 52 e2e + 2 schema parity)
- [x] `bun run test` — 3918 frontend tests pass
- [x] Pre-commit quality hook passes (eslint, svelte-check, rustfmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)