### PR TITLE
Fix: address review suggestions from PRs #1103 and #1104

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -261,7 +261,8 @@ fn def_search_semantic() -> ToolDefinition {
                 },
                 "property_filters": {
                     "type": "object",
-                    "description": "Filter by node properties (AND logic, e.g. {\"status\": \"done\"})"
+                    "description": "Filter by node properties (AND logic, e.g. {\"status\": \"done\"})",
+                    "additionalProperties": { "type": "string" }
                 },
                 "include_edges": {
                     "type": "boolean",
@@ -1926,6 +1927,17 @@ mod tests {
                 "Field '{}' is in the exclusion list but was found in the schema. \
                  Remove it from excluded_fields if it should be schema-exposed.",
                 field
+            );
+        }
+
+        // Reverse check: every schema property must be in schema_fields or excluded_fields.
+        // This catches schema properties added without updating the parity lists.
+        for key in props.keys() {
+            assert!(
+                schema_fields.contains(&key.as_str()) || excluded_fields.contains(&key.as_str()),
+                "Schema property '{}' is not listed in schema_fields or excluded_fields. \
+                 Add it to one of those lists in this test.",
+                key
             );
         }
     }

--- a/packages/desktop-app/src-tauri/tests/agent_e2e.rs
+++ b/packages/desktop-app/src-tauri/tests/agent_e2e.rs
@@ -2254,6 +2254,7 @@ fn skill_test_executor() -> MockToolExecutor {
 }
 
 /// Extract tool_whitelist from a skill NodeTemplate's root_properties.
+/// Adapter for the NodeTemplate API change in #1096 (fields moved to root_properties).
 fn tmpl_tool_whitelist(
     tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
 ) -> Vec<String> {
@@ -2269,6 +2270,7 @@ fn tmpl_tool_whitelist(
 }
 
 /// Extract max_iterations from a skill NodeTemplate's root_properties.
+/// Adapter for the NodeTemplate API change in #1096 (fields moved to root_properties).
 fn tmpl_max_iterations(tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate) -> usize {
     tmpl.root_properties
         .get("max_iterations")
@@ -2277,6 +2279,7 @@ fn tmpl_max_iterations(tmpl: &nodespace_core::mcp::handlers::markdown::NodeTempl
 }
 
 /// Build a Node from a NodeTemplate using prepare_nodes_from_template.
+/// Adapter for the NodeTemplate API change in #1096 (to_node() removed, replaced by prepare_nodes_from_template).
 fn tmpl_to_node(
     tmpl: &nodespace_core::mcp::handlers::markdown::NodeTemplate,
 ) -> nodespace_core::Node {


### PR DESCRIPTION
## Summary
Addresses 🟢 suggestions from retroactive reviews of PRs #1103 (#1082) and #1104 (#1086):

- Add `additionalProperties: { type: string }` to `property_filters` schema in `def_search_semantic` — guides LLM to generate correctly-typed objects
- Add reverse parity check to `search_semantic_schema_parity_with_params` test — bidirectional guard ensures schema properties can't be added without updating the parity lists
- Add doc comments to `tmpl_*` helper functions in `agent_e2e.rs` explaining they are adapters for the `NodeTemplate` API change in #1096

## Test results
1179 tests passing, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)