### PR TITLE
Fix: unify search_semantic params - wire all fields through local agent tool (#1086)

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -259,10 +259,6 @@ fn def_search_semantic() -> ToolDefinition {
                     "items": { "type": "string" },
                     "description": "Collection paths to exclude from results (e.g. [\"Archived\", \"Drafts\"]). Useful to narrow results when a collection is noisy."
                 },
-                "collection_id": {
-                    "type": "string",
-                    "description": "Filter by collection ID directly (alternative to collection path)."
-                },
                 "property_filters": {
                     "type": "object",
                     "description": "Filter by node properties (AND logic, e.g. {\"status\": \"done\"})"
@@ -1902,16 +1898,16 @@ mod tests {
             "include_archived",
             "node_types",
             "exclude_collections",
-            "collection_id",
             "property_filters",
             "include_edges",
             "graph_boost",
         ];
 
-        // No fields are currently excluded from the tool schema.
-        // If a field is added to SearchSemanticParams that should NOT be exposed
-        // to the LLM, add it here with a comment explaining why.
-        let excluded_fields: [&str; 0] = [];
+        // Fields intentionally excluded from the tool schema:
+        // - "collection_id": internal ID form; the LLM should use the human-readable
+        //   "collection" (path) form instead, which resolves to a collection_id server-side.
+        //   Still wired through exec_search_semantic for MCP clients that know the ID.
+        let excluded_fields = ["collection_id"];
 
         for field in &schema_fields {
             assert!(

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -808,11 +808,9 @@ impl GraphToolExecutor {
             include_archived: params.include_archived,
             scope: params.scope,
             node_types: params.node_types,
-            // property_filters is intentionally omitted from the tool schema:
-            // the complex filter structure (arbitrary key-value JSON object) is
-            // too difficult for the 8B model to construct reliably without
-            // additional scaffolding. Users can achieve type-based filtering
-            // via node_types and namespace-based filtering via collection.
+            // property_filters is exposed in the tool schema as a simple object.
+            // The 8B model may struggle with complex filter structures, but simple
+            // key-value pairs (e.g. {"status": "done"}) work well enough.
             property_filters: params.property_filters,
             include_edges: params.include_edges,
             graph_boost: params.graph_boost,

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -322,7 +322,7 @@ impl PromptAssembler {
                     - To find nodes by exact title or keyword (when you know the name): use search_nodes with query=<keyword>. To filter by type (e.g. \"show all tasks\"), pass node_type=\"task\" with query=\"\". To filter by property (e.g. \"open tasks\"), pass filters={\"status\":\"open\"}.\n\
                     - To find nodes by meaning/topic (when the exact name is unknown): use search_semantic (natural language query)\n\
                     - search_semantic results are ordered by relevance. Each result has: id, title, score (0-1), snippet, and optionally markdown (full content).\n\
-                    - search_semantic parameters: use 'collection' to scope to a namespace/folder, 'node_types' to filter by type (e.g. [\"task\"]), 'scope'='conversations' to search chat history, 'threshold' to tune precision (lower = broader recall), 'include_archived'=true to include archived content.\n\
+                    - search_semantic parameters: use 'collection' to scope to a namespace/folder, 'node_types' to filter by type (e.g. [\"task\"]), 'scope'='conversations' to search chat history, 'threshold' to tune precision (lower = broader recall), 'include_archived'=true to include archived content, 'exclude_collections' to suppress noisy collections, 'include_edges'=true to get relationship data with results, 'graph_boost'=true to rank well-connected nodes higher.\n\
                     - If a search_semantic result has a non-empty 'markdown' field, that IS the full document — summarize from it directly. Only call get_node for results that lack markdown.\n\
                     - To get full content for a known node ID: use get_node with format=markdown.\n\
                     - To find what nodes are connected to a node: use get_related_nodes with the node ID.\n\
@@ -411,7 +411,6 @@ impl PromptAssembler {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,7 +422,11 @@ mod tests {
 
         for seed in &seeds {
             let body = seed.content.as_deref().unwrap_or(&seed.markdown_content);
-            assert!(!body.is_empty(), "Seed '{}' content must not be empty", seed.title);
+            assert!(
+                !body.is_empty(),
+                "Seed '{}' content must not be empty",
+                seed.title
+            );
             assert!(!seed.title.is_empty(), "Seed title must not be empty");
             assert_eq!(seed.root_node_type, "prompt");
             assert_eq!(
@@ -449,11 +452,19 @@ mod tests {
         let seeds = PromptAssembler::seed_prompt_nodes();
         let priorities: Vec<i64> = seeds
             .iter()
-            .map(|s| s.root_properties.get("priority").and_then(|v| v.as_i64()).unwrap_or(0))
+            .map(|s| {
+                s.root_properties
+                    .get("priority")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0)
+            })
             .collect();
         let mut sorted = priorities.clone();
         sorted.sort();
-        assert_eq!(priorities, sorted, "Seed prompts should be in priority order");
+        assert_eq!(
+            priorities, sorted,
+            "Seed prompts should be in priority order"
+        );
     }
 
     #[test]

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -247,6 +247,9 @@ PARAMETER GUIDANCE:
 - Use 'threshold' to tune precision: default 0.3. Lower to 0.1-0.2 for broader recall when results are sparse.
 - Use 'include_archived'=true only when the user explicitly asks for archived or historical content.
 - Use 'exclude_collections' to suppress noisy collections (e.g. exclude_collections=["Archived"]).
+- Use 'include_edges'=true to get relationship data (outgoing 'mentions' edges) with each result — saves a separate get_related_nodes call.
+- Use 'graph_boost'=true to rank well-connected nodes higher (blends similarity with graph connectivity). Useful when the user wants the most referenced/central node on a topic.
+- Use 'property_filters' for simple key-value filtering (e.g. property_filters={"status": "done"}). Prefer 'node_types' for type filtering.
 
 MULTIPLE DOCUMENTS: If the user asks about multiple topics, call search_semantic once per topic rather than searching broadly and fetching each result individually.
 
@@ -462,7 +465,6 @@ fn extract_tool_whitelist(node: &Node) -> Vec<String> {
         .unwrap_or_default()
 }
 
-
 #[cfg(test)]
 mod tests {
     use nodespace_core::mcp::handlers::markdown::prepare_nodes_from_template;
@@ -553,7 +555,11 @@ mod tests {
         for seed in &seeds {
             let nodes = prepare_nodes_from_template(seed)
                 .unwrap_or_else(|e| panic!("Template '{}' failed: {:?}", seed.title, e));
-            assert!(!nodes.is_empty(), "Template '{}' produced no nodes", seed.title);
+            assert!(
+                !nodes.is_empty(),
+                "Template '{}' produced no nodes",
+                seed.title
+            );
             let root = &nodes[0];
             assert_eq!(root.node_type, "skill");
             assert_eq!(root.id.len(), 36, "Node ID should be a UUID");
@@ -564,7 +570,11 @@ mod tests {
                 .properties
                 .get("tool_whitelist")
                 .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect::<Vec<_>>())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect::<Vec<_>>()
+                })
                 .unwrap_or_default();
             assert_eq!(whitelist, tmpl_tool_whitelist(seed));
         }

--- a/packages/agent/tests/ollama_integration.rs
+++ b/packages/agent/tests/ollama_integration.rs
@@ -347,7 +347,11 @@ fn tools_for_skill(skill_name: &str, all_tools: &[ToolDefinition]) -> Vec<ToolDe
         .root_properties
         .get("tool_whitelist")
         .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
         .unwrap_or_default();
 
     all_tools

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -962,8 +962,7 @@ impl NodeService {
             .map(|n| n.node_type.clone())
             .collect();
 
-        let mut seeded_types: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut seeded_types: std::collections::HashSet<String> = std::collections::HashSet::new();
         for node_type in &root_types {
             let filter = crate::models::NodeFilter {
                 node_type: Some(node_type.clone()),
@@ -1004,20 +1003,26 @@ impl NodeService {
             // Insert children via bulk_create_hierarchy (single transaction).
             let children = &group[1..];
             if !children.is_empty() {
-                let bulk_nodes: Vec<(String, String, String, Option<String>, f64, serde_json::Value)> =
-                    children
-                        .iter()
-                        .map(|n| {
-                            (
-                                n.id.clone(),
-                                n.node_type.clone(),
-                                n.content.clone(),
-                                n.parent_id.clone(),
-                                n.order,
-                                n.properties.clone(),
-                            )
-                        })
-                        .collect();
+                let bulk_nodes: Vec<(
+                    String,
+                    String,
+                    String,
+                    Option<String>,
+                    f64,
+                    serde_json::Value,
+                )> = children
+                    .iter()
+                    .map(|n| {
+                        (
+                            n.id.clone(),
+                            n.node_type.clone(),
+                            n.content.clone(),
+                            n.parent_id.clone(),
+                            n.order,
+                            n.properties.clone(),
+                        )
+                    })
+                    .collect();
                 self.bulk_create_hierarchy(bulk_nodes).await?;
                 created_children += children.len() as u32;
             }

--- a/packages/desktop-app/src-tauri/src/commands/db.rs
+++ b/packages/desktop-app/src-tauri/src/commands/db.rs
@@ -71,15 +71,22 @@ pub(crate) async fn create_service_bundle(
         let skill_templates = SkillPipeline::seed_skill_nodes();
 
         // Expand all templates into PreparedNode lists.
-        let mut all_template_nodes: Vec<Vec<nodespace_core::mcp::handlers::markdown::PreparedNode>> = Vec::new();
+        let mut all_template_nodes: Vec<
+            Vec<nodespace_core::mcp::handlers::markdown::PreparedNode>,
+        > = Vec::new();
         for tmpl in prompt_templates.iter().chain(skill_templates.iter()) {
             match prepare_nodes_from_template(tmpl) {
                 Ok(nodes) => all_template_nodes.push(nodes),
-                Err(e) => tracing::warn!(error = ?e, title = %tmpl.title, "Failed to expand seed template"),
+                Err(e) => {
+                    tracing::warn!(error = ?e, title = %tmpl.title, "Failed to expand seed template")
+                }
             }
         }
 
-        if let Err(e) = node_service.seed_nodes_from_templates(all_template_nodes).await {
+        if let Err(e) = node_service
+            .seed_nodes_from_templates(all_template_nodes)
+            .await
+        {
             tracing::warn!(error = %e, "Failed to seed agent nodes (non-fatal)");
         }
 

--- a/packages/desktop-app/src-tauri/tests/agent_e2e.rs
+++ b/packages/desktop-app/src-tauri/tests/agent_e2e.rs
@@ -2269,9 +2269,7 @@ fn tmpl_tool_whitelist(
 }
 
 /// Extract max_iterations from a skill NodeTemplate's root_properties.
-fn tmpl_max_iterations(
-    tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
-) -> usize {
+fn tmpl_max_iterations(tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate) -> usize {
     tmpl.root_properties
         .get("max_iterations")
         .and_then(|v| v.as_u64())
@@ -2282,8 +2280,7 @@ fn tmpl_max_iterations(
 fn tmpl_to_node(
     tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
 ) -> nodespace_core::Node {
-    let nodes =
-        nodespace_core::mcp::handlers::markdown::prepare_nodes_from_template(tmpl).unwrap();
+    let nodes = nodespace_core::mcp::handlers::markdown::prepare_nodes_from_template(tmpl).unwrap();
     nodespace_core::Node::new(
         nodes[0].node_type.clone(),
         nodes[0].content.clone(),


### PR DESCRIPTION
## Summary
- Wires all SearchSemanticParams fields through exec_search_semantic (no hardcoded None or constant overrides)
- Expands def_search_semantic() tool schema with all LLM-controllable params (threshold, scope, include_archived, node_types, exclude_collections, property_filters, rerank, include_edges, graph_boost)
- Excludes collection_id from tool schema (internal ID — LLM should use human-readable collection path)
- Updates prompt assembler Tool Strategy Guide with new parameter guidance
- Adds parity test asserting all SearchSemanticParams fields are represented in schema or documented as excluded
- Fixes stale comment about property_filters

Supersedes PR #1099 (rebased to include #1085 graph enhancements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)