### PR TITLE
Add EmbeddingsService gRPC: proto, daemon handler, Tauri proxy (closes #1135)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,6 +4445,7 @@ dependencies = [
  "image",
  "nodespace-agent",
  "nodespace-core",
+ "nodespace-nlp-engine",
  "prost 0.13.5",
  "protoc-bin-vendored",
  "serde_json",

--- a/packages/daemon/Cargo.toml
+++ b/packages/daemon/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 nodespace-core = { workspace = true }
 nodespace-agent = { workspace = true }
+nodespace-nlp-engine = { workspace = true }
 
 # System tray (ADR-031): the daemon owns the tray icon, not the Tauri app.
 # tray-icon ships an event loop via `tao`; we run it on the main thread on

--- a/packages/daemon/proto/node_service.proto
+++ b/packages/daemon/proto/node_service.proto
@@ -524,3 +524,75 @@ message DeleteCollectionRequest {
   string collection_id = 1;
   int64 version = 2;
 }
+
+// ---------------------------------------------------------------------------
+// EmbeddingsService — semantic search and embedding management
+// ---------------------------------------------------------------------------
+
+service EmbeddingsService {
+  rpc GetEmbeddingStatus(GetEmbeddingStatusRequest)     returns (EmbeddingStatusResponse);
+  rpc SearchSemantic(SearchSemanticRequest)             returns (SearchSemanticResponse);
+  rpc RegenerateEmbedding(RegenerateEmbeddingRequest)   returns (RegenerateEmbeddingResponse);
+  rpc QueueEmbedding(QueueEmbeddingRequest)             returns (QueueEmbeddingResponse);
+  rpc TriggerBatchEmbed(TriggerBatchEmbedRequest)       returns (TriggerBatchEmbedResponse);
+  rpc GetStaleCount(GetStaleCountRequest)               returns (GetStaleCountResponse);
+  rpc BatchQueueEmbeddings(BatchQueueEmbeddingsRequest) returns (BatchQueueEmbeddingsResponse);
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingsService messages
+// ---------------------------------------------------------------------------
+
+message GetEmbeddingStatusRequest {}
+
+message EmbeddingStatusResponse {
+  bool available = 1;        // true when NLP engine loaded and ready
+  int32 stale_count = 2;     // number of root nodes awaiting (re-)embedding
+}
+
+message SearchSemanticRequest {
+  string query = 1;
+  float threshold = 2;       // 0.0 = use server default (0.7)
+  int32 limit = 3;           // 0 = use server default (20)
+  bool exact = 4;            // reserved for future use
+}
+
+message SearchSemanticResponse {
+  repeated NodeData nodes = 1;
+}
+
+message RegenerateEmbeddingRequest {
+  string node_id = 1;
+}
+
+message RegenerateEmbeddingResponse {}
+
+message QueueEmbeddingRequest {
+  string node_id = 1;
+}
+
+message QueueEmbeddingResponse {}
+
+message TriggerBatchEmbedRequest {}
+
+message TriggerBatchEmbedResponse {}
+
+message GetStaleCountRequest {}
+
+message GetStaleCountResponse {
+  int32 count = 1;
+}
+
+message BatchQueueEmbeddingsRequest {
+  repeated string node_ids = 1;
+}
+
+message BatchEmbeddingFailure {
+  string node_id = 1;
+  string error = 2;
+}
+
+message BatchQueueEmbeddingsResponse {
+  int32 success_count = 1;
+  repeated BatchEmbeddingFailure failures = 2;
+}

--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -47,10 +47,12 @@ pub mod nodespace {
 // to re-export and simultaneously verify that generated symbols exist.
 pub use nodespace::agent_session_service_client::AgentSessionServiceClient;
 pub use nodespace::agent_session_service_server::AgentSessionServiceServer;
+pub use nodespace::embeddings_service_client::EmbeddingsServiceClient;
+pub use nodespace::embeddings_service_server::EmbeddingsServiceServer;
 pub use nodespace::import_service_client::ImportServiceClient;
 pub use nodespace::import_service_server::ImportServiceServer;
 pub use nodespace::node_service_client::NodeServiceClient;
 pub use nodespace::node_service_server::NodeServiceServer;
 pub use nodespace::{NodeData, SessionInfo};
 
-pub use services::{AgentSessionHandler, ImportServiceImpl, NodeServiceImpl};
+pub use services::{AgentSessionHandler, EmbeddingsServiceImpl, ImportServiceImpl, NodeServiceImpl};

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -102,12 +102,17 @@ async fn serve_headless() -> Result<()> {
     let bundle = build_services(&db_path).await?;
 
     tracing::info!(%addr, "gRPC server listening");
-    let serve = Server::builder()
+    let builder = Server::builder()
         .add_service(NodeServiceServer::new(bundle.node_service_grpc))
         .add_service(AgentSessionServiceServer::new(bundle.agent_session))
-        .add_service(ImportServiceServer::new(bundle.import))
-        .add_service(EmbeddingsServiceServer::new(bundle.embeddings_service_grpc))
-        .serve_with_shutdown(addr, shutdown);
+        .add_service(ImportServiceServer::new(bundle.import));
+    let serve = if let Some(emb) = bundle.embeddings_service_grpc {
+        builder
+            .add_service(EmbeddingsServiceServer::new(emb))
+            .serve_with_shutdown(addr, shutdown)
+    } else {
+        builder.serve_with_shutdown(addr, shutdown)
+    };
 
     serve.await.context("gRPC server terminated with error")?;
     drain_gpu(bundle.embedding_state).await;
@@ -138,13 +143,18 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     };
 
     tracing::info!(%addr, "gRPC server listening");
-    let serve = Server::builder()
+    let builder = Server::builder()
         .layer(TrayMetricsLayer::new(controller))
         .add_service(NodeServiceServer::new(bundle.node_service_grpc))
         .add_service(AgentSessionServiceServer::new(bundle.agent_session))
-        .add_service(ImportServiceServer::new(bundle.import))
-        .add_service(EmbeddingsServiceServer::new(bundle.embeddings_service_grpc))
-        .serve_with_shutdown(addr, combined_shutdown);
+        .add_service(ImportServiceServer::new(bundle.import));
+    let serve = if let Some(emb) = bundle.embeddings_service_grpc {
+        builder
+            .add_service(EmbeddingsServiceServer::new(emb))
+            .serve_with_shutdown(addr, combined_shutdown)
+    } else {
+        builder.serve_with_shutdown(addr, combined_shutdown)
+    };
 
     serve.await.context("gRPC server terminated with error")?;
     drain_gpu(bundle.embedding_state).await;
@@ -156,7 +166,10 @@ struct ServiceBundle {
     node_service_grpc: NodeServiceImpl,
     agent_session: AgentSessionHandler,
     import: ImportServiceImpl,
-    embeddings_service_grpc: EmbeddingsServiceImpl,
+    /// `None` when the NLP model is absent — the daemon starts without semantic
+    /// search rather than refusing to run. The `EmbeddingsService` gRPC endpoint
+    /// is simply not registered in that case.
+    embeddings_service_grpc: Option<EmbeddingsServiceImpl>,
     /// Held so we can drain GPU resources after the server shuts down.
     embedding_state: Option<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>)>,
 }
@@ -185,17 +198,9 @@ async fn build_services(db_path: &std::path::Path) -> Result<ServiceBundle> {
     let embedding_service_opt = embedding_state.as_ref().map(|(svc, _)| svc.clone());
     let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_service_opt.clone());
 
-    let embeddings_service_grpc = match &embedding_state {
-        Some((svc, proc)) => {
-            EmbeddingsServiceImpl::new(node_service.clone(), svc.clone(), proc.clone())
-        }
-        None => {
-            return Err(anyhow::anyhow!(
-                "Embedding service unavailable — NLP model not found. \
-                 Place the model in ~/.nodespace/models/ to enable semantic search."
-            ));
-        }
-    };
+    let embeddings_service_grpc = embedding_state.as_ref().map(|(svc, proc)| {
+        EmbeddingsServiceImpl::new(node_service.clone(), svc.clone(), proc.clone())
+    });
 
     let manager = Arc::new(PtySessionManager::new());
     let assembler = Arc::new(GraphContextAssembler::new(node_service.clone(), embedding_service_opt));

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -17,12 +17,15 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use nodespace_agent::acp::context_assembly::GraphContextAssembler;
 use nodespace_agent::pty::PtySessionManager;
+use nodespace_core::services::{EmbeddingProcessor, NodeAccessor, NodeEmbeddingService};
 use nodespace_core::{NodeService as CoreNodeService, SurrealStore};
 use nodespace_daemon::tray::layer::TrayMetricsLayer;
 use nodespace_daemon::{
-    resolve_db_path, tray, AgentSessionHandler, AgentSessionServiceServer, ImportServiceImpl,
-    ImportServiceServer, NodeServiceImpl, NodeServiceServer,
+    resolve_db_path, tray, AgentSessionHandler, AgentSessionServiceServer, EmbeddingsServiceImpl,
+    EmbeddingsServiceServer, ImportServiceImpl, ImportServiceServer, NodeServiceImpl,
+    NodeServiceServer,
 };
+use nodespace_nlp_engine::EmbeddingService;
 use tonic::transport::Server;
 
 /// Default address the daemon binds to. ADR-031 standardizes on
@@ -96,16 +99,18 @@ async fn serve_headless() -> Result<()> {
     tracing::info!(db_path = %db_path.display(), %addr, "Starting nodespaced (headless)");
 
     let shutdown = install_shutdown_handler().context("Failed to install signal handlers")?;
-    let services = build_services(&db_path).await?;
+    let bundle = build_services(&db_path).await?;
 
     tracing::info!(%addr, "gRPC server listening");
-    Server::builder()
-        .add_service(NodeServiceServer::new(services.node))
-        .add_service(AgentSessionServiceServer::new(services.agent_session))
-        .add_service(ImportServiceServer::new(services.import))
-        .serve_with_shutdown(addr, shutdown)
-        .await
-        .context("gRPC server terminated with error")?;
+    let serve = Server::builder()
+        .add_service(NodeServiceServer::new(bundle.node_service_grpc))
+        .add_service(AgentSessionServiceServer::new(bundle.agent_session))
+        .add_service(ImportServiceServer::new(bundle.import))
+        .add_service(EmbeddingsServiceServer::new(bundle.embeddings_service_grpc))
+        .serve_with_shutdown(addr, shutdown);
+
+    serve.await.context("gRPC server terminated with error")?;
+    drain_gpu(bundle.embedding_state).await;
     Ok(())
 }
 
@@ -120,7 +125,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
 
     let signal_shutdown =
         install_shutdown_handler().context("Failed to install signal handlers")?;
-    let services = build_services(&db_path).await?;
+    let bundle = build_services(&db_path).await?;
 
     // `TrayController` is `Clone`; one copy goes to the metrics layer, the
     // other drives the shutdown future.
@@ -133,27 +138,31 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     };
 
     tracing::info!(%addr, "gRPC server listening");
-    Server::builder()
+    let serve = Server::builder()
         .layer(TrayMetricsLayer::new(controller))
-        .add_service(NodeServiceServer::new(services.node))
-        .add_service(AgentSessionServiceServer::new(services.agent_session))
-        .add_service(ImportServiceServer::new(services.import))
-        .serve_with_shutdown(addr, combined_shutdown)
-        .await
-        .context("gRPC server terminated with error")?;
+        .add_service(NodeServiceServer::new(bundle.node_service_grpc))
+        .add_service(AgentSessionServiceServer::new(bundle.agent_session))
+        .add_service(ImportServiceServer::new(bundle.import))
+        .add_service(EmbeddingsServiceServer::new(bundle.embeddings_service_grpc))
+        .serve_with_shutdown(addr, combined_shutdown);
+
+    serve.await.context("gRPC server terminated with error")?;
+    drain_gpu(bundle.embedding_state).await;
     Ok(())
 }
 
-/// Bundle of gRPC service implementations registered by both server loops.
-struct DaemonServices {
-    node: NodeServiceImpl,
+/// All initialized service handles for a daemon startup.
+struct ServiceBundle {
+    node_service_grpc: NodeServiceImpl,
     agent_session: AgentSessionHandler,
     import: ImportServiceImpl,
+    embeddings_service_grpc: EmbeddingsServiceImpl,
+    /// Held so we can drain GPU resources after the server shuts down.
+    embedding_state: Option<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>)>,
 }
 
-/// Open the database and assemble every gRPC service implementation the
-/// daemon exposes.
-async fn build_services(db_path: &std::path::Path) -> Result<DaemonServices> {
+/// Open the database and assemble the gRPC service implementations.
+async fn build_services(db_path: &std::path::Path) -> Result<ServiceBundle> {
     if let Some(parent) = db_path.parent() {
         tokio::fs::create_dir_all(parent).await.with_context(|| {
             format!("Failed to create database parent dir: {}", parent.display())
@@ -166,35 +175,117 @@ async fn build_services(db_path: &std::path::Path) -> Result<DaemonServices> {
             .context("Failed to initialize SurrealStore")?,
     );
 
-    let node_service = Arc::new(
-        CoreNodeService::new(&mut store)
-            .await
-            .context("Failed to initialize NodeService")?,
-    );
+    let mut node_service = CoreNodeService::new(&mut store)
+        .await
+        .context("Failed to initialize NodeService")?;
 
-    // Embedding service is wired by a follow-up issue. The gRPC `SearchNodes`
-    // handler returns `Unavailable` until it is provided. The same handle
-    // would feed semantic expansion in [`GraphContextAssembler`]; for now the
-    // assembler runs without semantic neighbours (it logs and skips).
-    let embedding_service = None;
+    let embedding_state = build_embedding_state(&store, &mut node_service);
+    let node_service = Arc::new(node_service);
 
-    let node = NodeServiceImpl::new(node_service.clone(), embedding_service.clone());
+    let embedding_service_opt = embedding_state.as_ref().map(|(svc, _)| svc.clone());
+    let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_service_opt.clone());
 
-    // The PTY engine and context assembler are shared across every
-    // `AgentSessionService` RPC call. `PtySessionManager` is `Clone` but
-    // wrapping in `Arc` keeps the manager itself a single instance so all
-    // sessions live in one map.
+    let embeddings_service_grpc = match &embedding_state {
+        Some((svc, proc)) => {
+            EmbeddingsServiceImpl::new(node_service.clone(), svc.clone(), proc.clone())
+        }
+        None => {
+            return Err(anyhow::anyhow!(
+                "Embedding service unavailable — NLP model not found. \
+                 Place the model in ~/.nodespace/models/ to enable semantic search."
+            ));
+        }
+    };
+
     let manager = Arc::new(PtySessionManager::new());
-    let assembler = Arc::new(GraphContextAssembler::new(node_service.clone(), embedding_service));
+    let assembler = Arc::new(GraphContextAssembler::new(node_service.clone(), embedding_service_opt));
     let agent_session = AgentSessionHandler::new(manager, assembler);
 
     let import = ImportServiceImpl::new(node_service);
 
-    Ok(DaemonServices {
-        node,
+    Ok(ServiceBundle {
+        node_service_grpc,
         agent_session,
         import,
+        embeddings_service_grpc,
+        embedding_state,
     })
+}
+
+/// Try to initialize NLP engine and embedding services. Non-fatal: returns
+/// `None` when the model is absent or fails to load.
+fn build_embedding_state(
+    store: &Arc<SurrealStore>,
+    node_service: &mut CoreNodeService,
+) -> Option<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>)> {
+    let model_path = {
+        // Allow override via env var so CI and alternate deployments can redirect.
+        let p = if let Ok(custom) = std::env::var("NODESPACED_MODEL_PATH") {
+            std::path::PathBuf::from(custom)
+        } else {
+            let home = std::env::var("HOME").ok()?;
+            std::path::PathBuf::from(home)
+                .join(".nodespace")
+                .join("models")
+                .join("nomic-embed-text-v1.5.Q8_0.gguf")
+        };
+        if !p.exists() {
+            tracing::warn!(path = %p.display(), "NLP model not found — semantic search disabled");
+            return None;
+        }
+        p
+    };
+
+    let config = nodespace_nlp_engine::EmbeddingConfig {
+        model_path: Some(model_path),
+        ..Default::default()
+    };
+
+    let mut nlp = match EmbeddingService::new(config) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to create NLP engine — semantic search disabled");
+            return None;
+        }
+    };
+    if let Err(e) = nlp.initialize() {
+        tracing::warn!(error = %e, "Failed to load NLP model — semantic search disabled");
+        return None;
+    }
+    let nlp = Arc::new(nlp);
+
+    let node_accessor: Arc<dyn NodeAccessor> = Arc::new(node_service.clone());
+    let behaviors = node_service.behaviors().clone();
+    let embedding_service = Arc::new(NodeEmbeddingService::new(
+        nlp,
+        store.clone(),
+        node_accessor,
+        behaviors,
+    ));
+
+    let processor = match EmbeddingProcessor::new(embedding_service.clone()) {
+        Ok(p) => Arc::new(p),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to init EmbeddingProcessor — semantic search disabled");
+            return None;
+        }
+    };
+    node_service.set_embedding_waker(processor.waker());
+    processor.wake();
+
+    Some((embedding_service, processor))
+}
+
+/// GPU drain protocol: drop processor first (shuts down background task),
+/// then release the GPU context from the NLP engine.
+async fn drain_gpu(state: Option<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>)>) {
+    if let Some((svc, proc)) = state {
+        drop(proc);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tracing::info!("Releasing GPU context...");
+        svc.nlp_engine().release_gpu_context();
+        tracing::info!("GPU context released");
+    }
 }
 
 /// Install the shutdown signal future at boot time so a failure to register

--- a/packages/daemon/src/services/embeddings_service.rs
+++ b/packages/daemon/src/services/embeddings_service.rs
@@ -1,0 +1,209 @@
+//! tonic `EmbeddingsService` implementation backed by `nodespace-core`.
+//!
+//! Wraps `NodeEmbeddingService` and `EmbeddingProcessor`. The GPU drain
+//! protocol (`release_gpu_context`) is handled on daemon shutdown, not by
+//! any individual RPC caller.
+
+use std::sync::Arc;
+
+use nodespace_core::models::EmbeddingConfig;
+use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService, NodeService};
+use tonic::{Request, Response, Status};
+
+use crate::nodespace::{
+    embeddings_service_server::EmbeddingsService as GrpcEmbeddingsService, BatchEmbeddingFailure,
+    BatchQueueEmbeddingsRequest, BatchQueueEmbeddingsResponse, EmbeddingStatusResponse,
+    GetEmbeddingStatusRequest, GetStaleCountRequest, GetStaleCountResponse, QueueEmbeddingRequest,
+    QueueEmbeddingResponse, RegenerateEmbeddingRequest, RegenerateEmbeddingResponse,
+    SearchSemanticRequest, SearchSemanticResponse, TriggerBatchEmbedRequest,
+    TriggerBatchEmbedResponse,
+};
+use crate::services::node_service::node_to_proto;
+
+pub struct EmbeddingsServiceImpl {
+    node_service: Arc<NodeService>,
+    embedding_service: Arc<NodeEmbeddingService>,
+    processor: Arc<EmbeddingProcessor>,
+}
+
+impl EmbeddingsServiceImpl {
+    pub fn new(
+        node_service: Arc<NodeService>,
+        embedding_service: Arc<NodeEmbeddingService>,
+        processor: Arc<EmbeddingProcessor>,
+    ) -> Self {
+        Self {
+            node_service,
+            embedding_service,
+            processor,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
+    async fn get_embedding_status(
+        &self,
+        _request: Request<GetEmbeddingStatusRequest>,
+    ) -> Result<Response<EmbeddingStatusResponse>, Status> {
+        let stale_count = self
+            .node_service
+            .store()
+            .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get stale count: {}", e)))?
+            .len() as i32;
+
+        Ok(Response::new(EmbeddingStatusResponse {
+            available: true,
+            stale_count,
+        }))
+    }
+
+    async fn search_semantic(
+        &self,
+        request: Request<SearchSemanticRequest>,
+    ) -> Result<Response<SearchSemanticResponse>, Status> {
+        let req = request.into_inner();
+
+        if req.query.trim().is_empty() {
+            return Err(Status::invalid_argument("query cannot be empty"));
+        }
+
+        let threshold = if req.threshold == 0.0 {
+            None
+        } else {
+            Some(req.threshold as f64)
+        };
+        let limit = if req.limit == 0 {
+            20i64
+        } else {
+            req.limit as i64
+        };
+
+        let query_embedding = self
+            .embedding_service
+            .nlp_engine()
+            .generate_embedding(&req.query)
+            .map_err(|e| Status::internal(format!("Failed to generate query embedding: {}", e)))?;
+
+        let store = self.node_service.store();
+        let search_results = store
+            .search_embeddings(&query_embedding, limit, threshold)
+            .await
+            .map_err(|e| Status::internal(format!("Vector search failed: {}", e)))?;
+
+        let mut nodes = Vec::with_capacity(search_results.len());
+        for result in search_results {
+            if let Ok(Some(node)) = store.get_node(&result.node_id).await {
+                nodes.push(node_to_proto(node, None, None));
+            }
+        }
+
+        Ok(Response::new(SearchSemanticResponse { nodes }))
+    }
+
+    async fn regenerate_embedding(
+        &self,
+        request: Request<RegenerateEmbeddingRequest>,
+    ) -> Result<Response<RegenerateEmbeddingResponse>, Status> {
+        let req = request.into_inner();
+
+        let node = self
+            .node_service
+            .get_node(&req.node_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get node: {}", e)))?
+            .ok_or_else(|| Status::not_found(format!("Node not found: {}", req.node_id)))?;
+
+        self.embedding_service
+            .queue_for_embedding(&node.id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to queue embedding: {}", e)))?;
+
+        Ok(Response::new(RegenerateEmbeddingResponse {}))
+    }
+
+    async fn queue_embedding(
+        &self,
+        request: Request<QueueEmbeddingRequest>,
+    ) -> Result<Response<QueueEmbeddingResponse>, Status> {
+        let req = request.into_inner();
+
+        let node = self
+            .node_service
+            .get_node(&req.node_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get node: {}", e)))?
+            .ok_or_else(|| Status::not_found(format!("Node not found: {}", req.node_id)))?;
+
+        self.embedding_service
+            .queue_for_embedding(&node.id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to queue embedding: {}", e)))?;
+
+        Ok(Response::new(QueueEmbeddingResponse {}))
+    }
+
+    async fn trigger_batch_embed(
+        &self,
+        _request: Request<TriggerBatchEmbedRequest>,
+    ) -> Result<Response<TriggerBatchEmbedResponse>, Status> {
+        self.processor
+            .trigger_batch_embed()
+            .map_err(|e| Status::internal(format!("Failed to trigger batch embed: {}", e)))?;
+
+        Ok(Response::new(TriggerBatchEmbedResponse {}))
+    }
+
+    async fn get_stale_count(
+        &self,
+        _request: Request<GetStaleCountRequest>,
+    ) -> Result<Response<GetStaleCountResponse>, Status> {
+        let count = self
+            .node_service
+            .store()
+            .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get stale count: {}", e)))?
+            .len() as i32;
+
+        Ok(Response::new(GetStaleCountResponse { count }))
+    }
+
+    async fn batch_queue_embeddings(
+        &self,
+        request: Request<BatchQueueEmbeddingsRequest>,
+    ) -> Result<Response<BatchQueueEmbeddingsResponse>, Status> {
+        let req = request.into_inner();
+        let mut success_count = 0i32;
+        let mut failures = Vec::new();
+
+        for node_id in req.node_ids {
+            match self.node_service.get_node(&node_id).await {
+                Ok(Some(node)) => {
+                    match self.embedding_service.queue_for_embedding(&node.id).await {
+                        Ok(_) => success_count += 1,
+                        Err(e) => failures.push(BatchEmbeddingFailure {
+                            node_id: node_id.clone(),
+                            error: format!("Failed to queue embedding: {}", e),
+                        }),
+                    }
+                }
+                Ok(None) => failures.push(BatchEmbeddingFailure {
+                    node_id: node_id.clone(),
+                    error: "Node not found".to_string(),
+                }),
+                Err(e) => failures.push(BatchEmbeddingFailure {
+                    node_id: node_id.clone(),
+                    error: format!("Failed to get node: {}", e),
+                }),
+            }
+        }
+
+        Ok(Response::new(BatchQueueEmbeddingsResponse {
+            success_count,
+            failures,
+        }))
+    }
+}

--- a/packages/daemon/src/services/embeddings_service.rs
+++ b/packages/daemon/src/services/embeddings_service.rs
@@ -38,6 +38,18 @@ impl EmbeddingsServiceImpl {
             processor,
         }
     }
+
+    /// Shared implementation for stale-count queries used by both
+    /// `get_embedding_status` and `get_stale_count` to avoid duplication.
+    async fn stale_count_inner(&self) -> Result<i32, Status> {
+        let ids = self
+            .node_service
+            .store()
+            .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get stale count: {}", e)))?;
+        Ok(i32::try_from(ids.len()).unwrap_or(i32::MAX))
+    }
 }
 
 #[tonic::async_trait]
@@ -46,14 +58,7 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         _request: Request<GetEmbeddingStatusRequest>,
     ) -> Result<Response<EmbeddingStatusResponse>, Status> {
-        let stale_count = self
-            .node_service
-            .store()
-            .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to get stale count: {}", e)))?
-            .len() as i32;
-
+        let stale_count = self.stale_count_inner().await?;
         Ok(Response::new(EmbeddingStatusResponse {
             available: true,
             stale_count,
@@ -160,14 +165,7 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         _request: Request<GetStaleCountRequest>,
     ) -> Result<Response<GetStaleCountResponse>, Status> {
-        let count = self
-            .node_service
-            .store()
-            .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to get stale count: {}", e)))?
-            .len() as i32;
-
+        let count = self.stale_count_inner().await?;
         Ok(Response::new(GetStaleCountResponse { count }))
     }
 

--- a/packages/daemon/src/services/mod.rs
+++ b/packages/daemon/src/services/mod.rs
@@ -4,9 +4,11 @@
 //! logic and adapts it to the tonic-generated service trait.
 
 pub mod agent_session_service;
+pub mod embeddings_service;
 pub mod import_service;
 pub mod node_service;
 
 pub use agent_session_service::AgentSessionHandler;
+pub use embeddings_service::EmbeddingsServiceImpl;
 pub use import_service::ImportServiceImpl;
 pub use node_service::NodeServiceImpl;

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -1101,7 +1101,11 @@ async fn fetch_node(service: &Arc<CoreNodeService>, node_id: &str) -> Result<Nod
         .ok_or_else(|| Status::not_found(format!("Node not found: {}", node_id)))
 }
 
-fn node_to_proto(node: Node, parent_id: Option<String>, collection_id: Option<String>) -> NodeData {
+pub(crate) fn node_to_proto(
+    node: Node,
+    parent_id: Option<String>,
+    collection_id: Option<String>,
+) -> NodeData {
     NodeData {
         id: node.id,
         node_type: node.node_type,

--- a/packages/desktop-app/src-tauri/src/app_services.rs
+++ b/packages/desktop-app/src-tauri/src/app_services.rs
@@ -1,36 +1,36 @@
 //! Centralized application services container with interior mutability.
 //!
-//! `AppServices` wraps all runtime services (database, node service, embeddings)
-//! behind `Arc<RwLock<>>` so they can be hot-swapped at runtime when the user
+//! `AppServices` wraps all runtime services (database, node service) behind
+//! `Arc<RwLock<>>` so they can be hot-swapped at runtime when the user
 //! switches databases — without restarting the entire application.
 //!
 //! Registered as a single Tauri managed state via `app.manage(AppServices::new())`.
 //! All commands access services through `State<'_, AppServices>`.
+//!
+//! The GPU lifecycle for embeddings is managed by the in-process gRPC server
+//! (`GrpcClient` / `EmbeddingsServiceImpl`) and released when the tokio runtime
+//! shuts down (Issue #1135). The `NodeEmbeddingService` Arc is still held here
+//! so the local agent's `GraphToolExecutor` can do in-process semantic skill
+//! injection without an extra gRPC round-trip.
 
 use crate::commands::nodes::CommandError;
 use crate::config::AppConfig;
-use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService};
+use nodespace_core::services::NodeEmbeddingService;
 use nodespace_core::{NodeService, SurrealStore};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-/// Application state containing embedding service and processor.
-///
-/// Moved from `commands/embeddings.rs` to centralize in AppServices.
-pub struct EmbeddingState {
-    pub service: Arc<NodeEmbeddingService>,
-    pub processor: Arc<EmbeddingProcessor>,
-}
-
 /// Active services that are initialized after database connection.
 ///
-/// All fields are populated during `init_services()` and can be
+/// All fields are populated during `initialize()` and can be
 /// replaced atomically during `switch_database()`.
 struct ActiveServices {
     store: Arc<SurrealStore>,
     node_service: Arc<NodeService>,
-    embedding_state: Option<EmbeddingState>,
+    /// Held for in-process use by the local agent (GraphToolExecutor). The GPU
+    /// lifecycle is managed by GrpcClient / EmbeddingsServiceImpl (Issue #1135).
+    embedding_service: Option<Arc<NodeEmbeddingService>>,
     config: AppConfig,
 }
 
@@ -90,31 +90,12 @@ impl AppServices {
             })
     }
 
-    /// Get the EmbeddingState, or error if not initialized or embeddings unavailable.
-    pub async fn embedding_state(
-        &self,
-    ) -> Result<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>), CommandError> {
+    /// Get the NodeEmbeddingService for in-process use (e.g. GraphToolExecutor).
+    ///
+    /// Returns `None` when embeddings are unavailable (model not loaded).
+    pub async fn embedding_service(&self) -> Option<Arc<NodeEmbeddingService>> {
         let guard = self.inner.read().await;
-        let active = guard.as_ref().ok_or_else(|| CommandError {
-            message: "Database not initialized. Please wait for startup to complete.".to_string(),
-            code: "NOT_INITIALIZED".to_string(),
-            details: None,
-        })?;
-
-        match &active.embedding_state {
-            Some(es) => Ok((es.service.clone(), es.processor.clone())),
-            None => Err(CommandError {
-                message: "Embedding service not available. Model may have failed to load."
-                    .to_string(),
-                code: "EMBEDDINGS_UNAVAILABLE".to_string(),
-                details: None,
-            }),
-        }
-    }
-
-    /// Get just the embedding service Arc (for MCP integration).
-    pub async fn embedding_service(&self) -> Result<Arc<NodeEmbeddingService>, CommandError> {
-        self.embedding_state().await.map(|(svc, _)| svc)
+        guard.as_ref()?.embedding_service.clone()
     }
 
     /// Get the AppConfig, or error if not yet initialized.
@@ -143,7 +124,7 @@ impl AppServices {
         &self,
         store: Arc<SurrealStore>,
         node_service: Arc<NodeService>,
-        embedding_state: Option<EmbeddingState>,
+        embedding_service: Option<Arc<NodeEmbeddingService>>,
         config: AppConfig,
         session_cancel_token: CancellationToken,
     ) {
@@ -152,7 +133,7 @@ impl AppServices {
             *guard = Some(ActiveServices {
                 store,
                 node_service,
-                embedding_state,
+                embedding_service,
                 config,
             });
         }
@@ -162,24 +143,18 @@ impl AppServices {
         }
     }
 
-    /// Hot-swap database: cancel session tasks, replace services, restart background tasks.
+    /// Hot-swap database: cancel session tasks and replace services.
     ///
-    /// The drain-then-replace protocol:
-    /// 1. Cancel the current session token (stops MCP server, domain event forwarder)
-    /// 2. Brief pause for background tasks to exit
-    /// 3. Release GPU resources from old embedding state
-    /// 4. Replace inner services with new ones
-    /// 5. Set new session token
-    /// 6. Caller restarts background tasks with new services
+    /// GPU drain is handled by the in-process gRPC server shutdown (Issue #1135).
     pub async fn switch_database(
         &self,
         store: Arc<SurrealStore>,
         node_service: Arc<NodeService>,
-        embedding_state: Option<EmbeddingState>,
+        embedding_service: Option<Arc<NodeEmbeddingService>>,
         config: AppConfig,
         new_session_token: CancellationToken,
     ) {
-        // Step 1: Cancel current session token
+        // Cancel current session token
         {
             let token_guard = self.session_token.read().await;
             if let Some(token) = token_guard.as_ref() {
@@ -187,46 +162,21 @@ impl AppServices {
             }
         }
 
-        // Step 2: Drain old embedding processor before releasing GPU.
-        // The processor's background task shuts down when its Arc is dropped
-        // (dropping the shutdown channel sender). We take ownership here so the
-        // old processor stops before we release the GPU context it depends on.
-        let old_embedding_state = {
-            let mut guard = self.inner.write().await;
-            guard
-                .as_mut()
-                .and_then(|active| active.embedding_state.take())
-        };
-
-        // Brief pause for background tasks (MCP, forwarder, processor) to exit
+        // Brief pause for background tasks (MCP, forwarder) to exit
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Step 3: Release GPU resources from old embedding state.
-        // The processor Arc should be the last reference — dropping it shuts down
-        // the background task. Then we can safely release the GPU context.
-        if let Some(old_es) = old_embedding_state {
-            // Drop processor first to stop its background task
-            let old_service = old_es.service;
-            drop(old_es.processor);
-            // Brief pause for processor task to exit
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            tracing::info!("Releasing GPU context from old embedding state...");
-            old_service.nlp_engine().release_gpu_context();
-            tracing::info!("GPU context released successfully");
-        }
-
-        // Step 4: Replace services
+        // Replace services
         {
             let mut guard = self.inner.write().await;
             *guard = Some(ActiveServices {
                 store,
                 node_service,
-                embedding_state,
+                embedding_service,
                 config,
             });
         }
 
-        // Step 5: Set new session token
+        // Set new session token
         {
             let mut token_guard = self.session_token.write().await;
             *token_guard = Some(new_session_token);
@@ -236,47 +186,5 @@ impl AppServices {
     /// Get the current session cancellation token (for background task coordination).
     pub async fn session_token(&self) -> Option<CancellationToken> {
         self.session_token.read().await.clone()
-    }
-
-    /// Release GPU resources. Called during graceful shutdown.
-    ///
-    /// Mirrors the drain-then-release protocol from `switch_database()`:
-    /// 1. Take ownership of embedding state (removes from ActiveServices)
-    /// 2. Drop processor first — closes shutdown channel, background task exits
-    /// 3. Brief pause for processor task to exit
-    /// 4. Release GPU context (now safe — no background tasks hold references)
-    pub async fn release_gpu_resources(&self) {
-        // Cancel session token to signal all session-scoped background tasks
-        // (MCP server, domain event forwarder, embedding processor).
-        // Note: graceful_shutdown() already cancelled the parent ShutdownToken
-        // and waited 200ms for tasks to exit, but we cancel explicitly for safety.
-        {
-            let mut token_guard = self.session_token.write().await;
-            if let Some(token) = token_guard.take() {
-                token.cancel();
-            }
-        }
-
-        // Take ownership of embedding state (drops from ActiveServices)
-        let old_embedding_state = {
-            let mut guard = self.inner.write().await;
-            guard
-                .as_mut()
-                .and_then(|active| active.embedding_state.take())
-        };
-
-        if let Some(old_es) = old_embedding_state {
-            // Step 2: Drop processor first — closes shutdown channel, background task exits
-            let old_service = old_es.service;
-            drop(old_es.processor);
-
-            // Step 3: Brief pause for processor task to exit.
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-            // Step 4: Now safe to release GPU context
-            tracing::info!("Releasing GPU context to prevent Metal crash...");
-            old_service.nlp_engine().release_gpu_context();
-            tracing::info!("GPU context released successfully");
-        }
     }
 }

--- a/packages/desktop-app/src-tauri/src/commands/collections.rs
+++ b/packages/desktop-app/src-tauri/src/commands/collections.rs
@@ -45,7 +45,7 @@ pub struct CollectionInfo {
 pub async fn get_all_collections(
     client: State<'_, GrpcClient>,
 ) -> Result<Vec<CollectionInfo>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_all_collections(Request::new(GetAllCollectionsRequest {}))
         .await
@@ -85,7 +85,7 @@ pub async fn get_collection_members(
     client: State<'_, GrpcClient>,
     collection_id: String,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_collection_members(Request::new(CollectionMembersRequest { collection_id }))
         .await
@@ -115,7 +115,7 @@ pub async fn get_collection_members_recursive(
     client: State<'_, GrpcClient>,
     collection_id: String,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_collection_members_recursive(Request::new(CollectionMembersRequest { collection_id }))
         .await
@@ -148,7 +148,7 @@ pub async fn get_node_collections(
     client: State<'_, GrpcClient>,
     node_id: String,
 ) -> Result<Vec<String>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_node_collections(Request::new(NodeCollectionsRequest { node_id }))
         .await
@@ -172,7 +172,7 @@ pub async fn add_node_to_collection(
     node_id: String,
     collection_id: String,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.add_node_to_collection(Request::new(AddNodeToCollectionRequest {
         node_id,
         collection_id,
@@ -197,7 +197,7 @@ pub async fn add_node_to_collection_path(
     node_id: String,
     collection_path: String,
 ) -> Result<String, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .add_node_to_collection_by_path(Request::new(AddNodeToCollectionByPathRequest {
             node_id,
@@ -224,7 +224,7 @@ pub async fn remove_node_from_collection(
     node_id: String,
     collection_id: String,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.remove_node_from_collection(Request::new(RemoveNodeFromCollectionRequest {
         node_id,
         collection_id,
@@ -249,7 +249,7 @@ pub async fn find_collection_by_path(
     client: State<'_, GrpcClient>,
     collection_path: String,
 ) -> Result<Option<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .find_collection_by_path(Request::new(FindCollectionByPathRequest {
             collection_path,
@@ -286,7 +286,7 @@ pub async fn get_collection_by_name(
     client: State<'_, GrpcClient>,
     name: String,
 ) -> Result<Option<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_collection_by_name(Request::new(GetCollectionByNameRequest { name }))
         .await
@@ -321,7 +321,7 @@ pub async fn create_collection(
     name: String,
     description: Option<String>,
 ) -> Result<String, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .create_collection(Request::new(CreateCollectionRequest {
             name,
@@ -356,7 +356,7 @@ pub async fn rename_collection(
     version: i64,
     new_name: String,
 ) -> Result<Value, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .rename_collection(Request::new(RenameCollectionRequest {
             collection_id,
@@ -400,7 +400,7 @@ pub async fn delete_collection(
     collection_id: String,
     version: i64,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.delete_collection(Request::new(DeleteCollectionRequest {
         collection_id,
         version,

--- a/packages/desktop-app/src-tauri/src/commands/db.rs
+++ b/packages/desktop-app/src-tauri/src/commands/db.rs
@@ -4,7 +4,7 @@
 //! As of Issue #690, SchemaService is removed - schema operations use NodeService directly.
 //! As of Issue #894, services are registered via AppServices container for hot-swappable DB.
 
-use crate::app_services::{AppServices, EmbeddingState};
+use crate::app_services::AppServices;
 use nodespace_core::services::{EmbeddingProcessor, NodeAccessor, NodeEmbeddingService};
 use nodespace_core::{NodeService, SurrealStore};
 use nodespace_nlp_engine::{EmbeddingConfig, EmbeddingService};
@@ -23,14 +23,15 @@ use crate::constants::EMBEDDING_MODEL_FILENAME;
 pub(crate) struct ServiceBundle {
     pub store: Arc<SurrealStore>,
     pub node_service: Arc<NodeService>,
-    pub embedding_state: Option<EmbeddingState>,
+    pub embedding_service: Option<Arc<NodeEmbeddingService>>,
+    pub processor: Option<Arc<EmbeddingProcessor>>,
 }
 
 /// Create core services for a given database + model path.
 ///
 /// Tiered initialization:
 /// - Store and NodeService failures are fatal (returned as `Err`).
-/// - NLP/embedding failures are non-fatal: `embedding_state` is set to `None`
+/// - NLP/embedding failures are non-fatal: embedding fields are set to `None`
 ///   and a warning is logged, allowing the app to run without semantic search.
 pub(crate) async fn create_service_bundle(
     db_path: PathBuf,
@@ -66,7 +67,6 @@ pub(crate) async fn create_service_bundle(
         let prompt_templates = PromptAssembler::seed_prompt_nodes();
         let skill_templates = seed_skill_nodes();
 
-        // Expand all templates into PreparedNode lists.
         let mut all_template_nodes: Vec<
             Vec<nodespace_core::mcp::handlers::markdown::PreparedNode>,
         > = Vec::new();
@@ -89,38 +89,37 @@ pub(crate) async fn create_service_bundle(
 
     // Tiered NLP init: failure here is non-fatal
     tracing::info!("Initializing NLP engine (model: {:?})...", model_path);
-    let embedding_state = match create_embedding_state(&store, &mut node_service, &model_path) {
-        Ok(state) => {
-            tracing::info!("Embedding services initialized");
-            Some(state)
-        }
-        Err(e) => {
-            tracing::warn!(
-                "NLP/embedding init failed (semantic search disabled): {}",
-                e
-            );
-            None
-        }
-    };
+    let (embedding_service, processor) =
+        match create_embedding_services(&store, &mut node_service, &model_path) {
+            Ok((svc, proc)) => {
+                tracing::info!("Embedding services initialized");
+                (Some(svc), Some(proc))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "NLP/embedding init failed (semantic search disabled): {}",
+                    e
+                );
+                (None, None)
+            }
+        };
 
     let node_service_arc = Arc::new(node_service);
 
     Ok(ServiceBundle {
         store,
         node_service: node_service_arc,
-        embedding_state,
+        embedding_service,
+        processor,
     })
 }
 
-/// Attempt to create embedding state (NLP engine + embedding service + processor).
-///
-/// Separated so the caller can treat the entire block as fallible without
-/// cluttering the happy path with nested matches.
-fn create_embedding_state(
+/// Attempt to create embedding services (NLP engine + embedding service + processor).
+fn create_embedding_services(
     store: &Arc<SurrealStore>,
     node_service: &mut NodeService,
     model_path: &Path,
-) -> Result<EmbeddingState, String> {
+) -> Result<(Arc<NodeEmbeddingService>, Arc<EmbeddingProcessor>), String> {
     let embedding_config = EmbeddingConfig {
         model_path: Some(model_path.to_path_buf()),
         ..Default::default()
@@ -154,10 +153,7 @@ fn create_embedding_state(
     processor.wake();
     tracing::info!("EmbeddingProcessor waker connected and woken for stale embeddings");
 
-    Ok(EmbeddingState {
-        service: embedding_service,
-        processor: Arc::new(processor),
-    })
+    Ok((embedding_service, Arc::new(processor)))
 }
 
 /// Resolve the path to the bundled NLP model (GGUF format for llama.cpp)
@@ -231,7 +227,7 @@ async fn init_services(app: &AppHandle, config: &crate::config::AppConfig) -> Re
         .initialize(
             bundle.store.clone(),
             bundle.node_service.clone(),
-            bundle.embedding_state,
+            bundle.embedding_service.clone(),
             config.clone(),
             session_token.clone(),
         )
@@ -265,11 +261,16 @@ async fn init_services(app: &AppHandle, config: &crate::config::AppConfig) -> Re
     }
 
     // Start in-process gRPC server and register the client as managed state
-    // so the migrated nodes/collections/schemas commands can proxy via tonic
-    // (Issue #1113). Reuses the same NodeService/embedding services so there
-    // is no second database open.
-    let embedding_service = services.embedding_service().await.ok();
-    match crate::services::GrpcClient::start(bundle.node_service.clone(), embedding_service).await {
+    // so the migrated nodes/collections/schemas/embeddings commands can proxy
+    // via tonic (Issue #1113, #1135). Reuses the same NodeService/embedding
+    // services so there is no second database open.
+    match crate::services::GrpcClient::start(
+        bundle.node_service.clone(),
+        bundle.embedding_service.clone(),
+        bundle.processor.clone(),
+    )
+    .await
+    {
         Ok(client) => {
             app.manage(client);
             tracing::info!("In-process gRPC client registered");

--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -31,8 +31,30 @@ fn embeddings_unavailable() -> CommandError {
 }
 
 fn node_from_proto(data: nodespace_daemon::NodeData) -> Option<Node> {
-    let created_at = data.created_at.parse().ok()?;
-    let modified_at = data.modified_at.parse().ok()?;
+    let created_at = match data.created_at.parse() {
+        Ok(ts) => ts,
+        Err(e) => {
+            tracing::warn!(
+                node_id = %data.id,
+                raw = %data.created_at,
+                error = %e,
+                "Dropping node from search results: unparseable created_at timestamp"
+            );
+            return None;
+        }
+    };
+    let modified_at = match data.modified_at.parse() {
+        Ok(ts) => ts,
+        Err(e) => {
+            tracing::warn!(
+                node_id = %data.id,
+                raw = %data.modified_at,
+                error = %e,
+                "Dropping node from search results: unparseable modified_at timestamp"
+            );
+            return None;
+        }
+    };
     let properties = serde_json::from_str(&data.properties).unwrap_or_default();
     Some(Node {
         id: data.id,
@@ -56,7 +78,7 @@ pub async fn generate_root_embedding(
     root_id: String,
 ) -> Result<(), CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     client
@@ -105,7 +127,7 @@ pub async fn search_roots(
     }
 
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     let response = client
@@ -135,7 +157,7 @@ pub async fn update_root_embedding(
     root_id: String,
 ) -> Result<(), CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     client
@@ -153,7 +175,7 @@ pub async fn on_root_closed(
     root_id: String,
 ) -> Result<(), CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     client
@@ -171,7 +193,7 @@ pub async fn on_root_idle(
     root_id: String,
 ) -> Result<bool, CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     client
@@ -179,6 +201,9 @@ pub async fn on_root_idle(
         .await
         .map_err(|e| grpc_err(e.message()))?;
 
+    // Returns `true` for compatibility with the frontend idle-trigger contract,
+    // which expects a boolean "was queued" signal. The gRPC call already returns
+    // an error on failure via the `?` above, so `true` is always correct here.
     Ok(true)
 }
 
@@ -186,7 +211,7 @@ pub async fn on_root_idle(
 #[tauri::command]
 pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     client
@@ -201,7 +226,7 @@ pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandE
 #[tauri::command]
 pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     let response = client
@@ -235,7 +260,7 @@ pub async fn batch_generate_embeddings(
     root_ids: Vec<String>,
 ) -> Result<BatchEmbeddingResult, CommandError> {
     let mut client = grpc
-        .embeddings_client()
+        .embeddings_client().await
         .ok_or_else(embeddings_unavailable)?;
 
     let response = client

--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -1,97 +1,69 @@
 //! Tauri Commands for Topic Embeddings
 //!
-//! This module provides frontend commands for:
-//! - Generating embeddings for topic nodes
-//! - Searching topics by semantic similarity
-//! - Updating embeddings on content changes
+//! Thin gRPC proxy: all operations are forwarded to the `EmbeddingsService`
+//! running in the in-process `nodespaced` server (Issue #1135).
 
-use crate::app_services::AppServices;
 use crate::commands::nodes::CommandError;
-use nodespace_core::models::embedding::EmbeddingConfig;
+use crate::services::GrpcClient;
 use nodespace_core::models::Node;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use crate::constants::TAURI_CLIENT_ID;
+use nodespace_daemon::nodespace::{
+    BatchQueueEmbeddingsRequest, GetStaleCountRequest, QueueEmbeddingRequest,
+    RegenerateEmbeddingRequest, SearchSemanticRequest, TriggerBatchEmbedRequest,
+};
 
-/// Helper to create CommandError instances
-fn command_error(message: impl Into<String>, code: impl Into<String>) -> CommandError {
+fn grpc_err(msg: impl std::fmt::Display) -> CommandError {
     CommandError {
-        message: message.into(),
-        code: code.into(),
+        message: msg.to_string(),
+        code: "GRPC_ERROR".to_string(),
         details: None,
     }
 }
 
-/// Helper to create CommandError instances with details
-fn command_error_with_details(
-    message: impl Into<String>,
-    code: impl Into<String>,
-    details: impl Into<String>,
-) -> CommandError {
+fn embeddings_unavailable() -> CommandError {
     CommandError {
-        message: message.into(),
-        code: code.into(),
-        details: Some(details.into()),
+        message: "Embedding service not available. Model may have failed to load.".to_string(),
+        code: "EMBEDDINGS_UNAVAILABLE".to_string(),
+        details: None,
     }
 }
 
+fn node_from_proto(data: nodespace_daemon::NodeData) -> Option<Node> {
+    let created_at = data.created_at.parse().ok()?;
+    let modified_at = data.modified_at.parse().ok()?;
+    let properties = serde_json::from_str(&data.properties).unwrap_or_default();
+    Some(Node {
+        id: data.id,
+        node_type: data.node_type,
+        content: data.content,
+        properties,
+        version: data.version,
+        lifecycle_status: data.lifecycle_status,
+        created_at,
+        modified_at,
+        mentions: Vec::new(),
+        mentioned_in: Vec::new(),
+        title: None,
+    })
+}
+
 /// Generate embedding for a topic node
-///
-/// # Arguments
-///
-/// * `root_id` - ID of the topic/root node to embed
-///
-/// # Errors
-///
-/// Returns error if:
-/// - Topic node not found
-/// - Embedding generation fails
-/// - Database update fails
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// await invoke('generate_root_embedding', {
-///   rootId: 'topic-uuid-123'
-/// });
-/// ```
 #[tauri::command]
 pub async fn generate_root_embedding(
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     root_id: String,
 ) -> Result<(), CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Get the node from the database
-    let node = node_service
-        .get_node(&root_id)
+    client
+        .queue_embedding(QueueEmbeddingRequest { node_id: root_id })
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to get node: {}", e),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?
-        .ok_or_else(|| command_error(format!("Node not found: {}", root_id), "NOT_FOUND"))?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    // Queue node's root for embedding via root-aggregate model (Issue #729)
-    embedding_service
-        .queue_for_embedding(&node.id)
-        .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to queue embedding: {}", e),
-                "EMBEDDING_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
-
-    tracing::info!("Queued embedding for node: {}", root_id);
     Ok(())
 }
 
@@ -99,470 +71,152 @@ pub async fn generate_root_embedding(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchRootsParams {
-    /// Search query text
     pub query: String,
-
-    /// Minimum similarity threshold (0.0-1.0, higher = more similar)
-    /// - 1.0 = Identical content
-    /// - 0.7-0.9 = Highly similar (semantic equivalents)
-    /// - 0.5-0.7 = Moderately similar (related topics)
-    /// - 0.3-0.5 = Loosely related
-    /// - < 0.3 = Unrelated content
-    ///
-    /// Default: 0.5 (moderate similarity)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold: Option<f32>,
-
-    /// Maximum number of results
-    /// Default: 20
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
-
-    /// Use exact search instead of approximate (slower but more accurate)
-    /// Default: false (use DiskANN approximate search)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exact: Option<bool>,
 }
 
 /// Search root nodes by semantic similarity using vector embeddings
-///
-/// Uses SurrealDB's native `vector::similarity::cosine()` function to find
-/// semantically similar nodes based on their content embeddings.
-///
-/// # Arguments
-///
-/// * `params` - Search parameters (query, threshold, limit)
-///   - `query`: Text to search for (will be converted to embedding)
-///   - `threshold`: Minimum similarity score (0.0-1.0, default: 0.5)
-///   - `limit`: Maximum number of results (default: 20)
-///
-/// # Returns
-///
-/// Vector of nodes sorted by similarity score descending (most similar first)
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// const results = await invoke('search_roots', {
-///   params: {
-///     query: 'machine learning algorithms',
-///     threshold: 0.5,  // 0.5 = moderate similarity (default)
-///     limit: 20
-///   }
-/// });
-///
-/// console.log(`Found ${results.length} similar nodes`);
-/// ```
 #[tauri::command]
 pub async fn search_roots(
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     params: SearchRootsParams,
 ) -> Result<Vec<Node>, CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
-
-    // Validate query parameter
     if params.query.trim().is_empty() {
-        return Err(command_error(
-            "Query parameter cannot be empty".to_string(),
-            "INVALID_PARAMETER",
-        ));
+        return Err(CommandError {
+            message: "Query parameter cannot be empty".to_string(),
+            code: "INVALID_PARAMETER".to_string(),
+            details: None,
+        });
     }
 
-    // Validate threshold if provided
     if let Some(threshold) = params.threshold {
         if !(0.0..=1.0).contains(&threshold) {
-            return Err(command_error(
-                "Threshold must be between 0.0 and 1.0".to_string(),
-                "INVALID_PARAMETER",
-            ));
+            return Err(CommandError {
+                message: "Threshold must be between 0.0 and 1.0".to_string(),
+                code: "INVALID_PARAMETER".to_string(),
+                details: None,
+            });
         }
     }
 
-    // Generate embedding for search query
-    let query_embedding = embedding_service
-        .nlp_engine()
-        .generate_embedding(&params.query)
-        .map_err(|e| {
-            command_error_with_details(
-                "Failed to generate query embedding".to_string(),
-                "EMBEDDING_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Search with default/custom parameters using new root-aggregate model (Issue #729)
-    let limit = params.limit.unwrap_or(20) as i64;
-    let threshold = params.threshold.map(|t| t as f64);
-
-    // Execute search using new embedding table
-    let service_with_client = node_service.with_client(TAURI_CLIENT_ID);
-    let store = service_with_client.store();
-    let search_results = store
-        .search_embeddings(&query_embedding, limit, threshold)
+    let response = client
+        .search_semantic(SearchSemanticRequest {
+            query: params.query,
+            threshold: params.threshold.unwrap_or(0.0),
+            limit: params.limit.map(|l| l as i32).unwrap_or(0),
+            exact: params.exact.unwrap_or(false),
+        })
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                "Vector search failed".to_string(),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    // Fetch actual nodes for each search result
-    let mut nodes = Vec::with_capacity(search_results.len());
-    for result in search_results {
-        if let Ok(Some(node)) = store.get_node(&result.node_id).await {
-            nodes.push(node);
-        }
-    }
+    let nodes = response
+        .into_inner()
+        .nodes
+        .into_iter()
+        .filter_map(node_from_proto)
+        .collect();
 
     Ok(nodes)
 }
 
 /// Update embedding for a topic/root node immediately
-///
-/// Use this for explicit user actions like "Regenerate Embedding" button.
-/// For automatic updates on content changes, use the smart triggers
-/// (on_root_closed, on_root_idle) instead.
-///
-/// # Arguments
-///
-/// * `root_id` - ID of the topic/root node to update
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// // User clicks "Regenerate Embedding" button
-/// await invoke('update_root_embedding', {
-///   rootId: 'topic-uuid-123'
-/// });
-/// ```
 #[tauri::command]
 pub async fn update_root_embedding(
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     root_id: String,
 ) -> Result<(), CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Get the node from the database
-    let node = node_service
-        .get_node(&root_id)
+    client
+        .regenerate_embedding(RegenerateEmbeddingRequest { node_id: root_id })
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to get node: {}", e),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?
-        .ok_or_else(|| command_error(format!("Node not found: {}", root_id), "NOT_FOUND"))?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    // Queue node's root for embedding via root-aggregate model (Issue #729)
-    embedding_service
-        .queue_for_embedding(&node.id)
-        .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to queue embedding update: {}", e),
-                "EMBEDDING_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
-
-    tracing::info!("Queued embedding update for node: {}", root_id);
     Ok(())
 }
 
 /// Smart trigger: Topic/root closed/unfocused
-///
-/// Called when user closes or navigates away from a topic/root.
-/// If the topic was recently edited, it triggers immediate re-embedding.
-///
-/// # Arguments
-///
-/// * `root_id` - ID of the topic/root that was closed
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// // User closes topic page or switches to another topic
-/// await invoke('on_root_closed', { rootId: 'topic-uuid-123' });
-/// ```
 #[tauri::command]
 pub async fn on_root_closed(
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     root_id: String,
 ) -> Result<(), CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Get the node from the database
-    let node = node_service
-        .get_node(&root_id)
+    client
+        .queue_embedding(QueueEmbeddingRequest { node_id: root_id })
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to get node: {}", e),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?
-        .ok_or_else(|| command_error(format!("Node not found: {}", root_id), "NOT_FOUND"))?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    // Queue node's root for embedding via root-aggregate model (Issue #729)
-    embedding_service
-        .queue_for_embedding(&node.id)
-        .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to queue embedding regeneration: {}", e),
-                "EMBEDDING_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
-
-    tracing::info!("Queued embedding on close for node: {}", root_id);
     Ok(())
 }
 
 /// Smart trigger: Idle timeout
-///
-/// Called when user has stopped editing for 30+ seconds.
-/// Triggers re-embedding if topic/root is stale.
-///
-/// # Arguments
-///
-/// * `root_id` - ID of the topic/root to check
-///
-/// # Returns
-///
-/// `true` if re-embedding was triggered, `false` if not needed
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// // After 30 seconds of idle time
-/// const wasEmbedded = await invoke('on_root_idle', {
-///   rootId: 'topic-uuid-123'
-/// });
-/// console.log(`Re-embedded: ${wasEmbedded}`);
-/// ```
 #[tauri::command]
 pub async fn on_root_idle(
-    services: State<'_, AppServices>,
+    grpc: State<'_, GrpcClient>,
     root_id: String,
 ) -> Result<bool, CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Get the node from the database
-    let node = node_service
-        .get_node(&root_id)
+    client
+        .queue_embedding(QueueEmbeddingRequest { node_id: root_id })
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to get node: {}", e),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?
-        .ok_or_else(|| command_error(format!("Node not found: {}", root_id), "NOT_FOUND"))?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    // Queue node's root for embedding via root-aggregate model (Issue #729)
-    embedding_service
-        .queue_for_embedding(&node.id)
-        .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to queue embedding regeneration: {}", e),
-                "EMBEDDING_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
-
-    tracing::info!("Queued embedding on idle for node: {}", root_id);
     Ok(true)
 }
 
 /// Manually sync all stale topics
-///
-/// Trigger embedding sync for all stale topics
-///
-/// Wakes the background embedding processor to process all stale embeddings.
-/// This is a fire-and-forget operation - the processor runs asynchronously.
-/// Useful for explicit user actions like "Sync All" button or app startup.
-///
-/// # Returns
-///
-/// Unit `()` on success (processing happens asynchronously in background)
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// // User clicks "Sync All Embeddings" button
-/// await invoke('sync_embeddings');
-/// console.log('Sync triggered (processing in background)');
-/// ```
 #[tauri::command]
-pub async fn sync_embeddings(services: State<'_, AppServices>) -> Result<(), CommandError> {
-    let (_, processor) = services.embedding_state().await?;
+pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandError> {
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Trigger batch embedding (fire-and-forget, wakes the processor)
-    processor.trigger_batch_embed().map_err(|e| {
-        command_error_with_details(
-            format!("Failed to trigger sync: {}", e),
-            "EMBEDDING_ERROR",
-            format!("{:?}", e),
-        )
-    })?;
+    client
+        .trigger_batch_embed(TriggerBatchEmbedRequest {})
+        .await
+        .map_err(|e| grpc_err(e.message()))?;
 
-    tracing::info!("Triggered batch embedding sync");
     Ok(())
 }
 
 /// Get count of stale topics/roots
-///
-/// Returns the number of topics/roots that need re-embedding.
-/// Useful for showing status indicators in UI.
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// const count = await invoke('get_stale_root_count');
-/// // Display badge: "${count} topics need indexing"
-/// ```
 #[tauri::command]
-pub async fn get_stale_root_count(services: State<'_, AppServices>) -> Result<usize, CommandError> {
-    let node_service = services.node_service().await?;
+pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
 
-    // Use new embedding table model (Issue #729)
-    // Pass debounce_secs=0 to get ALL stale embeddings (for reporting purposes)
-    // This shows the user the true count of pending work, including items still in debounce window
-    let service_with_client = node_service.with_client(TAURI_CLIENT_ID);
-    let store = service_with_client.store();
-    let stale_root_ids = store
-        .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
+    let response = client
+        .get_stale_count(GetStaleCountRequest {})
         .await
-        .map_err(|e| {
-            command_error_with_details(
-                format!("Failed to count stale roots: {}", e),
-                "DATABASE_ERROR",
-                format!("{:?}", e),
-            )
-        })?;
+        .map_err(|e| grpc_err(e.message()))?;
 
-    Ok(stale_root_ids.len())
-}
-
-/// Batch generate embeddings for multiple topics/roots
-///
-/// Useful for initial embedding generation or bulk operations.
-///
-/// # Arguments
-///
-/// * `root_ids` - Vector of topic/root IDs to embed
-///
-/// # Returns
-///
-/// Result containing number of successfully embedded topics/roots
-///
-/// # Example (from frontend)
-///
-/// ```typescript
-/// import { invoke } from '@tauri-apps/api/tauri';
-///
-/// const rootIds = ['topic-1', 'topic-2', 'topic-3'];
-/// const result = await invoke('batch_generate_embeddings', { rootIds });
-/// console.log(`Embedded ${result.success_count} out of ${rootIds.length} topics`);
-/// ```
-#[tauri::command]
-pub async fn batch_generate_embeddings(
-    services: State<'_, AppServices>,
-    root_ids: Vec<String>,
-) -> Result<BatchEmbeddingResult, CommandError> {
-    let (embedding_service, _) = services.embedding_state().await?;
-    let node_service = services.node_service().await?;
-
-    let mut success_count = 0;
-    let mut failed_embeddings = Vec::new();
-
-    for root_id in root_ids {
-        // Get the node from the database
-        match node_service
-            .with_client(TAURI_CLIENT_ID)
-            .get_node(&root_id)
-            .await
-        {
-            Ok(Some(node)) => {
-                // Queue node's root for embedding via root-aggregate model (Issue #729)
-                match embedding_service.queue_for_embedding(&node.id).await {
-                    Ok(_) => {
-                        success_count += 1;
-                        tracing::debug!("Queued embedding for node: {}", root_id);
-                    }
-                    Err(e) => {
-                        let error_msg = format!("Failed to queue embedding: {}", e);
-                        tracing::error!("Node {}: {}", root_id, error_msg);
-                        failed_embeddings.push(BatchEmbeddingError {
-                            root_id: root_id.clone(),
-                            error: error_msg,
-                        });
-                    }
-                }
-            }
-            Ok(None) => {
-                let error_msg = "Node not found".to_string();
-                tracing::error!("Node {}: {}", root_id, error_msg);
-                failed_embeddings.push(BatchEmbeddingError {
-                    root_id: root_id.clone(),
-                    error: error_msg,
-                });
-            }
-            Err(e) => {
-                let error_msg = format!("Failed to get node: {}", e);
-                tracing::error!("Node {}: {}", root_id, error_msg);
-                failed_embeddings.push(BatchEmbeddingError {
-                    root_id: root_id.clone(),
-                    error: error_msg,
-                });
-            }
-        }
-    }
-
-    tracing::info!(
-        "Batch embedding completed: {}/{} successful",
-        success_count,
-        success_count + failed_embeddings.len()
-    );
-
-    Ok(BatchEmbeddingResult {
-        success_count,
-        failed_embeddings,
-    })
+    Ok(response.into_inner().count as usize)
 }
 
 /// Error details for a failed batch embedding operation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchEmbeddingError {
-    /// ID of the topic/root that failed to embed
     pub root_id: String,
-
-    /// Error message describing the failure
     pub error: String,
 }
 
@@ -570,11 +224,39 @@ pub struct BatchEmbeddingError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchEmbeddingResult {
-    /// Number of successfully embedded topics
     pub success_count: usize,
-
-    /// Details of topics that failed to embed with error messages
     pub failed_embeddings: Vec<BatchEmbeddingError>,
+}
+
+/// Batch generate embeddings for multiple topics/roots
+#[tauri::command]
+pub async fn batch_generate_embeddings(
+    grpc: State<'_, GrpcClient>,
+    root_ids: Vec<String>,
+) -> Result<BatchEmbeddingResult, CommandError> {
+    let mut client = grpc
+        .embeddings_client()
+        .ok_or_else(embeddings_unavailable)?;
+
+    let response = client
+        .batch_queue_embeddings(BatchQueueEmbeddingsRequest { node_ids: root_ids })
+        .await
+        .map_err(|e| grpc_err(e.message()))?;
+
+    let inner = response.into_inner();
+    let failed_embeddings = inner
+        .failures
+        .into_iter()
+        .map(|f| BatchEmbeddingError {
+            root_id: f.node_id,
+            error: f.error,
+        })
+        .collect();
+
+    Ok(BatchEmbeddingResult {
+        success_count: inner.success_count as usize,
+        failed_embeddings,
+    })
 }
 
 #[cfg(test)]

--- a/packages/desktop-app/src-tauri/src/commands/import.rs
+++ b/packages/desktop-app/src-tauri/src/commands/import.rs
@@ -79,7 +79,7 @@ pub async fn import_markdown_file(
     file_path: String,
     options: Option<ImportOptions>,
 ) -> Result<FileImportResult, String> {
-    let mut client = grpc.import_client();
+    let mut client = grpc.import_client().await;
     let req = ImportMarkdownRequest {
         file_path: file_path.clone(),
         options: Some(options.unwrap_or_default().into_proto()),
@@ -146,7 +146,7 @@ pub async fn import_markdown_files(
     options: Option<ImportOptions>,
 ) -> Result<BatchImportResult, String> {
     let total_files = file_paths.len();
-    let mut client = grpc.import_client();
+    let mut client = grpc.import_client().await;
     let req = ImportMarkdownFilesRequest {
         file_paths,
         options: Some(options.unwrap_or_default().into_proto()),

--- a/packages/desktop-app/src-tauri/src/commands/local_agent.rs
+++ b/packages/desktop-app/src-tauri/src/commands/local_agent.rs
@@ -124,7 +124,7 @@ impl ManagedAgentState {
 
         // Resolve services from AppServices (should be initialized by now).
         let node_service = self.app_services.node_service().await.ok();
-        let embedding_service = self.app_services.embedding_service().await.ok();
+        let embedding_service = self.app_services.embedding_service().await;
 
         let executor: Arc<dyn AgentToolExecutor> = Arc::new(
             GraphToolExecutor::new_with_optional_services(node_service.clone(), embedding_service),

--- a/packages/desktop-app/src-tauri/src/commands/nodes.rs
+++ b/packages/desktop-app/src-tauri/src/commands/nodes.rs
@@ -190,7 +190,7 @@ pub async fn create_node(
     client: State<'_, GrpcClient>,
     node: CreateNodeInput,
 ) -> Result<String, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     validate_node_type(&node.node_type, &mut c).await?;
 
     let properties_str = node.properties.to_string();
@@ -217,7 +217,7 @@ pub async fn create_root_node(
     client: State<'_, GrpcClient>,
     input: CreateRootNodeInput,
 ) -> Result<String, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     validate_node_type(&input.node_type, &mut c).await?;
 
     let properties_str = input.properties.to_string();
@@ -257,7 +257,7 @@ pub async fn create_node_mention(
     mentioning_node_id: String,
     mentioned_node_id: String,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.create_mention(Request::new(CreateMentionRequest {
         mentioning_node_id,
         mentioned_node_id,
@@ -273,7 +273,7 @@ pub async fn get_node(
     client: State<'_, GrpcClient>,
     id: String,
 ) -> Result<Option<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_node(Request::new(GetNodeRequest { node_id: id }))
         .await;
@@ -296,7 +296,7 @@ pub async fn update_node(
     version: i64,
     update: NodeUpdate,
 ) -> Result<Value, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
 
     let content_preview = update.content.as_ref().map(|c| {
         if c.len() > 50 {
@@ -347,7 +347,7 @@ pub async fn delete_node(
     id: String,
     version: i64,
 ) -> Result<DeleteResult, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .delete_node(Request::new(DeleteNodeRequest {
             node_id: id,
@@ -371,7 +371,7 @@ pub async fn move_node(
     new_parent_id: Option<String>,
     insert_after_node_id: Option<String>,
 ) -> Result<Value, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .move_node(Request::new(MoveNodeRequest {
             node_id,
@@ -394,7 +394,7 @@ pub async fn reorder_node(
     version: i64,
     insert_after_node_id: Option<String>,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.reorder_node(Request::new(ReorderNodeRequest {
         node_id,
         version,
@@ -411,7 +411,7 @@ pub async fn get_children(
     client: State<'_, GrpcClient>,
     parent_id: String,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_children(Request::new(GetChildrenRequest { node_id: parent_id }))
         .await
@@ -433,7 +433,7 @@ pub async fn get_children_tree(
     client: State<'_, GrpcClient>,
     parent_id: String,
 ) -> Result<serde_json::Value, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_children_tree(Request::new(GetChildrenTreeRequest { node_id: parent_id }))
         .await
@@ -453,7 +453,7 @@ pub async fn get_nodes_by_root_id(
     client: State<'_, GrpcClient>,
     root_id: String,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     // Phase 5 (Issue #511): Redirect to get_children (graph-native)
     let resp = c
         .get_children(Request::new(GetChildrenRequest { node_id: root_id }))
@@ -476,7 +476,7 @@ pub async fn query_nodes_simple(
     client: State<'_, GrpcClient>,
     query: NodeQuery,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .query_nodes_simple(Request::new(QueryNodesSimpleRequest {
             id: query.id,
@@ -507,7 +507,7 @@ pub async fn mention_autocomplete(
     query: String,
     limit: Option<usize>,
 ) -> Result<Vec<Value>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .mention_autocomplete(Request::new(MentionAutocompleteRequest {
             query,
@@ -532,7 +532,7 @@ pub async fn save_node_with_parent(
     client: State<'_, GrpcClient>,
     input: SaveNodeWithParentInput,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     validate_node_type(&input.node_type, &mut c).await?;
 
     c.upsert_node_with_parent(Request::new(UpsertNodeWithParentRequest {
@@ -554,7 +554,7 @@ pub async fn get_outgoing_mentions(
     client: State<'_, GrpcClient>,
     node_id: String,
 ) -> Result<Vec<String>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_outgoing_mentions(Request::new(MentionTargetRequest { node_id }))
         .await
@@ -569,7 +569,7 @@ pub async fn get_incoming_mentions(
     client: State<'_, GrpcClient>,
     node_id: String,
 ) -> Result<Vec<String>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_incoming_mentions(Request::new(MentionTargetRequest { node_id }))
         .await
@@ -584,7 +584,7 @@ pub async fn get_mentioning_roots(
     client: State<'_, GrpcClient>,
     node_id: String,
 ) -> Result<Vec<NodeReference>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_mentioning_roots(Request::new(MentionTargetRequest { node_id }))
         .await
@@ -673,7 +673,7 @@ pub async fn update_task_node(
     version: i64,
     update: TaskNodeUpdate,
 ) -> Result<Value, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let req = task_update_to_proto(&id, version, update);
     let resp = c
         .update_task_node(Request::new(req))
@@ -691,7 +691,7 @@ pub async fn delete_node_mention(
     mentioning_node_id: String,
     mentioned_node_id: String,
 ) -> Result<(), CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     c.delete_mention(Request::new(DeleteMentionRequest {
         mentioning_node_id,
         mentioned_node_id,

--- a/packages/desktop-app/src-tauri/src/commands/schemas.rs
+++ b/packages/desktop-app/src-tauri/src/commands/schemas.rs
@@ -27,7 +27,7 @@ use crate::services::GrpcClient;
 pub async fn get_all_schemas(
     client: State<'_, GrpcClient>,
 ) -> Result<Vec<SchemaNode>, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_all_schemas(Request::new(GetAllSchemasRequest {}))
         .await
@@ -67,7 +67,7 @@ pub async fn get_schema_definition(
     client: State<'_, GrpcClient>,
     schema_id: String,
 ) -> Result<SchemaNode, CommandError> {
-    let mut c = client.client();
+    let mut c = client.client().await;
     let resp = c
         .get_schema_definition(Request::new(GetSchemaDefinitionRequest {
             schema_id: schema_id.clone(),

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -214,7 +214,7 @@ async fn switch_database_services(
         .switch_database(
             bundle.store.clone(),
             bundle.node_service.clone(),
-            bundle.embedding_state,
+            bundle.embedding_service.clone(),
             new_config.clone(),
             new_session_token.clone(),
         )

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -5,6 +5,7 @@
 //! Database settings now hot-swap services without requiring a restart.
 
 use crate::app_services::AppServices;
+use crate::services::GrpcClient;
 use tauri::{AppHandle, Manager};
 
 /// Settings response sent to the frontend
@@ -231,6 +232,23 @@ async fn switch_database_services(
             e
         );
     }
+
+    // Restart the in-process gRPC server with the new database services so
+    // all subsequent embedding/node/collection RPCs target the new database.
+    // The managed GrpcClient uses interior mutability (RwLock) for this swap.
+    let grpc_client: tauri::State<GrpcClient> = app.state();
+    if let Err(e) = grpc_client
+        .restart(
+            bundle.node_service.clone(),
+            bundle.embedding_service.clone(),
+            bundle.processor.clone(),
+        )
+        .await
+    {
+        tracing::error!("Failed to restart in-process gRPC server after database switch: {}", e);
+        return Err(format!("Failed to restart gRPC server: {}", e));
+    }
+    tracing::info!("In-process gRPC server restarted with new database");
 
     tracing::info!("Database switch complete");
     Ok(())

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -531,8 +531,8 @@ pub(crate) fn graceful_shutdown(app_handle: &tauri::AppHandle) {
     }
     // Grace period for background tasks (MCP server, domain event forwarder)
     // to exit their tokio::select! loops and drop their Arc references.
-    // Must complete BEFORE release_gpu_resources() takes ownership of embedding state,
-    // so those tasks don't race with GPU resource teardown.
+    // Grace period for background tasks (MCP server, domain event forwarder) to exit
+    // their tokio::select! loops before GPU resource teardown.
     std::thread::sleep(std::time::Duration::from_millis(200));
     release_gpu_resources(app_handle);
 }
@@ -595,23 +595,9 @@ pub(crate) fn release_gpu_resources(app_handle: &tauri::AppHandle) {
         }
     }
 
-    // Step 2b: Release embedding GPU resources
-    if let Some(services) = app_handle.try_state::<app_services::AppServices>() {
-        tracing::debug!("Shutdown: releasing embedding GPU resources");
-        let services_clone = services.inner().clone();
-        // Spawn a dedicated thread to avoid "cannot block_on inside a runtime" panic.
-        // The Tauri run-event handler runs on a Tokio runtime thread, so we need
-        // a fresh thread with its own block_on to drive the async GPU release.
-        let handle = std::thread::spawn(move || {
-            tauri::async_runtime::block_on(async {
-                services_clone.release_gpu_resources().await;
-            });
-        });
-        // Wait for GPU release to complete before releasing the backend
-        if let Err(e) = handle.join() {
-            tracing::error!("GPU resource release thread panicked: {:?}", e);
-        }
-    }
+    // Step 2b: Embedding GPU resources are owned by the in-process gRPC server
+    // (GrpcClient / EmbeddingsServiceImpl) and released when the tokio runtime
+    // shuts down after the Tauri window closes. No explicit release needed here.
 
     // Step 3: Release the global llama backend itself
     // Must happen AFTER all models/contexts are dropped (steps 1-2)

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -5,10 +5,10 @@
 //! `packages/core` directly. To avoid running a separate `nodespaced` process
 //! while migration is in flight, this module:
 //!
-//!   1. Spawns the `NodeServiceImpl` from `nodespace-daemon` on a localhost
-//!      port (default `127.0.0.1:50051`).
-//!   2. Connects a `NodeServiceClient` to that endpoint and stashes the
-//!      `Channel` so commands can clone the client cheaply.
+//!   1. Spawns `NodeServiceImpl`, `ImportServiceImpl`, and `EmbeddingsServiceImpl`
+//!      from `nodespace-daemon` on a localhost port.
+//!   2. Connects clients to that endpoint and stashes the `Channel`
+//!      so commands can clone the client cheaply.
 //!
 //! The same `Arc<NodeService>` AppServices already initializes is reused as
 //! the backing implementation, so there is no second database open and no
@@ -20,10 +20,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use nodespace_core::services::{NodeEmbeddingService, NodeService};
+use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService, NodeService};
 use nodespace_daemon::{
-    ImportServiceClient, ImportServiceImpl, ImportServiceServer, NodeServiceClient,
-    NodeServiceImpl, NodeServiceServer,
+    EmbeddingsServiceClient, EmbeddingsServiceImpl, EmbeddingsServiceServer, ImportServiceClient,
+    ImportServiceImpl, ImportServiceServer, NodeServiceClient, NodeServiceImpl, NodeServiceServer,
 };
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -43,23 +43,25 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Managed Tauri state wrapping the gRPC clients.
 ///
 /// `Channel` is cheap to clone (it is an `Arc` internally). Commands clone
-/// the client per call.
+/// clients per call since tonic's generated methods take `&mut self`.
 #[derive(Clone)]
 pub struct GrpcClient {
-    node_client: NodeServiceClient<Channel>,
-    import_client: ImportServiceClient<Channel>,
+    node: NodeServiceClient<Channel>,
+    import: ImportServiceClient<Channel>,
+    embeddings: Option<EmbeddingsServiceClient<Channel>>,
 }
 
 impl GrpcClient {
     /// Start the in-process gRPC server and return a connected client.
     ///
-    /// `node_service` and `embedding_service` are the same instances used by
-    /// the unmigrated Tauri command handlers, so there is exactly one
-    /// `NodeService` per process. The server is spawned on a tokio task and
-    /// runs until the runtime shuts down.
+    /// `node_service`, `embedding_service`, and `processor` are the same
+    /// instances used by the Tauri app — one database, no lock contention.
+    /// The server is spawned on a tokio task and runs until the runtime shuts
+    /// down.
     pub async fn start(
         node_service: Arc<NodeService>,
         embedding_service: Option<Arc<NodeEmbeddingService>>,
+        processor: Option<Arc<EmbeddingProcessor>>,
     ) -> Result<Self, GrpcClientError> {
         let listener = TcpListener::bind(BIND_ADDR_TEMPLATE)
             .await
@@ -68,17 +70,32 @@ impl GrpcClient {
 
         tracing::info!(%addr, "Starting in-process gRPC server");
 
-        let node_impl = NodeServiceImpl::new(Arc::clone(&node_service), embedding_service);
-        let import_impl = ImportServiceImpl::new(node_service);
+        let node_service_impl =
+            NodeServiceImpl::new(node_service.clone(), embedding_service.clone());
+        let import_impl = ImportServiceImpl::new(node_service.clone());
         let incoming = TcpListenerStream::new(listener);
 
+        let embeddings_impl =
+            embedding_service
+                .as_ref()
+                .zip(processor.as_ref())
+                .map(|(svc, proc)| {
+                    EmbeddingsServiceImpl::new(node_service.clone(), svc.clone(), proc.clone())
+                });
+
         tokio::spawn(async move {
-            if let Err(e) = Server::builder()
-                .add_service(NodeServiceServer::new(node_impl))
-                .add_service(ImportServiceServer::new(import_impl))
-                .serve_with_incoming(incoming)
-                .await
-            {
+            let builder = Server::builder()
+                .add_service(NodeServiceServer::new(node_service_impl))
+                .add_service(ImportServiceServer::new(import_impl));
+            let result = if let Some(emb) = embeddings_impl {
+                builder
+                    .add_service(EmbeddingsServiceServer::new(emb))
+                    .serve_with_incoming(incoming)
+                    .await
+            } else {
+                builder.serve_with_incoming(incoming).await
+            };
+            if let Err(e) = result {
                 tracing::error!(error = %e, "In-process gRPC server terminated unexpectedly");
             }
         });
@@ -88,26 +105,35 @@ impl GrpcClient {
             .connect_timeout(CONNECT_TIMEOUT);
 
         let channel = endpoint.connect().await.map_err(GrpcClientError::Connect)?;
-        let node_client = NodeServiceClient::new(channel.clone());
-        let import_client = ImportServiceClient::new(channel);
+
+        let embeddings_client = if embedding_service.is_some() {
+            Some(EmbeddingsServiceClient::new(channel.clone()))
+        } else {
+            None
+        };
 
         tracing::info!(%addr, "In-process gRPC client connected");
 
         Ok(Self {
-            node_client,
-            import_client,
+            node: NodeServiceClient::new(channel.clone()),
+            import: ImportServiceClient::new(channel),
+            embeddings: embeddings_client,
         })
     }
 
-    /// Borrow a clone of the node service client. Commands should clone per
-    /// call because tonic's generated methods take `&mut self`.
+    /// Borrow a clone of the `NodeServiceClient`.
     pub fn client(&self) -> NodeServiceClient<Channel> {
-        self.node_client.clone()
+        self.node.clone()
     }
 
-    /// Borrow a clone of the import service client.
+    /// Borrow a clone of the `ImportServiceClient`.
     pub fn import_client(&self) -> ImportServiceClient<Channel> {
-        self.import_client.clone()
+        self.import.clone()
+    }
+
+    /// Borrow a clone of the `EmbeddingsServiceClient`, if available.
+    pub fn embeddings_client(&self) -> Option<EmbeddingsServiceClient<Channel>> {
+        self.embeddings.clone()
     }
 }
 

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -15,6 +15,14 @@
 //! RocksDB lock contention. Once all command files migrate (#1135–#1138)
 //! the in-process server can be replaced by a real `nodespaced` subprocess
 //! without touching the Tauri command handlers.
+//!
+//! ## Database hot-swap
+//!
+//! `GrpcClient` uses interior mutability (`Arc<RwLock<Inner>>`) so its channels
+//! can be replaced atomically when `switch_database_services` restarts the
+//! in-process server. All Tauri commands hold `State<'_, GrpcClient>` and call
+//! `.client()` / `.embeddings_client()` per invocation, so they always pick up
+//! the current channels without any signature changes.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -26,6 +34,7 @@ use nodespace_daemon::{
     ImportServiceImpl, ImportServiceServer, NodeServiceClient, NodeServiceImpl, NodeServiceServer,
 };
 use tokio::net::TcpListener;
+use tokio::sync::RwLock;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Channel, Endpoint, Server};
 
@@ -40,15 +49,25 @@ const BIND_ADDR_TEMPLATE: &str = "127.0.0.1:0";
 /// finished binding, so we give tonic a brief window to retry.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// The live channel pair inside `GrpcClient`. Replaced atomically on
+/// `switch_database_services` via the wrapping `RwLock`.
+struct GrpcClientInner {
+    node: NodeServiceClient<Channel>,
+    import: ImportServiceClient<Channel>,
+    embeddings: Option<EmbeddingsServiceClient<Channel>>,
+}
+
 /// Managed Tauri state wrapping the gRPC clients.
 ///
 /// `Channel` is cheap to clone (it is an `Arc` internally). Commands clone
 /// clients per call since tonic's generated methods take `&mut self`.
-#[derive(Clone)]
+///
+/// The inner state is guarded by a `RwLock` so `switch_database_services` can
+/// restart the in-process gRPC server and replace the channels while commands
+/// are in flight. Reader locks are held only for the duration of the `.clone()`
+/// call, so contention is negligible.
 pub struct GrpcClient {
-    node: NodeServiceClient<Channel>,
-    import: ImportServiceClient<Channel>,
-    embeddings: Option<EmbeddingsServiceClient<Channel>>,
+    inner: Arc<RwLock<GrpcClientInner>>,
 }
 
 impl GrpcClient {
@@ -63,6 +82,33 @@ impl GrpcClient {
         embedding_service: Option<Arc<NodeEmbeddingService>>,
         processor: Option<Arc<EmbeddingProcessor>>,
     ) -> Result<Self, GrpcClientError> {
+        let inner = Self::start_server(node_service, embedding_service, processor).await?;
+        Ok(Self {
+            inner: Arc::new(RwLock::new(inner)),
+        })
+    }
+
+    /// Restart the in-process server with new service instances and atomically
+    /// replace the channels. Called by `switch_database_services` so subsequent
+    /// RPCs hit the new database rather than the old one.
+    pub async fn restart(
+        &self,
+        node_service: Arc<NodeService>,
+        embedding_service: Option<Arc<NodeEmbeddingService>>,
+        processor: Option<Arc<EmbeddingProcessor>>,
+    ) -> Result<(), GrpcClientError> {
+        let new_inner = Self::start_server(node_service, embedding_service, processor).await?;
+        let mut guard = self.inner.write().await;
+        *guard = new_inner;
+        Ok(())
+    }
+
+    /// Core server-start logic shared by `start` and `restart`.
+    async fn start_server(
+        node_service: Arc<NodeService>,
+        embedding_service: Option<Arc<NodeEmbeddingService>>,
+        processor: Option<Arc<EmbeddingProcessor>>,
+    ) -> Result<GrpcClientInner, GrpcClientError> {
         let listener = TcpListener::bind(BIND_ADDR_TEMPLATE)
             .await
             .map_err(GrpcClientError::Bind)?;
@@ -75,6 +121,8 @@ impl GrpcClient {
         let import_impl = ImportServiceImpl::new(node_service.clone());
         let incoming = TcpListenerStream::new(listener);
 
+        // Compute whether embeddings will be registered before moving the impl
+        // into the spawn closure (it is not Copy/Clone).
         let embeddings_impl =
             embedding_service
                 .as_ref()
@@ -82,6 +130,7 @@ impl GrpcClient {
                 .map(|(svc, proc)| {
                     EmbeddingsServiceImpl::new(node_service.clone(), svc.clone(), proc.clone())
                 });
+        let has_embeddings = embeddings_impl.is_some();
 
         tokio::spawn(async move {
             let builder = Server::builder()
@@ -106,7 +155,10 @@ impl GrpcClient {
 
         let channel = endpoint.connect().await.map_err(GrpcClientError::Connect)?;
 
-        let embeddings_client = if embedding_service.is_some() {
+        // Base the embeddings client on whether the server actually registered
+        // the EmbeddingsService, not just on whether an embedding_service Arc
+        // was supplied — they must agree.
+        let embeddings_client = if has_embeddings {
             Some(EmbeddingsServiceClient::new(channel.clone()))
         } else {
             None
@@ -114,7 +166,7 @@ impl GrpcClient {
 
         tracing::info!(%addr, "In-process gRPC client connected");
 
-        Ok(Self {
+        Ok(GrpcClientInner {
             node: NodeServiceClient::new(channel.clone()),
             import: ImportServiceClient::new(channel),
             embeddings: embeddings_client,
@@ -122,18 +174,18 @@ impl GrpcClient {
     }
 
     /// Borrow a clone of the `NodeServiceClient`.
-    pub fn client(&self) -> NodeServiceClient<Channel> {
-        self.node.clone()
+    pub async fn client(&self) -> NodeServiceClient<Channel> {
+        self.inner.read().await.node.clone()
     }
 
     /// Borrow a clone of the `ImportServiceClient`.
-    pub fn import_client(&self) -> ImportServiceClient<Channel> {
-        self.import.clone()
+    pub async fn import_client(&self) -> ImportServiceClient<Channel> {
+        self.inner.read().await.import.clone()
     }
 
     /// Borrow a clone of the `EmbeddingsServiceClient`, if available.
-    pub fn embeddings_client(&self) -> Option<EmbeddingsServiceClient<Channel>> {
-        self.embeddings.clone()
+    pub async fn embeddings_client(&self) -> Option<EmbeddingsServiceClient<Channel>> {
+        self.inner.read().await.embeddings.clone()
     }
 }
 


### PR DESCRIPTION
## Summary

- Defines `EmbeddingsService` in the nodespace proto with 7 RPCs (GetEmbeddingStatus, SearchSemantic, RegenerateEmbedding, QueueEmbedding, TriggerBatchEmbed, GetStaleCount, BatchQueueEmbeddings)
- Implements the tonic handler in nodespaced wrapping `NodeEmbeddingService` and `EmbeddingProcessor`
- Replaces all `AppServices` direct calls in `commands/embeddings.rs` with thin gRPC proxy calls via `GrpcClient`
- GPU drain protocol (`release_gpu_context`) handled on daemon shutdown; `EmbeddingState` struct removed from `AppServices`

## Test plan
- [ ] `cargo build --bin nodespaced` passes
- [ ] `bun run test:all` passes
- [ ] `bun run quality:fix` passes
- [ ] Semantic search end-to-end: Tauri UI → gRPC → nodespaced → response

🤖 Generated with [Claude Code](https://claude.com/claude-code)