### PR TITLE
Feature: search_semantic graph-aware enhancements (closes #1085)

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -1904,17 +1904,16 @@ mod tests {
             "include_archived",
             "node_types",
             "exclude_collections",
+            "collection_id",
+            "property_filters",
+            "include_edges",
+            "graph_boost",
         ];
 
-        // Fields intentionally excluded from the tool schema:
-        // - "collection_id": internal ID form; the LLM should use the human-readable
-        //   "collection" (path) form instead, which resolves to a collection_id.
-        // - "property_filters": the complex key-value JSON structure is too difficult
-        //   for the 8B model to construct reliably. Type-based filtering via
-        //   "node_types" and namespace-based filtering via "collection" cover the
-        //   primary use cases. The field is still wired through exec_search_semantic
-        //   so MCP callers (which can provide well-formed JSON) can use it.
-        let excluded_fields = ["collection_id", "property_filters"];
+        // No fields are currently excluded from the tool schema.
+        // If a field is added to SearchSemanticParams that should NOT be exposed
+        // to the LLM, add it here with a comment explaining why.
+        let excluded_fields: [&str; 0] = [];
 
         for field in &schema_fields {
             assert!(
@@ -1935,5 +1934,39 @@ mod tests {
                 field
             );
         }
+    }
+
+    // -- Scope passthrough test (issue #1085 acceptance criterion) --
+
+    /// Verifies that scope="conversations" is correctly parsed from JSON params
+    /// and would be forwarded to SearchSemanticInput by exec_search_semantic.
+    /// The executor builds SearchSemanticInput { scope: params.scope, ... },
+    /// so correct deserialization guarantees correct forwarding.
+    #[test]
+    fn search_semantic_scope_conversations_passthrough() {
+        let args = json!({
+            "query": "past discussions about architecture",
+            "scope": "conversations"
+        });
+        let params: SearchSemanticParams = serde_json::from_value(args).unwrap();
+        assert_eq!(params.scope, Some("conversations".to_string()));
+
+        // Build the same SearchSemanticInput that exec_search_semantic would
+        let input = nodespace_core::ops::search_ops::SearchSemanticInput {
+            query: params.query.clone(),
+            threshold: Some(params.threshold.unwrap_or(SEMANTIC_THRESHOLD)),
+            limit: Some(params.limit.unwrap_or(DEFAULT_SEMANTIC_LIMIT)),
+            collection_id: params.collection_id,
+            collection: params.collection,
+            exclude_collections: params.exclude_collections,
+            include_markdown: params.include_markdown,
+            include_archived: params.include_archived,
+            scope: params.scope.clone(),
+            node_types: params.node_types,
+            property_filters: params.property_filters,
+            include_edges: params.include_edges,
+            graph_boost: params.graph_boost,
+        };
+        assert_eq!(input.scope, Some("conversations".to_string()));
     }
 }

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -258,6 +258,22 @@ fn def_search_semantic() -> ToolDefinition {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Collection paths to exclude from results (e.g. [\"Archived\", \"Drafts\"]). Useful to narrow results when a collection is noisy."
+                },
+                "collection_id": {
+                    "type": "string",
+                    "description": "Filter by collection ID directly (alternative to collection path)."
+                },
+                "property_filters": {
+                    "type": "object",
+                    "description": "Filter by node properties (AND logic, e.g. {\"status\": \"done\"})"
+                },
+                "include_edges": {
+                    "type": "boolean",
+                    "description": "When true, attach outgoing 'mentions' relationships of each result as an 'edges' array. Reduces round-trips for graph traversal. Default: false."
+                },
+                "graph_boost": {
+                    "type": "boolean",
+                    "description": "When true, re-rank results by blending similarity with graph connectivity (nodes with more relationships score higher). Formula: 0.7 * similarity + 0.3 * normalized_degree. Default: false."
                 }
             },
             "required": ["query"]
@@ -798,8 +814,8 @@ impl GraphToolExecutor {
             // additional scaffolding. Users can achieve type-based filtering
             // via node_types and namespace-based filtering via collection.
             property_filters: params.property_filters,
-            include_edges: None,
-            graph_boost: None,
+            include_edges: params.include_edges,
+            graph_boost: params.graph_boost,
         };
 
         let output = search_ops::search_semantic(&ns, &emb, input)
@@ -828,6 +844,12 @@ impl GraphToolExecutor {
                 if let Some(md) = v.get("markdown").and_then(|v| v.as_str()) {
                     if !md.is_empty() {
                         item["markdown"] = json!(truncate(md, BODY_TRUNCATE_FULL));
+                    }
+                }
+                // Include edge data if the ops layer returned it (include_edges=true)
+                if let Some(edges) = v.get("edges") {
+                    if edges.is_array() {
+                        item["edges"] = edges.clone();
                     }
                 }
                 item

--- a/packages/core/src/mcp/handlers/search.rs
+++ b/packages/core/src/mcp/handlers/search.rs
@@ -99,7 +99,7 @@ pub struct SearchSemanticParams {
 
     /// When true, re-rank results by blending vector similarity with graph connectivity degree.
     /// Blending formula: combined_score = 0.7 * similarity + 0.3 * normalized_degree
-    /// where normalized_degree = outgoing_edge_count / max_outgoing_edge_count_in_result_set
+    /// where normalized_degree = (out_degree + in_degree) / max_degree_in_result_set
     /// Surfaces well-connected, central knowledge nodes over isolated but textually similar ones.
     /// Default: false (pure similarity ranking)
     #[serde(default)]

--- a/packages/core/src/mcp/handlers/search.rs
+++ b/packages/core/src/mcp/handlers/search.rs
@@ -4,91 +4,10 @@
 //! Pure business logic - no Tauri dependencies.
 
 use crate::mcp::types::MCPError;
-use crate::models::Node;
-use crate::services::{
-    CollectionService, NodeEmbeddingService, NodeService, NodeServiceError, SearchNodeFilters,
-    SearchScope,
-};
+use crate::services::{NodeEmbeddingService, NodeService};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-
-/// Maximum depth for markdown tree traversal (prevents stack overflow on deeply nested documents)
-const MARKDOWN_MAX_DEPTH: usize = 20;
-
-/// Recursively build markdown from a node tree
-/// This is a simplified version that produces clean markdown without node ID comments
-fn build_markdown_recursive(
-    node: &Node,
-    node_map: &HashMap<String, Node>,
-    adjacency_list: &HashMap<String, Vec<String>>,
-    output: &mut String,
-    depth: usize,
-    max_depth: usize,
-) {
-    if depth > max_depth {
-        return;
-    }
-
-    // Add node content with appropriate formatting based on type
-    match node.node_type.as_str() {
-        "header" => {
-            output.push_str(&node.content);
-            output.push_str("\n\n");
-        }
-        "text" => {
-            output.push_str(&node.content);
-            output.push_str("\n\n");
-        }
-        "task" => {
-            let status = node
-                .properties
-                .get("status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("todo");
-            let checkbox = if status == "done" { "[x]" } else { "[ ]" };
-            output.push_str(&format!("- {} {}\n", checkbox, node.content));
-        }
-        "code-block" => {
-            let language = node
-                .properties
-                .get("language")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            output.push_str(&format!("```{}\n{}\n```\n\n", language, node.content));
-        }
-        "quote-block" => {
-            for line in node.content.lines() {
-                output.push_str(&format!("> {}\n", line));
-            }
-            output.push('\n');
-        }
-        "ordered-list" => {
-            output.push_str(&format!("1. {}\n", node.content));
-        }
-        _ => {
-            output.push_str(&node.content);
-            output.push_str("\n\n");
-        }
-    }
-
-    // Recursively add children
-    if let Some(child_ids) = adjacency_list.get(&node.id) {
-        for child_id in child_ids {
-            if let Some(child) = node_map.get(child_id) {
-                build_markdown_recursive(
-                    child,
-                    node_map,
-                    adjacency_list,
-                    output,
-                    depth + 1,
-                    max_depth,
-                );
-            }
-        }
-    }
-}
 
 /// Parameters for search_nodes (keyword/title search) method
 #[derive(Debug, Deserialize)]
@@ -209,303 +128,52 @@ pub async fn handle_search_semantic(
     embedding_service: &Arc<NodeEmbeddingService>,
     params: Value,
 ) -> Result<Value, MCPError> {
+    use crate::ops::{search_ops, OpsError};
+
     // Parse parameters
     let params: SearchSemanticParams = serde_json::from_value(params)
         .map_err(|e| MCPError::invalid_params(format!("Invalid parameters: {}", e)))?;
 
-    // Apply defaults (authoritative - schema defaults are client hints only)
-    // These values override any client-side defaults from the JSON schema
-    let threshold = params.threshold.unwrap_or(0.7);
-    let limit = params.limit.unwrap_or(20);
-    let include_markdown = params.include_markdown.unwrap_or(1).min(5); // Default 1, max 5
-    let include_archived = params.include_archived.unwrap_or(false);
-
-    // Parse search scope (Issue #1018) — defaults to Knowledge
-    let scope = match params.scope.as_deref() {
-        Some("conversations") => SearchScope::Conversations,
-        Some("everything") => SearchScope::Everything,
-        Some("knowledge") | None => SearchScope::Knowledge,
-        Some(unknown) => {
-            return Err(MCPError::invalid_params(format!(
-                "Invalid scope '{}'. Valid values: knowledge, conversations, everything",
-                unknown
-            )));
-        }
+    // Delegate all search logic to the shared search_ops layer, which owns the single
+    // canonical implementation of collection resolution, scope/lifecycle filtering,
+    // over-fetching, markdown inlining, include_edges, and graph_boost.
+    let input = search_ops::SearchSemanticInput {
+        query: params.query,
+        threshold: params.threshold,
+        limit: params.limit,
+        collection_id: params.collection_id,
+        collection: params.collection,
+        exclude_collections: params.exclude_collections,
+        include_markdown: params.include_markdown,
+        include_archived: params.include_archived,
+        scope: params.scope,
+        node_types: params.node_types,
+        property_filters: params.property_filters,
+        include_edges: params.include_edges,
+        graph_boost: params.graph_boost,
     };
 
-    // Validate parameters
-    if !(0.0..=1.0).contains(&threshold) {
-        return Err(MCPError::invalid_params(
-            "threshold must be between 0.0 and 1.0".to_string(),
-        ));
-    }
-
-    if limit > 1000 {
-        return Err(MCPError::invalid_params(
-            "limit cannot exceed 1000".to_string(),
-        ));
-    }
-
-    if params.query.trim().is_empty() {
-        return Err(MCPError::invalid_params(
-            "query cannot be empty or whitespace".to_string(),
-        ));
-    }
-
-    // Resolve collection ID and get member IDs if filtering by collection
-    let (collection_id, collection_member_ids): (Option<String>, Option<HashSet<String>>) =
-        if let Some(path) = &params.collection {
-            let collection_service =
-                CollectionService::new(embedding_service.store(), node_service);
-            match collection_service.resolve_path(path).await {
-                Ok(resolved) => {
-                    let coll_id = resolved.leaf_id().to_string();
-                    let members = collection_service
-                        .get_collection_members(&coll_id)
-                        .await
-                        .map_err(|e| {
-                            MCPError::internal_error(format!(
-                                "Failed to get collection members: {}",
-                                e
-                            ))
-                        })?;
-                    // Extract IDs from nodes for membership filtering
-                    (
-                        Some(coll_id),
-                        Some(members.into_iter().map(|n| n.id).collect()),
-                    )
-                }
-                Err(NodeServiceError::CollectionNotFound(_)) => {
-                    // Collection doesn't exist, return empty result
-                    return Ok(json!({
-                        "nodes": [],
-                        "count": 0,
-                        "query": params.query,
-                        "threshold": threshold,
-                        "collection_id": null
-                    }));
-                }
-                Err(e) => {
-                    return Err(MCPError::internal_error(format!(
-                        "Failed to resolve collection path: {}",
-                        e
-                    )))
-                }
-            }
-        } else if let Some(coll_id) = &params.collection_id {
-            let collection_service =
-                CollectionService::new(embedding_service.store(), node_service);
-            let members = collection_service
-                .get_collection_members(coll_id)
-                .await
-                .map_err(|e| {
-                    MCPError::internal_error(format!("Failed to get collection members: {}", e))
-                })?;
-            // Extract IDs from nodes for membership filtering
-            (
-                Some(coll_id.clone()),
-                Some(members.into_iter().map(|n| n.id).collect()),
-            )
-        } else {
-            (None, None)
-        };
-
-    // Resolve excluded collection paths and collect member IDs to exclude
-    let excluded_node_ids: HashSet<String> = if let Some(exclude_paths) =
-        &params.exclude_collections
-    {
-        let collection_service = CollectionService::new(embedding_service.store(), node_service);
-        let mut excluded = HashSet::new();
-
-        for path in exclude_paths {
-            match collection_service.resolve_path(path).await {
-                Ok(resolved) => {
-                    let coll_id = resolved.leaf_id().to_string();
-                    if let Ok(members) = collection_service.get_collection_members(&coll_id).await {
-                        // Extract IDs from nodes for exclusion filtering
-                        excluded.extend(members.into_iter().map(|n| n.id));
-                    }
-                }
-                Err(NodeServiceError::CollectionNotFound(_)) => {
-                    // Collection doesn't exist, skip silently
-                    tracing::debug!("Excluded collection '{}' not found, skipping", path);
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to resolve excluded collection '{}': {}", path, e);
-                }
-            }
-        }
-        excluded
-    } else {
-        HashSet::new()
-    };
-
-    tracing::info!(
-        "Semantic search for: '{}' (scope: {:?})",
-        params.query,
-        scope
-    );
-
-    // Build service-layer filters (Issue #1059): delegating to the service ensures
-    // node_type / property filtering happens before results reach the handler.
-    let search_filters = if params.node_types.is_some() || params.property_filters.is_some() {
-        Some(SearchNodeFilters {
-            node_types: params.node_types.clone(),
-            property_filters: params.property_filters.clone(),
-        })
-    } else {
-        None
-    };
-
-    // When filtering by collection, excluding archived nodes, or applying scope,
-    // fetch more results to compensate for post-filtering.
-    // node_types / property_filters over-fetching is handled inside semantic_search_nodes.
-    let scope_filters = !matches!(scope, SearchScope::Everything);
-    let has_post_filters = collection_member_ids.is_some()
-        || !excluded_node_ids.is_empty()
-        || !include_archived
-        || scope_filters;
-    let effective_limit = if has_post_filters { limit * 3 } else { limit };
-
-    // Call the embedding service with service-layer filters (Issue #1059).
-    let results = embedding_service
-        .semantic_search_nodes(
-            &params.query,
-            effective_limit,
-            threshold,
-            search_filters.as_ref(),
-        )
+    let output = search_ops::search_semantic(node_service, embedding_service, input)
         .await
-        .map_err(|e| {
-            let err_msg = e.to_string();
-
-            // Check for specific error types to provide actionable feedback
-            if err_msg.contains("not initialized") || err_msg.contains("not available") {
-                MCPError::internal_error("Embedding service not ready".to_string())
-            } else if err_msg.contains("no embeddings") || err_msg.contains("not found") {
-                MCPError::invalid_params(
-                    "No content available for semantic search. Try adding content first."
-                        .to_string(),
-                )
-            } else if err_msg.contains("database") || err_msg.contains("Database") {
-                MCPError::internal_error(format!("Database error during search: {}", e))
-            } else {
-                MCPError::internal_error(format!("Search failed: {}", e))
+        .map_err(|e| match e {
+            OpsError::InvalidParams(msg) => MCPError::invalid_params(msg),
+            OpsError::Internal(msg) => MCPError::internal_error(msg),
+            OpsError::NotFound { id } => MCPError::node_not_found(&id),
+            OpsError::ValidationFailed(msg) => MCPError::validation_error(msg),
+            OpsError::VersionConflict { node_id, .. } => {
+                MCPError::internal_error(format!("Version conflict on node {}", node_id))
             }
         })?;
 
-    // Apply remaining post-filters: scope, lifecycle status, collection membership, exclusions.
-    // node_types and property_filters are already applied at the service layer above.
-    let filtered_results: Vec<_> = results
-        .into_iter()
-        .filter(|(node, _)| {
-            // Filter by search scope (Issue #1018)
-            if !NodeEmbeddingService::matches_scope(&node.node_type, &scope) {
-                return false;
-            }
-
-            // Filter by lifecycle status (Issue #755)
-            // Always exclude "deleted" nodes, exclude "archived" unless include_archived=true
-            let status = &node.lifecycle_status;
-            if status == "deleted" {
-                return false;
-            }
-            if status == "archived" && !include_archived {
-                return false;
-            }
-
-            // If include filter is specified, node must be in the collection
-            if let Some(ref member_ids) = collection_member_ids {
-                if !member_ids.contains(&node.id) {
-                    return false;
-                }
-            }
-            // Exclude nodes in excluded collections
-            if excluded_node_ids.contains(&node.id) {
-                return false;
-            }
-
-            true
-        })
-        .take(limit)
-        .collect();
-
-    // Fetch markdown for top N results if requested
-    // This saves AI agents from needing to call get_markdown_from_node_id separately
-    let mut markdown_contents: HashMap<String, String> = HashMap::new();
-
-    if include_markdown > 0 {
-        for (node, _) in filtered_results.iter().take(include_markdown) {
-            // Use get_subtree_data to fetch the full document tree (same as get_markdown_from_node_id)
-            if let Ok((Some(root_node), node_map, adjacency_list)) =
-                node_service.get_subtree_data(&node.id).await
-            {
-                // Build markdown from the tree (simplified version without node IDs for readability)
-                let mut markdown = String::new();
-                markdown.push_str(&root_node.content);
-                markdown.push_str("\n\n");
-
-                // Export children recursively
-                if let Some(child_ids) = adjacency_list.get(&root_node.id) {
-                    for child_id in child_ids {
-                        if let Some(child) = node_map.get(child_id) {
-                            build_markdown_recursive(
-                                child,
-                                &node_map,
-                                &adjacency_list,
-                                &mut markdown,
-                                0,
-                                MARKDOWN_MAX_DEPTH,
-                            );
-                        }
-                    }
-                }
-
-                markdown_contents.insert(node.id.clone(), markdown.trim().to_string());
-            }
-        }
-    }
-
-    // Transform results into JSON-serializable format
-    let nodes: Vec<Value> = filtered_results
-        .iter()
-        .enumerate()
-        .map(|(idx, (node, similarity))| {
-            let mut node_json = json!({
-                "id": node.id,
-                "nodeType": node.node_type,
-                "content": node.content,
-                "title": node.title,
-                "version": node.version,
-                "createdAt": node.created_at,
-                "modifiedAt": node.modified_at,
-                "properties": node.properties,
-                "similarity": similarity
-            });
-
-            // Include markdown for top N results
-            if idx < include_markdown {
-                if let Some(markdown) = markdown_contents.get(&node.id) {
-                    node_json["markdown"] = json!(markdown);
-                }
-            }
-
-            node_json
-        })
-        .collect();
-
-    // Return results with metadata
     Ok(json!({
-        "nodes": nodes,
-        "count": nodes.len(),
-        "query": params.query,
-        "threshold": threshold,
-        "collection_id": collection_id,
-        "include_markdown": include_markdown,
-        "include_archived": include_archived,
-        "scope": format!("{:?}", scope),
-        "node_types": params.node_types,
-        "property_filters": params.property_filters
+        "nodes": output.nodes,
+        "count": output.count,
+        "query": output.query,
+        "threshold": output.threshold,
+        "collection_id": output.collection_id,
+        "include_markdown": output.include_markdown,
+        "include_archived": output.include_archived,
+        "scope": output.scope,
     }))
 }
 
@@ -1097,5 +765,53 @@ mod search_tests {
         assert!(mock_response.get("node_types").is_some());
         assert!(mock_response.get("property_filters").is_some());
         assert_eq!(mock_response["node_types"], json!(["task"]));
+    }
+
+    // include_edges tests
+
+    #[test]
+    fn test_include_edges_param_default_none() {
+        let params = json!({ "query": "test" });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert!(parsed.include_edges.is_none());
+        assert!(!parsed.include_edges.unwrap_or(false));
+    }
+
+    #[test]
+    fn test_include_edges_param_explicit_true() {
+        let params = json!({ "query": "test", "include_edges": true });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert_eq!(parsed.include_edges, Some(true));
+    }
+
+    #[test]
+    fn test_include_edges_param_explicit_false() {
+        let params = json!({ "query": "test", "include_edges": false });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert_eq!(parsed.include_edges, Some(false));
+    }
+
+    // graph_boost tests
+
+    #[test]
+    fn test_graph_boost_param_default_none() {
+        let params = json!({ "query": "test" });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert!(parsed.graph_boost.is_none());
+        assert!(!parsed.graph_boost.unwrap_or(false));
+    }
+
+    #[test]
+    fn test_graph_boost_param_explicit_true() {
+        let params = json!({ "query": "test", "graph_boost": true });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert_eq!(parsed.graph_boost, Some(true));
+    }
+
+    #[test]
+    fn test_graph_boost_param_explicit_false() {
+        let params = json!({ "query": "test", "graph_boost": false });
+        let parsed: SearchSemanticParams = serde_json::from_value(params).unwrap();
+        assert_eq!(parsed.graph_boost, Some(false));
     }
 }

--- a/packages/core/src/mcp/handlers/tools.rs
+++ b/packages/core/src/mcp/handlers/tools.rs
@@ -1031,6 +1031,16 @@ fn get_tool_schemas(schemas: &[SchemaNode]) -> Value {
                     "property_filters": {
                         "type": "object",
                         "description": "Filter by node properties using key-value pairs. Only nodes whose properties contain all specified key-value pairs (AND logic) will be included. Example: {'status': 'done', 'priority': 'high'}"
+                    },
+                    "include_edges": {
+                        "type": "boolean",
+                        "description": "When true, attach outgoing 'mentions' relationships of each result node as an 'edges' array. Reduces round-trips for graph traversal. Default: false.",
+                        "default": false
+                    },
+                    "graph_boost": {
+                        "type": "boolean",
+                        "description": "When true, re-rank results by blending similarity with graph connectivity. Nodes with more 'mentions' relationships score higher. Formula: 0.7 * similarity + 0.3 * normalized_degree. Default: false.",
+                        "default": false
                     }
                 },
                 "required": ["query"]

--- a/packages/core/src/ops/search_ops.rs
+++ b/packages/core/src/ops/search_ops.rs
@@ -44,7 +44,7 @@ pub struct SearchSemanticInput {
 
     /// When true, re-rank results by blending vector similarity with graph connectivity degree.
     /// Blending formula: combined_score = 0.7 * similarity + 0.3 * normalized_degree
-    /// where normalized_degree = outgoing_edge_count / max_outgoing_edge_count_in_result_set
+    /// where normalized_degree = (out_degree + in_degree) / max_degree_in_result_set
     /// Surfaces well-connected, central knowledge nodes over isolated but textually similar ones.
     /// Default: false (pure similarity ranking)
     pub graph_boost: Option<bool>,
@@ -342,6 +342,19 @@ pub async fn search_semantic(
         .take(limit)
         .collect();
 
+    // Pre-fetch outgoing "mentions" edges when needed by graph_boost or include_edges.
+    // Cache them to avoid redundant DB round-trips when both features are enabled.
+    let mut outgoing_edges_cache: HashMap<String, Vec<Node>> = HashMap::new();
+    if graph_boost || include_edges {
+        for (node, _) in &filtered_results {
+            let related = node_service
+                .get_related_nodes(&node.id, "mentions", "out")
+                .await
+                .unwrap_or_default();
+            outgoing_edges_cache.insert(node.id.clone(), related);
+        }
+    }
+
     // graph_boost: re-rank by blending similarity with normalized edge degree.
     //
     // Formula: combined_score = 0.7 * similarity + 0.3 * normalized_degree
@@ -352,9 +365,8 @@ pub async fn search_semantic(
     let filtered_results: Vec<(Node, f64)> = if graph_boost && !filtered_results.is_empty() {
         let mut degrees: HashMap<String, usize> = HashMap::new();
         for (node, _) in &filtered_results {
-            let out_count = node_service
-                .get_related_nodes(&node.id, "mentions", "out")
-                .await
+            let out_count = outgoing_edges_cache
+                .get(&node.id)
                 .map(|v| v.len())
                 .unwrap_or(0);
             let in_count = node_service
@@ -384,14 +396,11 @@ pub async fn search_semantic(
         filtered_results
     };
 
-    // include_edges: fetch outgoing "mentions" relationships for all result nodes.
+    // include_edges: build edge data from cached outgoing relationships.
     let mut edges_map: HashMap<String, Vec<Value>> = HashMap::new();
     if include_edges {
         for (node, _) in &filtered_results {
-            let related = node_service
-                .get_related_nodes(&node.id, "mentions", "out")
-                .await
-                .unwrap_or_default();
+            let related = outgoing_edges_cache.remove(&node.id).unwrap_or_default();
 
             let edges: Vec<Value> = related
                 .into_iter()

--- a/packages/core/src/ops/search_ops.rs
+++ b/packages/core/src/ops/search_ops.rs
@@ -153,7 +153,7 @@ fn parse_scope(scope: Option<&str>) -> Result<SearchScope, OpsError> {
 // ============================================================================
 
 /// Semantic search with collection resolution, scope/lifecycle filtering,
-/// over-fetching, and optional markdown inlining for top results.
+/// over-fetching, optional markdown inlining, edge attachment, and graph boost re-ranking.
 pub async fn search_semantic(
     node_service: &Arc<NodeService>,
     embedding_service: &Arc<NodeEmbeddingService>,
@@ -164,6 +164,8 @@ pub async fn search_semantic(
     let limit = input.limit.unwrap_or(20);
     let include_markdown = input.include_markdown.unwrap_or(1).min(5);
     let include_archived = input.include_archived.unwrap_or(false);
+    let include_edges = input.include_edges.unwrap_or(false);
+    let graph_boost = input.graph_boost.unwrap_or(false);
     let scope = parse_scope(input.scope.as_deref())?;
 
     // Validate
@@ -340,6 +342,72 @@ pub async fn search_semantic(
         .take(limit)
         .collect();
 
+    // graph_boost: re-rank by blending similarity with normalized edge degree.
+    //
+    // Formula: combined_score = 0.7 * similarity + 0.3 * normalized_degree
+    //
+    // Degree is (out_degree + in_degree) counted over "mentions" relationships only.
+    // Degrees are normalized to [0, 1] within the result set so that the boost is
+    // relative — a node only benefits when it is more connected than its peers.
+    let filtered_results: Vec<(Node, f64)> = if graph_boost && !filtered_results.is_empty() {
+        let mut degrees: HashMap<String, usize> = HashMap::new();
+        for (node, _) in &filtered_results {
+            let out_count = node_service
+                .get_related_nodes(&node.id, "mentions", "out")
+                .await
+                .map(|v| v.len())
+                .unwrap_or(0);
+            let in_count = node_service
+                .get_related_nodes(&node.id, "mentions", "in")
+                .await
+                .map(|v| v.len())
+                .unwrap_or(0);
+            degrees.insert(node.id.clone(), out_count + in_count);
+        }
+
+        let max_degree = degrees.values().copied().max().unwrap_or(1).max(1);
+
+        let mut boosted: Vec<(Node, f64)> = filtered_results
+            .into_iter()
+            .map(|(node, similarity)| {
+                let degree = degrees.get(&node.id).copied().unwrap_or(0);
+                let normalized_degree = degree as f64 / max_degree as f64;
+                let combined = 0.7 * similarity + 0.3 * normalized_degree;
+                (node, combined)
+            })
+            .collect();
+
+        boosted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        boosted.truncate(limit);
+        boosted
+    } else {
+        filtered_results
+    };
+
+    // include_edges: fetch outgoing "mentions" relationships for all result nodes.
+    let mut edges_map: HashMap<String, Vec<Value>> = HashMap::new();
+    if include_edges {
+        for (node, _) in &filtered_results {
+            let related = node_service
+                .get_related_nodes(&node.id, "mentions", "out")
+                .await
+                .unwrap_or_default();
+
+            let edges: Vec<Value> = related
+                .into_iter()
+                .map(|target| {
+                    json!({
+                        "relationship": "mentions",
+                        "target_id": target.id,
+                        "target_title": target.title
+                    })
+                })
+                .collect();
+
+            edges_map.insert(node.id.clone(), edges);
+        }
+    }
+
     // Fetch markdown for top N results
     let mut markdown_contents: HashMap<String, String> = HashMap::new();
     if include_markdown > 0 {
@@ -394,6 +462,11 @@ pub async fn search_semantic(
                 }
             }
 
+            if include_edges {
+                let edges = edges_map.get(&node.id).cloned().unwrap_or_default();
+                node_json["edges"] = json!(edges);
+            }
+
             node_json
         })
         .collect();
@@ -437,5 +510,73 @@ mod tests {
     fn test_parse_scope_invalid() {
         let err = parse_scope(Some("bogus")).unwrap_err();
         assert!(matches!(err, OpsError::InvalidParams(_)));
+    }
+
+    /// Verify that graph_boost re-ranking formula correctly promotes well-connected nodes.
+    ///
+    /// Setup: Node A has similarity=0.9 and degree=0, Node B has similarity=0.6 and degree=5.
+    /// Without boost A ranks first. With boost:
+    ///   A: 0.7 * 0.9 + 0.3 * 0.0 = 0.63
+    ///   B: 0.7 * 0.6 + 0.3 * 1.0 = 0.72  (normalized_degree = 5/5 = 1.0)
+    /// So B should rank first after boosting.
+    #[test]
+    fn test_graph_boost_reranking_formula() {
+        let high_similarity: f64 = 0.9;
+        let low_similarity: f64 = 0.6;
+
+        let max_degree: usize = 5;
+        let degree_a: usize = 0;
+        let degree_b: usize = 5;
+
+        let norm_a = degree_a as f64 / max_degree as f64;
+        let norm_b = degree_b as f64 / max_degree as f64;
+
+        let combined_a = 0.7 * high_similarity + 0.3 * norm_a;
+        let combined_b = 0.7 * low_similarity + 0.3 * norm_b;
+
+        assert!(
+            combined_b > combined_a,
+            "graph_boost should promote well-connected node B ({combined_b}) above high-similarity node A ({combined_a})"
+        );
+    }
+
+    #[test]
+    fn test_include_edges_defaults_false() {
+        let input = SearchSemanticInput {
+            query: "test".to_string(),
+            threshold: None,
+            limit: None,
+            collection_id: None,
+            collection: None,
+            exclude_collections: None,
+            include_markdown: None,
+            include_archived: None,
+            scope: None,
+            node_types: None,
+            property_filters: None,
+            include_edges: None,
+            graph_boost: None,
+        };
+        assert!(!input.include_edges.unwrap_or(false));
+    }
+
+    #[test]
+    fn test_graph_boost_defaults_false() {
+        let input = SearchSemanticInput {
+            query: "test".to_string(),
+            threshold: None,
+            limit: None,
+            collection_id: None,
+            collection: None,
+            exclude_collections: None,
+            include_markdown: None,
+            include_archived: None,
+            scope: None,
+            node_types: None,
+            property_filters: None,
+            include_edges: None,
+            graph_boost: None,
+        };
+        assert!(!input.graph_boost.unwrap_or(false));
     }
 }


### PR DESCRIPTION
## Summary
Closes #1085 - Exposes missing opt-in parameters in the local agent's `search_semantic` tool and adds graph-aware search enhancements (`include_edges`, `graph_boost`) to both MCP and local agent paths.

### Changes

**Gap 1+2: Local agent tool schema parity**
- Exposes all `SearchSemanticParams` fields in the local agent tool definition: `threshold`, `exclude_collections`, `include_archived`, `scope`, `node_types`, `collection_id`, `property_filters`, `include_edges`, `graph_boost`
- `exec_search_semantic` now forwards all params to `search_ops` instead of hardcoding `None`

**Gap 3: Graph-aware enhancements (both paths)**
- **`include_edges`** (bool, default: false) — Attaches outgoing "mentions" relationships as an `edges` array on each result node. Reduces round-trips for graph traversal queries.
- **`graph_boost`** (bool, default: false) — Re-ranks results by blending similarity with graph connectivity: `combined_score = 0.7 * similarity + 0.3 * normalized_degree`. Surfaces well-connected central knowledge nodes over isolated but textually similar ones.

**Deduplication: MCP handler delegates to search_ops**
- `handle_search_semantic` in `search.rs` now delegates entirely to the shared `search_ops::search_semantic` layer, removing ~250 lines of duplicated collection resolution, scope filtering, lifecycle filtering, over-fetching, and markdown inlining logic.

### Files changed
- `packages/core/src/ops/search_ops.rs` — Core implementation: graph_boost re-ranking, include_edges attachment, new unit tests
- `packages/core/src/mcp/handlers/search.rs` — Replaced duplicated logic with delegation to search_ops; added param parsing tests
- `packages/core/src/mcp/handlers/tools.rs` — Added include_edges/graph_boost to MCP tool schema
- `packages/agent/src/local_agent/tools.rs` — Full param schema + forwarding in executor

## Test plan
- [x] `cargo test -p nodespace-core search` — 82 tests pass (52 unit + 23 integration + 7 embedding)
- [x] `cargo clippy -p nodespace-core -p nodespace-agent` — clean
- [x] `bun run test` — 3918 frontend tests pass
- [x] Pre-commit quality hook passes (eslint, svelte-check, rustfmt, clippy)
- [x] Unit tests for graph_boost formula, include_edges/graph_boost defaults
- [x] Param parsing tests for include_edges and graph_boost (true/false/default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)