### PR TITLE
Add ImportService gRPC: proto definition, nodespaced handler, and Tauri proxy (closes #1136)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -101,7 +101,7 @@ dependencies = [
  "cssparser 0.35.0",
  "html5ever 0.35.0",
  "maplit",
- "tendril",
+ "tendril 0.4.3",
  "url",
 ]
 
@@ -122,9 +122,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -137,15 +137,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -156,7 +156,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -239,27 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
-dependencies = [
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.2",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "tokio",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -312,14 +291,14 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -328,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -352,14 +331,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -370,7 +349,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -392,7 +371,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -409,7 +388,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -458,9 +437,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -469,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -508,7 +487,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -516,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
  "bytes",
@@ -534,7 +513,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -586,7 +565,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -609,9 +588,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
@@ -638,7 +617,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -649,7 +628,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -675,11 +654,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -705,16 +684,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -734,20 +713,11 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
-dependencies = [
- "objc2 0.6.1",
+ "objc2",
 ]
 
 [[package]]
@@ -781,25 +751,26 @@ checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -810,9 +781,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -830,10 +801,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.0"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecheck"
@@ -859,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -900,7 +880,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -921,11 +901,11 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -958,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.5",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1044,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -1065,7 +1045,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1118,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1128,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1140,27 +1120,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1187,7 +1167,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "block",
  "cocoa-foundation 0.2.1",
  "core-foundation 0.10.1",
@@ -1217,7 +1197,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "block",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
@@ -1260,12 +1240,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -1322,7 +1296,20 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
@@ -1346,7 +1333,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1356,6 +1343,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1420,7 +1416,7 @@ dependencies = [
  "chrono",
  "once_cell",
  "phf 0.11.3",
- "winnow 0.7.12",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1499,29 +1495,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.29.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "matches",
- "phf 0.10.1",
- "proc-macro2",
- "quote",
- "smallvec",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1538,24 +1517,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.104",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "curve25519-dalek"
@@ -1564,7 +1562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1581,14 +1579,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1596,34 +1594,33 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1635,9 +1632,20 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "der"
@@ -1652,25 +1660,33 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1730,7 +1746,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1741,14 +1757,14 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.1",
+ "bitflags 2.11.1",
+ "block2",
  "libc",
- "objc2 0.6.1",
+ "objc2",
 ]
 
 [[package]]
@@ -1759,16 +1775,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading 0.8.9",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1784,14 +1791,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlopen2_derive"
-version = "0.4.1"
+name = "dlopen2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1800,7 +1819,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1811,6 +1830,21 @@ checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
  "trice",
  "urlencoding",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "precomputed-hash",
+ "selectors",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1830,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -1842,6 +1876,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1932,14 +1981,14 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "3.0.5"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6d81016d6c977deefb2ef8d8290da019e27cc26167e102185da528e6c0ab38"
+checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.5",
+ "toml 1.1.2+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -1961,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "endi"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "endian-type"
@@ -2002,7 +2051,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2019,22 +2068,23 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2084,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -2125,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "file-locker"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c3e69656680c6c3d76750b46dfa64bf07626bd2130c540d6cf2d306ba595a8"
+checksum = "75ae8b5984a4863d8a32109a848d038bd6d914f20f010cc141375f7a183c41cf"
 dependencies = [
  "nix 0.29.0",
 ]
@@ -2170,16 +2220,16 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "rustc_version",
  "serde",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2202,6 +2252,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2230,7 +2286,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2294,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2309,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2319,15 +2375,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2336,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2355,26 +2411,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2384,9 +2440,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2396,7 +2452,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2407,15 +2462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -2578,7 +2624,7 @@ dependencies = [
  "i_overlay",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "robust",
  "rstar 0.12.2",
  "serde",
@@ -2588,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
@@ -2605,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
 dependencies = [
  "libm",
 ]
@@ -2623,25 +2669,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2710,7 +2745,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2734,11 +2769,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2828,14 +2863,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2843,7 +2878,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2852,12 +2887,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2913,13 +2949,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2927,6 +2963,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -3031,25 +3078,23 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token 0.1.0",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
  "markup5ever 0.35.0",
- "match_token 0.35.0",
+ "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -3105,13 +3150,14 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -3126,15 +3172,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3171,14 +3216,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -3187,7 +3231,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3240,9 +3284,9 @@ checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3250,7 +3294,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3264,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
+checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
  "png 0.17.16",
@@ -3274,12 +3318,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3287,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3300,11 +3345,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -3315,42 +3359,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3383,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3417,12 +3457,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3456,19 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-docker"
@@ -3481,13 +3511,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3544,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -3580,7 +3610,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3589,9 +3619,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3605,10 +3657,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -3637,26 +3691,27 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "ed25519-dalek",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hmac",
  "js-sys",
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
  "sha2",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3665,21 +3720,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "kuchikiki"
-version = "0.8.8-speedreader"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
-dependencies = [
- "cssparser 0.29.6",
- "html5ever 0.29.1",
- "indexmap 2.13.0",
- "selectors",
 ]
 
 [[package]]
@@ -3732,9 +3775,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3753,22 +3805,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.9.1",
  "libc",
 ]
 
@@ -3793,9 +3844,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3833,9 +3884,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
@@ -3876,9 +3927,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -3886,7 +3937,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3922,38 +3973,24 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "tendril",
- "web_atoms",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
 ]
 
 [[package]]
-name = "match_token"
-version = "0.1.0"
+name = "markup5ever"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.4",
 ]
 
 [[package]]
@@ -3964,7 +4001,7 @@ checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3975,12 +4012,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -4016,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -4097,13 +4128,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4118,24 +4149,44 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
  "gtk",
  "keyboard-types",
  "libxdo",
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "once_cell",
  "png 0.17.16",
- "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "muda"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "once_cell",
+ "png 0.18.1",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4191,13 +4242,13 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "ndarray",
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4206,8 +4257,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.1",
- "jni-sys",
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -4227,7 +4278,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -4265,23 +4316,10 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4299,7 +4337,7 @@ dependencies = [
  "nodespace-nlp-engine",
  "portable-pty",
  "regex",
- "reqwest 0.12.22",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -4389,7 +4427,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -4416,10 +4454,10 @@ dependencies = [
  "tokio-stream",
  "tonic 0.12.3",
  "tonic-build",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
- "tray-icon",
+ "tray-icon 0.21.3",
  "uuid",
 ]
 
@@ -4467,16 +4505,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "noisy_float"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fe6e6ebc0bf53de533cd456ca2d9de13de13856eda1518a285d7705a213af"
+checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
 dependencies = [
  "num-traits",
 ]
@@ -4493,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -4506,7 +4538,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4530,7 +4562,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4546,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -4592,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -4602,14 +4634,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4622,26 +4654,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
 name = "objc2"
-version = "0.5.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -4649,77 +4665,92 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.1",
- "libc",
- "objc2 0.6.1",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-foundation 0.3.1",
- "objc2-quartz-core 0.3.1",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17614fdcd9b411e6ff1117dfb1d0150f908ba83a7df81b1f118005fe0a8ea15d"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.9.1",
- "objc2 0.6.1",
- "objc2-foundation 0.3.1",
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-data"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291fbbf7d29287518e8686417cf7239c74700fd4b607623140a7d4a3c834329d"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.9.1",
- "objc2 0.6.1",
- "objc2-foundation 0.3.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2",
 ]
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
 
 [[package]]
 name = "objc2-core-image"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b3dc0cc4386b6ccf21c157591b34a7f44c8e75b064f85502901ab2188c007e"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2 0.6.1",
- "objc2-foundation 0.3.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4739,34 +4770,22 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.1",
- "block2 0.5.1",
+ "bitflags 2.11.1",
+ "block2",
  "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
-dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.1",
- "libc",
- "objc2 0.6.1",
+ "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -4774,87 +4793,84 @@ dependencies = [
 
 [[package]]
 name = "objc2-io-surface"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.9.1",
- "objc2 0.6.1",
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags 2.9.1",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
 name = "objc2-quartz-core"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.9.1",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
-dependencies = [
- "bitflags 2.9.1",
- "objc2 0.6.1",
- "objc2-foundation 0.3.1",
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.9.1",
- "objc2 0.6.1",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-web-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91672909de8b1ce1c2252e95bbee8c1649c9ad9d14b9248b3d7b4c47903c47ad"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.1",
- "objc2 0.6.1",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "humantime",
  "itertools 0.14.0",
@@ -4871,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4889,9 +4905,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.2"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -4901,15 +4917,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4922,7 +4937,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4933,9 +4948,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -5020,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -5054,7 +5069,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5136,27 +5151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5182,16 +5177,6 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
-dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
@@ -5201,23 +5186,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_generator"
-version = "0.8.0"
+name = "phf_codegen"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.5",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5227,7 +5202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5242,20 +5217,6 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
@@ -5264,7 +5225,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5277,26 +5238,8 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5305,7 +5248,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -5314,35 +5257,35 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
  "unicase",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -5352,9 +5295,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -5384,19 +5327,19 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
- "quick-xml 0.38.1",
+ "indexmap 2.14.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -5448,7 +5391,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5457,16 +5400,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5477,9 +5420,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -5507,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -5537,12 +5480,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5566,20 +5509,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.22.27",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -5607,16 +5551,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -5657,7 +5595,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -5671,7 +5609,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5684,7 +5622,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5801,7 +5739,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -5822,27 +5760,18 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick_cache"
-version = "0.6.19"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -5852,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5890,23 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5915,22 +5830,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5950,16 +5855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5968,34 +5864,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6012,9 +5890,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6038,11 +5916,11 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6051,7 +5929,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -6062,29 +5940,29 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6112,9 +5990,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -6133,9 +6011,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6164,7 +6042,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6176,9 +6054,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6199,7 +6077,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6211,9 +6089,9 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c3c8ec8b2be254beb5f8acdd80cdd57b7b5d40988c2ec3d0b7cdb6f7c2829b"
+checksum = "3b66f44139d1fe8e1b6c21bf1a855f12df38517aab94e21cea2a077e9753f216"
 dependencies = [
  "bytes",
  "chrono",
@@ -6227,13 +6105,13 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76be63634a8b1809e663bc0b975d78f6883c0fadbcce9c52e19b9e421f423357"
+checksum = "696cbf6f9d0bdeb7d75ef3a037c8295ea9fb665c89c6b70c23022f5918713353"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6248,27 +6126,26 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "ashpd",
- "block2 0.6.1",
+ "block2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6279,7 +6156,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -6316,31 +6193,28 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
- "byteorder",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6453,13 +6327,13 @@ checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -6485,25 +6359,26 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -6520,18 +6395,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -6542,9 +6417,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6552,9 +6427,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6563,15 +6438,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -6606,7 +6481,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6638,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -6657,14 +6532,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6712,11 +6581,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6740,32 +6609,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 1.3.2",
- "cssparser 0.29.6",
+ "bitflags 2.11.1",
+ "cssparser 0.36.0",
  "derive_more",
- "fxhash",
  "log",
- "phf 0.8.0",
- "phf_codegen 0.8.0",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -6783,12 +6653,13 @@ dependencies = [
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
 dependencies = [
  "erased-serde",
  "serde",
+ "serde_core",
  "typeid",
 ]
 
@@ -6809,7 +6680,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6820,7 +6691,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6855,7 +6726,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6869,11 +6740,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6890,19 +6761,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.0.4",
- "serde",
- "serde_derive",
+ "schemars 1.2.1",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -6910,14 +6781,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6964,9 +6835,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -6979,20 +6850,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serialize-to-javascript"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9823f2d3b6a81d98228151fdeaf848206a7855a7a042bbf9bf870449a66cafb"
+checksum = "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -7001,22 +6872,21 @@ dependencies = [
 
 [[package]]
 name = "serialize-to-javascript-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
+checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "servo_arc"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
- "nodrop",
  "stable_deref_trait",
 ]
 
@@ -7027,7 +6897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7038,7 +6908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7081,10 +6951,11 @@ checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -7100,9 +6971,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -7112,9 +6983,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -7124,21 +6995,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -7158,34 +7023,34 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "softbuffer"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
- "cfg_aliases",
- "core-graphics 0.24.0",
- "foreign-types 0.5.0",
  "js-sys",
- "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "ndk",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7216,11 +7081,11 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.14.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14e31a007e9f85c32784b04f89e6e194bb252a4d41b4a8ccd9e77245d901c8c"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "num-traits",
  "robust",
  "smallvec",
@@ -7247,15 +7112,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storekey"
@@ -7276,7 +7135,7 @@ checksum = "6079d53242246522ec982de613c5c952cc7b1380ef2f8622fcdab9bfe73c0098"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7293,6 +7152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7300,6 +7171,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -7318,9 +7201,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19f5232640cfe8b1423b49582f36bc4c867dac9e85ad87f9a81b5fd1633621f"
+checksum = "504a96b55e86ef8653a03b6b97e771f49c954e26bcc0308160b0134d94f334fd"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7328,10 +7211,10 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.3.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "js-sys",
  "path-clean",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "ring",
  "rustls-pki-types",
  "semver",
@@ -7354,9 +7237,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089a8dc4b88097a84ca3663ad0c152ae53d2e23ffc8b636dac7f65aa86ba3766"
+checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
 dependencies = [
  "addr",
  "affinitypool",
@@ -7405,7 +7288,7 @@ dependencies = [
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
@@ -7444,9 +7327,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-librocksdb-sys"
-version = "0.17.3+10.6.2"
+version = "0.18.3+11.0.0-4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db194f1cf601bb6f2d0f4cbf0931bc3e5a602bac41ef2e9a87eccdfb28b7fed2"
+checksum = "25b82a18c7fa4b57206784a1a31e7b942ae1d3e24493e0c733019a409b2b4bea"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -7476,16 +7359,16 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "uuid",
 ]
 
 [[package]]
 name = "surrealdb-rocksdb"
-version = "0.24.0-surreal.1"
+version = "0.24.0-surreal.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057727f56d48825ddbe45e4e7401cda6e99d864fbc004e7474b4689a5e72c86d"
+checksum = "02e8c3a004982458af159bcbf369e41663d538cd4a291a49c0d4a2fb373cbb7e"
 dependencies = [
  "libc",
  "surrealdb-librocksdb-sys",
@@ -7493,9 +7376,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a8277f923a20960c82cd7d133524fb2c5d0a73d5f52abd74f28d8d83a8b6fa"
+checksum = "c79e71d035367b933cf528c09b7ed186bc17dea58c66a1bca84d22f9abf167db"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7505,7 +7388,7 @@ dependencies = [
  "hex",
  "http",
  "papaya",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rstest",
  "rust_decimal",
@@ -7519,13 +7402,13 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491b1457e76011c800818421d814472e0a9a4d3c690ae1edb44381678e97a554"
+checksum = "a76abdbfc597e062daae5269251e18a84553f9090cfff423591f57c8c6765aa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7552,9 +7435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7578,7 +7461,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7611,11 +7494,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7639,7 +7522,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.23",
+ "toml 0.8.2",
  "version-compare",
 ]
 
@@ -7649,13 +7532,13 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3731d04d4ac210cd5f344087733943b9bfb1a32654387dad4d1c70de21aee2c9"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cocoa 0.26.1",
  "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
- "dlopen2",
+ "dlopen2 0.7.0",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
@@ -7683,34 +7566,35 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
+ "block2",
  "core-foundation 0.10.1",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
- "dispatch",
- "dlopen2",
+ "dbus",
+ "dispatch2",
+ "dlopen2 0.8.2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -7728,7 +7612,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7745,12 +7629,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.7.0"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352a4bc7bf6c25f5624227e3641adf475a6535707451b09bb83271df8b7a6ac7"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
+ "cookie",
  "dirs 6.0.0",
  "dunce",
  "embed_plist",
@@ -7763,15 +7648,16 @@ dependencies = [
  "libc",
  "log",
  "mime",
- "muda",
- "objc2 0.6.1",
+ "muda 0.19.1",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "objc2-ui-kit",
+ "objc2-web-kit",
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.12.22",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7784,9 +7670,8 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.18",
  "tokio",
- "tray-icon",
+ "tray-icon 0.23.1",
  "url",
- "urlpattern",
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
@@ -7795,9 +7680,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.3.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182d688496c06bf08ea896459bf483eb29cdff35c1c4c115fb14053514303064"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7811,15 +7696,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.8.23",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.3.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54a99a6cd8e01abcfa61508177e6096a4fe2681efecee9214e962f2f073ae4a"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -7833,7 +7717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.104",
+ "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
  "time",
@@ -7844,23 +7728,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.3.2"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7945b14dc45e23532f2ded6e120170bbdd4af5ceaa45784a6b33d250fbce3f9e"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.3.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd5c1e56990c70a906ef67a9851bbdba9136d26075ee9a2b19c8b46986b3e02"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
 dependencies = [
  "anyhow",
  "glob",
@@ -7869,7 +7753,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.8.23",
  "walkdir",
 ]
 
@@ -7884,7 +7767,7 @@ dependencies = [
  "enigo",
  "linicon",
  "objc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tauri",
  "tauri-plugin",
@@ -7892,9 +7775,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.3.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5858cc7b455a73ab4ea2ebc08b5be33682c00ff1bf4cad5537d4fb62499d9"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -7910,13 +7793,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6ef84ee2f2094ce093e55106d90d763ba343fad57566992962e8f76d113f99"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -7926,20 +7811,20 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-plugin-opener"
-version = "2.4.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecee219f11cdac713ab32959db5d0cceec4810ba4f4458da992292ecf9660321"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
 dependencies = [
  "dunce",
  "glob",
  "objc2-app-kit",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -7954,44 +7839,46 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.7.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1cc885be806ea15ff7b0eb47098a7b16323d9228876afda329e34e2d6c4676"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
  "gtk",
  "http",
  "jni",
- "objc2 0.6.1",
+ "objc2",
  "objc2-ui-kit",
+ "objc2-web-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
  "thiserror 2.0.18",
  "url",
+ "webkit2gtk",
+ "webview2-com",
  "windows 0.61.3",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.7.2"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe653a2fbbef19fe898efc774bc52c8742576342a33d3d028c189b57eb1d2439"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
  "jni",
  "log",
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.1",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
  "softbuffer",
- "tao 0.34.0",
+ "tao 0.35.2",
  "tauri-runtime",
  "tauri-utils",
  "url",
@@ -8003,24 +7890,24 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.6.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330c15cabfe1d9f213478c9e8ec2b0c76dab26bb6f314b8ad1c8a568c1d186e"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
- "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -8032,7 +7919,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -8041,26 +7928,26 @@ dependencies = [
 
 [[package]]
 name = "tauri-winres"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6d9028d41d4de835e3c482c677a8cb88137ac435d6ff9a71f392d4421576c9"
+checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
+ "dunce",
  "embed-resource",
- "indexmap 2.13.0",
- "toml 0.9.5",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8071,6 +7958,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -8109,7 +8006,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8120,7 +8017,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8134,30 +8031,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8165,9 +8062,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -8185,9 +8082,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8200,9 +8097,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -8210,21 +8107,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
- "tracing",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8249,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8261,12 +8157,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "async-stream",
- "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -8319,47 +8213,71 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.12",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -8368,56 +8286,50 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.6.11",
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.12",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.12",
+ "winnow 1.0.3",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -8451,12 +8363,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -8468,11 +8380,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8489,18 +8401,18 @@ dependencies = [
  "prost-build",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.5",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -8514,7 +8426,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -8525,13 +8437,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8544,21 +8456,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -8593,7 +8505,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8619,9 +8531,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -8637,24 +8549,45 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.1"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d92153331e7d02ec09137538996a7786fe679c629c279e82a6be762b7e6fe2"
+checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
  "libappindicator",
- "muda",
- "objc2 0.6.1",
+ "muda 0.17.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "once_cell",
  "png 0.17.16",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tray-icon"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+dependencies = [
+ "crossbeam-channel",
+ "dirs 6.0.0",
+ "libappindicator",
+ "muda 0.19.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "once_cell",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8685,7 +8618,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -8705,19 +8638,19 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8726,7 +8659,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "web-time",
 ]
@@ -8780,15 +8713,15 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -8865,9 +8798,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8895,9 +8828,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -8946,23 +8879,17 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -8971,41 +8898,38 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9013,22 +8937,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -9050,7 +8974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -9087,9 +9011,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.9.1",
- "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -9107,70 +9031,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
-dependencies = [
- "bitflags 2.9.1",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
-dependencies = [
- "bitflags 2.9.1",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
-dependencies = [
- "proc-macro2",
- "quick-xml 0.37.5",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
-dependencies = [
- "dlib",
- "log",
- "pkg-config",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9194,15 +9058,27 @@ checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
 name = "webkit2gtk"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -9224,9 +9100,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk-sys"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62daa38afc514d1f8f12b8693d30d5993ff77ced33ce30cd04deebc267a6d57c"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -9244,34 +9120,34 @@ dependencies = [
 
 [[package]]
 name = "webview2-com"
-version = "0.38.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
+checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
 name = "webview2-com-macros"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.38.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
+checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
@@ -9308,11 +9184,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9327,10 +9203,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -9428,11 +9304,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -9454,7 +9343,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9465,18 +9354,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9487,7 +9376,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9498,18 +9387,18 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9520,9 +9409,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -9536,13 +9425,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -9573,6 +9462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9589,6 +9487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9633,16 +9540,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9693,19 +9600,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9719,11 +9626,11 @@ dependencies = [
 
 [[package]]
 name = "windows-version"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9746,9 +9653,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9770,9 +9677,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9794,9 +9701,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -9806,9 +9713,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9830,9 +9737,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9854,9 +9761,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9878,9 +9785,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9902,9 +9809,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -9917,9 +9824,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9959,6 +9875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9977,9 +9899,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.104",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -9995,7 +9917,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -10007,8 +9929,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -10027,7 +9949,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -10039,35 +9961,35 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.52.1"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a714d9ba7075aae04a6e50229d6109e3d584774b99a6a8c60de1698ca111b9"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
- "block2 0.6.1",
+ "block2",
  "cookie",
  "crossbeam-channel",
+ "dirs 6.0.0",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever 0.29.1",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
- "objc2 0.6.1",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -10119,11 +10041,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -10131,21 +10052,21 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.9.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -10161,15 +10082,16 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.30.1",
+ "libc",
  "ordered-stream",
+ "rustix",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
- "winnow 0.7.12",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -10177,14 +10099,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.9.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -10192,54 +10114,53 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "static_assertions",
- "winnow 0.7.12",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10248,12 +10169,26 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -10262,9 +10197,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10273,13 +10208,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10300,42 +10235,40 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.6.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
- "winnow 0.7.12",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.6.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
- "syn 2.0.104",
- "winnow 0.7.12",
+ "syn 2.0.117",
+ "winnow 1.0.3",
 ]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive", "env"] }
 tonic = "0.12"
 tokio = { workspace = true }
+tokio-stream = "0.1"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 nodespace-daemon = { path = "../daemon" }
@@ -21,4 +22,3 @@ nodespace-daemon = { path = "../daemon" }
 [dev-dependencies]
 nodespace-core = { workspace = true }
 tempfile = "3.0"
-tokio-stream = "0.1"

--- a/packages/cli/src/commands/import.rs
+++ b/packages/cli/src/commands/import.rs
@@ -1,0 +1,242 @@
+//! `nodespace import` — import markdown files into NodeSpace via the daemon.
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use nodespace_daemon::nodespace::{
+    FileImportResult, ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions,
+};
+use nodespace_daemon::ImportServiceClient;
+use tokio_stream::StreamExt;
+use tonic::{transport::Channel, Request};
+
+#[derive(Subcommand, Debug)]
+pub enum ImportAction {
+    /// Import a single markdown file.
+    File(ImportFileArgs),
+    /// Import all markdown files from a directory (recursive).
+    Dir(ImportDirArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ImportFileArgs {
+    /// Path to the markdown file.
+    pub file: String,
+
+    /// Collection path to assign the document to (e.g. "docs:rust").
+    #[arg(long)]
+    pub collection: Option<String>,
+
+    /// Use the filename stem as the document title.
+    #[arg(long)]
+    pub use_filename_as_title: bool,
+
+    /// Route files to collections based on directory structure.
+    #[arg(long)]
+    pub auto_collection_routing: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ImportDirArgs {
+    /// Path to the directory containing markdown files.
+    pub directory: String,
+
+    /// Collection path to assign all documents to.
+    #[arg(long)]
+    pub collection: Option<String>,
+
+    /// Use filename stems as document titles.
+    #[arg(long)]
+    pub use_filename_as_title: bool,
+
+    /// Route files to collections based on directory structure.
+    #[arg(long)]
+    pub auto_collection_routing: bool,
+
+    /// Directory names to exclude (repeatable, e.g. --exclude node_modules).
+    #[arg(long = "exclude")]
+    pub exclude_patterns: Vec<String>,
+}
+
+pub async fn run(
+    client: &mut ImportServiceClient<Channel>,
+    action: ImportAction,
+    json: bool,
+) -> Result<()> {
+    match action {
+        ImportAction::File(args) => run_file(client, args, json).await,
+        ImportAction::Dir(args) => run_dir(client, args, json).await,
+    }
+}
+
+fn results_to_json(results: &[FileImportResult]) -> serde_json::Value {
+    serde_json::Value::Array(
+        results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "file_path": r.file_path,
+                    "root_id": r.root_id,
+                    "nodes_created": r.nodes_created,
+                    "success": r.success,
+                    "error": r.error,
+                    "collection": r.collection,
+                    "archived": r.archived,
+                })
+            })
+            .collect(),
+    )
+}
+
+async fn run_file(
+    client: &mut ImportServiceClient<Channel>,
+    args: ImportFileArgs,
+    json: bool,
+) -> Result<()> {
+    let opts = ImportOptions {
+        collection: args.collection.unwrap_or_default(),
+        use_filename_as_title: args.use_filename_as_title,
+        auto_collection_routing: args.auto_collection_routing,
+        exclude_patterns: vec![],
+        base_directory: String::new(),
+    };
+
+    let mut stream = client
+        .import_markdown(Request::new(ImportMarkdownRequest {
+            file_path: args.file,
+            options: Some(opts),
+        }))
+        .await?
+        .into_inner();
+
+    while let Some(event) = stream.next().await {
+        let event = event?;
+        if json {
+            if event.step == 9 {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&results_to_json(&event.results))?
+                );
+            }
+        } else {
+            eprintln!("[{}/9] {}: {}", event.step, event.step_name, event.message);
+            if event.step == 9 {
+                for r in &event.results {
+                    if r.success {
+                        println!(
+                            "✓ {} ({} nodes){}",
+                            r.file_path,
+                            r.nodes_created,
+                            if r.collection.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" → {}", r.collection)
+                            }
+                        );
+                    } else {
+                        println!("✗ {}: {}", r.file_path, r.error);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_dir(
+    client: &mut ImportServiceClient<Channel>,
+    args: ImportDirArgs,
+    json: bool,
+) -> Result<()> {
+    let file_paths = collect_markdown_files(&args.directory, &args.exclude_patterns)?;
+
+    if file_paths.is_empty() {
+        if !json {
+            eprintln!("No markdown files found in {}", args.directory);
+        }
+        return Ok(());
+    }
+
+    let opts = ImportOptions {
+        collection: args.collection.unwrap_or_default(),
+        use_filename_as_title: args.use_filename_as_title,
+        auto_collection_routing: args.auto_collection_routing,
+        exclude_patterns: args.exclude_patterns,
+        base_directory: args.directory,
+    };
+
+    let mut stream = client
+        .import_markdown_files(Request::new(ImportMarkdownFilesRequest {
+            file_paths,
+            options: Some(opts),
+        }))
+        .await?
+        .into_inner();
+
+    while let Some(event) = stream.next().await {
+        let event = event?;
+        if json {
+            if event.step == 9 {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&results_to_json(&event.results))?
+                );
+            }
+        } else {
+            eprintln!("[{}/9] {}: {}", event.step, event.step_name, event.message);
+            if event.step == 9 {
+                let successful = event.results.iter().filter(|r| r.success).count();
+                let failed = event.results.len().saturating_sub(successful);
+                println!("Imported {}/{} files", successful, event.results.len());
+                if failed > 0 {
+                    for r in event.results.iter().filter(|r| !r.success) {
+                        println!("  ✗ {}: {}", r.file_path, r.error);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_markdown_files(dir: &str, exclude_patterns: &[String]) -> Result<Vec<String>> {
+    let mut files = Vec::new();
+    collect_recursive(std::path::Path::new(dir), &mut files, exclude_patterns)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_recursive(
+    dir: &std::path::Path,
+    files: &mut Vec<String>,
+    exclude_patterns: &[String],
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let path_str = path.to_string_lossy();
+
+        let excluded = exclude_patterns.iter().any(|p| {
+            path.components().any(|c| {
+                c.as_os_str()
+                    .to_str()
+                    .map(|s| s.eq_ignore_ascii_case(p))
+                    .unwrap_or(false)
+            }) || path_str.contains(p.as_str())
+        });
+
+        if excluded {
+            continue;
+        }
+
+        if path.is_dir() {
+            collect_recursive(&path, files, exclude_patterns)?;
+        } else if path.extension().map(|e| e == "md").unwrap_or(false) {
+            if let Some(s) = path.to_str() {
+                files.push(s.to_string());
+            }
+        }
+    }
+    Ok(())
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod diagnostics;
+pub mod import;
 pub mod node;
 pub mod search;

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -8,7 +8,7 @@ pub mod output;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use nodespace_daemon::NodeServiceClient;
+use nodespace_daemon::{ImportServiceClient, NodeServiceClient};
 use tonic::transport::Channel;
 
 /// Default endpoint the CLI dials. ADR-031 reserves `localhost:50051` for the
@@ -49,6 +49,11 @@ pub enum Command {
     Search(commands::search::SearchArgs),
     /// Developer diagnostics: database path, size, node counts, schema count.
     Diagnostics(commands::diagnostics::DiagnosticsArgs),
+    /// Import markdown files into NodeSpace.
+    Import {
+        #[command(subcommand)]
+        action: commands::import::ImportAction,
+    },
 }
 
 /// Resolve the configured endpoint, falling back to `DEFAULT_ENDPOINT`.
@@ -74,15 +79,39 @@ pub async fn connect(endpoint: &str) -> Result<NodeServiceClient<Channel>> {
         })
 }
 
+/// Connect an ImportServiceClient to the daemon.
+pub async fn connect_import(endpoint: &str) -> Result<ImportServiceClient<Channel>> {
+    ImportServiceClient::connect(endpoint.to_string())
+        .await
+        .with_context(|| {
+            format!(
+                "Could not connect to nodespaced at {endpoint}.\n\
+                 Is the daemon running? Start it with `nodespaced` in another terminal."
+            )
+        })
+}
+
 /// Top-level dispatch — wired by `main.rs` and reused by integration tests.
 pub async fn run(cli: Cli) -> Result<()> {
     let endpoint = resolve_endpoint(cli.endpoint.as_deref());
-    let mut client = connect(&endpoint).await?;
     let json = cli.json;
 
     match cli.command {
-        Command::Node { action } => commands::node::run(&mut client, action, json).await,
-        Command::Search(args) => commands::search::run(&mut client, args, json).await,
-        Command::Diagnostics(args) => commands::diagnostics::run(&mut client, args, json).await,
+        Command::Node { action } => {
+            let mut client = connect(&endpoint).await?;
+            commands::node::run(&mut client, action, json).await
+        }
+        Command::Search(args) => {
+            let mut client = connect(&endpoint).await?;
+            commands::search::run(&mut client, args, json).await
+        }
+        Command::Diagnostics(args) => {
+            let mut client = connect(&endpoint).await?;
+            commands::diagnostics::run(&mut client, args, json).await
+        }
+        Command::Import { action } => {
+            let mut client = connect_import(&endpoint).await?;
+            commands::import::run(&mut client, action, json).await
+        }
     }
 }

--- a/packages/daemon/Cargo.toml
+++ b/packages/daemon/Cargo.toml
@@ -20,11 +20,11 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = { workspace = true }
+uuid = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 nodespace-core = { workspace = true }
 nodespace-agent = { workspace = true }
-uuid = { workspace = true }
 
 # System tray (ADR-031): the daemon owns the tray icon, not the Tauri app.
 # tray-icon ships an event loop via `tao`; we run it on the main thread on

--- a/packages/daemon/build.rs
+++ b/packages/daemon/build.rs
@@ -5,6 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &[
             "proto/node_service.proto",
             "proto/agent_session_service.proto",
+            "proto/import_service.proto",
         ],
         &["proto"],
     )?;

--- a/packages/daemon/proto/import_service.proto
+++ b/packages/daemon/proto/import_service.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+package nodespace;
+
+// ImportService exposes markdown import operations over gRPC.
+//
+// Imports run entirely inside the daemon's Tokio runtime so they survive
+// Tauri window close and are accessible from CLI and agent tools.
+//
+// The two-phase pipeline (parse → background DB write) is preserved:
+//   - Phase 1: file reads and markdown parsing happen synchronously
+//   - Phase 2: DB writes run in a spawned task; progress is streamed back
+service ImportService {
+  // Import a single markdown file. Streams progress events; final event
+  // carries step=9 ("complete") with the import summary.
+  rpc ImportMarkdown(ImportMarkdownRequest) returns (stream ImportProgressEvent);
+
+  // Import a batch of markdown files. Supports smart collection routing
+  // and the two-phase async pipeline from commands/import.rs.
+  rpc ImportMarkdownFiles(ImportMarkdownFilesRequest) returns (stream ImportProgressEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Shared import options
+// ---------------------------------------------------------------------------
+
+message ImportOptions {
+  // Collection path to assign imported documents to (e.g. "rust-book").
+  // Ignored when auto_collection_routing is true.
+  string collection = 1;
+  // Use the filename stem as the document title instead of the first heading.
+  bool use_filename_as_title = 2;
+  // Route files to collections automatically based on their directory path.
+  bool auto_collection_routing = 3;
+  // Directory path components to exclude (e.g. ["design-system", "node_modules"]).
+  repeated string exclude_patterns = 4;
+  // Base directory for relative path calculation in auto-routing.
+  // Empty string = use the import directory.
+  string base_directory = 5;
+}
+
+// ---------------------------------------------------------------------------
+// ImportMarkdown — single file
+// ---------------------------------------------------------------------------
+
+message ImportMarkdownRequest {
+  // Absolute path to the markdown file on the daemon's filesystem.
+  string file_path = 1;
+  ImportOptions options = 2;
+}
+
+// ---------------------------------------------------------------------------
+// ImportMarkdownFiles — batch
+// ---------------------------------------------------------------------------
+
+message ImportMarkdownFilesRequest {
+  // Absolute paths to the markdown files on the daemon's filesystem.
+  repeated string file_paths = 1;
+  ImportOptions options = 2;
+}
+
+// ---------------------------------------------------------------------------
+// Progress events (shared by both RPCs)
+// ---------------------------------------------------------------------------
+
+// ImportProgressEvent mirrors commands/import.rs::ImportProgressEvent.
+//
+// Steps:
+//   1 = scanning    — folder scan complete
+//   2 = reading     — reading individual files
+//   3 = parsing     — parsing individual files
+//   4 = resolving   — resolving inter-file links
+//   5 = collections — creating/resolving collections
+//   6 = importing   — bulk node insertion
+//   7 = assigning   — collection membership
+//   8 = references  — creating mention edges
+//   9 = complete    — final summary; file_result populated for single-file RPC
+message ImportProgressEvent {
+  // Step number 1-9.
+  uint32 step = 1;
+  // Machine-readable step name (e.g. "scanning", "reading", "complete").
+  string step_name = 2;
+  // Human-readable message (e.g. "Reading: overview.md").
+  string message = 3;
+  // Current item count within this step.
+  uint32 current = 4;
+  // Total item count for this step.
+  uint32 total = 5;
+  // Populated on the final event (step=9) with per-file import results.
+  repeated FileImportResult results = 6;
+}
+
+// Result for a single file, carried on the final progress event.
+message FileImportResult {
+  string file_path = 1;
+  // Root node ID assigned to this document; empty when success=false.
+  string root_id = 2;
+  uint32 nodes_created = 3;
+  bool success = 4;
+  // Non-empty when success=false or when there was a non-fatal warning.
+  string error = 5;
+  // Collection the file was routed to (empty when not assigned).
+  string collection = 6;
+  bool archived = 7;
+}

--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -47,8 +47,10 @@ pub mod nodespace {
 // to re-export and simultaneously verify that generated symbols exist.
 pub use nodespace::agent_session_service_client::AgentSessionServiceClient;
 pub use nodespace::agent_session_service_server::AgentSessionServiceServer;
+pub use nodespace::import_service_client::ImportServiceClient;
+pub use nodespace::import_service_server::ImportServiceServer;
 pub use nodespace::node_service_client::NodeServiceClient;
 pub use nodespace::node_service_server::NodeServiceServer;
 pub use nodespace::{NodeData, SessionInfo};
 
-pub use services::{AgentSessionHandler, NodeServiceImpl};
+pub use services::{AgentSessionHandler, ImportServiceImpl, NodeServiceImpl};

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -20,8 +20,8 @@ use nodespace_agent::pty::PtySessionManager;
 use nodespace_core::{NodeService as CoreNodeService, SurrealStore};
 use nodespace_daemon::tray::layer::TrayMetricsLayer;
 use nodespace_daemon::{
-    resolve_db_path, tray, AgentSessionHandler, AgentSessionServiceServer, NodeServiceImpl,
-    NodeServiceServer,
+    resolve_db_path, tray, AgentSessionHandler, AgentSessionServiceServer, ImportServiceImpl,
+    ImportServiceServer, NodeServiceImpl, NodeServiceServer,
 };
 use tonic::transport::Server;
 
@@ -102,6 +102,7 @@ async fn serve_headless() -> Result<()> {
     Server::builder()
         .add_service(NodeServiceServer::new(services.node))
         .add_service(AgentSessionServiceServer::new(services.agent_session))
+        .add_service(ImportServiceServer::new(services.import))
         .serve_with_shutdown(addr, shutdown)
         .await
         .context("gRPC server terminated with error")?;
@@ -136,6 +137,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
         .layer(TrayMetricsLayer::new(controller))
         .add_service(NodeServiceServer::new(services.node))
         .add_service(AgentSessionServiceServer::new(services.agent_session))
+        .add_service(ImportServiceServer::new(services.import))
         .serve_with_shutdown(addr, combined_shutdown)
         .await
         .context("gRPC server terminated with error")?;
@@ -146,6 +148,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
 struct DaemonServices {
     node: NodeServiceImpl,
     agent_session: AgentSessionHandler,
+    import: ImportServiceImpl,
 }
 
 /// Open the database and assemble every gRPC service implementation the
@@ -182,12 +185,15 @@ async fn build_services(db_path: &std::path::Path) -> Result<DaemonServices> {
     // wrapping in `Arc` keeps the manager itself a single instance so all
     // sessions live in one map.
     let manager = Arc::new(PtySessionManager::new());
-    let assembler = Arc::new(GraphContextAssembler::new(node_service, embedding_service));
+    let assembler = Arc::new(GraphContextAssembler::new(node_service.clone(), embedding_service));
     let agent_session = AgentSessionHandler::new(manager, assembler);
+
+    let import = ImportServiceImpl::new(node_service);
 
     Ok(DaemonServices {
         node,
         agent_session,
+        import,
     })
 }
 

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -531,12 +531,27 @@ async fn run_batch_import(
         )
         .await;
 
-        match node_service_clone
+        let bulk_insert_failed = match node_service_clone
             .bulk_create_hierarchy_trusted(all_nodes)
             .await
         {
-            Ok(ids) => tracing::info!("Bulk created {} nodes", ids.len()),
-            Err(e) => tracing::error!("Failed to bulk create nodes: {:?}", e),
+            Ok(ids) => {
+                tracing::info!("Bulk created {} nodes", ids.len());
+                false
+            }
+            Err(e) => {
+                tracing::error!("Failed to bulk create nodes: {:?}", e);
+                true
+            }
+        };
+
+        // When the bulk insert fails, surface it to the caller rather than
+        // silently reporting success — mark all phase1 results as failed.
+        if bulk_insert_failed {
+            for r in &mut phase1_results {
+                r.success = false;
+                r.error = Some("Bulk node insertion failed; see daemon logs".to_string());
+            }
         }
 
         send_progress(
@@ -550,7 +565,7 @@ async fn run_batch_import(
         )
         .await;
 
-        if !collection_assignments.is_empty() {
+        if !bulk_insert_failed && !collection_assignments.is_empty() {
             match store.bulk_add_to_collections(&collection_assignments).await {
                 Ok(count) => tracing::info!("Bulk assigned {} collection memberships", count),
                 Err(e) => tracing::error!("Failed to bulk add to collections: {:?}", e),
@@ -568,24 +583,26 @@ async fn run_batch_import(
         )
         .await;
 
-        if !all_mentions.is_empty() {
+        if !bulk_insert_failed && !all_mentions.is_empty() {
             match store.bulk_create_mentions(&all_mentions).await {
                 Ok(count) => tracing::info!("Bulk created {} mentions", count),
                 Err(e) => tracing::error!("Failed to bulk create mentions: {:?}", e),
             }
         }
 
-        for prepared in &prepared_files {
-            if prepared.is_archived {
-                if let Err(e) = store
-                    .update_lifecycle_status(&prepared.root_id, "archived")
-                    .await
-                {
-                    tracing::warn!(
-                        "Failed to set lifecycle_status for {}: {}",
-                        prepared.root_id,
-                        e
-                    );
+        if !bulk_insert_failed {
+            for prepared in &prepared_files {
+                if prepared.is_archived {
+                    if let Err(e) = store
+                        .update_lifecycle_status(&prepared.root_id, "archived")
+                        .await
+                    {
+                        tracing::warn!(
+                            "Failed to set lifecycle_status for {}: {}",
+                            prepared.root_id,
+                            e
+                        );
+                    }
                 }
             }
         }

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -1,0 +1,982 @@
+//! tonic `ImportService` implementation backed by `nodespace-core`.
+//!
+//! Preserves the two-phase pipeline from `commands/import.rs`:
+//!   Phase 1 — file reads, markdown parsing, link resolution (sync, fast)
+//!   Phase 2 — DB writes, collection assignment, mention creation (async background)
+//!
+//! Progress events are streamed back to the caller via a tokio channel that
+//! bridges the background task to the tonic server-streaming response.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use nodespace_core::mcp::handlers::markdown::{
+    prepare_nodes_from_markdown, transform_links_in_nodes_with_mentions, PreparedNode,
+};
+use nodespace_core::services::{CollectionService, NodeService as CoreNodeService};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use crate::nodespace::{
+    import_service_server::ImportService as GrpcImportService, FileImportResult,
+    ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions, ImportProgressEvent,
+};
+
+const CHANNEL_BUFFER: usize = 64;
+
+pub struct ImportServiceImpl {
+    node_service: Arc<CoreNodeService>,
+}
+
+impl ImportServiceImpl {
+    pub fn new(node_service: Arc<CoreNodeService>) -> Self {
+        Self { node_service }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tonic service trait
+// ---------------------------------------------------------------------------
+
+#[tonic::async_trait]
+impl GrpcImportService for ImportServiceImpl {
+    type ImportMarkdownStream = ReceiverStream<Result<ImportProgressEvent, Status>>;
+    type ImportMarkdownFilesStream = ReceiverStream<Result<ImportProgressEvent, Status>>;
+
+    async fn import_markdown(
+        &self,
+        request: Request<ImportMarkdownRequest>,
+    ) -> Result<Response<Self::ImportMarkdownStream>, Status> {
+        let req = request.into_inner();
+        let opts = req.options.unwrap_or_default();
+        let node_service = Arc::clone(&self.node_service);
+
+        let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
+
+        tokio::spawn(async move {
+            run_single_file_import(node_service, req.file_path, opts, tx).await;
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn import_markdown_files(
+        &self,
+        request: Request<ImportMarkdownFilesRequest>,
+    ) -> Result<Response<Self::ImportMarkdownFilesStream>, Status> {
+        let req = request.into_inner();
+        let opts = req.options.unwrap_or_default();
+        let node_service = Arc::clone(&self.node_service);
+
+        let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
+
+        tokio::spawn(async move {
+            run_batch_import(node_service, req.file_paths, opts, tx).await;
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Single-file import
+// ---------------------------------------------------------------------------
+
+async fn run_single_file_import(
+    node_service: Arc<CoreNodeService>,
+    file_path: String,
+    opts: ImportOptions,
+    tx: mpsc::Sender<Result<ImportProgressEvent, Status>>,
+) {
+    let path = PathBuf::from(&file_path);
+
+    let result = import_single_file(&node_service, &path, &opts).await;
+
+    let _ = tx
+        .send(Ok(ImportProgressEvent {
+            step: 9,
+            step_name: "complete".to_string(),
+            message: if result.success {
+                format!(
+                    "Imported {} ({} nodes)",
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or(&file_path),
+                    result.nodes_created
+                )
+            } else {
+                format!(
+                    "Failed: {}",
+                    result.error.as_deref().unwrap_or("unknown error")
+                )
+            },
+            current: 1,
+            total: 1,
+            results: vec![proto_file_result(result)],
+        }))
+        .await;
+}
+
+async fn import_single_file(
+    node_service: &CoreNodeService,
+    path: &Path,
+    opts: &ImportOptions,
+) -> LocalFileImportResult {
+    if !path.exists() {
+        return LocalFileImportResult::error(
+            path.to_string_lossy().to_string(),
+            "File does not exist",
+        );
+    }
+    if !path.is_file() {
+        return LocalFileImportResult::error(
+            path.to_string_lossy().to_string(),
+            "Path is not a file",
+        );
+    }
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return LocalFileImportResult::error(
+                path.to_string_lossy().to_string(),
+                &format!("Failed to read file: {}", e),
+            );
+        }
+    };
+
+    let (collection, is_archived) = if opts.auto_collection_routing {
+        let base_dir = if opts.base_directory.is_empty() {
+            path.parent().unwrap_or(Path::new(".")).to_path_buf()
+        } else {
+            PathBuf::from(&opts.base_directory)
+        };
+        let meta = derive_collection_metadata(path, &base_dir);
+        (Some(meta.collection), meta.is_archived)
+    } else if !opts.collection.is_empty() {
+        (Some(opts.collection.clone()), false)
+    } else {
+        (None, false)
+    };
+
+    let title = if opts.use_filename_as_title {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "Untitled".to_string())
+    } else {
+        content
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "Untitled".to_string())
+    };
+
+    match import_markdown_content(node_service, &title, &content, is_archived).await {
+        Ok((root_id, nodes_created)) => {
+            if let Some(ref coll) = collection {
+                let collection_service = CollectionService::new(node_service.store(), node_service);
+                if let Err(e) = collection_service
+                    .add_to_collection_by_path(&root_id, coll)
+                    .await
+                {
+                    return LocalFileImportResult {
+                        file_path: path.to_string_lossy().to_string(),
+                        root_id: Some(root_id),
+                        nodes_created,
+                        success: true,
+                        error: Some(format!("Imported but failed to add to collection: {}", e)),
+                        collection,
+                        archived: is_archived,
+                    };
+                }
+            }
+            LocalFileImportResult {
+                file_path: path.to_string_lossy().to_string(),
+                root_id: Some(root_id),
+                nodes_created,
+                success: true,
+                error: None,
+                collection,
+                archived: is_archived,
+            }
+        }
+        Err(e) => LocalFileImportResult::error(path.to_string_lossy().to_string(), &e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Batch import (two-phase pipeline)
+// ---------------------------------------------------------------------------
+
+async fn run_batch_import(
+    node_service: Arc<CoreNodeService>,
+    file_paths: Vec<String>,
+    opts: ImportOptions,
+    tx: mpsc::Sender<Result<ImportProgressEvent, Status>>,
+) {
+    let total_files = file_paths.len();
+
+    let base_dir = if !opts.base_directory.is_empty() {
+        PathBuf::from(&opts.base_directory)
+    } else {
+        file_paths
+            .first()
+            .map(|p| {
+                PathBuf::from(p)
+                    .parent()
+                    .unwrap_or(Path::new("."))
+                    .to_path_buf()
+            })
+            .unwrap_or_else(|| PathBuf::from("."))
+    };
+
+    // ========================================================================
+    // PHASE 1: Parse all files (sync, in-memory)
+    // ========================================================================
+
+    send_progress(
+        &tx,
+        1,
+        "scanning",
+        "Scanning folder...",
+        0,
+        total_files,
+        vec![],
+    )
+    .await;
+
+    let mut file_contents: Vec<FileReadResult> = Vec::new();
+    let mut failed_results: Vec<LocalFileImportResult> = Vec::new();
+
+    for (index, file_path) in file_paths.iter().enumerate() {
+        let path = PathBuf::from(file_path);
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(file_path)
+            .to_string();
+
+        send_progress(
+            &tx,
+            2,
+            "reading",
+            &format!("Reading: {}", filename),
+            index + 1,
+            total_files,
+            vec![],
+        )
+        .await;
+
+        if !path.exists() || !path.is_file() {
+            failed_results.push(LocalFileImportResult::error(
+                file_path.clone(),
+                "File does not exist or is not a file",
+            ));
+            continue;
+        }
+
+        let (collection_path, is_archived) = if opts.auto_collection_routing {
+            let meta = derive_collection_metadata(&path, &base_dir);
+            (Some(meta.collection), meta.is_archived)
+        } else if !opts.collection.is_empty() {
+            (Some(opts.collection.clone()), false)
+        } else {
+            (None, false)
+        };
+
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                let relative_path = path
+                    .strip_prefix(&base_dir)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .to_string();
+                file_contents.push(FileReadResult {
+                    path,
+                    content,
+                    relative_path,
+                    collection_path,
+                    is_archived,
+                });
+            }
+            Err(e) => {
+                failed_results.push(LocalFileImportResult::error(
+                    file_path.clone(),
+                    &format!("Failed to read file: {}", e),
+                ));
+            }
+        }
+    }
+
+    // Parse phase
+    let mut prepared_files: Vec<PreparedFileImport> = Vec::new();
+
+    for (index, file_read) in file_contents.iter().enumerate() {
+        let filename = file_read
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&file_read.relative_path)
+            .to_string();
+
+        send_progress(
+            &tx,
+            3,
+            "parsing",
+            &format!("Parsing: {}", filename),
+            index + 1,
+            file_contents.len(),
+            vec![],
+        )
+        .await;
+
+        let title = if opts.use_filename_as_title {
+            file_read
+                .path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "Untitled".to_string())
+        } else {
+            file_read
+                .content
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "Untitled".to_string())
+        };
+
+        let root_id = uuid::Uuid::new_v4().to_string();
+
+        let root_content = if title.starts_with('#') {
+            title.clone()
+        } else {
+            format!("# {}", title)
+        };
+
+        let content_for_children = {
+            let first_line = file_read.content.lines().find(|l| !l.trim().is_empty());
+            if first_line == Some(&title) {
+                let lines: Vec<&str> = file_read.content.lines().collect();
+                let first_idx = lines.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
+                lines[first_idx + 1..].join("\n")
+            } else {
+                file_read.content.clone()
+            }
+        };
+
+        match prepare_nodes_from_markdown(&content_for_children, Some(root_id.clone())) {
+            Ok(children) => {
+                prepared_files.push(PreparedFileImport {
+                    file_path: file_read.path.clone(),
+                    root_id,
+                    root_content,
+                    is_archived: file_read.is_archived,
+                    collection_path: file_read.collection_path.clone(),
+                    children,
+                });
+            }
+            Err(e) => {
+                failed_results.push(LocalFileImportResult::error(
+                    file_read.path.to_string_lossy().to_string(),
+                    &format!("Failed to parse markdown: {:?}", e),
+                ));
+            }
+        }
+    }
+
+    // Build file→UUID map for link transformation
+    let file_to_uuid_map: HashMap<PathBuf, String> = prepared_files
+        .iter()
+        .map(|f| (f.file_path.clone(), f.root_id.clone()))
+        .collect();
+
+    send_progress(
+        &tx,
+        4,
+        "resolving",
+        "Resolving internal links...",
+        0,
+        prepared_files.len(),
+        vec![],
+    )
+    .await;
+
+    let mut all_mentions: Vec<(String, String)> = Vec::new();
+    for prepared in &mut prepared_files {
+        let result = transform_links_in_nodes_with_mentions(
+            &mut prepared.children,
+            &file_to_uuid_map,
+            Some(&prepared.file_path),
+            &prepared.root_id,
+        );
+        all_mentions.extend(result.mentions);
+    }
+
+    // Collect unique collection paths
+    let unique_collections: Vec<String> = prepared_files
+        .iter()
+        .filter_map(|f| f.collection_path.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    // Build Phase 1 results (success entries; failed_results holds failures)
+    let mut phase1_results: Vec<LocalFileImportResult> = prepared_files
+        .iter()
+        .map(|p| LocalFileImportResult {
+            file_path: p.file_path.to_string_lossy().to_string(),
+            root_id: Some(p.root_id.clone()),
+            nodes_created: 1 + p.children.len(),
+            success: true,
+            error: None,
+            collection: p.collection_path.clone(),
+            archived: p.is_archived,
+        })
+        .collect();
+
+    // ========================================================================
+    // PHASE 2: DB operations (background task, results streamed back via tx)
+    // ========================================================================
+
+    let unique_collections_count = unique_collections.len();
+    let successful_files_count = prepared_files.len();
+    let total_nodes_count: usize = prepared_files.iter().map(|f| 1 + f.children.len()).sum();
+    let all_mentions_count = all_mentions.len();
+    let store = Arc::clone(node_service.store());
+    let node_service_clone = (*node_service).clone();
+    let tx_bg = tx.clone();
+
+    tokio::spawn(async move {
+        send_progress(
+            &tx_bg,
+            5,
+            "collections",
+            &format!("Creating {} collections...", unique_collections_count),
+            0,
+            unique_collections_count,
+            vec![],
+        )
+        .await;
+
+        let collection_service = CollectionService::new(&store, &node_service_clone);
+        let collection_map = match collection_service
+            .bulk_resolve_collections(&unique_collections)
+            .await
+        {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::error!("Failed to bulk resolve collections: {:?}", e);
+                HashMap::new()
+            }
+        };
+
+        let mut all_nodes: Vec<(
+            String,
+            String,
+            String,
+            Option<String>,
+            f64,
+            serde_json::Value,
+        )> = Vec::new();
+        let mut collection_assignments: Vec<(String, String)> = Vec::new();
+
+        for prepared in &prepared_files {
+            let mut root_props = serde_json::json!({});
+            if prepared.is_archived {
+                root_props["lifecycle_status"] = serde_json::json!("archived");
+            }
+            all_nodes.push((
+                prepared.root_id.clone(),
+                "header".to_string(),
+                prepared.root_content.clone(),
+                None,
+                1.0,
+                root_props,
+            ));
+
+            for child in &prepared.children {
+                let parent = child
+                    .parent_id
+                    .clone()
+                    .or_else(|| Some(prepared.root_id.clone()));
+                all_nodes.push((
+                    child.id.clone(),
+                    child.node_type.clone(),
+                    child.content.clone(),
+                    parent,
+                    child.order,
+                    child.properties.clone(),
+                ));
+            }
+
+            if let Some(ref coll_path) = prepared.collection_path {
+                if let Some(coll_id) = collection_map.get(coll_path) {
+                    collection_assignments.push((prepared.root_id.clone(), coll_id.clone()));
+                }
+            }
+        }
+
+        send_progress(
+            &tx_bg,
+            6,
+            "importing",
+            &format!("Importing {} nodes...", all_nodes.len()),
+            0,
+            all_nodes.len(),
+            vec![],
+        )
+        .await;
+
+        match node_service_clone
+            .bulk_create_hierarchy_trusted(all_nodes)
+            .await
+        {
+            Ok(ids) => tracing::info!("Bulk created {} nodes", ids.len()),
+            Err(e) => tracing::error!("Failed to bulk create nodes: {:?}", e),
+        }
+
+        send_progress(
+            &tx_bg,
+            7,
+            "assigning",
+            "Assigning to collections...",
+            0,
+            collection_assignments.len(),
+            vec![],
+        )
+        .await;
+
+        if !collection_assignments.is_empty() {
+            match store.bulk_add_to_collections(&collection_assignments).await {
+                Ok(count) => tracing::info!("Bulk assigned {} collection memberships", count),
+                Err(e) => tracing::error!("Failed to bulk add to collections: {:?}", e),
+            }
+        }
+
+        send_progress(
+            &tx_bg,
+            8,
+            "references",
+            &format!("Creating {} references...", all_mentions_count),
+            0,
+            all_mentions_count,
+            vec![],
+        )
+        .await;
+
+        if !all_mentions.is_empty() {
+            match store.bulk_create_mentions(&all_mentions).await {
+                Ok(count) => tracing::info!("Bulk created {} mentions", count),
+                Err(e) => tracing::error!("Failed to bulk create mentions: {:?}", e),
+            }
+        }
+
+        for prepared in &prepared_files {
+            if prepared.is_archived {
+                if let Err(e) = store
+                    .update_lifecycle_status(&prepared.root_id, "archived")
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to set lifecycle_status for {}: {}",
+                        prepared.root_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        let mut all_results: Vec<LocalFileImportResult> = failed_results;
+        all_results.append(&mut phase1_results);
+        let proto_results: Vec<FileImportResult> =
+            all_results.into_iter().map(proto_file_result).collect();
+
+        send_progress(
+            &tx_bg,
+            9,
+            "complete",
+            &format!(
+                "Imported {} files ({} nodes)",
+                successful_files_count, total_nodes_count
+            ),
+            total_files,
+            total_files,
+            proto_results,
+        )
+        .await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async fn send_progress(
+    tx: &mpsc::Sender<Result<ImportProgressEvent, Status>>,
+    step: u32,
+    step_name: &str,
+    message: &str,
+    current: usize,
+    total: usize,
+    results: Vec<FileImportResult>,
+) {
+    let _ = tx
+        .send(Ok(ImportProgressEvent {
+            step,
+            step_name: step_name.to_string(),
+            message: message.to_string(),
+            current: current as u32,
+            total: total as u32,
+            results,
+        }))
+        .await;
+}
+
+fn proto_file_result(r: LocalFileImportResult) -> FileImportResult {
+    FileImportResult {
+        file_path: r.file_path,
+        root_id: r.root_id.unwrap_or_default(),
+        nodes_created: r.nodes_created as u32,
+        success: r.success,
+        error: r.error.unwrap_or_default(),
+        collection: r.collection.unwrap_or_default(),
+        archived: r.archived,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Smart collection routing (ported from commands/import.rs)
+// ---------------------------------------------------------------------------
+
+struct CollectionMetadata {
+    collection: String,
+    is_archived: bool,
+}
+
+fn derive_collection_metadata(file_path: &Path, base_dir: &Path) -> CollectionMetadata {
+    let relative = file_path.strip_prefix(base_dir).unwrap_or(file_path);
+    let path_str = relative.to_string_lossy().to_lowercase();
+    let segments: Vec<&str> = relative
+        .parent()
+        .unwrap_or(Path::new(""))
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+
+    if path_str.contains("/archived/")
+        || segments.iter().any(|s| s.eq_ignore_ascii_case("archived"))
+    {
+        return CollectionMetadata {
+            collection: "Archived".to_string(),
+            is_archived: true,
+        };
+    }
+
+    if path_str.contains("/decisions/") || path_str.contains("/adr/") {
+        return CollectionMetadata {
+            collection: "ADR".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if path_str.contains("/lessons/") || segments.iter().any(|s| s.eq_ignore_ascii_case("lessons"))
+    {
+        return CollectionMetadata {
+            collection: "Lessons".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if segments
+        .first()
+        .map(|s| s.eq_ignore_ascii_case("troubleshooting"))
+        .unwrap_or(false)
+    {
+        return CollectionMetadata {
+            collection: "Troubleshooting".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if segments
+        .first()
+        .map(|s| s.eq_ignore_ascii_case("architecture"))
+        .unwrap_or(false)
+    {
+        let sub_segments: Vec<&str> = segments.iter().skip(1).copied().collect();
+
+        if sub_segments
+            .first()
+            .map(|s| s.eq_ignore_ascii_case("components"))
+            .unwrap_or(false)
+        {
+            return CollectionMetadata {
+                collection: "Components".to_string(),
+                is_archived: false,
+            };
+        }
+
+        if sub_segments
+            .first()
+            .map(|s| s.eq_ignore_ascii_case("business-logic"))
+            .unwrap_or(false)
+        {
+            return CollectionMetadata {
+                collection: "Business Logic".to_string(),
+                is_archived: false,
+            };
+        }
+
+        if sub_segments
+            .first()
+            .map(|s| s.eq_ignore_ascii_case("development"))
+            .unwrap_or(false)
+        {
+            let dev_sub: Vec<&str> = sub_segments.iter().skip(1).copied().collect();
+            if !dev_sub.is_empty() {
+                let nested = dev_sub
+                    .iter()
+                    .map(|s| to_title_case(s))
+                    .collect::<Vec<_>>()
+                    .join(":");
+                return CollectionMetadata {
+                    collection: format!("Development:{}", nested),
+                    is_archived: false,
+                };
+            }
+            return CollectionMetadata {
+                collection: "Development".to_string(),
+                is_archived: false,
+            };
+        }
+
+        if sub_segments
+            .first()
+            .map(|s| s.eq_ignore_ascii_case("core"))
+            .unwrap_or(false)
+        {
+            return CollectionMetadata {
+                collection: "Architecture:Core".to_string(),
+                is_archived: false,
+            };
+        }
+
+        if !sub_segments.is_empty() {
+            let arch_sub = sub_segments
+                .iter()
+                .map(|s| to_title_case(s))
+                .collect::<Vec<_>>()
+                .join(":");
+            return CollectionMetadata {
+                collection: format!("Architecture:{}", arch_sub),
+                is_archived: false,
+            };
+        }
+
+        return CollectionMetadata {
+            collection: "Architecture".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if segments
+        .first()
+        .map(|s| s.eq_ignore_ascii_case("performance"))
+        .unwrap_or(false)
+    {
+        return CollectionMetadata {
+            collection: "Performance".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if segments
+        .first()
+        .map(|s| s.eq_ignore_ascii_case("testing"))
+        .unwrap_or(false)
+    {
+        return CollectionMetadata {
+            collection: "Testing".to_string(),
+            is_archived: false,
+        };
+    }
+
+    if segments.is_empty() {
+        return CollectionMetadata {
+            collection: "Docs".to_string(),
+            is_archived: false,
+        };
+    }
+
+    let collection = segments
+        .iter()
+        .map(|s| to_title_case(s))
+        .collect::<Vec<_>>()
+        .join(":");
+
+    CollectionMetadata {
+        collection,
+        is_archived: false,
+    }
+}
+
+fn to_title_case(s: &str) -> String {
+    s.split(['-', '_'])
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().chain(chars).collect(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Internal data types (not exposed over wire)
+// ---------------------------------------------------------------------------
+
+struct PreparedFileImport {
+    file_path: PathBuf,
+    root_id: String,
+    root_content: String,
+    is_archived: bool,
+    collection_path: Option<String>,
+    children: Vec<PreparedNode>,
+}
+
+struct FileReadResult {
+    path: PathBuf,
+    content: String,
+    relative_path: String,
+    collection_path: Option<String>,
+    is_archived: bool,
+}
+
+struct LocalFileImportResult {
+    file_path: String,
+    root_id: Option<String>,
+    nodes_created: usize,
+    success: bool,
+    error: Option<String>,
+    collection: Option<String>,
+    archived: bool,
+}
+
+impl LocalFileImportResult {
+    fn error(file_path: String, msg: &str) -> Self {
+        Self {
+            file_path,
+            root_id: None,
+            nodes_created: 0,
+            success: false,
+            error: Some(msg.to_string()),
+            collection: None,
+            archived: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown content importer (from commands/import.rs)
+// ---------------------------------------------------------------------------
+
+async fn import_markdown_content(
+    node_service: &CoreNodeService,
+    title: &str,
+    content: &str,
+    is_archived: bool,
+) -> Result<(String, usize), String> {
+    use nodespace_core::services::CreateNodeParams;
+
+    let (_, clean_title) = if title.starts_with('#') {
+        ("header", title.to_string())
+    } else {
+        ("header", format!("# {}", title))
+    };
+
+    let content_for_children = {
+        let first_line = content.lines().find(|l| !l.trim().is_empty());
+        if first_line == Some(title) {
+            let lines: Vec<&str> = content.lines().collect();
+            let first_idx = lines.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
+            lines[first_idx + 1..].join("\n")
+        } else {
+            content.to_string()
+        }
+    };
+
+    let prepared_nodes = prepare_nodes_from_markdown(&content_for_children, None)
+        .map_err(|e| format!("Failed to parse markdown: {:?}", e))?;
+
+    let mut properties = serde_json::json!({});
+    if is_archived {
+        properties["lifecycle_status"] = serde_json::json!("archived");
+    }
+
+    let root_id = node_service
+        .create_node_with_parent(CreateNodeParams {
+            id: None,
+            node_type: "header".to_string(),
+            content: clean_title,
+            parent_id: None,
+            insert_after_node_id: None,
+            properties,
+        })
+        .await
+        .map_err(|e| format!("Failed to create root node: {}", e))?;
+
+    if is_archived {
+        if let Err(e) = node_service
+            .store()
+            .update_lifecycle_status(&root_id, "archived")
+            .await
+        {
+            tracing::warn!(
+                "Failed to set lifecycle_status to archived for {}: {}",
+                root_id,
+                e
+            );
+        }
+    }
+
+    let mut nodes_created = 1;
+
+    if !prepared_nodes.is_empty() {
+        let nodes_for_bulk: Vec<(
+            String,
+            String,
+            String,
+            Option<String>,
+            f64,
+            serde_json::Value,
+        )> = prepared_nodes
+            .iter()
+            .map(|n| {
+                let parent = n.parent_id.clone().or_else(|| Some(root_id.clone()));
+                (
+                    n.id.clone(),
+                    n.node_type.clone(),
+                    n.content.clone(),
+                    parent,
+                    n.order,
+                    n.properties.clone(),
+                )
+            })
+            .collect();
+
+        let created_ids = node_service
+            .bulk_create_hierarchy_root_notify(nodes_for_bulk)
+            .await
+            .map_err(|e| format!("Failed to bulk create nodes: {}", e))?;
+
+        nodes_created += created_ids.len();
+    }
+
+    Ok((root_id, nodes_created))
+}

--- a/packages/daemon/src/services/mod.rs
+++ b/packages/daemon/src/services/mod.rs
@@ -4,7 +4,9 @@
 //! logic and adapts it to the tonic-generated service trait.
 
 pub mod agent_session_service;
+pub mod import_service;
 pub mod node_service;
 
 pub use agent_session_service::AgentSessionHandler;
+pub use import_service::ImportServiceImpl;
 pub use node_service::NodeServiceImpl;

--- a/packages/daemon/tests/import_round_trip.rs
+++ b/packages/daemon/tests/import_round_trip.rs
@@ -1,0 +1,264 @@
+//! End-to-end integration test for the `ImportService` gRPC handler.
+//!
+//! Spins up an in-process `nodespaced` with both `NodeService` and
+//! `ImportService` registered, drives `ImportMarkdown` and
+//! `ImportMarkdownFiles` via a real gRPC client, and verifies the streaming
+//! progress protocol end to end.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nodespace_core::{NodeService as CoreNodeService, SurrealStore};
+use nodespace_daemon::nodespace::{
+    ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions,
+};
+use nodespace_daemon::{
+    ImportServiceClient, ImportServiceImpl, ImportServiceServer, NodeServiceImpl, NodeServiceServer,
+};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio_stream::StreamExt;
+use tonic::transport::Server;
+
+/// Spin up an in-process daemon with both services registered and return a
+/// connected `ImportServiceClient` plus a shutdown handle. Mirrors the pattern
+/// in `grpc_round_trip.rs::spawn_test_daemon`.
+async fn spawn_import_daemon() -> (
+    ImportServiceClient<tonic::transport::Channel>,
+    oneshot::Sender<()>,
+    TempDir,
+) {
+    let tempdir = TempDir::new().expect("failed to create tempdir");
+
+    let mut store = Arc::new(
+        SurrealStore::new(tempdir.path().join("daemon-db"))
+            .await
+            .expect("failed to open SurrealStore"),
+    );
+    let node_service = Arc::new(
+        CoreNodeService::new(&mut store)
+            .await
+            .expect("failed to build NodeService"),
+    );
+    let node_svc = NodeServiceImpl::new(Arc::clone(&node_service), None);
+    let import_svc = ImportServiceImpl::new(Arc::clone(&node_service));
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(NodeServiceServer::new(node_svc))
+            .add_service(ImportServiceServer::new(import_svc))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("server crashed");
+    });
+
+    let endpoint = format!("http://{}", addr);
+    let mut last_err = None;
+    for _ in 0..50 {
+        match ImportServiceClient::connect(endpoint.clone()).await {
+            Ok(client) => return (client, shutdown_tx, tempdir),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+    panic!("failed to connect to in-process daemon: {:?}", last_err);
+}
+
+/// Write a temporary markdown file and return its absolute path.
+fn write_temp_md(dir: &TempDir, name: &str, content: &str) -> String {
+    let path = dir.path().join(name);
+    std::fs::write(&path, content).expect("failed to write temp markdown file");
+    path.to_str().expect("non-UTF-8 path").to_string()
+}
+
+/// ImportMarkdown for a simple file streams progress events ending with step 9
+/// carrying a successful `FileImportResult`.
+#[tokio::test]
+async fn import_markdown_single_file_streams_progress_and_succeeds() {
+    let (mut client, shutdown, tempdir) = spawn_import_daemon().await;
+
+    let md_path = write_temp_md(
+        &tempdir,
+        "hello.md",
+        "# Hello\n\nThis is a test document.\n",
+    );
+
+    let mut stream = client
+        .import_markdown(ImportMarkdownRequest {
+            file_path: md_path.clone(),
+            options: Some(ImportOptions {
+                collection: String::new(),
+                use_filename_as_title: true,
+                auto_collection_routing: false,
+                exclude_patterns: vec![],
+                base_directory: String::new(),
+            }),
+        })
+        .await
+        .expect("import_markdown RPC failed")
+        .into_inner();
+
+    let mut steps_seen: Vec<u32> = Vec::new();
+    let mut final_results = vec![];
+
+    while let Some(event) = stream.next().await {
+        let event = event.expect("stream error");
+        steps_seen.push(event.step);
+        if event.step == 9 {
+            final_results = event.results;
+        }
+    }
+
+    assert!(
+        !steps_seen.is_empty(),
+        "expected at least one progress event"
+    );
+    assert!(
+        steps_seen.contains(&9),
+        "expected a step-9 completion event, got steps: {:?}",
+        steps_seen
+    );
+    assert_eq!(
+        final_results.len(),
+        1,
+        "expected exactly one result for single-file import"
+    );
+
+    let result = &final_results[0];
+    assert!(
+        result.success,
+        "expected success=true, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.file_path, md_path);
+    assert!(
+        result.nodes_created > 0,
+        "expected at least one node created"
+    );
+
+    let _ = shutdown.send(());
+}
+
+/// ImportMarkdownFiles for a batch of two files produces one step-9 event
+/// with two results, both successful.
+#[tokio::test]
+async fn import_markdown_files_batch_reports_all_results() {
+    let (mut client, shutdown, tempdir) = spawn_import_daemon().await;
+
+    let path_a = write_temp_md(&tempdir, "alpha.md", "# Alpha\n\nFirst doc.\n");
+    let path_b = write_temp_md(&tempdir, "beta.md", "# Beta\n\nSecond doc.\n");
+
+    let mut stream = client
+        .import_markdown_files(ImportMarkdownFilesRequest {
+            file_paths: vec![path_a.clone(), path_b.clone()],
+            options: Some(ImportOptions {
+                collection: String::new(),
+                use_filename_as_title: true,
+                auto_collection_routing: false,
+                exclude_patterns: vec![],
+                base_directory: tempdir.path().to_str().unwrap().to_string(),
+            }),
+        })
+        .await
+        .expect("import_markdown_files RPC failed")
+        .into_inner();
+
+    let mut final_results = vec![];
+
+    while let Some(event) = stream.next().await {
+        let event = event.expect("stream error");
+        if event.step == 9 {
+            final_results = event.results;
+        }
+    }
+
+    assert_eq!(
+        final_results.len(),
+        2,
+        "expected two results for two-file batch import"
+    );
+
+    let paths: Vec<&str> = final_results.iter().map(|r| r.file_path.as_str()).collect();
+    assert!(
+        paths.contains(&path_a.as_str()),
+        "missing result for alpha.md"
+    );
+    assert!(
+        paths.contains(&path_b.as_str()),
+        "missing result for beta.md"
+    );
+
+    for result in &final_results {
+        assert!(
+            result.success,
+            "expected success=true for {}, got error: {:?}",
+            result.file_path, result.error
+        );
+        assert!(
+            result.nodes_created > 0,
+            "expected nodes created for {}",
+            result.file_path
+        );
+    }
+
+    let _ = shutdown.send(());
+}
+
+/// ImportMarkdown for a non-existent file must produce a step-9 event with
+/// `success=false` rather than leaving the stream open or crashing the server.
+#[tokio::test]
+async fn import_markdown_missing_file_surfaces_failure() {
+    let (mut client, shutdown, tempdir) = spawn_import_daemon().await;
+
+    let bad_path = tempdir
+        .path()
+        .join("does-not-exist.md")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let mut stream = client
+        .import_markdown(ImportMarkdownRequest {
+            file_path: bad_path.clone(),
+            options: Some(ImportOptions::default()),
+        })
+        .await
+        .expect("import_markdown RPC itself should not fail (error is in the stream)")
+        .into_inner();
+
+    let mut final_results = vec![];
+
+    while let Some(event) = stream.next().await {
+        let event = event.expect("stream transport error");
+        if event.step == 9 {
+            final_results = event.results;
+        }
+    }
+
+    assert_eq!(
+        final_results.len(),
+        1,
+        "expected one result even on failure"
+    );
+    let result = &final_results[0];
+    assert!(!result.success, "expected success=false for a missing file");
+    assert!(
+        !result.error.is_empty(),
+        "expected a non-empty error message"
+    );
+
+    let _ = shutdown.send(());
+}

--- a/packages/desktop-app/src-tauri/src/commands/import.rs
+++ b/packages/desktop-app/src-tauri/src/commands/import.rs
@@ -1,42 +1,44 @@
-//! File import commands for bulk markdown import
+//! File import commands — thin gRPC proxy to ImportService in nodespaced.
 //!
-//! Provides direct file system import bypassing MCP for faster bulk operations.
-//! Useful for importing large documentation sets (e.g., entire book chapters).
-//!
-//! ## Smart Collection Routing
-//!
-//! When `auto_collection_routing` is enabled, files are automatically assigned
-//! to collections based on their directory path:
-//!
-//! - `*/archived/*` → "Archived" collection (with lifecycle_status: "archived")
-//! - `*/decisions/*` or `*/adr/*` → "ADR" collection
-//! - `*/lessons/*` → "Lessons" collection
-//! - `*/troubleshooting/*` → "Troubleshooting" collection
-//! - `*/components/*` → "Components" collection
-//! - `*/business-logic/*` → "Business Logic" collection
-//! - `*/development/process/*` → "Development:Process" collection
-//! - `*/architecture/core/*` → "Architecture:Core" collection
-//! - etc.
-//!
-//! ## Performance Optimization (Issue #854)
-//!
-//! The import pipeline uses a two-phase architecture:
-//!
-//! 1. **Phase 1 (Sync)**: Parse all files, prepare nodes, transform inter-file links
-//! 2. **Phase 2 (Async)**: Spawn background task for bulk DB operations
-//!
-//! This returns immediately to the UI while heavy database work happens in background.
+//! All import logic (smart collection routing, two-phase async pipeline) runs
+//! inside the daemon so imports continue if the Tauri window is closed
+//! mid-import. These handlers subscribe to the progress stream and forward
+//! each event to the frontend via Tauri events.
 
-use crate::app_services::AppServices;
-use nodespace_core::mcp::handlers::markdown::{
-    prepare_nodes_from_markdown, transform_links_in_nodes_with_mentions, PreparedNode,
+use nodespace_daemon::nodespace::{
+    ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions as ProtoImportOptions,
 };
-use nodespace_core::services::{CollectionService, CreateNodeParams, NodeService};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+use crate::services::GrpcClient;
+
+/// Options for file import (mirrors proto ImportOptions)
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ImportOptions {
+    pub collection: Option<String>,
+    #[serde(default)]
+    pub use_filename_as_title: bool,
+    #[serde(default)]
+    pub auto_collection_routing: bool,
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
+    pub base_directory: Option<String>,
+}
+
+impl ImportOptions {
+    fn into_proto(self) -> ProtoImportOptions {
+        ProtoImportOptions {
+            collection: self.collection.unwrap_or_default(),
+            use_filename_as_title: self.use_filename_as_title,
+            auto_collection_routing: self.auto_collection_routing,
+            exclude_patterns: self.exclude_patterns,
+            base_directory: self.base_directory.unwrap_or_default(),
+        }
+    }
+}
 
 /// Result of importing a single file
 #[derive(Debug, Clone, Serialize)]
@@ -46,9 +48,7 @@ pub struct FileImportResult {
     pub nodes_created: usize,
     pub success: bool,
     pub error: Option<String>,
-    /// Collection the file was assigned to (if auto-routing enabled)
     pub collection: Option<String>,
-    /// Whether the file was marked as archived
     pub archived: bool,
 }
 
@@ -59,980 +59,189 @@ pub struct BatchImportResult {
     pub successful: usize,
     pub failed: usize,
     pub results: Vec<FileImportResult>,
-    pub duration_ms: u128,
 }
 
-/// Options for file import
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct ImportOptions {
-    /// Collection path to add imported documents to (e.g., "rust-book")
-    /// Ignored if `auto_collection_routing` is true.
-    pub collection: Option<String>,
-    /// Whether to use filename as title (default: false - uses first heading/line)
-    #[serde(default)]
-    pub use_filename_as_title: bool,
-    /// Enable smart collection routing based on file paths (default: false)
-    /// When enabled, files are assigned to collections based on directory structure.
-    #[serde(default)]
-    pub auto_collection_routing: bool,
-    /// Directory patterns to exclude (e.g., ["design-system", "node_modules"])
-    #[serde(default)]
-    pub exclude_patterns: Vec<String>,
-    /// Base directory for relative path calculation in auto-routing
-    /// If not set, uses the import directory as base.
-    pub base_directory: Option<String>,
-}
-
-/// Progress event emitted during import
-///
-/// Shows 9 distinct steps during import:
-/// 1. Scanning folder
-/// 2. Reading files (shows each filename)
-/// 3. Parsing markdown (shows each filename)
-/// 4. Resolving links
-/// 5. Creating collections
-/// 6. Importing nodes
-/// 7. Assigning to collections
-/// 8. Creating references
-/// 9. Complete (shows summary)
+/// Progress event forwarded to the frontend during import
 #[derive(Debug, Clone, Serialize)]
 pub struct ImportProgressEvent {
-    /// Step number (1-9)
     pub step: u8,
-    /// Step name (e.g., "scanning", "reading", "parsing", etc.)
     pub step_name: String,
-    /// User-friendly message (e.g., "Reading: overview.md")
     pub message: String,
-    /// Current item in step (if applicable)
     pub current: usize,
-    /// Total items in step (if applicable)
     pub total: usize,
 }
 
-/// Prepared file data for batched import (Issue #854)
-///
-/// Contains all parsed data for a single file, ready for batch insertion.
-#[derive(Debug)]
-struct PreparedFileImport {
-    /// Original file path
-    file_path: PathBuf,
-    /// Root node ID (pre-assigned UUID)
-    root_id: String,
-    /// Root node content (title)
-    root_content: String,
-    /// Whether this is an archived document
-    is_archived: bool,
-    /// Collection path for assignment (if any)
-    collection_path: Option<String>,
-    /// Prepared child nodes from markdown parsing
-    children: Vec<PreparedNode>,
-}
-
-/// Metadata derived from file path for collection routing
-#[derive(Debug, Clone)]
-struct CollectionMetadata {
-    /// Collection path (e.g., "Architecture:Core")
-    collection: String,
-    /// Whether the file should be marked as archived
-    is_archived: bool,
-}
-
-/// Intermediate result from reading a file (before parsing)
-///
-/// Holds file content and metadata between the "reading" and "parsing" phases,
-/// enabling per-step progress events.
-#[derive(Debug)]
-struct FileReadResult {
-    /// Full path to the file
-    path: PathBuf,
-    /// Raw file content
-    content: String,
-    /// Path relative to base directory (for display)
-    relative_path: String,
-    /// Collection path for assignment (if auto-routing enabled)
-    collection_path: Option<String>,
-    /// Whether this file is in an archived directory
-    is_archived: bool,
-}
-
-/// Derive collection and metadata from file path relative to base directory
-///
-/// Implements smart routing rules:
-/// - `*/archived/*` → "Archived" (is_archived: true)
-/// - `*/decisions/*` → "ADR"
-/// - `*/lessons/*` → "Lessons"
-/// - `*/troubleshooting/*` → "Troubleshooting"
-/// - `*/components/*` → "Components"
-/// - `*/business-logic/*` → "Business Logic"
-/// - `*/development/X/*` → "Development:X"
-/// - `*/architecture/core/*` → "Architecture:Core"
-/// - `*/architecture/X/*` → "Architecture:X"
-fn derive_collection_metadata(file_path: &Path, base_dir: &Path) -> CollectionMetadata {
-    let relative = file_path.strip_prefix(base_dir).unwrap_or(file_path);
-
-    let path_str = relative.to_string_lossy().to_lowercase();
-    let segments: Vec<&str> = relative
-        .parent()
-        .unwrap_or(Path::new(""))
-        .components()
-        .filter_map(|c| c.as_os_str().to_str())
-        .collect();
-
-    // Check for archived content anywhere in path
-    if path_str.contains("/archived/")
-        || segments.iter().any(|s| s.eq_ignore_ascii_case("archived"))
-    {
-        return CollectionMetadata {
-            collection: "Archived".to_string(),
-            is_archived: true,
-        };
-    }
-
-    // ADR / Decisions
-    if path_str.contains("/decisions/") || path_str.contains("/adr/") {
-        return CollectionMetadata {
-            collection: "ADR".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Lessons
-    if path_str.contains("/lessons/") || segments.iter().any(|s| s.eq_ignore_ascii_case("lessons"))
-    {
-        return CollectionMetadata {
-            collection: "Lessons".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Troubleshooting
-    if segments
-        .first()
-        .map(|s| s.eq_ignore_ascii_case("troubleshooting"))
-        .unwrap_or(false)
-    {
-        return CollectionMetadata {
-            collection: "Troubleshooting".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Architecture-specific routing
-    if segments
-        .first()
-        .map(|s| s.eq_ignore_ascii_case("architecture"))
-        .unwrap_or(false)
-    {
-        let sub_segments: Vec<&str> = segments.iter().skip(1).copied().collect();
-
-        if sub_segments
-            .first()
-            .map(|s| s.eq_ignore_ascii_case("components"))
-            .unwrap_or(false)
-        {
-            return CollectionMetadata {
-                collection: "Components".to_string(),
-                is_archived: false,
-            };
-        }
-
-        if sub_segments
-            .first()
-            .map(|s| s.eq_ignore_ascii_case("business-logic"))
-            .unwrap_or(false)
-        {
-            return CollectionMetadata {
-                collection: "Business Logic".to_string(),
-                is_archived: false,
-            };
-        }
-
-        if sub_segments
-            .first()
-            .map(|s| s.eq_ignore_ascii_case("development"))
-            .unwrap_or(false)
-        {
-            let dev_sub: Vec<&str> = sub_segments.iter().skip(1).copied().collect();
-            if !dev_sub.is_empty() {
-                let nested = dev_sub
-                    .iter()
-                    .map(|s| to_title_case(s))
-                    .collect::<Vec<_>>()
-                    .join(":");
-                return CollectionMetadata {
-                    collection: format!("Development:{}", nested),
-                    is_archived: false,
-                };
-            }
-            return CollectionMetadata {
-                collection: "Development".to_string(),
-                is_archived: false,
-            };
-        }
-
-        if sub_segments
-            .first()
-            .map(|s| s.eq_ignore_ascii_case("core"))
-            .unwrap_or(false)
-        {
-            return CollectionMetadata {
-                collection: "Architecture:Core".to_string(),
-                is_archived: false,
-            };
-        }
-
-        if !sub_segments.is_empty() {
-            let arch_sub = sub_segments
-                .iter()
-                .map(|s| to_title_case(s))
-                .collect::<Vec<_>>()
-                .join(":");
-            return CollectionMetadata {
-                collection: format!("Architecture:{}", arch_sub),
-                is_archived: false,
-            };
-        }
-
-        return CollectionMetadata {
-            collection: "Architecture".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Performance
-    if segments
-        .first()
-        .map(|s| s.eq_ignore_ascii_case("performance"))
-        .unwrap_or(false)
-    {
-        return CollectionMetadata {
-            collection: "Performance".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Testing
-    if segments
-        .first()
-        .map(|s| s.eq_ignore_ascii_case("testing"))
-        .unwrap_or(false)
-    {
-        return CollectionMetadata {
-            collection: "Testing".to_string(),
-            is_archived: false,
-        };
-    }
-
-    // Default: use directory path as collection
-    if segments.is_empty() {
-        return CollectionMetadata {
-            collection: "Docs".to_string(),
-            is_archived: false,
-        };
-    }
-
-    let collection = segments
-        .iter()
-        .map(|s| to_title_case(s))
-        .collect::<Vec<_>>()
-        .join(":");
-
-    CollectionMetadata {
-        collection,
-        is_archived: false,
-    }
-}
-
-/// Convert kebab-case or snake_case to Title Case
-fn to_title_case(s: &str) -> String {
-    s.split(['-', '_'])
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => first.to_uppercase().chain(chars).collect(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-/// Import a single markdown file directly into NodeSpace
-///
-/// Bypasses MCP for faster direct import. Reads file from disk,
-/// parses markdown, and creates nodes using bulk_create_hierarchy.
+/// Import a single markdown file via gRPC ImportService
 #[tauri::command]
 pub async fn import_markdown_file(
-    services: State<'_, AppServices>,
+    app: AppHandle,
+    grpc: State<'_, GrpcClient>,
     file_path: String,
     options: Option<ImportOptions>,
 ) -> Result<FileImportResult, String> {
-    let node_service = services.node_service().await.map_err(|e| e.message)?;
-    let path = PathBuf::from(&file_path);
-    let options = options.unwrap_or_default();
-
-    // Validate file exists and is readable
-    if !path.exists() {
-        return Ok(FileImportResult {
-            file_path,
-            root_id: None,
-            nodes_created: 0,
-            success: false,
-            error: Some("File does not exist".to_string()),
-            collection: None,
-            archived: false,
-        });
-    }
-
-    if !path.is_file() {
-        return Ok(FileImportResult {
-            file_path,
-            root_id: None,
-            nodes_created: 0,
-            success: false,
-            error: Some("Path is not a file".to_string()),
-            collection: None,
-            archived: false,
-        });
-    }
-
-    // Read file content
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) => {
-            return Ok(FileImportResult {
-                file_path,
-                root_id: None,
-                nodes_created: 0,
-                success: false,
-                error: Some(format!("Failed to read file: {}", e)),
-                collection: None,
-                archived: false,
-            });
-        }
+    let mut client = grpc.import_client();
+    let req = ImportMarkdownRequest {
+        file_path: file_path.clone(),
+        options: Some(options.unwrap_or_default().into_proto()),
     };
 
-    // Determine collection and metadata
-    let (collection, is_archived) = if options.auto_collection_routing {
-        let base_dir = options
-            .base_directory
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| path.parent().unwrap_or(Path::new(".")).to_path_buf());
-        let metadata = derive_collection_metadata(&path, &base_dir);
-        (Some(metadata.collection), metadata.is_archived)
-    } else {
-        (options.collection.clone(), false)
-    };
+    let mut stream = client
+        .import_markdown(Request::new(req))
+        .await
+        .map_err(|e| e.to_string())?
+        .into_inner();
 
-    // Determine title - prefer first heading from content
-    let title = if options.use_filename_as_title {
-        path.file_stem()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "Untitled".to_string())
-    } else {
-        // Use first non-empty line as title
-        content
-            .lines()
-            .find(|l| !l.trim().is_empty())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "Untitled".to_string())
-    };
+    let mut last_result: Option<FileImportResult> = None;
 
-    // Import using internal function
-    match import_markdown_content(&node_service, &title, &content, is_archived).await {
-        Ok((root_id, nodes_created)) => {
-            // For single file import, do collection assignment immediately
-            if let Some(ref coll) = collection {
-                let collection_service =
-                    CollectionService::new(node_service.store(), &node_service);
-                if let Err(e) = collection_service
-                    .add_to_collection_by_path(&root_id, coll)
-                    .await
-                {
-                    return Ok(FileImportResult {
-                        file_path,
-                        root_id: Some(root_id),
-                        nodes_created,
-                        success: true,
-                        error: Some(format!("Imported but failed to add to collection: {}", e)),
-                        collection,
-                        archived: is_archived,
-                    });
-                }
+    while let Some(event) = stream.next().await {
+        let event = event.map_err(|e| e.to_string())?;
+
+        let _ = app.emit(
+            "import-progress",
+            ImportProgressEvent {
+                step: event.step as u8,
+                step_name: event.step_name.clone(),
+                message: event.message.clone(),
+                current: event.current as usize,
+                total: event.total as usize,
+            },
+        );
+
+        if event.step == 9 {
+            if let Some(r) = event.results.into_iter().next() {
+                last_result = Some(FileImportResult {
+                    file_path: r.file_path,
+                    root_id: if r.root_id.is_empty() {
+                        None
+                    } else {
+                        Some(r.root_id)
+                    },
+                    nodes_created: r.nodes_created as usize,
+                    success: r.success,
+                    error: if r.error.is_empty() {
+                        None
+                    } else {
+                        Some(r.error)
+                    },
+                    collection: if r.collection.is_empty() {
+                        None
+                    } else {
+                        Some(r.collection)
+                    },
+                    archived: r.archived,
+                });
             }
-            Ok(FileImportResult {
-                file_path,
-                root_id: Some(root_id),
-                nodes_created,
-                success: true,
-                error: None,
-                collection,
-                archived: is_archived,
-            })
         }
-        Err(e) => Ok(FileImportResult {
-            file_path,
-            root_id: None,
-            nodes_created: 0,
-            success: false,
-            error: Some(e),
-            collection: None,
-            archived: false,
-        }),
     }
+
+    last_result.ok_or_else(|| "Import stream ended without a result".to_string())
 }
 
-/// Import multiple markdown files in batch (Issue #854 - Optimized)
-///
-/// Uses a two-phase architecture for maximum performance:
-///
-/// **Phase 1 (Sync - Fast):**
-/// - Read all files from disk
-/// - Parse markdown content to prepared nodes
-/// - Build file→UUID map for inter-file link resolution
-/// - Transform links to nodespace:// format
-/// - Collect unique collection paths
-///
-/// **Phase 2 (Async - Background):**
-/// - Bulk resolve/create all collections (one pass)
-/// - Bulk create ALL nodes (one transaction)
-/// - Bulk assign ALL collection memberships (one transaction)
-/// - Emit progress events during each phase
-///
-/// Returns immediately after Phase 1 completes. Phase 2 runs in background.
+/// Import multiple markdown files via gRPC ImportService
 #[tauri::command]
 pub async fn import_markdown_files(
     app: AppHandle,
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     file_paths: Vec<String>,
     options: Option<ImportOptions>,
 ) -> Result<BatchImportResult, String> {
-    let node_service = services.node_service().await.map_err(|e| e.message)?;
-    let start = std::time::Instant::now();
     let total_files = file_paths.len();
-    let options = options.unwrap_or_default();
+    let mut client = grpc.import_client();
+    let req = ImportMarkdownFilesRequest {
+        file_paths,
+        options: Some(options.unwrap_or_default().into_proto()),
+    };
 
-    // Determine base directory for auto-routing
-    let base_dir = options
-        .base_directory
-        .as_ref()
-        .map(PathBuf::from)
-        .or_else(|| {
-            file_paths.first().map(|p| {
-                PathBuf::from(p)
-                    .parent()
-                    .unwrap_or(Path::new("."))
-                    .to_path_buf()
-            })
-        })
-        .unwrap_or_else(|| PathBuf::from("."));
+    let mut stream = client
+        .import_markdown_files(Request::new(req))
+        .await
+        .map_err(|e| e.to_string())?
+        .into_inner();
 
-    // ========================================================================
-    // PHASE 1: Parse all files (sync, in-memory, fast)
-    // ========================================================================
+    let mut final_results: Vec<FileImportResult> = Vec::new();
 
-    let mut prepared_files: Vec<PreparedFileImport> = Vec::with_capacity(total_files);
-    let mut results: Vec<FileImportResult> = Vec::with_capacity(total_files);
-    let mut failed = 0;
+    while let Some(event) = stream.next().await {
+        let event = event.map_err(|e| e.to_string())?;
 
-    // Step 1: Scanning folder
-    let _ = app.emit(
-        "import-progress",
-        ImportProgressEvent {
-            step: 1,
-            step_name: "scanning".to_string(),
-            message: "Scanning folder...".to_string(),
-            current: 0,
-            total: total_files,
-        },
-    );
-
-    // Store file contents for reading/parsing phases
-    let mut file_contents: Vec<FileReadResult> = Vec::new();
-
-    // Step 2: Reading files (emit per-file progress)
-    for (index, file_path) in file_paths.iter().enumerate() {
-        let path = PathBuf::from(file_path);
-        let relative_path = path
-            .strip_prefix(&base_dir)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .to_string();
-
-        // Extract just the filename for display
-        let filename = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&relative_path)
-            .to_string();
-
-        // Emit reading progress
         let _ = app.emit(
             "import-progress",
             ImportProgressEvent {
-                step: 2,
-                step_name: "reading".to_string(),
-                message: format!("Reading: {}", filename),
-                current: index + 1,
-                total: total_files,
+                step: event.step as u8,
+                step_name: event.step_name.clone(),
+                message: event.message.clone(),
+                current: event.current as usize,
+                total: event.total as usize,
             },
         );
 
-        // Skip non-existent files
-        if !path.exists() || !path.is_file() {
-            results.push(FileImportResult {
-                file_path: file_path.clone(),
-                root_id: None,
-                nodes_created: 0,
-                success: false,
-                error: Some("File does not exist or is not a file".to_string()),
-                collection: None,
-                archived: false,
-            });
-            failed += 1;
-            continue;
+        if event.step == 9 {
+            final_results = event
+                .results
+                .into_iter()
+                .map(|r| FileImportResult {
+                    file_path: r.file_path,
+                    root_id: if r.root_id.is_empty() {
+                        None
+                    } else {
+                        Some(r.root_id)
+                    },
+                    nodes_created: r.nodes_created as usize,
+                    success: r.success,
+                    error: if r.error.is_empty() {
+                        None
+                    } else {
+                        Some(r.error)
+                    },
+                    collection: if r.collection.is_empty() {
+                        None
+                    } else {
+                        Some(r.collection)
+                    },
+                    archived: r.archived,
+                })
+                .collect();
         }
-
-        // Determine collection and metadata
-        let (collection_path, is_archived) = if options.auto_collection_routing {
-            let metadata = derive_collection_metadata(&path, &base_dir);
-            (Some(metadata.collection), metadata.is_archived)
-        } else {
-            (options.collection.clone(), false)
-        };
-
-        // Read file content
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                results.push(FileImportResult {
-                    file_path: file_path.clone(),
-                    root_id: None,
-                    nodes_created: 0,
-                    success: false,
-                    error: Some(format!("Failed to read file: {}", e)),
-                    collection: None,
-                    archived: false,
-                });
-                failed += 1;
-                continue;
-            }
-        };
-
-        file_contents.push(FileReadResult {
-            path,
-            content,
-            relative_path,
-            collection_path,
-            is_archived,
-        });
     }
 
-    // Step 3: Parsing markdown (emit per-file progress)
-    for (index, file_read) in file_contents.iter().enumerate() {
-        let FileReadResult {
-            path,
-            content,
-            relative_path,
-            collection_path,
-            is_archived,
-        } = file_read;
+    let successful = final_results.iter().filter(|r| r.success).count();
+    let failed = final_results.len().saturating_sub(successful);
 
-        // Extract just the filename for display
-        let filename = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(relative_path)
-            .to_string();
-
-        // Emit parsing progress
-        let _ = app.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 3,
-                step_name: "parsing".to_string(),
-                message: format!("Parsing: {}", filename),
-                current: index + 1,
-                total: file_contents.len(),
-            },
-        );
-
-        // Determine title
-        let title = if options.use_filename_as_title {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "Untitled".to_string())
-        } else {
-            content
-                .lines()
-                .find(|l| !l.trim().is_empty())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "Untitled".to_string())
-        };
-
-        // Generate root node ID upfront
-        let root_id = uuid::Uuid::new_v4().to_string();
-
-        // Determine root content (title as header)
-        let root_content = if title.starts_with('#') {
-            title.clone()
-        } else {
-            format!("# {}", title)
-        };
-
-        // Skip the first line of content if it matches the title (de-duplication)
-        let content_for_children = {
-            let first_line = content.lines().find(|l| !l.trim().is_empty());
-            if first_line == Some(&title) {
-                let lines: Vec<&str> = content.lines().collect();
-                let first_idx = lines.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
-                lines[first_idx + 1..].join("\n")
-            } else {
-                content.to_string()
-            }
-        };
-
-        // Parse markdown to prepared nodes
-        let children =
-            match prepare_nodes_from_markdown(&content_for_children, Some(root_id.clone())) {
-                Ok(nodes) => nodes,
-                Err(e) => {
-                    results.push(FileImportResult {
-                        file_path: path.to_string_lossy().to_string(),
-                        root_id: None,
-                        nodes_created: 0,
-                        success: false,
-                        error: Some(format!("Failed to parse markdown: {:?}", e)),
-                        collection: None,
-                        archived: false,
-                    });
-                    failed += 1;
-                    continue;
-                }
-            };
-
-        prepared_files.push(PreparedFileImport {
-            file_path: path.clone(),
-            root_id,
-            root_content,
-            is_archived: *is_archived,
-            collection_path: collection_path.clone(),
-            children,
-        });
-    }
-
-    // Build file→UUID map for link transformation
-    let file_to_uuid_map: HashMap<PathBuf, String> = prepared_files
-        .iter()
-        .map(|f| (f.file_path.clone(), f.root_id.clone()))
-        .collect();
-
-    // Step 4: Resolving links
-    let _ = app.emit(
-        "import-progress",
-        ImportProgressEvent {
-            step: 4,
-            step_name: "resolving".to_string(),
-            message: "Resolving internal links...".to_string(),
-            current: 0,
-            total: prepared_files.len(),
-        },
-    );
-
-    // Transform inter-file links in all nodes and collect mentions (Issue #868)
-    let mut all_mentions: Vec<(String, String)> = Vec::new();
-    for prepared in &mut prepared_files {
-        let result = transform_links_in_nodes_with_mentions(
-            &mut prepared.children,
-            &file_to_uuid_map,
-            Some(&prepared.file_path),
-            &prepared.root_id,
-        );
-        all_mentions.extend(result.mentions);
-    }
-
-    // Collect unique collection paths
-    let unique_collections: Vec<String> = prepared_files
-        .iter()
-        .filter_map(|f| f.collection_path.clone())
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .collect();
-
-    // Build results for successfully parsed files (will be updated after insertion)
-    let successful_count = prepared_files.len();
-    for prepared in &prepared_files {
-        results.push(FileImportResult {
-            file_path: prepared.file_path.to_string_lossy().to_string(),
-            root_id: Some(prepared.root_id.clone()),
-            nodes_created: 1 + prepared.children.len(), // Root + children
-            success: true,
-            error: None,
-            collection: prepared.collection_path.clone(),
-            archived: prepared.is_archived,
-        });
-    }
-
-    // ========================================================================
-    // PHASE 2: Spawn async task for DB operations (fire-and-forget)
-    // ========================================================================
-
-    let parsing_duration = start.elapsed().as_millis();
-
-    // Clone data for the spawned task.
-    // These values are computed before tokio::spawn because:
-    // 1. The async block uses `move`, which takes ownership of captured variables
-    // 2. Computing lengths/counts here avoids borrowing issues in the async context
-    // 3. Cloning Arc/handles is cheap and allows the original references to be dropped
-    let store = Arc::clone(node_service.store());
-    let node_service_clone = (*node_service).clone();
-    let app_clone = app.clone();
-    let total_files_clone = total_files;
-    let successful_files_clone = prepared_files.len();
-    let total_nodes_clone: usize = prepared_files.iter().map(|f| 1 + f.children.len()).sum();
-    let all_mentions_count = all_mentions.len();
-    let unique_collections_count = unique_collections.len();
-
-    // Spawn background task for DB operations
-    tokio::spawn(async move {
-        let insert_start = std::time::Instant::now();
-
-        // Step 5: Creating collections
-        let _ = app_clone.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 5,
-                step_name: "collections".to_string(),
-                message: format!("Creating {} collections...", unique_collections_count),
-                current: 0,
-                total: unique_collections_count,
-            },
-        );
-
-        let collection_service = CollectionService::new(&store, &node_service_clone);
-        let collection_map = match collection_service
-            .bulk_resolve_collections(&unique_collections)
-            .await
-        {
-            Ok(map) => map,
-            Err(e) => {
-                tracing::error!("Failed to bulk resolve collections: {:?}", e);
-                HashMap::new()
-            }
-        };
-
-        // Build all nodes for bulk insertion
-        let mut all_nodes: Vec<(
-            String,
-            String,
-            String,
-            Option<String>,
-            f64,
-            serde_json::Value,
-        )> = Vec::new();
-        let mut collection_assignments: Vec<(String, String)> = Vec::new();
-
-        for prepared in &prepared_files {
-            // Add root node
-            let mut root_props = serde_json::json!({});
-            if prepared.is_archived {
-                root_props["lifecycle_status"] = serde_json::json!("archived");
-            }
-            all_nodes.push((
-                prepared.root_id.clone(),
-                "header".to_string(),
-                prepared.root_content.clone(),
-                None, // Root has no parent
-                1.0,
-                root_props,
-            ));
-
-            // Add child nodes (with parent remapping)
-            for child in &prepared.children {
-                let parent = child
-                    .parent_id
-                    .clone()
-                    .or_else(|| Some(prepared.root_id.clone()));
-                all_nodes.push((
-                    child.id.clone(),
-                    child.node_type.clone(),
-                    child.content.clone(),
-                    parent,
-                    child.order,
-                    child.properties.clone(),
-                ));
-            }
-
-            // Track collection assignment
-            if let Some(ref coll_path) = prepared.collection_path {
-                if let Some(coll_id) = collection_map.get(coll_path) {
-                    collection_assignments.push((prepared.root_id.clone(), coll_id.clone()));
-                }
-            }
-        }
-
-        // Step 6: Importing nodes
-        let _ = app_clone.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 6,
-                step_name: "importing".to_string(),
-                message: format!("Importing {} nodes...", all_nodes.len()),
-                current: 0,
-                total: all_nodes.len(),
-            },
-        );
-
-        // Bulk create all nodes using trusted import (skips schema validation)
-        match node_service_clone
-            .bulk_create_hierarchy_trusted(all_nodes)
-            .await
-        {
-            Ok(created_ids) => {
-                tracing::info!(
-                    "Bulk created {} nodes in {:?}",
-                    created_ids.len(),
-                    insert_start.elapsed()
-                );
-            }
-            Err(e) => {
-                tracing::error!("Failed to bulk create nodes: {:?}", e);
-            }
-        }
-
-        // Step 7: Assigning to collections
-        let _ = app_clone.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 7,
-                step_name: "assigning".to_string(),
-                message: "Assigning to collections...".to_string(),
-                current: 0,
-                total: collection_assignments.len(),
-            },
-        );
-
-        if !collection_assignments.is_empty() {
-            match store.bulk_add_to_collections(&collection_assignments).await {
-                Ok(count) => {
-                    tracing::info!("Bulk assigned {} collection memberships", count);
-                }
-                Err(e) => {
-                    tracing::error!("Failed to bulk add to collections: {:?}", e);
-                }
-            }
-        }
-
-        // Step 8: Creating references (mentions)
-        let _ = app_clone.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 8,
-                step_name: "references".to_string(),
-                message: format!("Creating {} references...", all_mentions_count),
-                current: 0,
-                total: all_mentions_count,
-            },
-        );
-
-        if !all_mentions.is_empty() {
-            match store.bulk_create_mentions(&all_mentions).await {
-                Ok(count) => {
-                    tracing::info!("Bulk created {} mentions", count);
-                }
-                Err(e) => {
-                    tracing::error!("Failed to bulk create mentions: {:?}", e);
-                }
-            }
-        }
-
-        // Update lifecycle_status for archived documents
-        for prepared in &prepared_files {
-            if prepared.is_archived {
-                if let Err(e) = store
-                    .update_lifecycle_status(&prepared.root_id, "archived")
-                    .await
-                {
-                    tracing::warn!(
-                        "Failed to set lifecycle_status for {}: {}",
-                        prepared.root_id,
-                        e
-                    );
-                }
-            }
-        }
-
-        // Step 9: Complete
-        let total_duration = insert_start.elapsed();
-        let _ = app_clone.emit(
-            "import-progress",
-            ImportProgressEvent {
-                step: 9,
-                step_name: "complete".to_string(),
-                message: format!(
-                    "Imported {} files ({} nodes) in {:.1}s",
-                    successful_files_clone,
-                    total_nodes_clone,
-                    total_duration.as_secs_f64()
-                ),
-                current: total_files_clone,
-                total: total_files_clone,
-            },
-        );
-
-        tracing::info!(
-            "Background import complete: {} files, {} nodes in {:?}",
-            prepared_files.len(),
-            prepared_files
-                .iter()
-                .map(|f| 1 + f.children.len())
-                .sum::<usize>(),
-            total_duration
-        );
-    });
-
-    // Return immediately with parsing results (Phase 1 complete)
     Ok(BatchImportResult {
         total_files,
-        successful: successful_count,
+        successful,
         failed,
-        results,
-        duration_ms: parsing_duration,
+        results: final_results,
     })
 }
 
-/// Import markdown from a directory (all .md files)
-///
-/// Recursively finds all markdown files and imports them.
-/// Supports exclusion patterns and auto-collection routing.
+/// Import markdown from a directory — collects .md files and delegates to batch import
 #[tauri::command]
 pub async fn import_markdown_directory(
     app: AppHandle,
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     directory_path: String,
     options: Option<ImportOptions>,
 ) -> Result<BatchImportResult, String> {
-    let path = PathBuf::from(&directory_path);
+    use std::path::PathBuf;
 
-    if !path.exists() {
+    let dir = PathBuf::from(&directory_path);
+    if !dir.exists() {
         return Err("Directory does not exist".to_string());
     }
-
-    if !path.is_dir() {
+    if !dir.is_dir() {
         return Err("Path is not a directory".to_string());
     }
 
-    let options = options.unwrap_or_default();
-    let exclude_patterns = &options.exclude_patterns;
+    let mut opts = options.unwrap_or_default();
+    let exclude_patterns = opts.exclude_patterns.clone();
 
-    // Collect all .md files, respecting exclusion patterns
+    // Set base_directory if not provided
+    if opts.base_directory.is_none() {
+        opts.base_directory = Some(directory_path.clone());
+    }
+
     let mut md_files: Vec<String> = Vec::new();
-    collect_markdown_files_with_exclusions(&path, &mut md_files, exclude_patterns)?;
-
-    // Sort for consistent ordering
+    collect_markdown_files_with_exclusions(&dir, &mut md_files, &exclude_patterns)?;
     md_files.sort();
 
     tracing::info!(
@@ -1042,19 +251,11 @@ pub async fn import_markdown_directory(
         exclude_patterns
     );
 
-    // Set base directory if not already set
-    let mut import_options = options.clone();
-    if import_options.base_directory.is_none() {
-        import_options.base_directory = Some(directory_path.clone());
-    }
-
-    // Import all files
-    import_markdown_files(app, services, md_files, Some(import_options)).await
+    import_markdown_files(app, grpc, md_files, Some(opts)).await
 }
 
-/// Recursively collect markdown files from a directory with exclusion patterns
 fn collect_markdown_files_with_exclusions(
-    dir: &PathBuf,
+    dir: &std::path::Path,
     files: &mut Vec<String>,
     exclude_patterns: &[String],
 ) -> Result<(), String> {
@@ -1064,10 +265,8 @@ fn collect_markdown_files_with_exclusions(
         let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
         let path = entry.path();
 
-        // Check if this path matches any exclusion pattern
         let path_str = path.to_string_lossy();
         let should_exclude = exclude_patterns.iter().any(|pattern| {
-            // Simple pattern matching: check if any path component equals the pattern
             path.components().any(|c| {
                 c.as_os_str()
                     .to_str()
@@ -1082,136 +281,13 @@ fn collect_markdown_files_with_exclusions(
         }
 
         if path.is_dir() {
-            // Recurse into subdirectories
             collect_markdown_files_with_exclusions(&path, files, exclude_patterns)?;
-        } else if path.is_file() {
-            // Check for .md extension
-            if let Some(ext) = path.extension() {
-                if ext == "md" {
-                    if let Some(path_str) = path.to_str() {
-                        files.push(path_str.to_string());
-                    }
-                }
+        } else if path.is_file() && path.extension().map(|e| e == "md").unwrap_or(false) {
+            if let Some(s) = path.to_str() {
+                files.push(s.to_string());
             }
         }
     }
 
     Ok(())
-}
-
-/// Internal function to import markdown content
-///
-/// Creates root node and bulk-creates children efficiently.
-/// Collection assignment is deferred - returns root_id for later batch assignment.
-/// Supports lifecycle_status for archived docs.
-///
-/// **De-duplication Logic**: If the title was extracted from the first line of content
-/// (indicated by `title` being the raw first line), the children are parsed from content
-/// AFTER the first line to avoid duplicate nodes.
-async fn import_markdown_content(
-    node_service: &NodeService,
-    title: &str,
-    content: &str,
-    is_archived: bool,
-) -> Result<(String, usize), String> {
-    // Determine root node type - if title starts with # it's a header, otherwise text
-    let (node_type, clean_title) = if title.starts_with('#') {
-        ("header", title.to_string())
-    } else {
-        ("header", format!("# {}", title))
-    };
-
-    // Skip the first line of content if it matches the title (de-duplication)
-    // This prevents creating a duplicate H1 child when the title came from content
-    let content_for_children = {
-        let first_line = content.lines().find(|l| !l.trim().is_empty());
-        if first_line == Some(title) {
-            // Title matches first line - skip it in children
-            let lines: Vec<&str> = content.lines().collect();
-            let first_idx = lines.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
-            lines[first_idx + 1..].join("\n")
-        } else {
-            // Title was provided separately or doesn't match - use full content
-            content.to_string()
-        }
-    };
-
-    // Prepare nodes from markdown (phase 1 - in memory, no DB)
-    let prepared_nodes = prepare_nodes_from_markdown(&content_for_children, None)
-        .map_err(|e| format!("Failed to parse markdown: {:?}", e))?;
-
-    // Create root node with lifecycle_status if archived
-    let mut properties = serde_json::json!({});
-    if is_archived {
-        properties["lifecycle_status"] = serde_json::json!("archived");
-    }
-
-    let root_id = node_service
-        .create_node_with_parent(CreateNodeParams {
-            id: None,
-            node_type: node_type.to_string(),
-            content: clean_title,
-            parent_id: None,
-            insert_after_node_id: None,
-            properties,
-        })
-        .await
-        .map_err(|e| format!("Failed to create root node: {}", e))?;
-
-    // If archived, update lifecycle_status explicitly (in case properties didn't work)
-    if is_archived {
-        if let Err(e) = node_service
-            .store()
-            .update_lifecycle_status(&root_id, "archived")
-            .await
-        {
-            tracing::warn!(
-                "Failed to set lifecycle_status to archived for {}: {}",
-                root_id,
-                e
-            );
-        }
-    }
-
-    let mut nodes_created = 1; // Root node
-
-    // Bulk create children if any
-    if !prepared_nodes.is_empty() {
-        // Remap parent_ids: None -> root_id, Some(id) -> id
-        let nodes_for_bulk: Vec<(
-            String,
-            String,
-            String,
-            Option<String>,
-            f64,
-            serde_json::Value,
-        )> = prepared_nodes
-            .iter()
-            .map(|n| {
-                let parent = n.parent_id.clone().or_else(|| Some(root_id.clone()));
-                (
-                    n.id.clone(),
-                    n.node_type.clone(),
-                    n.content.clone(),
-                    parent,
-                    n.order,
-                    n.properties.clone(),
-                )
-            })
-            .collect();
-
-        // Use root-only notification - emits single event for root node
-        // Other clients receive "tree created" event without per-node overhead
-        let created_ids = node_service
-            .bulk_create_hierarchy_root_notify(nodes_for_bulk)
-            .await
-            .map_err(|e| format!("Failed to bulk create nodes: {}", e))?;
-
-        nodes_created += created_ids.len();
-    }
-
-    // NOTE: Collection assignment is now deferred to batch processing after all imports
-    // This avoids N+1 collection lookups that cause slowdown
-
-    Ok((root_id, nodes_created))
 }

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -21,7 +21,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use nodespace_core::services::{NodeEmbeddingService, NodeService};
-use nodespace_daemon::{NodeServiceClient, NodeServiceImpl, NodeServiceServer};
+use nodespace_daemon::{
+    ImportServiceClient, ImportServiceImpl, ImportServiceServer, NodeServiceClient,
+    NodeServiceImpl, NodeServiceServer,
+};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Channel, Endpoint, Server};
@@ -37,13 +40,14 @@ const BIND_ADDR_TEMPLATE: &str = "127.0.0.1:0";
 /// finished binding, so we give tonic a brief window to retry.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Managed Tauri state wrapping the gRPC client.
+/// Managed Tauri state wrapping the gRPC clients.
 ///
-/// `Channel` is cheap to clone (it is an `Arc` internally) and so is
-/// `NodeServiceClient<Channel>`. Commands clone the client per call.
+/// `Channel` is cheap to clone (it is an `Arc` internally). Commands clone
+/// the client per call.
 #[derive(Clone)]
 pub struct GrpcClient {
-    inner: NodeServiceClient<Channel>,
+    node_client: NodeServiceClient<Channel>,
+    import_client: ImportServiceClient<Channel>,
 }
 
 impl GrpcClient {
@@ -64,12 +68,14 @@ impl GrpcClient {
 
         tracing::info!(%addr, "Starting in-process gRPC server");
 
-        let service_impl = NodeServiceImpl::new(node_service, embedding_service);
+        let node_impl = NodeServiceImpl::new(Arc::clone(&node_service), embedding_service);
+        let import_impl = ImportServiceImpl::new(node_service);
         let incoming = TcpListenerStream::new(listener);
 
         tokio::spawn(async move {
             if let Err(e) = Server::builder()
-                .add_service(NodeServiceServer::new(service_impl))
+                .add_service(NodeServiceServer::new(node_impl))
+                .add_service(ImportServiceServer::new(import_impl))
                 .serve_with_incoming(incoming)
                 .await
             {
@@ -82,18 +88,26 @@ impl GrpcClient {
             .connect_timeout(CONNECT_TIMEOUT);
 
         let channel = endpoint.connect().await.map_err(GrpcClientError::Connect)?;
-        let inner = NodeServiceClient::new(channel);
+        let node_client = NodeServiceClient::new(channel.clone());
+        let import_client = ImportServiceClient::new(channel);
 
         tracing::info!(%addr, "In-process gRPC client connected");
 
-        Ok(Self { inner })
+        Ok(Self {
+            node_client,
+            import_client,
+        })
     }
 
-    /// Borrow a clone of the underlying tonic client. Callers should clone
-    /// the client per request because tonic's generated methods take
-    /// `&mut self`.
+    /// Borrow a clone of the node service client. Commands should clone per
+    /// call because tonic's generated methods take `&mut self`.
     pub fn client(&self) -> NodeServiceClient<Channel> {
-        self.inner.clone()
+        self.node_client.clone()
+    }
+
+    /// Borrow a clone of the import service client.
+    pub fn import_client(&self) -> ImportServiceClient<Channel> {
+        self.import_client.clone()
     }
 }
 


### PR DESCRIPTION
## Summary

- Defines `ImportService` in a new `import_service.proto` with server-streaming `ImportMarkdown` and `ImportMarkdownFiles` RPCs
- Implements `ImportServiceImpl` in `nodespaced`, preserving the two-phase pipeline (parse → background DB write) and smart collection routing from the original Tauri commands
- Migrates `commands/import.rs` in the Tauri app to a thin gRPC proxy; all import logic now runs in the daemon (survives window close)
- Wires `nodespace import file` and `nodespace import dir` CLI subcommands
- Fixes pre-existing `CreateNodeRequest` struct literal errors in three test/integration files

## Test plan
- [ ] `cargo build` succeeds with no errors
- [ ] `bun run test:all` passes with no new failures
- [ ] `bun run quality:fix` passes clean
- [ ] `nodespace import file <path>` streams progress and reports success
- [ ] `nodespace import dir <path>` imports all .md files recursively
- [ ] Tauri `import_markdown_file` and `import_markdown_files` commands work via gRPC proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)