### PR TITLE
Gate AgentSession.system_prompt_override behind testing feature (closes #1093)

### DIFF
--- a/packages/agent/Cargo.toml
+++ b/packages/agent/Cargo.toml
@@ -31,6 +31,24 @@ which = "7"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[features]
+# Exposes test-only hooks (e.g. `LocalAgentService::set_system_prompt` and
+# `AgentSession::system_prompt_override`) so integration tests in `tests/`
+# can inject prebuilt prompts without a live database. The `tests/` binaries
+# link against the library in non-test mode, so `#[cfg(test)]` alone is not
+# enough — this feature gate is what keeps the hook out of production builds
+# while making it visible to integration tests run with `--features testing`.
+testing = []
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = "3"
+
+# `ollama_integration.rs` calls `set_system_prompt`, which lives behind the
+# `testing` feature. Declaring it here means `cargo test -p nodespace-agent`
+# without features simply skips this binary instead of failing to compile,
+# while `cargo test -p nodespace-agent --features testing` builds and runs it.
+[[test]]
+name = "ollama_integration"
+path = "tests/ollama_integration.rs"
+required-features = ["testing"]

--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -541,7 +541,10 @@ pub struct AgentSession {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dynamic_context: Option<String>,
     /// Full system prompt override (bypasses PromptAssembler / fallback).
-    /// Used in tests to inject a pre-built prompt without a live database.
+    /// Test-only: integration tests inject a pre-built prompt without a live
+    /// database. Gated by the `testing` feature so the field does not exist
+    /// in production builds and never reaches the Tauri serialization layer.
+    #[cfg(any(test, feature = "testing"))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt_override: Option<String>,
 }

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -44,6 +44,20 @@ const HISTORY_TOKEN_BUDGET: u32 = TOTAL_TOKEN_BUDGET - SYSTEM_PROMPT_BUDGET;
 /// are likely too vague to dispatch to the full 13-tool agent path.
 const AMBIGUOUS_MESSAGE_WORD_LIMIT: usize = 10;
 
+/// Returns the test-only system-prompt override on a session, or `None` in
+/// production. The two cfg variants let `run_turn` keep a single
+/// override → assembler → fallback chain without duplicating the assembler
+/// branch under each cfg arm. The `None`-returning variant is optimized
+/// away by the compiler.
+#[cfg(any(test, feature = "testing"))]
+fn session_prompt_override(session: &AgentSession) -> Option<&str> {
+    session.system_prompt_override.as_deref()
+}
+#[cfg(not(any(test, feature = "testing")))]
+fn session_prompt_override(_session: &AgentSession) -> Option<&str> {
+    None
+}
+
 /// Clarifying question returned when the skill pipeline finds no match and
 /// the user message is too short/vague to confidently invoke the full agent.
 const CLARIFYING_QUESTION: &str =
@@ -236,21 +250,11 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         };
 
         // Build base prompt: use override (tests), assembler (production), or fallback.
-        // The override branch is compiled out of production builds — see the
+        // `session_prompt_override` returns `None` in production builds — see the
         // `testing` feature on the agent crate.
-        #[cfg(any(test, feature = "testing"))]
-        let base_prompt = if let Some(ref override_prompt) = session.system_prompt_override {
-            override_prompt.clone()
+        let base_prompt = if let Some(override_prompt) = session_prompt_override(session) {
+            override_prompt.to_string()
         } else if let Some(ref assembler) = self.prompt_assembler {
-            assembler
-                .assemble(&template_ctx, all_tools.clone())
-                .await
-                .system_prompt
-        } else {
-            prompt_templates::fallback_system_prompt(dynamic_ctx)
-        };
-        #[cfg(not(any(test, feature = "testing")))]
-        let base_prompt = if let Some(ref assembler) = self.prompt_assembler {
             assembler
                 .assemble(&template_ctx, all_tools.clone())
                 .await

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -236,9 +236,21 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         };
 
         // Build base prompt: use override (tests), assembler (production), or fallback.
+        // The override branch is compiled out of production builds — see the
+        // `testing` feature on the agent crate.
+        #[cfg(any(test, feature = "testing"))]
         let base_prompt = if let Some(ref override_prompt) = session.system_prompt_override {
             override_prompt.clone()
         } else if let Some(ref assembler) = self.prompt_assembler {
+            assembler
+                .assemble(&template_ctx, all_tools.clone())
+                .await
+                .system_prompt
+        } else {
+            prompt_templates::fallback_system_prompt(dynamic_ctx)
+        };
+        #[cfg(not(any(test, feature = "testing")))]
+        let base_prompt = if let Some(ref assembler) = self.prompt_assembler {
             assembler
                 .assemble(&template_ctx, all_tools.clone())
                 .await
@@ -852,6 +864,7 @@ impl<E: ChatInferenceEngine + ?Sized + 'static, T: AgentToolExecutor + ?Sized + 
             created_at: chrono::Utc::now(),
             tool_executions: Vec::new(),
             dynamic_context: None,
+            #[cfg(any(test, feature = "testing"))]
             system_prompt_override: None,
         };
 
@@ -884,6 +897,10 @@ impl<E: ChatInferenceEngine + ?Sized + 'static, T: AgentToolExecutor + ?Sized + 
     /// When set, this bypasses both `PromptAssembler` and `fallback_system_prompt`.
     /// Intended for integration tests that want to inject a pre-built prompt
     /// (constructed via `PromptAssembler::assemble_static`) without a live database.
+    ///
+    /// Gated by the `testing` Cargo feature so it does not leak into the
+    /// production API surface.
+    #[cfg(any(test, feature = "testing"))]
     pub async fn set_system_prompt(&self, session_id: &str, prompt: String) {
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(session_id) {


### PR DESCRIPTION
## Summary

- Adds a `testing` Cargo feature on `nodespace-agent` and gates `AgentSession.system_prompt_override`, `LocalAgentService::set_system_prompt`, and the override branch in `run_turn` behind `#[cfg(any(test, feature = "testing"))]`.
- Production builds (no features) compile without the field, the method, or the override branch — so the test-only hook never reaches the Tauri serialization layer or the production prompt-assembly path.
- `tests/ollama_integration.rs` is declared as `[[test]] required-features = ["testing"]`, so `cargo test -p nodespace-agent` skips it cleanly without the feature and builds/runs it under `cargo test -p nodespace-agent --features testing`.

## Why this approach

Integration tests in `tests/` link against the library as a non-`#[cfg(test)]` crate, which is why the originally-flagged design (per PR #1091 review) put the field directly on `AgentSession`. A `testing` Cargo feature is the conventional Rust solution: the gate is visible to integration tests when the feature is enabled, but absent from production builds entirely. No wrapper indirection, no API churn, minimal diff.

## Verification

- `cargo build -p nodespace-agent` (no features) — clean, 22m23s
- `cargo check -p nodespace-agent --features testing --tests` — clean, 5m15s, proves the feature-gated code and `ollama_integration.rs` compile
- `bun run quality:fix` — passes clean (eslint 0 errors, svelte-check 0 warnings, cargo fmt + cargo clippy `-D warnings` across the workspace)
- Frontend test baseline: 128 files / 3918 tests passed (unchanged — no frontend touched)

## Test plan
- [x] `cargo build -p nodespace-agent` (no features) compiles cleanly
- [x] `cargo check -p nodespace-agent --features testing --tests` compiles cleanly
- [x] `bun run quality:fix` clean across workspace
- [x] Frontend tests unchanged from baseline (no frontend touched)
- [ ] Reviewer: confirm Tauri-serialized `AgentSession` no longer carries `system_prompt_override` in production (the field doesn't exist in the prod build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)