### PR TITLE
Unify search_semantic params: complete prompt/skill guidance (closes #1086)

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -808,11 +808,9 @@ impl GraphToolExecutor {
             include_archived: params.include_archived,
             scope: params.scope,
             node_types: params.node_types,
-            // property_filters is intentionally omitted from the tool schema:
-            // the complex filter structure (arbitrary key-value JSON object) is
-            // too difficult for the 8B model to construct reliably without
-            // additional scaffolding. Users can achieve type-based filtering
-            // via node_types and namespace-based filtering via collection.
+            // property_filters is exposed in the tool schema as a simple object.
+            // The 8B model may struggle with complex filter structures, but simple
+            // key-value pairs (e.g. {"status": "done"}) work well enough.
             property_filters: params.property_filters,
             include_edges: params.include_edges,
             graph_boost: params.graph_boost,

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -322,7 +322,7 @@ impl PromptAssembler {
                     - To find nodes by exact title or keyword (when you know the name): use search_nodes with query=<keyword>. To filter by type (e.g. \"show all tasks\"), pass node_type=\"task\" with query=\"\". To filter by property (e.g. \"open tasks\"), pass filters={\"status\":\"open\"}.\n\
                     - To find nodes by meaning/topic (when the exact name is unknown): use search_semantic (natural language query)\n\
                     - search_semantic results are ordered by relevance. Each result has: id, title, score (0-1), snippet, and optionally markdown (full content).\n\
-                    - search_semantic parameters: use 'collection' to scope to a namespace/folder, 'node_types' to filter by type (e.g. [\"task\"]), 'scope'='conversations' to search chat history, 'threshold' to tune precision (lower = broader recall), 'include_archived'=true to include archived content.\n\
+                    - search_semantic parameters: use 'collection' to scope to a namespace/folder, 'node_types' to filter by type (e.g. [\"task\"]), 'scope'='conversations' to search chat history, 'threshold' to tune precision (lower = broader recall), 'include_archived'=true to include archived content, 'exclude_collections' to suppress noisy collections, 'include_edges'=true to get relationship data with results, 'graph_boost'=true to rank well-connected nodes higher.\n\
                     - If a search_semantic result has a non-empty 'markdown' field, that IS the full document — summarize from it directly. Only call get_node for results that lack markdown.\n\
                     - To get full content for a known node ID: use get_node with format=markdown.\n\
                     - To find what nodes are connected to a node: use get_related_nodes with the node ID.\n\
@@ -411,7 +411,6 @@ impl PromptAssembler {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,7 +422,11 @@ mod tests {
 
         for seed in &seeds {
             let body = seed.content.as_deref().unwrap_or(&seed.markdown_content);
-            assert!(!body.is_empty(), "Seed '{}' content must not be empty", seed.title);
+            assert!(
+                !body.is_empty(),
+                "Seed '{}' content must not be empty",
+                seed.title
+            );
             assert!(!seed.title.is_empty(), "Seed title must not be empty");
             assert_eq!(seed.root_node_type, "prompt");
             assert_eq!(
@@ -449,11 +452,19 @@ mod tests {
         let seeds = PromptAssembler::seed_prompt_nodes();
         let priorities: Vec<i64> = seeds
             .iter()
-            .map(|s| s.root_properties.get("priority").and_then(|v| v.as_i64()).unwrap_or(0))
+            .map(|s| {
+                s.root_properties
+                    .get("priority")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0)
+            })
             .collect();
         let mut sorted = priorities.clone();
         sorted.sort();
-        assert_eq!(priorities, sorted, "Seed prompts should be in priority order");
+        assert_eq!(
+            priorities, sorted,
+            "Seed prompts should be in priority order"
+        );
     }
 
     #[test]

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -247,6 +247,9 @@ PARAMETER GUIDANCE:
 - Use 'threshold' to tune precision: default 0.3. Lower to 0.1-0.2 for broader recall when results are sparse.
 - Use 'include_archived'=true only when the user explicitly asks for archived or historical content.
 - Use 'exclude_collections' to suppress noisy collections (e.g. exclude_collections=["Archived"]).
+- Use 'include_edges'=true to get relationship data (outgoing 'mentions' edges) with each result — saves a separate get_related_nodes call.
+- Use 'graph_boost'=true to rank well-connected nodes higher (blends similarity with graph connectivity). Useful when the user wants the most referenced/central node on a topic.
+- Use 'property_filters' for simple key-value filtering (e.g. property_filters={"status": "done"}). Prefer 'node_types' for type filtering.
 
 MULTIPLE DOCUMENTS: If the user asks about multiple topics, call search_semantic once per topic rather than searching broadly and fetching each result individually.
 
@@ -462,7 +465,6 @@ fn extract_tool_whitelist(node: &Node) -> Vec<String> {
         .unwrap_or_default()
 }
 
-
 #[cfg(test)]
 mod tests {
     use nodespace_core::mcp::handlers::markdown::prepare_nodes_from_template;
@@ -553,7 +555,11 @@ mod tests {
         for seed in &seeds {
             let nodes = prepare_nodes_from_template(seed)
                 .unwrap_or_else(|e| panic!("Template '{}' failed: {:?}", seed.title, e));
-            assert!(!nodes.is_empty(), "Template '{}' produced no nodes", seed.title);
+            assert!(
+                !nodes.is_empty(),
+                "Template '{}' produced no nodes",
+                seed.title
+            );
             let root = &nodes[0];
             assert_eq!(root.node_type, "skill");
             assert_eq!(root.id.len(), 36, "Node ID should be a UUID");
@@ -564,7 +570,11 @@ mod tests {
                 .properties
                 .get("tool_whitelist")
                 .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect::<Vec<_>>())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect::<Vec<_>>()
+                })
                 .unwrap_or_default();
             assert_eq!(whitelist, tmpl_tool_whitelist(seed));
         }


### PR DESCRIPTION
## Summary
- Fix stale code comment claiming property_filters was "intentionally omitted from tool schema" — it is now exposed
- Add `include_edges`, `graph_boost`, `exclude_collections`, and `property_filters` to the Tool Strategy Guide prompt
- Add `include_edges`, `graph_boost`, and `property_filters` guidance to the Research & Search skill definition

Most of #1086's acceptance criteria were already addressed by #1085 (PR #1101). This PR completes the remaining prompt/skill documentation items.

## Acceptance Criteria Status (from #1086)
- [x] All SearchSemanticParams fields wired through exec_search_semantic (done in #1085)
- [x] def_search_semantic() tool schema exposes all params (done in #1085)
- [x] property_filters inclusion documented in code comment (this PR - fixed stale comment)
- [x] Prompt and skill guidance updated with new params (this PR)
- [x] Parity test added (done in #1085)
- [x] Existing tests pass (290 agent lib tests pass)
- [x] Forward-compatible with #1085 (already integrated)

## Test plan
- [x] `cargo build -p nodespace-agent` clean
- [x] `cargo clippy` clean with `-D warnings -D clippy::unused-async`
- [x] 290 agent lib tests pass
- [x] Pre-commit quality hook passes

Closes #1086

Co-Authored-By: Claude <noreply@anthropic.com>