### PR TITLE
Implement nodespace CLI binary (closes #1116)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,10 +121,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "antlr4rust"
@@ -1073,6 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1081,8 +1126,22 @@ version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1129,6 +1188,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -3368,6 +3433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,6 +4225,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodespace-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "nodespace-core",
+ "nodespace-daemon",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+]
+
+[[package]]
 name = "nodespace-core"
 version = "0.1.0"
 dependencies = [
@@ -4656,6 +4742,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -8487,6 +8579,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "packages/nlp-engine",
     "packages/agent",
     "packages/daemon",
+    "packages/cli",
     "packages/desktop-app/src-tauri",
     "packages/dev-tools"
 ]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "nodespace-cli"
+version = "0.1.0"
+description = "Command-line interface for NodeSpace — a gRPC client for nodespaced"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "nodespace"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive", "env"] }
+tonic = "0.12"
+tokio = { workspace = true }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+nodespace-daemon = { path = "../daemon" }
+
+[dev-dependencies]
+nodespace-core = { workspace = true }
+tempfile = "3.0"
+tokio-stream = "0.1"

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod node;
+pub mod search;

--- a/packages/cli/src/commands/node.rs
+++ b/packages/cli/src/commands/node.rs
@@ -1,0 +1,167 @@
+//! `nodespace node ...` subcommands — thin gRPC wrappers around NodeService.
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use nodespace_daemon::nodespace::{
+    CreateNodeRequest, DeleteNodeRequest, GetChildrenRequest, GetNodeRequest, UpdateNodeRequest,
+};
+use nodespace_daemon::NodeServiceClient;
+use tonic::transport::Channel;
+
+use crate::output;
+
+#[derive(Subcommand, Debug)]
+pub enum NodeAction {
+    /// Retrieve a node by ID.
+    Get(GetArgs),
+    /// Create a new node.
+    Create(CreateArgs),
+    /// Update an existing node's content.
+    Update(UpdateArgs),
+    /// Delete a node.
+    Delete(DeleteArgs),
+    /// List the direct children of a node.
+    Children(ChildrenArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct GetArgs {
+    /// Node ID (UUID).
+    pub id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct CreateArgs {
+    /// Node type, e.g. `text`, `task`, `date`.
+    #[arg(long = "type")]
+    pub node_type: String,
+    /// Content (plain text or markdown).
+    #[arg(long)]
+    pub content: String,
+    /// Parent node ID (omit to create a root node).
+    #[arg(long)]
+    pub parent: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Node ID to update.
+    pub id: String,
+    /// New content.
+    #[arg(long)]
+    pub content: String,
+}
+
+#[derive(Args, Debug)]
+pub struct DeleteArgs {
+    /// Node ID to delete.
+    pub id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ChildrenArgs {
+    /// Parent node ID.
+    pub id: String,
+}
+
+pub async fn run(
+    client: &mut NodeServiceClient<Channel>,
+    action: NodeAction,
+    json: bool,
+) -> Result<()> {
+    match action {
+        NodeAction::Get(args) => get(client, args, json).await,
+        NodeAction::Create(args) => create(client, args, json).await,
+        NodeAction::Update(args) => update(client, args, json).await,
+        NodeAction::Delete(args) => delete(client, args, json).await,
+        NodeAction::Children(args) => children(client, args, json).await,
+    }
+}
+
+async fn get(client: &mut NodeServiceClient<Channel>, args: GetArgs, json: bool) -> Result<()> {
+    let response = client
+        .get_node(GetNodeRequest { node_id: args.id })
+        .await
+        .context("GetNode RPC failed")?
+        .into_inner();
+
+    let node = response.node_data.context("daemon returned no node_data")?;
+    output::print_node(&node, json)
+}
+
+async fn create(
+    client: &mut NodeServiceClient<Channel>,
+    args: CreateArgs,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .create_node(CreateNodeRequest {
+            node_type: args.node_type,
+            content: args.content,
+            parent_id: args.parent.unwrap_or_default(),
+            properties: String::new(),
+            collection: String::new(),
+            lifecycle_status: String::new(),
+        })
+        .await
+        .context("CreateNode RPC failed")?
+        .into_inner();
+
+    let node = response.node_data.context("daemon returned no node_data")?;
+    output::print_node(&node, json)
+}
+
+async fn update(
+    client: &mut NodeServiceClient<Channel>,
+    args: UpdateArgs,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .update_node(UpdateNodeRequest {
+            node_id: args.id,
+            version: None, // auto-fetch current version on the server
+            node_type: String::new(),
+            content: Some(args.content),
+            properties: None,
+            add_to_collection: String::new(),
+            remove_from_collection: String::new(),
+            lifecycle_status: String::new(),
+        })
+        .await
+        .context("UpdateNode RPC failed")?
+        .into_inner();
+
+    let node = response.node_data.context("daemon returned no node_data")?;
+    output::print_node(&node, json)
+}
+
+async fn delete(
+    client: &mut NodeServiceClient<Channel>,
+    args: DeleteArgs,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .delete_node(DeleteNodeRequest {
+            node_id: args.id,
+            version: None,
+        })
+        .await
+        .context("DeleteNode RPC failed")?
+        .into_inner();
+
+    output::print_delete(&response, json)
+}
+
+async fn children(
+    client: &mut NodeServiceClient<Channel>,
+    args: ChildrenArgs,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .get_children(GetChildrenRequest { node_id: args.id })
+        .await
+        .context("GetChildren RPC failed")?
+        .into_inner();
+
+    output::print_node_list(&response, json)
+}

--- a/packages/cli/src/commands/search.rs
+++ b/packages/cli/src/commands/search.rs
@@ -12,8 +12,8 @@ use crate::output;
 pub struct SearchArgs {
     /// Free-text query.
     pub query: String,
-    /// Maximum number of results to return (default: server-side, currently 20).
-    #[arg(long, default_value_t = 0)]
+    /// Maximum number of results to return (0 = server default, currently 20).
+    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(i32).range(0..))]
     pub limit: i32,
 }
 

--- a/packages/cli/src/commands/search.rs
+++ b/packages/cli/src/commands/search.rs
@@ -1,0 +1,42 @@
+//! `nodespace search <query>` — semantic search via NodeService.SearchNodes.
+
+use anyhow::{Context, Result};
+use clap::Args;
+use nodespace_daemon::nodespace::SearchRequest;
+use nodespace_daemon::NodeServiceClient;
+use tonic::transport::Channel;
+
+use crate::output;
+
+#[derive(Args, Debug)]
+pub struct SearchArgs {
+    /// Free-text query.
+    pub query: String,
+    /// Maximum number of results to return (default: server-side, currently 20).
+    #[arg(long, default_value_t = 0)]
+    pub limit: i32,
+}
+
+pub async fn run(
+    client: &mut NodeServiceClient<Channel>,
+    args: SearchArgs,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .search_nodes(SearchRequest {
+            query: args.query,
+            node_types: vec![],
+            collection: String::new(),
+            collection_id: String::new(),
+            limit: args.limit,
+            offset: 0,
+            threshold: 0.0,
+            semantic: true,
+            filters: String::new(),
+        })
+        .await
+        .context("SearchNodes RPC failed")?
+        .into_inner();
+
+    output::print_node_list(&response, json)
+}

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1,0 +1,85 @@
+//! `nodespace` CLI library surface.
+//!
+//! Exposed primarily so integration tests can drive the command handlers
+//! against an in-process daemon without shelling out to the built binary.
+
+pub mod commands;
+pub mod output;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use nodespace_daemon::NodeServiceClient;
+use tonic::transport::Channel;
+
+/// Default endpoint the CLI dials. ADR-031 reserves `localhost:50051` for the
+/// loopback-only gRPC endpoint exposed by `nodespaced`.
+pub const DEFAULT_ENDPOINT: &str = "http://[::1]:50051";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "nodespace",
+    version,
+    about = "Command-line interface for NodeSpace — talks to the local nodespaced daemon over gRPC.",
+    long_about = "nodespace is a stateless gRPC client that connects to the nodespaced daemon \
+                  (default: localhost:50051) and exposes the knowledge graph as shell commands.\n\n\
+                  Start the daemon with `nodespaced` before invoking subcommands."
+)]
+pub struct Cli {
+    /// Emit raw JSON instead of human-readable output.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Override the daemon endpoint (default: http://[::1]:50051).
+    /// Honors the `NODESPACE_ENDPOINT` environment variable when this flag is absent.
+    #[arg(long, global = true, env = "NODESPACE_ENDPOINT")]
+    pub endpoint: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Operate on individual nodes (get, create, update, delete, children).
+    Node {
+        #[command(subcommand)]
+        action: commands::node::NodeAction,
+    },
+    /// Semantic search across the knowledge graph.
+    Search(commands::search::SearchArgs),
+}
+
+/// Resolve the configured endpoint, falling back to `DEFAULT_ENDPOINT`.
+pub fn resolve_endpoint(override_: Option<&str>) -> String {
+    override_
+        .map(str::to_string)
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+}
+
+/// Connect to the daemon, returning a friendly error if it isn't running.
+///
+/// `tonic` surfaces "connection refused" as a transport error with a tower
+/// hyper cause; users running `nodespace` without first launching `nodespaced`
+/// need a clear remediation, not a stack of generic transport errors.
+pub async fn connect(endpoint: &str) -> Result<NodeServiceClient<Channel>> {
+    NodeServiceClient::connect(endpoint.to_string())
+        .await
+        .with_context(|| {
+            format!(
+                "Could not connect to nodespaced at {endpoint}.\n\
+                 Is the daemon running? Start it with `nodespaced` in another terminal."
+            )
+        })
+}
+
+/// Top-level dispatch — wired by `main.rs` and reused by integration tests.
+pub async fn run(cli: Cli) -> Result<()> {
+    let endpoint = resolve_endpoint(cli.endpoint.as_deref());
+    let mut client = connect(&endpoint).await?;
+    let json = cli.json;
+
+    match cli.command {
+        Command::Node { action } => commands::node::run(&mut client, action, json).await,
+        Command::Search(args) => commands::search::run(&mut client, args, json).await,
+    }
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use clap::Parser;
+use nodespace_cli::{run, Cli};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    run(cli).await
+}

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -85,10 +85,13 @@ fn write_human_node(node: &NodeData) {
     }
 }
 
-fn node_to_json(node: &NodeData) -> serde_json::Value {
-    // properties is already a JSON-encoded string on the wire — try to inline
-    // it as nested JSON, falling back to the raw string when malformed so we
-    // never silently swallow daemon-side issues.
+pub(crate) fn node_to_json(node: &NodeData) -> serde_json::Value {
+    // properties is a JSON-encoded string on the wire — inline it as nested
+    // JSON so scripts can `jq '.properties.foo'` without a second parse.
+    // Falls back to the raw string if it doesn't parse; in practice this
+    // branch is unreachable because the daemon serializes via
+    // serde_json::Value::to_string, but we'd rather degrade than panic if
+    // that contract ever breaks.
     let properties = serde_json::from_str::<serde_json::Value>(&node.properties)
         .unwrap_or_else(|_| serde_json::Value::String(node.properties.clone()));
 
@@ -104,4 +107,48 @@ fn node_to_json(node: &NodeData) -> serde_json::Value {
         "modified_at": node.modified_at,
         "collection_id": node.collection_id,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_node() -> NodeData {
+        NodeData {
+            id: "abc-123".into(),
+            node_type: "text".into(),
+            content: "hello".into(),
+            parent_id: Some("parent-id".into()),
+            properties: r#"{"foo":"bar","n":42}"#.into(),
+            version: 7,
+            lifecycle_status: "active".into(),
+            created_at: "2026-05-17T12:00:00Z".into(),
+            modified_at: "2026-05-17T12:00:01Z".into(),
+            collection_id: "hr:policy".into(),
+        }
+    }
+
+    #[test]
+    fn node_to_json_inlines_properties_as_nested_object() {
+        let json = node_to_json(&sample_node());
+        // Scripts pipe `nodespace node get --json ID | jq '.properties.foo'`;
+        // if this regresses to a JSON-encoded string they'd need a double
+        // decode. Lock the inlined shape in.
+        assert_eq!(json["properties"]["foo"], "bar");
+        assert_eq!(json["properties"]["n"], 42);
+        assert_eq!(json["id"], "abc-123");
+        assert_eq!(json["version"], 7);
+        assert_eq!(json["parent_id"], "parent-id");
+        assert_eq!(json["collection_id"], "hr:policy");
+    }
+
+    #[test]
+    fn node_to_json_falls_back_to_raw_string_for_malformed_properties() {
+        let mut node = sample_node();
+        node.properties = "{not valid json".into();
+        let json = node_to_json(&node);
+        // Unreachable in practice (daemon always serializes via serde), but
+        // we degrade rather than panic if that contract ever breaks.
+        assert_eq!(json["properties"], "{not valid json");
+    }
 }

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -1,0 +1,107 @@
+//! Output formatters for CLI subcommands.
+//!
+//! Human-readable mode emits a stable, label-prefixed layout intended for
+//! interactive use. JSON mode emits the proto-as-JSON representation so the
+//! output is unambiguous and scriptable.
+
+use anyhow::Result;
+use nodespace_daemon::nodespace::{DeleteNodeResponse, NodeListResponse};
+use nodespace_daemon::NodeData;
+use serde_json::json;
+
+pub fn print_node(node: &NodeData, json: bool) -> Result<()> {
+    if json {
+        let value = node_to_json(node);
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        write_human_node(node);
+    }
+    Ok(())
+}
+
+pub fn print_delete(response: &DeleteNodeResponse, json: bool) -> Result<()> {
+    if json {
+        let value = json!({
+            "node_id": response.node_id,
+            "existed": response.existed,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else if response.existed {
+        println!("Deleted node {}", response.node_id);
+    } else {
+        println!("Node {} did not exist (no-op)", response.node_id);
+    }
+    Ok(())
+}
+
+pub fn print_node_list(response: &NodeListResponse, json: bool) -> Result<()> {
+    if json {
+        let value = json!({
+            "count": response.count,
+            "collection_id": response.collection_id,
+            "nodes": response.nodes.iter().map(node_to_json).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    if response.nodes.is_empty() {
+        println!("No nodes returned (count: 0)");
+        return Ok(());
+    }
+
+    println!("{} node(s):", response.count);
+    for (idx, node) in response.nodes.iter().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+        write_human_node(node);
+    }
+    Ok(())
+}
+
+fn write_human_node(node: &NodeData) {
+    println!("id:              {}", node.id);
+    println!("type:            {}", node.node_type);
+    if let Some(parent) = &node.parent_id {
+        println!("parent:          {}", parent);
+    }
+    println!("version:         {}", node.version);
+    println!("lifecycle:       {}", node.lifecycle_status);
+    println!("created_at:      {}", node.created_at);
+    println!("modified_at:     {}", node.modified_at);
+    if !node.collection_id.is_empty() {
+        println!("collection_id:   {}", node.collection_id);
+    }
+    if !node.properties.is_empty() && node.properties != "{}" {
+        println!("properties:      {}", node.properties);
+    }
+    println!("content:");
+    for line in node.content.lines() {
+        println!("    {}", line);
+    }
+    if node.content.is_empty() {
+        println!("    (empty)");
+    }
+}
+
+fn node_to_json(node: &NodeData) -> serde_json::Value {
+    // properties is already a JSON-encoded string on the wire — try to inline
+    // it as nested JSON, falling back to the raw string when malformed so we
+    // never silently swallow daemon-side issues.
+    let properties = serde_json::from_str::<serde_json::Value>(&node.properties)
+        .unwrap_or_else(|_| serde_json::Value::String(node.properties.clone()));
+
+    json!({
+        "id": node.id,
+        "node_type": node.node_type,
+        "content": node.content,
+        "parent_id": node.parent_id,
+        "properties": properties,
+        "version": node.version,
+        "lifecycle_status": node.lifecycle_status,
+        "created_at": node.created_at,
+        "modified_at": node.modified_at,
+        "collection_id": node.collection_id,
+    })
+}

--- a/packages/cli/tests/cli_integration.rs
+++ b/packages/cli/tests/cli_integration.rs
@@ -164,7 +164,9 @@ async fn create_get_update_children_delete_round_trip() {
         "parent updated via CLI"
     );
 
-    // list children
+    // list children — exercise the CLI handler, then verify via raw gRPC
+    // that the response shape the handler renders is correct. The handler
+    // itself only prints, so we cross-check the underlying state.
     commands::node::run(
         &mut client,
         commands::node::NodeAction::Children(commands::node::ChildrenArgs {
@@ -174,6 +176,32 @@ async fn create_get_update_children_delete_round_trip() {
     )
     .await
     .expect("list children");
+
+    let children = raw_client
+        .get_children(nodespace_daemon::nodespace::GetChildrenRequest {
+            node_id: parent_id.clone(),
+        })
+        .await
+        .expect("children fetch")
+        .into_inner();
+    assert_eq!(
+        children.count, 1,
+        "expected exactly one child seeded via CLI"
+    );
+    assert_eq!(
+        children.nodes.len(),
+        1,
+        "nodes len must match count for non-paginated results"
+    );
+    assert_eq!(
+        children.nodes[0].content, "child via CLI",
+        "child content should match what the CLI handler created"
+    );
+    assert_eq!(
+        children.nodes[0].parent_id.as_deref(),
+        Some(parent_id.as_str()),
+        "child must link back to the seeded parent"
+    );
 
     // delete the parent
     commands::node::run(

--- a/packages/cli/tests/cli_integration.rs
+++ b/packages/cli/tests/cli_integration.rs
@@ -1,0 +1,268 @@
+//! End-to-end integration test for the `nodespace` CLI.
+//!
+//! Spins an in-process `nodespaced` gRPC server up against a tempdir-backed
+//! SurrealDB, then drives the CLI's command handlers (via the library
+//! surface) at it. This validates that the CLI's gRPC plumbing — connection,
+//! request construction, response unwrapping, error mapping — works end to
+//! end against the same service stack the real binary uses.
+//!
+//! We exercise the handlers directly rather than spawning the compiled
+//! binary so test failures point at the code path under test rather than
+//! at fork/exec or stdout-capture plumbing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nodespace_cli::{commands, connect};
+use nodespace_core::{NodeService as CoreNodeService, SurrealStore};
+use nodespace_daemon::nodespace::GetNodeRequest;
+use nodespace_daemon::{NodeServiceImpl, NodeServiceServer};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tonic::transport::Server;
+use tonic::Code;
+
+/// Spawn an in-process daemon and return the endpoint URL the CLI should
+/// dial. Mirrors `packages/daemon/tests/grpc_round_trip.rs::spawn_test_daemon`
+/// but exposes the endpoint string rather than a pre-built client because the
+/// CLI owns its own client construction.
+async fn spawn_test_daemon() -> (String, oneshot::Sender<()>, TempDir) {
+    let tempdir = TempDir::new().expect("failed to create tempdir");
+
+    let mut store = Arc::new(
+        SurrealStore::new(tempdir.path().join("daemon-db"))
+            .await
+            .expect("failed to open SurrealStore"),
+    );
+    let node_service = Arc::new(
+        CoreNodeService::new(&mut store)
+            .await
+            .expect("failed to build NodeService"),
+    );
+    let service = NodeServiceImpl::new(node_service, None);
+
+    // Ephemeral port — parallel test runs must not collide on 50051.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(NodeServiceServer::new(service))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("server crashed");
+    });
+
+    let endpoint = format!("http://{}", addr);
+
+    // Wait for the server to start accepting before handing back the endpoint.
+    // The CLI's `connect` helper already retries via tonic, but giving the
+    // listener a moment removes spurious connect errors on slow CI runners.
+    for _ in 0..50 {
+        if connect(&endpoint).await.is_ok() {
+            return (endpoint, shutdown_tx, tempdir);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("daemon did not start accepting connections on {}", endpoint);
+}
+
+#[tokio::test]
+async fn create_get_update_children_delete_round_trip() {
+    let (endpoint, shutdown, _tempdir) = spawn_test_daemon().await;
+    let mut client = connect(&endpoint).await.expect("connect");
+
+    // create root node
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Create(commands::node::CreateArgs {
+            node_type: "text".into(),
+            content: "root via CLI".into(),
+            parent: None,
+        }),
+        true, // json mode keeps stdout machine-readable, but mostly we care that no errors propagate
+    )
+    .await
+    .expect("create root");
+
+    // grab an ID by listing the root's children (it has none) and then by
+    // creating one via a direct gRPC call so we can run the rest of the
+    // commands against a known id without parsing stdout.
+    let mut raw_client = nodespace_daemon::NodeServiceClient::connect(endpoint.clone())
+        .await
+        .expect("raw client connect");
+
+    let created = raw_client
+        .create_node(nodespace_daemon::nodespace::CreateNodeRequest {
+            node_type: "text".into(),
+            content: "parent".into(),
+            parent_id: String::new(),
+            properties: String::new(),
+            collection: String::new(),
+            lifecycle_status: String::new(),
+        })
+        .await
+        .expect("seed parent")
+        .into_inner();
+    let parent_id = created.node_id;
+
+    // create a child under that parent via the CLI handler
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Create(commands::node::CreateArgs {
+            node_type: "text".into(),
+            content: "child via CLI".into(),
+            parent: Some(parent_id.clone()),
+        }),
+        false,
+    )
+    .await
+    .expect("create child");
+
+    // get the parent
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Get(commands::node::GetArgs {
+            id: parent_id.clone(),
+        }),
+        false,
+    )
+    .await
+    .expect("get parent");
+
+    // update the parent's content
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Update(commands::node::UpdateArgs {
+            id: parent_id.clone(),
+            content: "parent updated via CLI".into(),
+        }),
+        true,
+    )
+    .await
+    .expect("update parent");
+
+    // verify update took effect via a direct gRPC fetch — the CLI handler
+    // only prints, so we check the underlying state independently
+    let fetched = raw_client
+        .get_node(GetNodeRequest {
+            node_id: parent_id.clone(),
+        })
+        .await
+        .expect("post-update fetch")
+        .into_inner();
+    assert_eq!(
+        fetched.node_data.expect("node_data").content,
+        "parent updated via CLI"
+    );
+
+    // list children
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Children(commands::node::ChildrenArgs {
+            id: parent_id.clone(),
+        }),
+        true,
+    )
+    .await
+    .expect("list children");
+
+    // delete the parent
+    commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Delete(commands::node::DeleteArgs {
+            id: parent_id.clone(),
+        }),
+        false,
+    )
+    .await
+    .expect("delete parent");
+
+    // confirm gone
+    let err = raw_client
+        .get_node(GetNodeRequest { node_id: parent_id })
+        .await
+        .expect_err("expected not_found after delete");
+    assert_eq!(err.code(), Code::NotFound);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn get_missing_node_surfaces_not_found() {
+    let (endpoint, shutdown, _tempdir) = spawn_test_daemon().await;
+    let mut client = connect(&endpoint).await.expect("connect");
+
+    let err = commands::node::run(
+        &mut client,
+        commands::node::NodeAction::Get(commands::node::GetArgs {
+            id: "does-not-exist".into(),
+        }),
+        false,
+    )
+    .await
+    .expect_err("expected error");
+
+    // anyhow wraps the tonic Status; make sure the original code survives in
+    // the chain so users can still distinguish missing-node from transport
+    // failures when they inspect the cause.
+    let status = err
+        .chain()
+        .find_map(|e| e.downcast_ref::<tonic::Status>())
+        .expect("expected tonic::Status in error chain");
+    assert_eq!(status.code(), Code::NotFound);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn search_without_embedding_service_reports_unavailable() {
+    let (endpoint, shutdown, _tempdir) = spawn_test_daemon().await;
+    let mut client = connect(&endpoint).await.expect("connect");
+
+    let err = commands::search::run(
+        &mut client,
+        commands::search::SearchArgs {
+            query: "anything".into(),
+            limit: 0,
+        },
+        true,
+    )
+    .await
+    .expect_err("expected unavailable");
+
+    let status = err
+        .chain()
+        .find_map(|e| e.downcast_ref::<tonic::Status>())
+        .expect("expected tonic::Status in error chain");
+    assert_eq!(status.code(), Code::Unavailable);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn connect_refused_returns_friendly_error() {
+    // A port reserved by IANA that no daemon should be on. The CLI's `connect`
+    // helper must surface a friendly message rather than a raw transport error.
+    let err = connect("http://127.0.0.1:1")
+        .await
+        .expect_err("expected refusal");
+
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("Could not connect to nodespaced"),
+        "expected friendly error, got: {msg}"
+    );
+    assert!(
+        msg.contains("Is the daemon running?"),
+        "expected remediation hint, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the `nodespace` CLI from issue #1116 — a thin gRPC client that connects to `nodespaced` on `localhost:50051` and exposes the knowledge graph as shell commands (Ollama-style).

- New `packages/cli` crate added to the workspace, ships the `nodespace` binary
- `clap`-derived subcommands: `node get|create|update|delete|children`, `search <query> [--limit]`
- Global `--json` flag and `--endpoint` override (also honored via `NODESPACE_ENDPOINT`)
- Friendly remediation when the daemon is unreachable instead of raw transport errors
- Human-readable and JSON output formatters in `src/output.rs`
- Integration test (`tests/cli_integration.rs`) drives the handlers against an in-process daemon: full create/get/update/children/delete round trip, not-found mapping, search-unavailable surface, and connect-refused friendly error

## Acceptance criteria

- [x] `nodespace` binary builds and is installable alongside `nodespaced` (`cargo build --bin nodespace`)
- [x] `nodespace node get <id>` retrieves and prints a node
- [x] `nodespace node create --type <type> --content <content> [--parent <id>]`
- [x] `nodespace node update <id> --content <content>`
- [x] `nodespace node delete <id>`
- [x] `nodespace node children <id>`
- [x] `nodespace search <query> [--limit <n>]`
- [x] `--json` flag on all commands outputs raw JSON
- [x] Clear error when `nodespaced` is not running (connection refused → friendly remediation)
- [x] `nodespace --help` and `nodespace <subcommand> --help` print useful usage text
- [x] `cargo build --bin nodespace` succeeds
- [x] Code passes `bun run quality:fix`

## Test plan

- [x] Frontend baseline: 128 files / 3918 tests passing (before and after — no regression)
- [x] `cargo test -p nodespace-cli` — 4 integration tests pass
- [x] `cargo test -p nodespace-daemon` — 7 tests still pass (no regression)
- [x] `nodespace --help` / `nodespace node --help` / `nodespace search --help` reviewed manually
- [x] `nodespace --endpoint http://127.0.0.1:1 node get x` prints the friendly remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)