### PR TITLE
Implement PtySessionManager and PtySession (closes #1118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ research_*.rs
 *_investigation.rs
 session*.rs
 !**/src/acp/session.rs
+!**/src/pty/session.rs
 *_test.rs.bak
 check_*.rs
 temp_*.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1906,7 +1906,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.5",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
 ]
 
@@ -2095,6 +2095,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c3e69656680c6c3d76750b46dfa64bf07626bd2130c540d6cf2d306ba595a8"
 dependencies = [
  "nix 0.29.0",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -3387,6 +3398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,6 +3970,15 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4140,6 +4169,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -4160,7 +4203,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4176,6 +4219,7 @@ dependencies = [
  "minijinja",
  "nodespace-core",
  "nodespace-nlp-engine",
+ "portable-pty",
  "regex",
  "reqwest 0.12.22",
  "serde",
@@ -5337,6 +5381,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -6749,6 +6814,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6836,6 +6943,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -7807,6 +7930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8438,7 +8570,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "winapi",
 ]
@@ -9581,6 +9713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/packages/agent/Cargo.toml
+++ b/packages/agent/Cargo.toml
@@ -27,6 +27,8 @@ minijinja = "2"
 dirs = "5.0"
 sysinfo = "0.33"
 which = "7"
+portable-pty = "0.8"
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/packages/agent/src/lib.rs
+++ b/packages/agent/src/lib.rs
@@ -31,3 +31,6 @@ pub mod props;
 
 // ACP (Agent Communication Protocol) subsystem
 pub mod acp;
+
+// PTY-based agent session engine (ADR-032)
+pub mod pty;

--- a/packages/agent/src/pty/manager.rs
+++ b/packages/agent/src/pty/manager.rs
@@ -1,0 +1,218 @@
+//! Owns the collection of running [`PtySession`]s.
+//!
+//! [`PtySessionManager`] is held in `nodespaced`'s shared state and is the
+//! single entry point through which gRPC handlers / Tauri commands create,
+//! drive, and tear down agent sessions. Sessions live behind an
+//! `Arc<Mutex<...>>` so concurrent callers can interact safely; the manager
+//! also spawns a small watcher task per session that drops the entry when
+//! the underlying agent process exits on its own.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::acp::context_assembly::GraphContextAssembler;
+use crate::agent_types::AgentType;
+use crate::pty::session::PtySession;
+
+/// Lightweight snapshot of a session suitable for listing in a UI / RPC.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    pub id: Uuid,
+    pub agent_type: AgentType,
+    pub started_at: DateTime<Utc>,
+}
+
+impl SessionMetadata {
+    fn from_session(s: &PtySession) -> Self {
+        Self {
+            id: s.id,
+            agent_type: s.agent_type,
+            started_at: s.started_at,
+        }
+    }
+}
+
+/// Holds all active PTY sessions.
+#[derive(Default, Clone)]
+pub struct PtySessionManager {
+    sessions: Arc<Mutex<HashMap<Uuid, Arc<PtySession>>>>,
+}
+
+impl PtySessionManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Launch a new agent session and register it. Returns the session id.
+    pub async fn launch(
+        &self,
+        agent_type: AgentType,
+        initial_prompt: Option<String>,
+        assembler: &GraphContextAssembler,
+    ) -> anyhow::Result<Uuid> {
+        let session = PtySession::launch(agent_type, initial_prompt, assembler).await?;
+        Ok(self.insert(session).await)
+    }
+
+    /// Register an already-launched session. Split out so tests can build
+    /// sessions without a real [`GraphContextAssembler`].
+    pub async fn insert(&self, session: PtySession) -> Uuid {
+        let id = session.id;
+        let mut exit_rx = session.subscribe_exit();
+        let session = Arc::new(session);
+
+        {
+            let mut sessions = self.sessions.lock().await;
+            sessions.insert(id, session);
+        }
+
+        // Auto-cleanup: when the child process exits, drop the session out
+        // of the map so the temp dir gets cleaned up.
+        let sessions = self.sessions.clone();
+        tokio::spawn(async move {
+            let _ = exit_rx.recv().await;
+            let mut guard = sessions.lock().await;
+            guard.remove(&id);
+        });
+
+        id
+    }
+
+    /// Return an `Arc` to the session, if it exists.
+    pub async fn get(&self, id: &Uuid) -> Option<Arc<PtySession>> {
+        self.sessions.lock().await.get(id).cloned()
+    }
+
+    /// Terminate and remove a session. Returns `Ok(false)` if the session
+    /// was not in the map (already cleaned up by the natural-exit watcher).
+    ///
+    /// The temp dir is dropped when the last `Arc<PtySession>` is dropped;
+    /// since this method takes ownership out of the map, that usually happens
+    /// at the end of this call (assuming no other caller is holding an
+    /// `Arc` from a prior `get()`).
+    pub async fn terminate(&self, id: &Uuid) -> anyhow::Result<bool> {
+        let session = {
+            let mut sessions = self.sessions.lock().await;
+            sessions.remove(id)
+        };
+
+        let Some(session) = session else {
+            return Ok(false);
+        };
+
+        session.terminate().await?;
+        Ok(true)
+    }
+
+    /// Return a snapshot of every active session.
+    pub async fn list(&self) -> Vec<SessionMetadata> {
+        let sessions = self.sessions.lock().await;
+        sessions
+            .values()
+            .map(|s| SessionMetadata::from_session(s))
+            .collect()
+    }
+
+    /// Number of currently registered sessions. Useful for tests.
+    #[cfg(test)]
+    pub(crate) async fn len(&self) -> usize {
+        self.sessions.lock().await.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Wait until the manager's session count reaches `target` or the deadline
+    /// expires. Polls every 50 ms because the natural-exit watcher is an
+    /// independently-spawned task.
+    async fn wait_for_len(manager: &PtySessionManager, target: usize, deadline: Duration) {
+        let start = std::time::Instant::now();
+        while start.elapsed() < deadline {
+            if manager.len().await == target {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!(
+            "manager len {} did not reach {} within {:?}",
+            manager.len().await,
+            target,
+            deadline
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_then_list_returns_metadata() {
+        let manager = PtySessionManager::new();
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "sleep 1".into()])
+            .expect("launch session");
+
+        let id = manager.insert(session).await;
+        let listed = manager.list().await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+
+        // Wait for the session to exit naturally so the manager's auto-prune
+        // runs; otherwise the test would leak the watcher task.
+        wait_for_len(&manager, 0, Duration::from_secs(3)).await;
+    }
+
+    #[tokio::test]
+    async fn terminate_removes_session_and_returns_true() {
+        let manager = PtySessionManager::new();
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "sleep 30".into()])
+            .expect("launch session");
+
+        let id = manager.insert(session).await;
+        assert_eq!(manager.len().await, 1);
+
+        let removed = timeout(Duration::from_secs(3), manager.terminate(&id))
+            .await
+            .expect("terminate returns within deadline")
+            .expect("terminate succeeds");
+        assert!(removed, "terminate should return true for active session");
+        assert_eq!(manager.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn terminate_unknown_returns_false() {
+        let manager = PtySessionManager::new();
+        let removed = manager
+            .terminate(&Uuid::new_v4())
+            .await
+            .expect("terminate succeeds");
+        assert!(!removed);
+    }
+
+    #[tokio::test]
+    async fn natural_exit_auto_removes_session() {
+        let manager = PtySessionManager::new();
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "echo bye".into()])
+            .expect("launch session");
+
+        let _id = manager.insert(session).await;
+        wait_for_len(&manager, 0, Duration::from_secs(3)).await;
+    }
+
+    #[tokio::test]
+    async fn get_returns_session_and_supports_write_resize() {
+        let manager = PtySessionManager::new();
+        let session = PtySession::launch_for_test("cat", vec![]).expect("launch cat");
+        let id = manager.insert(session).await;
+
+        let arc = manager.get(&id).await.expect("session present");
+        arc.write_input(b"ok\n").await.expect("write input");
+        arc.resize(100, 30).await.expect("resize");
+
+        manager.terminate(&id).await.expect("terminate cat");
+    }
+}

--- a/packages/agent/src/pty/manager.rs
+++ b/packages/agent/src/pty/manager.rs
@@ -72,10 +72,21 @@ impl PtySessionManager {
         }
 
         // Auto-cleanup: when the child process exits, drop the session out
-        // of the map so the temp dir gets cleaned up.
+        // of the map so the temp dir gets cleaned up. `watch` latches the
+        // final value, so this works whether the child exits before or
+        // after the receiver was constructed.
         let sessions = self.sessions.clone();
         tokio::spawn(async move {
-            let _ = exit_rx.recv().await;
+            // Fast path: exit already happened before insert returned.
+            if exit_rx.borrow().is_none() {
+                // Loop until the latched value transitions to Some, or the
+                // sender is dropped (session removed by another path).
+                while exit_rx.changed().await.is_ok() {
+                    if exit_rx.borrow().is_some() {
+                        break;
+                    }
+                }
+            }
             let mut guard = sessions.lock().await;
             guard.remove(&id);
         });
@@ -125,7 +136,7 @@ impl PtySessionManager {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::time::Duration;
@@ -214,5 +225,22 @@ mod tests {
         arc.resize(100, 30).await.expect("resize");
 
         manager.terminate(&id).await.expect("terminate cat");
+    }
+
+    /// Regression for review Finding #2: very short-lived processes whose
+    /// exit fires before the manager's auto-prune task has a chance to
+    /// subscribe. The watch-channel redesign latches the final value so the
+    /// subscriber still observes it. Repeated to make the race more likely.
+    #[tokio::test]
+    async fn ultra_short_lived_processes_are_pruned() {
+        let manager = PtySessionManager::new();
+        for _ in 0..10 {
+            // `true` exits with status 0 essentially immediately. The watcher
+            // very plausibly fires before the manager's auto-prune subscribes.
+            let session =
+                PtySession::launch_for_test("true", vec![]).expect("launch true session");
+            manager.insert(session).await;
+        }
+        wait_for_len(&manager, 0, Duration::from_secs(3)).await;
     }
 }

--- a/packages/agent/src/pty/mod.rs
+++ b/packages/agent/src/pty/mod.rs
@@ -1,0 +1,22 @@
+//! PTY-based agent session engine (ADR-032).
+//!
+//! [`PtySession`] owns one running external agent process attached to a
+//! pseudo-terminal. [`PtySessionManager`] owns the collection of active
+//! sessions and is meant to be held in `nodespaced`'s shared state.
+//!
+//! The session lifecycle is:
+//!
+//! 1. Create a per-session temp directory.
+//! 2. Write the context file ([`GraphContextAssembler::write_context_file`])
+//!    so the agent picks up its `CLAUDE.md` / `AGENTS.md` on launch.
+//! 3. Spawn the agent binary inside a freshly opened PTY rooted at the temp dir.
+//! 4. Stream stdout/stderr bytes through a `broadcast::Sender<OutputChunk>`.
+//! 5. Accept stdin via [`PtySession::write_input`] and resize via [`PtySession::resize`].
+//! 6. On [`PtySession::terminate`] (or when the child exits naturally), drop the
+//!    [`tempfile::TempDir`] so the working directory is cleaned up.
+
+pub mod manager;
+pub mod session;
+
+pub use manager::{PtySessionManager, SessionMetadata};
+pub use session::{OutputChunk, PtySession};

--- a/packages/agent/src/pty/session.rs
+++ b/packages/agent/src/pty/session.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, watch, Mutex};
 use uuid::Uuid;
 
 use crate::acp::context_assembly::GraphContextAssembler;
@@ -99,12 +99,15 @@ pub struct PtySession {
 
     /// Fan-out for output chunks.
     output_tx: broadcast::Sender<OutputChunk>,
-    /// Fan-out for process exit. A single value is sent when the child exits;
-    /// subscribers created before exit will receive it.
-    exit_tx: broadcast::Sender<ExitStatus>,
+    /// Latched exit status. Starts at `None` and transitions to `Some(...)`
+    /// exactly once when the watcher observes the child exiting. `watch` (not
+    /// `broadcast`) so subscribers created *after* the exit still see the
+    /// final value — terminate() and the manager's auto-prune both rely on
+    /// this.
+    exit_tx: watch::Sender<Option<ExitStatus>>,
 
-    /// Per-session working directory. Dropping this session drops the
-    /// `TempDir`, which deletes the directory tree on disk.
+    // Held only for its Drop side effect — deletes the temp dir on disk when
+    // this session is dropped. Never read directly.
     _session_dir: tempfile::TempDir,
 }
 
@@ -192,7 +195,7 @@ impl PtySession {
         let child_killer = child.clone_killer();
 
         let (output_tx, _) = broadcast::channel::<OutputChunk>(OUTPUT_CHANNEL_CAPACITY);
-        let (exit_tx, _) = broadcast::channel::<ExitStatus>(1);
+        let (exit_tx, _) = watch::channel::<Option<ExitStatus>>(None);
 
         let id = Uuid::new_v4();
         let started_at = Utc::now();
@@ -228,10 +231,17 @@ impl PtySession {
 
     /// Subscribe to the child-exit signal.
     ///
-    /// Exactly one [`ExitStatus`] value is broadcast when the child exits;
-    /// subscribers that subscribed before exit will receive it.
-    pub fn subscribe_exit(&self) -> broadcast::Receiver<ExitStatus> {
+    /// The returned receiver always sees the *latest* value of the exit
+    /// status, including if the child has already exited before the call
+    /// (the watch channel latches the final `Some(...)`).
+    pub fn subscribe_exit(&self) -> watch::Receiver<Option<ExitStatus>> {
         self.exit_tx.subscribe()
+    }
+
+    /// Return the exit status if the child has already terminated, or `None`
+    /// while it is still running.
+    pub fn exit_status(&self) -> Option<ExitStatus> {
+        *self.exit_tx.borrow()
     }
 
     /// Write `data` to the PTY's stdin.
@@ -267,16 +277,30 @@ impl PtySession {
     /// `Arc<PtySession>` from `get()`). Temp-dir cleanup happens when the
     /// last `Arc` is dropped — usually the manager removing the entry
     /// after this returns.
+    ///
+    /// Safe to call when the child has already exited: returns immediately
+    /// without erroring.
+    ///
+    /// On Unix the kill is `SIGHUP` (what `portable_pty::ChildKiller::kill`
+    /// emits); on Windows it is `TerminateProcess`. Most agent CLIs treat
+    /// either as a clean shutdown signal. If a future agent needs `SIGTERM`
+    /// specifically, signal it directly via `libc::kill` from `cfg(unix)`
+    /// code rather than changing this default.
     pub async fn terminate(&self) -> anyhow::Result<()> {
-        // Subscribe BEFORE sending the kill so we cannot miss the broadcast
-        // if the watcher fires immediately. (Late subscribers see Closed
-        // once the watcher drops its sender, which would be a spurious
-        // failure here.)
+        // Subscribe to the watch channel up front. `watch::Receiver` always
+        // sees the latest value, so this works whether the child has already
+        // exited or is still running.
         let mut exit_rx = self.exit_tx.subscribe();
 
+        // Fast path: if the watcher has already latched a value, the child
+        // is gone and there is nothing to kill.
+        if exit_rx.borrow().is_some() {
+            return Ok(());
+        }
+
         // Send the kill signal. If the child has already exited, kill()
-        // returns an error which we ignore — we just want to make sure the
-        // process is gone before we drop the temp dir.
+        // returns an error which we ignore — the watch loop below will
+        // observe the exit either way.
         {
             let killer = self.child_killer.clone();
             tokio::task::spawn_blocking(move || {
@@ -287,11 +311,19 @@ impl PtySession {
             .map_err(|e| anyhow::anyhow!("terminate kill task panicked: {}", e))?;
         }
 
-        match exit_rx.recv().await {
-            Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => Ok(()),
-            Err(broadcast::error::RecvError::Closed) => Err(anyhow::anyhow!(
-                "exit watcher closed without reporting status"
-            )),
+        // Wait for the watcher to publish a `Some(_)`. `changed()` resolves
+        // every time the value transitions; we loop until the latched value
+        // is non-None to guard against spurious wakeups.
+        loop {
+            if exit_rx.borrow().is_some() {
+                return Ok(());
+            }
+            if exit_rx.changed().await.is_err() {
+                // Sender dropped — only happens if the session itself was
+                // dropped concurrently, which would be a logic error in
+                // the caller. Treat as success since the process is gone.
+                return Ok(());
+            }
         }
     }
 }
@@ -357,7 +389,7 @@ impl PtySession {
         let child_killer = child.clone_killer();
 
         let (output_tx, _) = broadcast::channel::<OutputChunk>(OUTPUT_CHANNEL_CAPACITY);
-        let (exit_tx, _) = broadcast::channel::<ExitStatus>(1);
+        let (exit_tx, _) = watch::channel::<Option<ExitStatus>>(None);
 
         let id = Uuid::new_v4();
         let started_at = Utc::now();
@@ -388,10 +420,10 @@ impl PtySession {
     }
 }
 
-/// Background task: own the child, wait for it to exit, broadcast the status.
+/// Background task: own the child, wait for it to exit, latch the status.
 fn spawn_exit_watcher_task(
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
-    exit_tx: broadcast::Sender<ExitStatus>,
+    exit_tx: watch::Sender<Option<ExitStatus>>,
 ) {
     tokio::task::spawn_blocking(move || {
         let status = match child.wait() {
@@ -407,11 +439,11 @@ fn spawn_exit_watcher_task(
                 }
             }
         };
-        let _ = exit_tx.send(status);
+        let _ = exit_tx.send(Some(status));
     });
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::time::Duration;
@@ -435,6 +467,26 @@ mod tests {
         out
     }
 
+    /// Wait for the watch receiver to latch a `Some(_)` exit status, with a
+    /// deadline. Returns the latched status or panics on timeout.
+    async fn await_exit(
+        rx: &mut watch::Receiver<Option<ExitStatus>>,
+        deadline: Duration,
+    ) -> ExitStatus {
+        timeout(deadline, async {
+            loop {
+                if let Some(s) = *rx.borrow() {
+                    return s;
+                }
+                if rx.changed().await.is_err() {
+                    panic!("exit sender dropped before publishing status");
+                }
+            }
+        })
+        .await
+        .expect("exit status latched within deadline")
+    }
+
     #[tokio::test]
     async fn launch_for_test_runs_command_and_emits_output() {
         let session =
@@ -454,10 +506,7 @@ mod tests {
             text
         );
 
-        let status = timeout(Duration::from_secs(2), exit_rx.recv())
-            .await
-            .expect("exit broadcast within deadline")
-            .expect("clean exit broadcast");
+        let status = await_exit(&mut exit_rx, Duration::from_secs(2)).await;
         assert!(status.success, "echo should exit successfully");
     }
 
@@ -494,10 +543,7 @@ mod tests {
         session.resize(80, 24).await.expect("resize back succeeds");
 
         let mut exit_rx = session.subscribe_exit();
-        timeout(Duration::from_secs(3), exit_rx.recv())
-            .await
-            .expect("sleep completes")
-            .expect("clean exit");
+        await_exit(&mut exit_rx, Duration::from_secs(3)).await;
     }
 
     #[tokio::test]
@@ -513,10 +559,7 @@ mod tests {
             .expect("terminate returns within deadline")
             .expect("terminate succeeds");
 
-        let status = timeout(Duration::from_secs(1), exit_rx.recv())
-            .await
-            .expect("exit broadcast lands")
-            .expect("exit status received");
+        let status = await_exit(&mut exit_rx, Duration::from_secs(1)).await;
         assert!(!status.success, "killed process should not report success");
     }
 
@@ -529,10 +572,7 @@ mod tests {
         assert!(temp_path.exists(), "temp dir should exist immediately");
 
         let mut exit_rx = session.subscribe_exit();
-        timeout(Duration::from_secs(2), exit_rx.recv())
-            .await
-            .expect("exit lands")
-            .expect("clean exit");
+        await_exit(&mut exit_rx, Duration::from_secs(2)).await;
 
         // Session still in scope: temp dir still exists.
         assert!(
@@ -547,5 +587,100 @@ mod tests {
             !temp_path.exists(),
             "temp dir should be removed when session drops"
         );
+    }
+
+    // ---- Regression: late subscribers and double-terminate -------------------
+
+    /// `terminate()` must not hang if the child has already exited naturally
+    /// before terminate is called. Regression test for review Finding #1.
+    #[tokio::test]
+    async fn terminate_after_natural_exit_returns_immediately() {
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "echo done".into()])
+            .expect("launch echo session");
+
+        // Wait until the watcher has latched the exit.
+        let mut exit_rx = session.subscribe_exit();
+        await_exit(&mut exit_rx, Duration::from_secs(2)).await;
+        assert!(session.exit_status().is_some());
+
+        // Now terminate — must not block on a missing broadcast.
+        timeout(Duration::from_secs(2), session.terminate())
+            .await
+            .expect("terminate returns immediately after natural exit")
+            .expect("terminate succeeds");
+    }
+
+    /// `subscribe_exit()` after the child has exited must immediately observe
+    /// the latched status — the `watch` channel does not drop values like a
+    /// single-shot `broadcast` does. Regression test for review Finding #2.
+    #[tokio::test]
+    async fn subscribe_exit_after_exit_observes_status() {
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "echo done".into()])
+            .expect("launch echo session");
+
+        // Wait via a first subscriber.
+        let mut exit_rx = session.subscribe_exit();
+        await_exit(&mut exit_rx, Duration::from_secs(2)).await;
+
+        // Now create a fresh subscriber after exit. It must see Some(_).
+        let late_rx = session.subscribe_exit();
+        let latched = *late_rx.borrow();
+        assert!(
+            latched.is_some(),
+            "watch receiver subscribed after exit should still see the status"
+        );
+        assert!(latched.unwrap().success);
+    }
+
+    /// Calling `terminate()` twice must be safe.
+    #[tokio::test]
+    async fn terminate_is_idempotent() {
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "sleep 30".into()])
+            .expect("launch sleep session");
+
+        timeout(Duration::from_secs(3), session.terminate())
+            .await
+            .expect("first terminate returns")
+            .expect("first terminate succeeds");
+
+        timeout(Duration::from_secs(1), session.terminate())
+            .await
+            .expect("second terminate returns immediately")
+            .expect("second terminate succeeds");
+    }
+
+    /// `write_input` and `resize` use independent locks (writer vs master);
+    /// hammering both concurrently should not deadlock.
+    #[tokio::test]
+    async fn concurrent_write_and_resize_do_not_deadlock() {
+        let session =
+            Arc::new(PtySession::launch_for_test("cat", vec![]).expect("launch cat session"));
+
+        let writer_session = session.clone();
+        let writer = tokio::spawn(async move {
+            for i in 0..20 {
+                writer_session
+                    .write_input(format!("line {}\n", i).as_bytes())
+                    .await
+                    .expect("write succeeds");
+            }
+        });
+
+        let resizer_session = session.clone();
+        let resizer = tokio::spawn(async move {
+            for _ in 0..20 {
+                let _ = resizer_session.resize(80, 24).await;
+                let _ = resizer_session.resize(120, 40).await;
+            }
+        });
+
+        timeout(Duration::from_secs(5), async {
+            writer.await.unwrap();
+            resizer.await.unwrap();
+        })
+        .await
+        .expect("writer + resizer complete without deadlock");
+
+        session.terminate().await.expect("terminate cat");
     }
 }

--- a/packages/agent/src/pty/session.rs
+++ b/packages/agent/src/pty/session.rs
@@ -1,0 +1,551 @@
+//! One running agent process attached to a pseudo-terminal.
+//!
+//! A [`PtySession`] owns:
+//!
+//! * a per-session [`tempfile::TempDir`] (the agent's working directory),
+//! * the master end of a PTY pair (`portable-pty`),
+//! * a writer into the PTY's stdin,
+//! * a [`portable_pty::ChildKiller`] handle for the spawned process,
+//! * a background blocking task that reads the PTY's output and fans it out
+//!   through `broadcast::Sender<OutputChunk>`,
+//! * a watcher task (which owns the actual `Child`) that broadcasts the
+//!   process exit status through `broadcast::Sender<ExitStatus>`.
+//!
+//! The temp dir is dropped when the session value is dropped, so any cleanup
+//! path — explicit [`PtySession::terminate`] or natural process exit followed
+//! by the manager removing the entry — also removes the working directory.
+//!
+//! ## Concurrency
+//!
+//! The exit-watcher task owns the [`portable_pty::Child`] exclusively so it
+//! can block in `wait()` without holding any lock the session might need.
+//! [`PtySession::terminate`] kills the child through a separately-cloned
+//! [`portable_pty::ChildKiller`], avoiding the obvious deadlock of a kill
+//! call waiting on a mutex the wait-loop already holds.
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, Mutex};
+use uuid::Uuid;
+
+use crate::acp::context_assembly::GraphContextAssembler;
+use crate::acp::registry::SystemAgentRegistry;
+use crate::agent_types::{AgentType, ContextError};
+
+/// Number of buffered chunks per output subscriber. Slow consumers that fall
+/// behind by more than this many chunks will see `RecvError::Lagged`; that is
+/// preferable to unbounded memory growth when an agent is streaming faster
+/// than a UI can render.
+const OUTPUT_CHANNEL_CAPACITY: usize = 256;
+
+/// Read buffer for the PTY output thread. PTY data is byte-by-byte in the
+/// worst case (one keystroke echo), but typical chunks are tens to a few
+/// hundred bytes, so 4 KiB amortises syscalls without delaying small writes.
+const READ_BUFFER_BYTES: usize = 4096;
+
+/// Default PTY size used at launch. Callers reshape via [`PtySession::resize`]
+/// as soon as they know their terminal geometry.
+const DEFAULT_PTY_ROWS: u16 = 24;
+const DEFAULT_PTY_COLS: u16 = 80;
+
+/// One chunk of raw bytes read from the PTY master.
+///
+/// The PTY merges stdout and stderr into a single byte stream — there is no
+/// way to distinguish them at this layer. Consumers (UI, capture pipeline)
+/// are expected to render the stream as a terminal would.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputChunk {
+    /// Raw bytes from the PTY. May contain partial UTF-8 sequences and
+    /// terminal escape codes.
+    pub data: Vec<u8>,
+    /// Wall-clock time the chunk was read off the master FD.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Exit status observed when the agent process terminates.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ExitStatus {
+    /// Raw exit code reported by `portable_pty::ExitStatus`. Zero on clean
+    /// exit, non-zero on failure or signal termination.
+    pub code: u32,
+    /// `true` if the child exited cleanly (code == 0, no signal).
+    pub success: bool,
+}
+
+/// One agent process running inside a PTY.
+pub struct PtySession {
+    /// Stable identifier for this session.
+    pub id: Uuid,
+    /// Which external agent (Claude Code, Codex, ...) is running.
+    pub agent_type: AgentType,
+    /// When [`PtySession::launch`] returned successfully.
+    pub started_at: DateTime<Utc>,
+
+    /// Master end of the PTY. Held under a mutex so [`resize`](Self::resize)
+    /// can be called from any task without racing the output reader.
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+    /// Writer to the PTY's stdin. Acquired once at launch via
+    /// `master.take_writer()` so [`write_input`](Self::write_input) does not
+    /// have to fight the reader for the master.
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// Kill handle for the child process. The actual [`portable_pty::Child`]
+    /// lives in the exit-watcher task; this handle is what we use to send
+    /// a signal without contending on that task's ownership.
+    child_killer: Arc<Mutex<Box<dyn portable_pty::ChildKiller + Send + Sync>>>,
+
+    /// Fan-out for output chunks.
+    output_tx: broadcast::Sender<OutputChunk>,
+    /// Fan-out for process exit. A single value is sent when the child exits;
+    /// subscribers created before exit will receive it.
+    exit_tx: broadcast::Sender<ExitStatus>,
+
+    /// Per-session working directory. Dropping this session drops the
+    /// `TempDir`, which deletes the directory tree on disk.
+    _session_dir: tempfile::TempDir,
+}
+
+impl PtySession {
+    /// Spawn the agent binary for `agent_type` in a fresh PTY.
+    ///
+    /// Steps, in order:
+    ///
+    /// 1. Create a temp directory (auto-cleaned on session drop).
+    /// 2. Have `assembler` write the context file (`CLAUDE.md` / `AGENTS.md`)
+    ///    into the temp directory.
+    /// 3. Resolve the agent binary on `PATH` via [`which::which`].
+    /// 4. Open a PTY pair and spawn the binary with `cwd` set to the temp dir.
+    /// 5. Start the reader and exit-watcher tasks.
+    pub async fn launch(
+        agent_type: AgentType,
+        initial_prompt: Option<String>,
+        assembler: &GraphContextAssembler,
+    ) -> anyhow::Result<Self> {
+        let session_dir = tempfile::tempdir()?;
+
+        assembler
+            .write_context_file(session_dir.path(), agent_type)
+            .await
+            .map_err(|e| match e {
+                ContextError::Other(err) => err,
+                other => anyhow::Error::new(other),
+            })?;
+
+        let definition = SystemAgentRegistry::new()
+            .get(agent_type)
+            .ok_or_else(|| anyhow::anyhow!("agent {:?} missing from catalog", agent_type))?;
+
+        let binary_path = which::which(definition.binary).map_err(|e| {
+            anyhow::anyhow!(
+                "agent binary '{}' not found on PATH: {}",
+                definition.binary,
+                e
+            )
+        })?;
+
+        Self::spawn_in_pty(
+            agent_type,
+            binary_path,
+            initial_prompt,
+            session_dir,
+            DEFAULT_PTY_ROWS,
+            DEFAULT_PTY_COLS,
+        )
+    }
+
+    /// Inner helper that opens the PTY, spawns the process, and wires up
+    /// reader / exit-watcher tasks. Split out from [`launch`](Self::launch)
+    /// so tests can construct sessions without going through
+    /// [`GraphContextAssembler`].
+    fn spawn_in_pty(
+        agent_type: AgentType,
+        binary_path: std::path::PathBuf,
+        initial_prompt: Option<String>,
+        session_dir: tempfile::TempDir,
+        rows: u16,
+        cols: u16,
+    ) -> anyhow::Result<Self> {
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+
+        let mut cmd = CommandBuilder::new(binary_path);
+        cmd.cwd(session_dir.path());
+        if let Some(prompt) = initial_prompt {
+            cmd.arg(prompt);
+        }
+
+        let child = pair.slave.spawn_command(cmd)?;
+        // `portable-pty` recommends dropping the slave handle once the child
+        // is spawned so closing the master tears down the PTY cleanly.
+        drop(pair.slave);
+
+        let reader = pair.master.try_clone_reader()?;
+        let writer = pair.master.take_writer()?;
+        let child_killer = child.clone_killer();
+
+        let (output_tx, _) = broadcast::channel::<OutputChunk>(OUTPUT_CHANNEL_CAPACITY);
+        let (exit_tx, _) = broadcast::channel::<ExitStatus>(1);
+
+        let id = Uuid::new_v4();
+        let started_at = Utc::now();
+
+        let master = Arc::new(Mutex::new(pair.master));
+        let writer = Arc::new(Mutex::new(writer));
+        let child_killer = Arc::new(Mutex::new(child_killer));
+
+        spawn_reader_task(reader, output_tx.clone());
+        spawn_exit_watcher_task(child, exit_tx.clone());
+
+        Ok(Self {
+            id,
+            agent_type,
+            started_at,
+            master,
+            writer,
+            child_killer,
+            output_tx,
+            exit_tx,
+            _session_dir: session_dir,
+        })
+    }
+
+    /// Subscribe to the PTY's output byte stream.
+    ///
+    /// Every subscriber sees the same stream from the point of subscription
+    /// forward. Subscribers that fall too far behind will get
+    /// `RecvError::Lagged`.
+    pub fn subscribe_output(&self) -> broadcast::Receiver<OutputChunk> {
+        self.output_tx.subscribe()
+    }
+
+    /// Subscribe to the child-exit signal.
+    ///
+    /// Exactly one [`ExitStatus`] value is broadcast when the child exits;
+    /// subscribers that subscribed before exit will receive it.
+    pub fn subscribe_exit(&self) -> broadcast::Receiver<ExitStatus> {
+        self.exit_tx.subscribe()
+    }
+
+    /// Write `data` to the PTY's stdin.
+    pub async fn write_input(&self, data: &[u8]) -> anyhow::Result<()> {
+        let writer = self.writer.clone();
+        let buf = data.to_vec();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let mut guard = writer.blocking_lock();
+            guard.write_all(&buf)?;
+            guard.flush()?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("write_input task panicked: {}", e))?
+    }
+
+    /// Resize the PTY to `cols` x `rows`.
+    pub async fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<()> {
+        let master = self.master.lock().await;
+        master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        Ok(())
+    }
+
+    /// Kill the child process and wait for the exit-watcher to observe it.
+    ///
+    /// Takes `&self` rather than consuming the session, because typical
+    /// callers hold the session behind an `Arc` (the manager hands out
+    /// `Arc<PtySession>` from `get()`). Temp-dir cleanup happens when the
+    /// last `Arc` is dropped — usually the manager removing the entry
+    /// after this returns.
+    pub async fn terminate(&self) -> anyhow::Result<()> {
+        // Subscribe BEFORE sending the kill so we cannot miss the broadcast
+        // if the watcher fires immediately. (Late subscribers see Closed
+        // once the watcher drops its sender, which would be a spurious
+        // failure here.)
+        let mut exit_rx = self.exit_tx.subscribe();
+
+        // Send the kill signal. If the child has already exited, kill()
+        // returns an error which we ignore — we just want to make sure the
+        // process is gone before we drop the temp dir.
+        {
+            let killer = self.child_killer.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut guard = killer.blocking_lock();
+                let _ = guard.kill();
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("terminate kill task panicked: {}", e))?;
+        }
+
+        match exit_rx.recv().await {
+            Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => Ok(()),
+            Err(broadcast::error::RecvError::Closed) => Err(anyhow::anyhow!(
+                "exit watcher closed without reporting status"
+            )),
+        }
+    }
+}
+
+/// Background task: read from the PTY master and fan bytes out to subscribers.
+///
+/// Runs on the blocking pool because `portable-pty`'s reader is synchronous.
+/// The task ends naturally when the reader returns EOF (child closed the PTY)
+/// or hits an error.
+fn spawn_reader_task(mut reader: Box<dyn Read + Send>, output_tx: broadcast::Sender<OutputChunk>) {
+    tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; READ_BUFFER_BYTES];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break, // EOF: child closed the PTY.
+                Ok(n) => {
+                    let chunk = OutputChunk {
+                        data: buf[..n].to_vec(),
+                        timestamp: Utc::now(),
+                    };
+                    // Send errors only happen when no receivers exist; that
+                    // is fine — keep draining the PTY so the kernel buffer
+                    // does not fill and block the child.
+                    let _ = output_tx.send(chunk);
+                }
+                Err(e) => {
+                    tracing::warn!("pty reader error: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+impl PtySession {
+    /// Test-only constructor: spawn an arbitrary binary in a PTY without
+    /// going through [`GraphContextAssembler`]. Lets tests use shell utilities
+    /// (`cat`, `sh -c '...'`) instead of depending on a real agent binary.
+    pub(crate) fn launch_for_test(binary: &str, args: Vec<String>) -> anyhow::Result<Self> {
+        let session_dir = tempfile::tempdir()?;
+        let binary_path = which::which(binary)
+            .map_err(|e| anyhow::anyhow!("test binary '{}' not on PATH: {}", binary, e))?;
+        let agent_type = AgentType::ClaudeCode;
+
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows: DEFAULT_PTY_ROWS,
+            cols: DEFAULT_PTY_COLS,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        let mut cmd = CommandBuilder::new(binary_path);
+        cmd.cwd(session_dir.path());
+        for a in &args {
+            cmd.arg(a);
+        }
+        let child = pair.slave.spawn_command(cmd)?;
+        drop(pair.slave);
+
+        let reader = pair.master.try_clone_reader()?;
+        let writer = pair.master.take_writer()?;
+        let child_killer = child.clone_killer();
+
+        let (output_tx, _) = broadcast::channel::<OutputChunk>(OUTPUT_CHANNEL_CAPACITY);
+        let (exit_tx, _) = broadcast::channel::<ExitStatus>(1);
+
+        let id = Uuid::new_v4();
+        let started_at = Utc::now();
+
+        let master = Arc::new(Mutex::new(pair.master));
+        let writer = Arc::new(Mutex::new(writer));
+        let child_killer = Arc::new(Mutex::new(child_killer));
+
+        spawn_reader_task(reader, output_tx.clone());
+        spawn_exit_watcher_task(child, exit_tx.clone());
+
+        Ok(Self {
+            id,
+            agent_type,
+            started_at,
+            master,
+            writer,
+            child_killer,
+            output_tx,
+            exit_tx,
+            _session_dir: session_dir,
+        })
+    }
+
+    /// Test-only accessor: where this session's temp dir lives.
+    pub(crate) fn session_dir_path(&self) -> &std::path::Path {
+        self._session_dir.path()
+    }
+}
+
+/// Background task: own the child, wait for it to exit, broadcast the status.
+fn spawn_exit_watcher_task(
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    exit_tx: broadcast::Sender<ExitStatus>,
+) {
+    tokio::task::spawn_blocking(move || {
+        let status = match child.wait() {
+            Ok(s) => ExitStatus {
+                code: s.exit_code(),
+                success: s.success(),
+            },
+            Err(e) => {
+                tracing::warn!("pty child wait error: {}", e);
+                ExitStatus {
+                    code: u32::MAX,
+                    success: false,
+                }
+            }
+        };
+        let _ = exit_tx.send(status);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Drain at most `max_chunks` chunks within `wait` from a subscriber and
+    /// return the concatenated bytes. Used by tests that need to inspect the
+    /// PTY's output stream without depending on exact chunk boundaries.
+    async fn collect_output(
+        rx: &mut broadcast::Receiver<OutputChunk>,
+        wait: Duration,
+        max_chunks: usize,
+    ) -> Vec<u8> {
+        let mut out = Vec::new();
+        for _ in 0..max_chunks {
+            match timeout(wait, rx.recv()).await {
+                Ok(Ok(chunk)) => out.extend_from_slice(&chunk.data),
+                _ => break,
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn launch_for_test_runs_command_and_emits_output() {
+        let session =
+            PtySession::launch_for_test("sh", vec!["-c".into(), "echo hello-from-pty".into()])
+                .expect("launch test session");
+
+        assert_eq!(session.agent_type, AgentType::ClaudeCode);
+        assert!(session.session_dir_path().exists());
+
+        let mut rx = session.subscribe_output();
+        let mut exit_rx = session.subscribe_exit();
+        let output = collect_output(&mut rx, Duration::from_secs(2), 32).await;
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("hello-from-pty"),
+            "expected echoed text in PTY output, got: {:?}",
+            text
+        );
+
+        let status = timeout(Duration::from_secs(2), exit_rx.recv())
+            .await
+            .expect("exit broadcast within deadline")
+            .expect("clean exit broadcast");
+        assert!(status.success, "echo should exit successfully");
+    }
+
+    #[tokio::test]
+    async fn write_input_is_echoed_back_through_pty() {
+        // `cat` echoes stdin back to stdout, which the PTY then loops back
+        // to its output stream.
+        let session = PtySession::launch_for_test("cat", vec![]).expect("launch cat session");
+
+        let mut rx = session.subscribe_output();
+
+        session
+            .write_input(b"ping\n")
+            .await
+            .expect("write input succeeds");
+
+        let output = collect_output(&mut rx, Duration::from_secs(2), 32).await;
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("ping"),
+            "expected echoed input in PTY output, got: {:?}",
+            text
+        );
+
+        session.terminate().await.expect("terminate cat session");
+    }
+
+    #[tokio::test]
+    async fn resize_does_not_error() {
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "sleep 1".into()])
+            .expect("launch sleep session");
+
+        session.resize(120, 40).await.expect("resize succeeds");
+        session.resize(80, 24).await.expect("resize back succeeds");
+
+        let mut exit_rx = session.subscribe_exit();
+        timeout(Duration::from_secs(3), exit_rx.recv())
+            .await
+            .expect("sleep completes")
+            .expect("clean exit");
+    }
+
+    #[tokio::test]
+    async fn terminate_kills_long_running_process() {
+        // `sleep 30` would normally outlive the test; terminate must end it.
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "sleep 30".into()])
+            .expect("launch sleep session");
+
+        let mut exit_rx = session.subscribe_exit();
+
+        timeout(Duration::from_secs(3), session.terminate())
+            .await
+            .expect("terminate returns within deadline")
+            .expect("terminate succeeds");
+
+        let status = timeout(Duration::from_secs(1), exit_rx.recv())
+            .await
+            .expect("exit broadcast lands")
+            .expect("exit status received");
+        assert!(!status.success, "killed process should not report success");
+    }
+
+    #[tokio::test]
+    async fn natural_exit_keeps_temp_dir_until_session_drops() {
+        let session = PtySession::launch_for_test("sh", vec!["-c".into(), "echo done".into()])
+            .expect("launch echo session");
+
+        let temp_path = session.session_dir_path().to_path_buf();
+        assert!(temp_path.exists(), "temp dir should exist immediately");
+
+        let mut exit_rx = session.subscribe_exit();
+        timeout(Duration::from_secs(2), exit_rx.recv())
+            .await
+            .expect("exit lands")
+            .expect("clean exit");
+
+        // Session still in scope: temp dir still exists.
+        assert!(
+            temp_path.exists(),
+            "temp dir should outlive process exit until session drops"
+        );
+
+        drop(session);
+
+        // After drop the TempDir's destructor removes the directory tree.
+        assert!(
+            !temp_path.exists(),
+            "temp dir should be removed when session drops"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1118.

## Summary

Adds the Rust-side engine for ADR-032: PTY-based agent sessions. Everything else
(gRPC handler, Tauri UI, CLI) depends on this layer working correctly.

- `packages/agent/src/pty/session.rs` — `PtySession` owns one external agent
  process attached to a pseudo-terminal. Methods: `launch`, `subscribe_output`,
  `subscribe_exit`, `write_input`, `resize`, `terminate`. Each session has its
  own `tempfile::TempDir`; `GraphContextAssembler` writes `CLAUDE.md`/`AGENTS.md`
  into it and the binary spawns with `cwd` = temp dir. Stdout/stderr stream
  through `broadcast::Sender<OutputChunk>`; child exit fans out through a
  separate `broadcast::Sender<ExitStatus>`.

- `packages/agent/src/pty/manager.rs` — `PtySessionManager` owns the collection,
  backed by `Arc<Mutex<HashMap<Uuid, Arc<PtySession>>>>`. Each `insert` spawns a
  task that prunes the session from the map when the exit broadcast fires, so
  the temp dir cleans up on its own when the agent exits naturally.

## Key design decisions

- **Bytes, not strings**, on the output stream (`OutputChunk.data: Vec<u8>`).
  PTY output can split UTF-8 sequences mid-byte and carries terminal escape
  codes. Higher layers render the stream like a terminal would.

- **Deadlock-free terminate.** The exit-watcher task owns the `portable_pty::Child`
  exclusively so it can block in `wait()` without holding any lock `terminate()`
  needs. `terminate()` signals the kill through a separately-cloned `ChildKiller`,
  avoiding the obvious deadlock where kill waits on a mutex the wait-loop holds.

- **Subscribe-before-kill in `terminate`** to avoid racing the watcher: if we
  subscribed after sending the kill, a fast exit could broadcast and close
  before we ever called `subscribe()`, leaving us hanging on a closed channel.

- **Temp dir lives in the session struct**, so it auto-cleans on drop — both
  paths (explicit `terminate`, natural exit pruning) end with the manager
  releasing its `Arc`, which drops the session, which drops the `TempDir`.

## Test plan

- [x] `cargo test -p nodespace-agent --lib` — **245 passed** (235 prior + 10 new pty tests)
- [x] `cargo clippy -p nodespace-agent --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] `bun run test` (frontend) — **3918/3918 passed** (baseline unchanged)
- [x] `bun run quality:fix` (eslint + svelte-check) — 0 errors, 0 warnings

### New PTY tests (`packages/agent/src/pty/`)

Session tests use `sh`/`cat` from `PATH` so they do not depend on a real agent
binary being installed.

- `launch_for_test_runs_command_and_emits_output` — `echo` round-trips through the PTY
- `write_input_is_echoed_back_through_pty` — `cat` echoes stdin back via the stream
- `resize_does_not_error` — resize before and during a running process
- `terminate_kills_long_running_process` — `sleep 30` ends within 3s of terminate
- `natural_exit_keeps_temp_dir_until_session_drops` — temp dir lifetime matches session lifetime, not process lifetime
- `insert_then_list_returns_metadata` — manager round-trip with `SessionMetadata`
- `terminate_removes_session_and_returns_true` — explicit terminate path
- `terminate_unknown_returns_false` — terminate on stale id
- `natural_exit_auto_removes_session` — exit watcher prunes the map
- `get_returns_session_and_supports_write_resize` — `Arc<PtySession>` from `get()` is fully usable

## Acceptance criteria (from #1118)

- [x] `PtySessionManager` holds all active sessions; supports concurrent access
- [x] `PtySession::launch()` creates a temp dir, writes context via `GraphContextAssembler`, spawns the agent in a PTY
- [x] stdout/stderr stream through `broadcast::Sender<OutputChunk>`
- [x] `write_input(data: &[u8])` sends bytes to PTY stdin
- [x] `resize(cols: u16, rows: u16)` resizes the PTY
- [x] `terminate()` signals the child and cleans up the temp directory
- [x] Natural exit also triggers temp dir cleanup (via manager's auto-prune watcher)
- [x] `list_sessions()` (named `list()` here) returns metadata for all active sessions
- [x] Session IDs are UUIDs generated at launch time
- [x] Unit tests cover launch, write_input, resize, terminate, natural exit cleanup
- [x] `cargo test -p nodespace-agent` passes (the issue body wrote `-p agent`, which is a typo — the crate name is `nodespace-agent`)
- [x] Code passes `bun run quality:fix`

## Deviations from the spec

- `terminate()` takes `&self` instead of `self`. The manager hands out `Arc<PtySession>` from `get()`, so consuming `self` would require either `Arc::try_unwrap` (fragile under concurrent `get()` callers) or a fallback path. Taking `&self` is simpler and equivalent: the temp dir still drops when the last `Arc` is dropped — usually right after `terminate()` returns, when the manager removes its entry.
- Added `ExitStatus` and `subscribe_exit()` (not in the issue spec) because the manager needs them for auto-prune, and gRPC handlers in the follow-up issue will likely surface them too.
- `.gitignore` carried a `session*.rs` rule for debug artifacts; added `!**/src/pty/session.rs` to the existing allowlist (the rule already had `!**/src/acp/session.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)