### PR TITLE
Address review findings from PR #1157 (issue #1123)

### DIFF
--- a/packages/agent-tools/shims/gemini/nodespace-handler.ts
+++ b/packages/agent-tools/shims/gemini/nodespace-handler.ts
@@ -7,6 +7,11 @@
  *
  * GraphContextAssembler writes both files into the session temp dir and sets
  * GEMINI_TOOLS_DIR to that directory before spawning Gemini CLI.
+ *
+ * Protocol (Gemini stdio contract):
+ *   stdin:  `{ "name": "<tool>", "args": { ... } }`
+ *   stdout (success): `{ "result": <value> }`
+ *   stdout (error):   `{ "error": "<message>" }` + exit code 1
  */
 
 import { searchSemantic, getNode, createNode, updateNode, getChildren, ToolError }

--- a/packages/agent/src/acp/context_assembly.rs
+++ b/packages/agent/src/acp/context_assembly.rs
@@ -48,16 +48,34 @@ the nodes you (the agent) have been given and the immediate graph context
 around them. Treat the sections below as the authoritative starting point.
 ";
 
-/// Markdown section appended to the context file when NodeSpace tools are registered.
-const TOOLS_SECTION: &str = "\
-## NodeSpace Tools
+/// Shared tool list included in every agent's activation section.
+const TOOLS_LIST: &str = "Tools available: `nodespace_search_semantic`, `nodespace_get_node`, \
+`nodespace_create_node`, `nodespace_update_node`, `nodespace_get_children`";
 
-NodeSpace knowledge graph tools are available. Use them to search documentation,
-create notes, and update the graph during this session.
+/// Build the markdown section appended to the context file when NodeSpace tools are registered.
+///
+/// Claude Code needs an explicit path to the hook file so its hooks runtime can
+/// load it; other agents discover shim files via their own plugin/tool directories.
+fn tools_section(agent_type: AgentType) -> String {
+    let mut section = String::from(
+        "## NodeSpace Tools\n\
+         \n\
+         NodeSpace knowledge graph tools are available. Use them to search documentation,\n\
+         create notes, and update the graph during this session.\n\
+         \n",
+    );
 
-Tools available: `nodespace_search_semantic`, `nodespace_get_node`, \
-`nodespace_create_node`, `nodespace_update_node`, `nodespace_get_children`
-";
+    if agent_type == AgentType::ClaudeCode {
+        section.push_str(
+            "Hook file: `./nodespace-hook.ts` (written to this directory — \
+             Claude Code will load it automatically via hooks discovery).\n\n",
+        );
+    }
+
+    section.push_str(TOOLS_LIST);
+    section.push('\n');
+    section
+}
 
 /// Files (relative to the per-agent shim subdirectory) that must be copied into
 /// the session directory for each agent type.
@@ -302,7 +320,7 @@ impl GraphContextAssembler {
         if let Some(ref shim_dir) = self.shim_source_dir {
             write_shim_files(session_dir, agent_type, shim_dir).await?;
             content.push('\n');
-            content.push_str(TOOLS_SECTION);
+            content.push_str(&tools_section(agent_type));
         }
 
         write_context_to_dir(session_dir, agent_type, &content).await
@@ -424,11 +442,7 @@ async fn write_shim_files(
         tokio::fs::copy(&src, &dst).await.map_err(|e| {
             ContextError::WriteFailed(std::io::Error::new(
                 e.kind(),
-                format!(
-                    "failed to copy shim file '{}' to session dir: {}",
-                    src.display(),
-                    e
-                ),
+                format!("failed to copy shim '{}': {e}", src.display()),
             ))
         })?;
     }
@@ -895,17 +909,48 @@ mod tests {
 
     #[test]
     fn tools_section_mentions_all_five_tool_names() {
-        for tool in [
-            "nodespace_search_semantic",
-            "nodespace_get_node",
-            "nodespace_create_node",
-            "nodespace_update_node",
-            "nodespace_get_children",
+        for agent_type in [
+            AgentType::ClaudeCode,
+            AgentType::Codex,
+            AgentType::GeminiCli,
+            AgentType::Pi,
+            AgentType::OpenCode,
         ] {
+            let section = tools_section(agent_type);
+            for tool in [
+                "nodespace_search_semantic",
+                "nodespace_get_node",
+                "nodespace_create_node",
+                "nodespace_update_node",
+                "nodespace_get_children",
+            ] {
+                assert!(
+                    section.contains(tool),
+                    "tools_section({:?}) missing tool: {}",
+                    agent_type,
+                    tool
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tools_section_claude_code_includes_hook_file_path() {
+        let section = tools_section(AgentType::ClaudeCode);
+        assert!(
+            section.contains("nodespace-hook.ts"),
+            "Claude Code tools section should reference the hook file path"
+        );
+    }
+
+    #[test]
+    fn tools_section_non_claude_does_not_include_hook_path() {
+        for agent_type in [AgentType::Codex, AgentType::GeminiCli, AgentType::Pi, AgentType::OpenCode] {
+            let section = tools_section(agent_type);
             assert!(
-                TOOLS_SECTION.contains(tool),
-                "TOOLS_SECTION missing tool: {}",
-                tool
+                !section.contains("nodespace-hook.ts"),
+                "{:?} tools section should not reference the Claude Code hook file",
+                agent_type
             );
         }
     }

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -205,7 +205,15 @@ async fn build_services(db_path: &std::path::Path) -> Result<ServiceBundle> {
     let manager = Arc::new(PtySessionManager::new());
     let mut assembler = GraphContextAssembler::new(node_service.clone(), embedding_service_opt);
     if let Ok(shim_dir) = std::env::var("NODESPACED_SHIM_DIR") {
-        assembler = assembler.with_shim_dir(std::path::PathBuf::from(shim_dir));
+        let shim_path = std::path::PathBuf::from(&shim_dir);
+        if !shim_path.is_dir() {
+            tracing::warn!(
+                "NODESPACED_SHIM_DIR '{}' does not exist or is not a directory; \
+                 per-agent shim files will not be written",
+                shim_dir
+            );
+        }
+        assembler = assembler.with_shim_dir(shim_path);
     }
     let assembler = Arc::new(assembler);
     let agent_session = AgentSessionHandler::new(manager, assembler);


### PR DESCRIPTION
## Summary

Follow-up to #1157 addressing non-blocker review findings:

- **Startup validation**: `NODESPACED_SHIM_DIR` now logs a warning at daemon startup if the path is missing, instead of failing silently per session
- **Per-agent activation text**: `tools_section()` is now agent-specific — Claude Code gets an explicit `nodespace-hook.ts` path hint so hooks discovery works; other agents get the generic tool list
- **Error message**: `write_shim_files` error message simplified (no source chain regression)
- **Gemini handler docs**: stdio protocol documented (`{ result }` / `{ error }` + exit 1)
- **Tests**: expanded to cover per-agent tools_section behavior (13 total for tools section)

**Skipped with justification:**
- Flat `session_dir` collision risk — one-agent-per-session invariant holds; the spec writes files flat and no collision path exists today
- `tsconfig.json` shims include — shim files use agent-runtime `declare` globals that produce false-positive tsc errors when compiled standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)