### PR TITLE
Fix: schema nodes always get normalized ID from content, not UUID

### DIFF
--- a/packages/core/src/mcp/handlers/nodes_test.rs
+++ b/packages/core/src/mcp/handlers/nodes_test.rs
@@ -2028,4 +2028,42 @@ mod property_filter_tests {
         let nodes = result["nodes"].as_array().unwrap();
         assert_eq!(nodes.len(), 0);
     }
+
+    // Regression test: schema nodes created via create_node must get a normalized name ID,
+    // not a UUID. Previously, only handle_create_schema applied normalization; create_node
+    // with node_type="schema" fell through to uuid::Uuid::new_v4().
+    #[tokio::test]
+    async fn test_create_node_schema_gets_normalized_id() {
+        use crate::mcp::handlers::nodes::handle_create_node;
+
+        let (ns, _dir) = setup_test_service().await.unwrap();
+
+        let result = handle_create_node(
+            &ns,
+            json!({
+                "node_type": "schema",
+                "content": "Customer Profile",
+                "properties": {
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": "Test",
+                    "fields": [],
+                    "relationships": []
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+        let node_id = result["node_id"].as_str().unwrap();
+        assert_eq!(
+            node_id, "customer-profile",
+            "Schema node ID should be normalized name, not UUID"
+        );
+
+        // Verify the node is retrievable by the normalized ID
+        let node = ns.get_node("customer-profile").await.unwrap();
+        assert!(node.is_some(), "Should be fetchable by normalized ID");
+        assert_eq!(node.unwrap().node_type, "schema");
+    }
 }

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -196,9 +196,9 @@ pub async fn handle_create_schema(
         properties["propertiesHeaderSummaryTemplate"] = serde_json::Value::String(template.clone());
     }
 
-    // Create schema node params
+    // Create schema node params — no explicit ID; create_node_with_parent derives it from content
     let schema_node_params = CreateNodeParams {
-        id: Some(schema_id.clone()),
+        id: None,
         node_type: "schema".to_string(),
         content: params.name.clone(),
         parent_id: None,

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -166,7 +166,7 @@ pub async fn handle_create_schema(
     let relationships = params.relationships.unwrap_or_default();
 
     // Generate schema ID
-    let schema_id = normalize_schema_id(&params.name);
+    let schema_id = crate::services::node_service::normalize_schema_id(&params.name);
 
     // Check if schema already exists — return a clear error so the agent knows
     // to use create_node instead of retrying create_schema.
@@ -1018,22 +1018,6 @@ fn normalize_and_namespace_fields(inferred_fields: Vec<InferredField>) -> Vec<Sc
         .collect()
 }
 
-/// Normalize schema ID to kebab-case (e.g., "Customer Profile" → "customer-profile").
-///
-/// Schema IDs use kebab-case to match existing core type conventions
-/// (e.g., "code-block", "quote-block", "ordered-list").
-fn normalize_schema_id(entity_name: &str) -> String {
-    entity_name
-        .to_lowercase()
-        .replace([' ', '_'], "-")
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '-')
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
-}
 
 #[cfg(test)]
 #[path = "schema_test.rs"]
@@ -1166,6 +1150,7 @@ mod tests {
 
     #[test]
     fn test_normalize_schema_id() {
+        use crate::services::node_service::normalize_schema_id;
         assert_eq!(normalize_schema_id("Invoice"), "invoice");
         assert_eq!(normalize_schema_id("Customer Profile"), "customer-profile");
         assert_eq!(normalize_schema_id("code_block"), "code-block");
@@ -1311,6 +1296,7 @@ mod tests {
 
     #[test]
     fn test_integration_schema_id_generation() {
+        use crate::services::node_service::normalize_schema_id;
         let entity_name = "Customer Invoice";
         let schema_id = normalize_schema_id(entity_name);
         assert_eq!(schema_id, "customer-invoice");

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -2156,7 +2156,14 @@ impl NodeService {
         } else if params.node_type == "date" {
             params.content.clone()
         } else if params.node_type == "schema" {
-            normalize_schema_id(&params.content)
+            let id = normalize_schema_id(&params.content);
+            if id.is_empty() {
+                return Err(NodeServiceError::invalid_update(
+                    "Schema content must not be empty or contain only special characters"
+                        .to_string(),
+                ));
+            }
+            id
         } else {
             uuid::Uuid::new_v4().to_string()
         };

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -566,6 +566,26 @@ pub(crate) fn normalize_schema_id(name: &str) -> String {
         .join("-")
 }
 
+#[cfg(test)]
+mod normalize_schema_id_tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_schema_id_basic() {
+        assert_eq!(normalize_schema_id("Invoice"), "invoice");
+        assert_eq!(normalize_schema_id("Customer Profile"), "customer-profile");
+        assert_eq!(normalize_schema_id("code_block"), "code-block");
+        assert_eq!(normalize_schema_id("My Widget"), "my-widget");
+    }
+
+    #[test]
+    fn test_normalize_schema_id_edge_cases() {
+        assert_eq!(normalize_schema_id("  spaces  "), "spaces");
+        assert_eq!(normalize_schema_id("already-kebab"), "already-kebab");
+        assert_eq!(normalize_schema_id("UPPER CASE"), "upper-case");
+    }
+}
+
 /// Extract nodespace:// mentions from content
 ///
 /// Supports both markdown format and plain URIs:

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -549,6 +549,23 @@ pub fn is_valid_node_id(node_id: &str) -> bool {
     false
 }
 
+/// Derive a stable schema node ID from the schema's display name.
+///
+/// Schema nodes use their normalized name as ID (e.g. "Invoice" → "invoice",
+/// "Customer Profile" → "customer-profile") so they can be referenced
+/// predictably by type name rather than an opaque UUID.
+pub(crate) fn normalize_schema_id(name: &str) -> String {
+    name.to_lowercase()
+        .replace([' ', '_'], "-")
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-')
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
 /// Extract nodespace:// mentions from content
 ///
 /// Supports both markdown format and plain URIs:
@@ -2118,6 +2135,8 @@ impl NodeService {
             }
         } else if params.node_type == "date" {
             params.content.clone()
+        } else if params.node_type == "schema" {
+            normalize_schema_id(&params.content)
         } else {
             uuid::Uuid::new_v4().to_string()
         };


### PR DESCRIPTION
## Summary

- Schema nodes created via `create_node` MCP tool or local agent were receiving UUIDs instead of normalized name IDs (e.g. `"Invoice"` → `"invoice"`)
- Root cause: `normalize_schema_id` only lived in `handle_create_schema`; the `create_node` path had `id: None` hardcoded, falling through to `uuid::Uuid::new_v4()`
- Fix: moved `normalize_schema_id` to `node_service::create_node_with_parent` — the single shared layer all creation paths pass through — same pattern as date nodes using content as ID

## Test plan

- [ ] New regression test: `test_create_node_schema_gets_normalized_id` — verifies `handle_create_node` with `node_type="schema"` produces a normalized ID, not a UUID
- [ ] New unit tests: `test_normalize_schema_id_basic` and `test_normalize_schema_id_edge_cases` in `node_service`
- [ ] Existing `test_normalize_schema_id` in `schema_test.rs` now calls through to the service function
- [ ] Verified e2e via live MCP: `create_node(node_type="schema", content="Widget")` → `id: "widget"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)