### PR TITLE
Add Tauri commands and xterm.js terminal UI for PTY agent sessions (#1120)

### DIFF
--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -55,7 +55,11 @@ pub use nodespace::node_service_client::NodeServiceClient;
 pub use nodespace::node_service_server::NodeServiceServer;
 pub use nodespace::settings_service_client::SettingsServiceClient;
 pub use nodespace::settings_service_server::SettingsServiceServer;
-pub use nodespace::{NodeData, SessionInfo};
+pub use nodespace::{
+    LaunchSessionRequest, LaunchSessionResponse, ListSessionsRequest, ListSessionsResponse,
+    NodeData, ResizeRequest, ResizeResponse, SessionInfo, StreamOutputRequest,
+    TerminateSessionRequest, TerminateSessionResponse, WriteInputRequest, WriteInputResponse,
+};
 
 pub use services::{
     AgentSessionHandler, EmbeddingsServiceImpl, ImportServiceImpl, NodeServiceImpl,

--- a/packages/desktop-app/eslint.config.js
+++ b/packages/desktop-app/eslint.config.js
@@ -72,7 +72,10 @@ export default [
         Response: 'readonly',
         fetch: 'readonly',
         crypto: 'readonly',
-        CSS: 'readonly'
+        CSS: 'readonly',
+        ResizeObserver: 'readonly',
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly'
       }
     },
     plugins: {
@@ -213,6 +216,9 @@ export default [
         Response: 'readonly',
         BeforeUnloadEvent: 'readonly',
         btoa: 'readonly',
+        ResizeObserver: 'readonly',
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly',
       }
     },
     plugins: {

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -46,6 +46,8 @@
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2.5.0",
     "@thisux/sveltednd": "^0.0.20",
+    "@xterm/addon-fit": "^0.10",
+    "@xterm/xterm": "^5.5",
     "baseline-browser-mapping": "^2.9.18",
     "clsx": "^2.1.1",
     "core-js-compat": "^3.48.0",

--- a/packages/desktop-app/src-tauri/src/commands/agent_session.rs
+++ b/packages/desktop-app/src-tauri/src/commands/agent_session.rs
@@ -4,6 +4,16 @@
 //! background task that reads the `StreamOutput` server-streaming response
 //! and emits Tauri events keyed by session ID so the frontend's
 //! `PtyTerminal.svelte` can subscribe via `listen("pty-output-{sessionId}")`.
+//!
+//! ## Streaming task lifecycle
+//!
+//! Each launched session gets a `CancellationToken` stored in
+//! `StreamingTaskRegistry`. When `terminate_session` is called, the registry
+//! cancels the token, which causes the background streaming loop to exit
+//! promptly rather than waiting for the next gRPC message or a closed stream.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 use futures::StreamExt;
 use nodespace_daemon::{
@@ -12,10 +22,39 @@ use nodespace_daemon::{
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
+use tokio_util::sync::CancellationToken;
 use tonic::Request;
 
 use crate::commands::nodes::CommandError;
 use crate::services::GrpcClient;
+
+// ---------------------------------------------------------------------------
+// Streaming task registry — tracks cancellation tokens by session ID
+// ---------------------------------------------------------------------------
+
+/// Tauri managed state that maps session IDs to cancellation tokens for their
+/// background `StreamOutput` reader tasks. Allows `terminate_session` to stop
+/// the reader promptly rather than waiting for the gRPC stream to drain.
+#[derive(Default)]
+pub struct StreamingTaskRegistry {
+    tokens: Mutex<HashMap<String, CancellationToken>>,
+}
+
+impl StreamingTaskRegistry {
+    pub fn insert(&self, session_id: &str, token: CancellationToken) {
+        if let Ok(mut map) = self.tokens.lock() {
+            map.insert(session_id.to_string(), token);
+        }
+    }
+
+    pub fn cancel_and_remove(&self, session_id: &str) {
+        if let Ok(mut map) = self.tokens.lock() {
+            if let Some(token) = map.remove(session_id) {
+                token.cancel();
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Frontend-facing types
@@ -92,10 +131,11 @@ fn status_to_command_error(status: tonic::Status) -> CommandError {
 ///
 /// The frontend should listen on `"pty-output-{sessionId}"` immediately after
 /// calling this command. The background streaming task runs until the session
-/// closes or the client disconnects.
+/// closes, the client disconnects, or `terminate_session` cancels it.
 #[tauri::command]
 pub async fn launch_session(
     client: State<'_, GrpcClient>,
+    registry: State<'_, StreamingTaskRegistry>,
     app: AppHandle,
     input: LaunchSessionInput,
 ) -> Result<LaunchSessionResult, CommandError> {
@@ -118,15 +158,16 @@ pub async fn launch_session(
     // Obtain the client before spawning (State<'_> has a non-'static lifetime).
     let mut stream_client = client.agent_session_client().await;
 
+    let cancel_token = CancellationToken::new();
+    registry.insert(&session_id, cancel_token.clone());
+
     // Spawn background task: reads StreamOutput and emits Tauri events.
     let session_id_for_task = session_id.clone();
     tauri::async_runtime::spawn(async move {
         let stream_result = stream_client
-            .stream_output(Request::new(
-                nodespace_daemon::StreamOutputRequest {
-                    session_id: session_id_for_task.clone(),
-                },
-            ))
+            .stream_output(Request::new(nodespace_daemon::StreamOutputRequest {
+                session_id: session_id_for_task.clone(),
+            }))
             .await;
 
         let mut stream = match stream_result {
@@ -142,29 +183,39 @@ pub async fn launch_session(
         };
 
         let event_name = format!("pty-output-{}", session_id_for_task);
-        while let Some(chunk_result) = stream.next().await {
-            match chunk_result {
-                Ok(chunk) => {
-                    let payload = PtyOutputPayload {
-                        data: chunk.data.to_vec(),
-                        timestamp_ms: chunk.timestamp_ms,
-                    };
-                    if let Err(e) = app.emit(&event_name, payload) {
-                        tracing::warn!(
-                            session_id = %session_id_for_task,
-                            error = %e,
-                            "Failed to emit pty-output event"
-                        );
-                        break;
-                    }
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        session_id = %session_id_for_task,
-                        error = %e,
-                        "StreamOutput ended"
-                    );
+        loop {
+            tokio::select! {
+                // Stop the loop when terminate_session cancels the token.
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!(session_id = %session_id_for_task, "StreamOutput reader cancelled");
                     break;
+                }
+                chunk_result = stream.next() => {
+                    match chunk_result {
+                        Some(Ok(chunk)) => {
+                            let payload = PtyOutputPayload {
+                                data: chunk.data.to_vec(),
+                                timestamp_ms: chunk.timestamp_ms,
+                            };
+                            if let Err(e) = app.emit(&event_name, payload) {
+                                tracing::warn!(
+                                    session_id = %session_id_for_task,
+                                    error = %e,
+                                    "Failed to emit pty-output event"
+                                );
+                                break;
+                            }
+                        }
+                        Some(Err(e)) => {
+                            tracing::debug!(
+                                session_id = %session_id_for_task,
+                                error = %e,
+                                "StreamOutput ended"
+                            );
+                            break;
+                        }
+                        None => break,
+                    }
                 }
             }
         }
@@ -217,11 +268,18 @@ pub async fn resize_terminal(
 }
 
 /// Terminate a PTY session and clean up its resources.
+///
+/// Cancels the background `StreamOutput` reader task in addition to sending the
+/// gRPC `TerminateSession` RPC, so the reader exits immediately rather than
+/// waiting for the next message from a now-dead stream.
 #[tauri::command]
 pub async fn terminate_session(
     client: State<'_, GrpcClient>,
+    registry: State<'_, StreamingTaskRegistry>,
     session_id: String,
 ) -> Result<TerminateSessionResult, CommandError> {
+    registry.cancel_and_remove(&session_id);
+
     let mut c = client.agent_session_client().await;
     let resp = c
         .terminate_session(Request::new(TerminateSessionRequest { session_id }))

--- a/packages/desktop-app/src-tauri/src/commands/agent_session.rs
+++ b/packages/desktop-app/src-tauri/src/commands/agent_session.rs
@@ -1,0 +1,261 @@
+//! Tauri command proxies for `AgentSessionService` gRPC RPCs (Issue #1120).
+//!
+//! Each command wraps one RPC. `launch_session` additionally spawns a
+//! background task that reads the `StreamOutput` server-streaming response
+//! and emits Tauri events keyed by session ID so the frontend's
+//! `PtyTerminal.svelte` can subscribe via `listen("pty-output-{sessionId}")`.
+
+use futures::StreamExt;
+use nodespace_daemon::{
+    LaunchSessionRequest, ListSessionsRequest, ResizeRequest, TerminateSessionRequest,
+    WriteInputRequest,
+};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+use tonic::Request;
+
+use crate::commands::nodes::CommandError;
+use crate::services::GrpcClient;
+
+// ---------------------------------------------------------------------------
+// Frontend-facing types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchSessionResult {
+    pub session_id: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PtyOutputPayload {
+    pub data: Vec<u8>,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PtySessionInfo {
+    pub session_id: String,
+    pub agent_type: String,
+    pub started_at: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSessionsResult {
+    pub sessions: Vec<PtySessionInfo>,
+    pub count: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminateSessionResult {
+    pub session_id: String,
+    pub was_running: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchSessionInput {
+    pub agent_type: String,
+    pub prompt: Option<String>,
+    pub cols: u32,
+    pub rows: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn status_to_command_error(status: tonic::Status) -> CommandError {
+    let code = match status.code() {
+        tonic::Code::NotFound => "SESSION_NOT_FOUND",
+        tonic::Code::InvalidArgument => "INVALID_ARGUMENT",
+        _ => "GRPC_ERROR",
+    }
+    .to_string();
+    CommandError {
+        message: status.message().to_string(),
+        code,
+        details: Some(format!("{:?}", status.code())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/// Launch a PTY agent session and start streaming its output as Tauri events.
+///
+/// The frontend should listen on `"pty-output-{sessionId}"` immediately after
+/// calling this command. The background streaming task runs until the session
+/// closes or the client disconnects.
+#[tauri::command]
+pub async fn launch_session(
+    client: State<'_, GrpcClient>,
+    app: AppHandle,
+    input: LaunchSessionInput,
+) -> Result<LaunchSessionResult, CommandError> {
+    let mut c = client.agent_session_client().await;
+
+    let resp = c
+        .launch_session(Request::new(LaunchSessionRequest {
+            agent_type: input.agent_type,
+            prompt: input.prompt,
+            cols: input.cols,
+            rows: input.rows,
+        }))
+        .await
+        .map_err(status_to_command_error)?;
+
+    let inner = resp.into_inner();
+    let session_id = inner.session_id.clone();
+    let created_at = inner.created_at;
+
+    // Obtain the client before spawning (State<'_> has a non-'static lifetime).
+    let mut stream_client = client.agent_session_client().await;
+
+    // Spawn background task: reads StreamOutput and emits Tauri events.
+    let session_id_for_task = session_id.clone();
+    tauri::async_runtime::spawn(async move {
+        let stream_result = stream_client
+            .stream_output(Request::new(
+                nodespace_daemon::StreamOutputRequest {
+                    session_id: session_id_for_task.clone(),
+                },
+            ))
+            .await;
+
+        let mut stream = match stream_result {
+            Ok(r) => r.into_inner(),
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %session_id_for_task,
+                    error = %e,
+                    "Failed to open StreamOutput for session"
+                );
+                return;
+            }
+        };
+
+        let event_name = format!("pty-output-{}", session_id_for_task);
+        while let Some(chunk_result) = stream.next().await {
+            match chunk_result {
+                Ok(chunk) => {
+                    let payload = PtyOutputPayload {
+                        data: chunk.data.to_vec(),
+                        timestamp_ms: chunk.timestamp_ms,
+                    };
+                    if let Err(e) = app.emit(&event_name, payload) {
+                        tracing::warn!(
+                            session_id = %session_id_for_task,
+                            error = %e,
+                            "Failed to emit pty-output event"
+                        );
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        session_id = %session_id_for_task,
+                        error = %e,
+                        "StreamOutput ended"
+                    );
+                    break;
+                }
+            }
+        }
+
+        // Emit a sentinel so the frontend knows the stream is done.
+        let _ = app.emit(&format!("pty-closed-{}", session_id_for_task), ());
+    });
+
+    Ok(LaunchSessionResult {
+        session_id,
+        created_at,
+    })
+}
+
+/// Write raw bytes (keystrokes) to a PTY session's stdin.
+#[tauri::command]
+pub async fn write_input(
+    client: State<'_, GrpcClient>,
+    session_id: String,
+    data: Vec<u8>,
+) -> Result<i64, CommandError> {
+    let mut c = client.agent_session_client().await;
+    let resp = c
+        .write_input(Request::new(WriteInputRequest {
+            session_id,
+            data: data.into(),
+        }))
+        .await
+        .map_err(status_to_command_error)?;
+    Ok(resp.into_inner().bytes_written)
+}
+
+/// Notify the PTY session of a terminal resize.
+#[tauri::command]
+pub async fn resize_terminal(
+    client: State<'_, GrpcClient>,
+    session_id: String,
+    cols: u32,
+    rows: u32,
+) -> Result<(), CommandError> {
+    let mut c = client.agent_session_client().await;
+    c.resize_terminal(Request::new(ResizeRequest {
+        session_id,
+        cols,
+        rows,
+    }))
+    .await
+    .map_err(status_to_command_error)?;
+    Ok(())
+}
+
+/// Terminate a PTY session and clean up its resources.
+#[tauri::command]
+pub async fn terminate_session(
+    client: State<'_, GrpcClient>,
+    session_id: String,
+) -> Result<TerminateSessionResult, CommandError> {
+    let mut c = client.agent_session_client().await;
+    let resp = c
+        .terminate_session(Request::new(TerminateSessionRequest { session_id }))
+        .await
+        .map_err(status_to_command_error)?;
+    let inner = resp.into_inner();
+    Ok(TerminateSessionResult {
+        session_id: inner.session_id,
+        was_running: inner.was_running,
+    })
+}
+
+/// List all active PTY sessions.
+#[tauri::command]
+pub async fn list_sessions(
+    client: State<'_, GrpcClient>,
+) -> Result<ListSessionsResult, CommandError> {
+    let mut c = client.agent_session_client().await;
+    let resp = c
+        .list_sessions(Request::new(ListSessionsRequest {}))
+        .await
+        .map_err(status_to_command_error)?;
+    let inner = resp.into_inner();
+    let sessions = inner
+        .sessions
+        .into_iter()
+        .map(|s| PtySessionInfo {
+            session_id: s.session_id,
+            agent_type: s.agent_type,
+            started_at: s.started_at,
+        })
+        .collect();
+    Ok(ListSessionsResult {
+        sessions,
+        count: inner.count,
+    })
+}

--- a/packages/desktop-app/src-tauri/src/commands/mod.rs
+++ b/packages/desktop-app/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module exposes Rust functionality to the frontend via Tauri commands.
 
+pub mod agent_session;
 pub mod chat_models;
 pub mod collections;
 pub mod db;

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -472,6 +472,12 @@ pub fn run() {
             commands::chat_models::chat_model_load,
             commands::chat_models::chat_model_unload,
             commands::chat_models::ollama_available,
+            // PTY agent session commands (Issue #1120)
+            commands::agent_session::launch_session,
+            commands::agent_session::write_input,
+            commands::agent_session::resize_terminal,
+            commands::agent_session::terminate_session,
+            commands::agent_session::list_sessions,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -352,6 +352,9 @@ pub fn run() {
                 tracing::info!("Agent services registered as independent managed state");
             }
 
+            // Streaming task registry for PTY session cancellation (Issue #1120)
+            app.manage(commands::agent_session::StreamingTaskRegistry::default());
+
             Ok(())
         })
         .on_menu_event(|app, event| {

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -4,7 +4,7 @@
 //! tonic instead of calling `packages/core` directly. This module:
 //!
 //!   1. Spawns `NodeServiceImpl`, `ImportServiceImpl`, `EmbeddingsServiceImpl`,
-//!      and `SettingsServiceImpl` from `nodespace-daemon` on a localhost port.
+//!      `SettingsServiceImpl`, and `AgentSessionHandler` from `nodespace-daemon` on a localhost port.
 //!   2. Connects clients to that endpoint and stashes the `Channel`
 //!      so commands can clone the client cheaply.
 //!
@@ -16,8 +16,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use nodespace_agent::acp::context_assembly::GraphContextAssembler;
+use nodespace_agent::pty::PtySessionManager;
 use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService, NodeService};
 use nodespace_daemon::{
+    AgentSessionHandler, AgentSessionServiceClient, AgentSessionServiceServer,
     EmbeddingsServiceClient, EmbeddingsServiceImpl, EmbeddingsServiceServer, ImportServiceClient,
     ImportServiceImpl, ImportServiceServer, NodeServiceClient, NodeServiceImpl, NodeServiceServer,
     SettingsServiceClient, SettingsServiceImpl, SettingsServiceServer,
@@ -43,6 +46,7 @@ struct GrpcClientInner {
     import: ImportServiceClient<Channel>,
     settings: SettingsServiceClient<Channel>,
     embeddings: Option<EmbeddingsServiceClient<Channel>>,
+    agent_session: AgentSessionServiceClient<Channel>,
 }
 
 /// Managed Tauri state wrapping the gRPC clients.
@@ -100,11 +104,19 @@ impl GrpcClient {
                 });
         let has_embeddings = embeddings_impl.is_some();
 
+        let pty_manager = Arc::new(PtySessionManager::new());
+        let assembler = Arc::new(GraphContextAssembler::new(
+            node_service.clone(),
+            embedding_service.clone(),
+        ));
+        let agent_session_impl = AgentSessionHandler::new(pty_manager, assembler);
+
         tokio::spawn(async move {
             let builder = Server::builder()
                 .add_service(NodeServiceServer::new(node_service_impl))
                 .add_service(ImportServiceServer::new(import_impl))
-                .add_service(SettingsServiceServer::new(settings_impl));
+                .add_service(SettingsServiceServer::new(settings_impl))
+                .add_service(AgentSessionServiceServer::new(agent_session_impl));
             let result = if let Some(emb) = embeddings_impl {
                 builder
                     .add_service(EmbeddingsServiceServer::new(emb))
@@ -135,8 +147,9 @@ impl GrpcClient {
         Ok(GrpcClientInner {
             node: NodeServiceClient::new(channel.clone()),
             import: ImportServiceClient::new(channel.clone()),
-            settings: SettingsServiceClient::new(channel),
+            settings: SettingsServiceClient::new(channel.clone()),
             embeddings: embeddings_client,
+            agent_session: AgentSessionServiceClient::new(channel),
         })
     }
 
@@ -158,6 +171,11 @@ impl GrpcClient {
     /// Borrow a clone of the `EmbeddingsServiceClient`, if available.
     pub async fn embeddings_client(&self) -> Option<EmbeddingsServiceClient<Channel>> {
         self.inner.read().await.embeddings.clone()
+    }
+
+    /// Borrow a clone of the `AgentSessionServiceClient`.
+    pub async fn agent_session_client(&self) -> AgentSessionServiceClient<Channel> {
+        self.inner.read().await.agent_session.clone()
     }
 }
 

--- a/packages/desktop-app/src/app.css
+++ b/packages/desktop-app/src/app.css
@@ -1,3 +1,5 @@
+@import '@xterm/xterm/css/xterm.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { ptyLaunchSession } from '$lib/services/tauri-commands';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('AgentLaunchPanel');
@@ -27,13 +27,11 @@
     launching = true;
     error = null;
     try {
-      const result = await invoke<{ sessionId: string; createdAt: number }>('launch_session', {
-        input: {
-          agentType: selectedAgent,
-          prompt: prompt.trim() || null,
-          cols: 80,
-          rows: 24,
-        },
+      const result = await ptyLaunchSession({
+        agentType: selectedAgent,
+        prompt: prompt.trim() || null,
+        cols: 80,
+        rows: 24,
       });
       prompt = '';
       onSessionLaunched(result.sessionId);

--- a/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('AgentLaunchPanel');
+
+  const AGENT_OPTIONS = [
+    { id: 'claude-code', label: 'Claude Code' },
+    { id: 'codex', label: 'Codex' },
+    { id: 'gemini-cli', label: 'Gemini CLI' },
+    { id: 'pi', label: 'Pi' },
+    { id: 'open-code', label: 'Open Code' },
+  ];
+
+  let {
+    onSessionLaunched,
+  }: {
+    onSessionLaunched: (_sessionId: string) => void;
+  } = $props();
+
+  let selectedAgent = $state('claude-code');
+  let prompt = $state('');
+  let launching = $state(false);
+  let error = $state<string | null>(null);
+
+  async function launch() {
+    launching = true;
+    error = null;
+    try {
+      const result = await invoke<{ sessionId: string; createdAt: number }>('launch_session', {
+        input: {
+          agentType: selectedAgent,
+          prompt: prompt.trim() || null,
+          cols: 80,
+          rows: 24,
+        },
+      });
+      prompt = '';
+      onSessionLaunched(result.sessionId);
+    } catch (e) {
+      log.error('Failed to launch session', e);
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      launching = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      launch();
+    }
+  }
+</script>
+
+<div class="launch-panel">
+  <div class="launch-panel-header">
+    <h3 class="launch-panel-title">Launch Agent Session</h3>
+  </div>
+
+  <div class="launch-panel-body">
+    <div class="field">
+      <label class="field-label" for="agent-select">Agent</label>
+      <select
+        id="agent-select"
+        class="field-select"
+        bind:value={selectedAgent}
+        disabled={launching}
+      >
+        {#each AGENT_OPTIONS as option (option.id)}
+          <option value={option.id}>{option.label}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="prompt-input">
+        Initial prompt
+        <span class="field-hint">(optional)</span>
+      </label>
+      <textarea
+        id="prompt-input"
+        class="field-textarea"
+        bind:value={prompt}
+        onkeydown={handleKeydown}
+        placeholder="Enter a task or leave blank for interactive mode…"
+        rows={3}
+        disabled={launching}
+      ></textarea>
+      <span class="field-hint-inline">⌘↩ to launch</span>
+    </div>
+
+    {#if error}
+      <div class="error-banner" role="alert">{error}</div>
+    {/if}
+
+    <button class="launch-button" onclick={launch} disabled={launching}>
+      {#if launching}
+        <span class="spinner" aria-hidden="true"></span>
+        Launching…
+      {:else}
+        Launch
+      {/if}
+    </button>
+  </div>
+</div>
+
+<style>
+  .launch-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.5rem;
+    background: hsl(var(--card));
+    overflow: hidden;
+  }
+
+  .launch-panel-header {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--muted) / 0.4);
+  }
+
+  .launch-panel-title {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+  }
+
+  .launch-panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+    padding: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .field-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: hsl(var(--foreground));
+  }
+
+  .field-hint {
+    font-weight: 400;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+  }
+
+  .field-select,
+  .field-textarea {
+    padding: 0.5rem 0.625rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.375rem;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 0.8125rem;
+    font-family: inherit;
+    resize: vertical;
+    transition: border-color 0.15s;
+  }
+
+  .field-select:focus,
+  .field-textarea:focus {
+    outline: none;
+    border-color: hsl(var(--ring));
+  }
+
+  .field-select:disabled,
+  .field-textarea:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .field-hint-inline {
+    font-size: 0.6875rem;
+    color: hsl(var(--muted-foreground));
+    align-self: flex-end;
+  }
+
+  .error-banner {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    background: hsl(0 72% 51% / 0.1);
+    border: 1px solid hsl(0 72% 51% / 0.3);
+    color: hsl(0 72% 51%);
+    font-size: 0.8125rem;
+  }
+
+  .launch-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 0.375rem;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .launch-button:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .launch-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid hsl(var(--primary-foreground) / 0.3);
+    border-top-color: hsl(var(--primary-foreground));
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/agent/agent-sessions-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/agent-sessions-panel.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import AgentLaunchPanel from './agent-launch-panel.svelte';
+  import SessionsPanel from './sessions-panel.svelte';
+  import PtyTerminal from './pty-terminal.svelte';
+
+  let activeSessionId = $state<string | null>(null);
+
+  function handleSessionLaunched(sessionId: string) {
+    activeSessionId = sessionId;
+  }
+
+  function handleSelectSession(sessionId: string) {
+    activeSessionId = sessionId;
+  }
+
+  function handleSessionTerminated(sessionId: string) {
+    if (activeSessionId === sessionId) {
+      activeSessionId = null;
+    }
+  }
+</script>
+
+<div class="agent-sessions-panel">
+  <div class="sidebar">
+    <AgentLaunchPanel onSessionLaunched={handleSessionLaunched} />
+    <div class="sidebar-divider"></div>
+    <SessionsPanel
+      {activeSessionId}
+      onSelectSession={handleSelectSession}
+      onSessionTerminated={handleSessionTerminated}
+    />
+  </div>
+
+  <div class="terminal-area">
+    {#if activeSessionId}
+      {#key activeSessionId}
+        <PtyTerminal sessionId={activeSessionId} />
+      {/key}
+    {:else}
+      <div class="terminal-empty">
+        <p class="terminal-empty-text">Launch an agent session to get started</p>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .agent-sessions-panel {
+    display: flex;
+    height: 100%;
+    overflow: hidden;
+    background: hsl(var(--background));
+  }
+
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 18rem;
+    flex-shrink: 0;
+    padding: 0.875rem;
+    border-right: 1px solid hsl(var(--border));
+    overflow-y: auto;
+  }
+
+  .sidebar-divider {
+    height: 1px;
+    background: hsl(var(--border));
+    margin: 0 -0.875rem;
+  }
+
+  .terminal-area {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    padding: 0.5rem;
+    background: hsl(222 47% 8%);
+  }
+
+  .terminal-empty {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .terminal-empty-text {
+    font-size: 0.875rem;
+    color: hsl(0 0% 50%);
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/agent/pty-terminal.svelte
+++ b/packages/desktop-app/src/lib/components/agent/pty-terminal.svelte
@@ -3,7 +3,7 @@
   import { Terminal } from '@xterm/xterm';
   import { FitAddon } from '@xterm/addon-fit';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-  import { invoke } from '@tauri-apps/api/core';
+  import { ptyWriteInput, ptyResizeTerminal } from '$lib/services/tauri-commands';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('PtyTerminal');
@@ -38,10 +38,7 @@
     // Forward keystrokes to the PTY
     terminal.onData(async (data) => {
       try {
-        await invoke('write_input', {
-          sessionId,
-          data: Array.from(new TextEncoder().encode(data)),
-        });
+        await ptyWriteInput(sessionId, Array.from(new TextEncoder().encode(data)));
       } catch (e) {
         log.warn('write_input failed', e);
       }
@@ -64,7 +61,7 @@
     resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
       const { cols, rows } = terminal;
-      invoke('resize_terminal', { sessionId, cols, rows }).catch((e) =>
+      ptyResizeTerminal(sessionId, cols, rows).catch((e) =>
         log.warn('resize_terminal failed', e)
       );
     });

--- a/packages/desktop-app/src/lib/components/agent/pty-terminal.svelte
+++ b/packages/desktop-app/src/lib/components/agent/pty-terminal.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { Terminal } from '@xterm/xterm';
+  import { FitAddon } from '@xterm/addon-fit';
+  import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+  import { invoke } from '@tauri-apps/api/core';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('PtyTerminal');
+
+  let { sessionId }: { sessionId: string } = $props();
+
+  let terminalEl: HTMLDivElement;
+  let terminal: Terminal;
+  let fitAddon: FitAddon;
+  let unlistenOutput: UnlistenFn | null = null;
+  let unlistenClosed: UnlistenFn | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+
+  onMount(async () => {
+    terminal = new Terminal({
+      cursorBlink: true,
+      fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
+      fontSize: 13,
+      theme: {
+        background: 'hsl(222 47% 8%)',
+        foreground: 'hsl(0 0% 90%)',
+        cursor: 'hsl(210 100% 70%)',
+        selectionBackground: 'hsl(210 100% 50% / 0.3)',
+      },
+    });
+
+    fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(terminalEl);
+    fitAddon.fit();
+
+    // Forward keystrokes to the PTY
+    terminal.onData(async (data) => {
+      try {
+        await invoke('write_input', {
+          sessionId,
+          data: Array.from(new TextEncoder().encode(data)),
+        });
+      } catch (e) {
+        log.warn('write_input failed', e);
+      }
+    });
+
+    // Subscribe to output events from the Tauri backend
+    unlistenOutput = await listen<{ data: number[]; timestampMs: number }>(
+      `pty-output-${sessionId}`,
+      (event) => {
+        const bytes = new Uint8Array(event.payload.data);
+        terminal.write(bytes);
+      }
+    );
+
+    unlistenClosed = await listen(`pty-closed-${sessionId}`, () => {
+      terminal.writeln('\r\n\x1b[33m[Session closed]\x1b[0m');
+    });
+
+    // Resize terminal when the component or window resizes
+    resizeObserver = new ResizeObserver(() => {
+      fitAddon.fit();
+      const { cols, rows } = terminal;
+      invoke('resize_terminal', { sessionId, cols, rows }).catch((e) =>
+        log.warn('resize_terminal failed', e)
+      );
+    });
+    resizeObserver.observe(terminalEl);
+  });
+
+  onDestroy(() => {
+    resizeObserver?.disconnect();
+    unlistenOutput?.();
+    unlistenClosed?.();
+    terminal?.dispose();
+  });
+</script>
+
+<div bind:this={terminalEl} class="pty-terminal"></div>
+
+<style>
+  .pty-terminal {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: hsl(222 47% 8%);
+  }
+
+  /* xterm.js injects its own styles; ensure its canvas fills the container */
+  :global(.pty-terminal .xterm) {
+    height: 100%;
+  }
+
+  :global(.pty-terminal .xterm-viewport) {
+    overflow-y: auto;
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/agent/sessions-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/sessions-panel.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('SessionsPanel');
+
+  const AGENT_LABELS: Record<string, string> = {
+    'claude-code': 'Claude Code',
+    codex: 'Codex',
+    'gemini-cli': 'Gemini CLI',
+    pi: 'Pi',
+    'open-code': 'Open Code',
+  };
+
+  interface SessionInfo {
+    sessionId: string;
+    agentType: string;
+    startedAt: number;
+  }
+
+  let {
+    activeSessionId = null,
+    onSelectSession,
+    onSessionTerminated,
+  }: {
+    activeSessionId?: string | null;
+    onSelectSession: (_sessionId: string) => void;
+    onSessionTerminated: (_sessionId: string) => void;
+  } = $props();
+
+  let sessions = $state<SessionInfo[]>([]);
+  let loading = $state(false);
+  let terminatingIds = $state(new Set<string>());
+
+  async function refresh() {
+    loading = true;
+    try {
+      const result = await invoke<{ sessions: SessionInfo[]; count: number }>('list_sessions');
+      sessions = result.sessions;
+    } catch (e) {
+      log.warn('Failed to list sessions', e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function terminate(sessionId: string) {
+    terminatingIds = new Set([...terminatingIds, sessionId]);
+    try {
+      await invoke('terminate_session', { sessionId });
+      onSessionTerminated(sessionId);
+      sessions = sessions.filter((s) => s.sessionId !== sessionId);
+    } catch (e) {
+      log.error('Failed to terminate session', e);
+    } finally {
+      terminatingIds = new Set([...terminatingIds].filter((id) => id !== sessionId));
+    }
+  }
+
+  function formatAge(startedAt: number): string {
+    const seconds = Math.floor(Date.now() / 1000) - startedAt;
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    return `${Math.floor(seconds / 3600)}h`;
+  }
+
+  $effect(() => {
+    refresh();
+  });
+</script>
+
+<div class="sessions-panel">
+  <div class="sessions-header">
+    <h3 class="sessions-title">Active Sessions</h3>
+    <button
+      class="refresh-button"
+      onclick={refresh}
+      disabled={loading}
+      aria-label="Refresh sessions"
+      title="Refresh"
+    >
+      <svg
+        class="refresh-icon"
+        class:spinning={loading}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        width="14"
+        height="14"
+        aria-hidden="true"
+      >
+        <polyline points="23 4 23 10 17 10" />
+        <polyline points="1 20 1 14 7 14" />
+        <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="sessions-body">
+    {#if sessions.length === 0}
+      <div class="sessions-empty">No active sessions</div>
+    {:else}
+      {#each sessions as session (session.sessionId)}
+        {@const agentLabel = AGENT_LABELS[session.agentType] ?? session.agentType}
+        {@const isActive = session.sessionId === activeSessionId}
+        {@const isTerminating = terminatingIds.has(session.sessionId)}
+        <div class="session-row" class:active={isActive}>
+          <button
+            class="session-select"
+            onclick={() => onSelectSession(session.sessionId)}
+            aria-pressed={isActive}
+            title="Open terminal"
+          >
+            <span class="session-agent">{agentLabel}</span>
+            <span class="session-meta">
+              <span class="session-id">{session.sessionId.slice(0, 8)}</span>
+              <span class="session-age">{formatAge(session.startedAt)}</span>
+            </span>
+          </button>
+          <button
+            class="terminate-button"
+            onclick={() => terminate(session.sessionId)}
+            disabled={isTerminating}
+            aria-label="Terminate {agentLabel} session"
+            title="Terminate"
+          >
+            {#if isTerminating}
+              <span class="spinner" aria-hidden="true"></span>
+            {:else}
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                width="12"
+                height="12"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            {/if}
+          </button>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .sessions-panel {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.5rem;
+    background: hsl(var(--card));
+    overflow: hidden;
+  }
+
+  .sessions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--muted) / 0.4);
+  }
+
+  .sessions-title {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+  }
+
+  .refresh-button {
+    display: flex;
+    align-items: center;
+    padding: 0.25rem;
+    border: none;
+    background: none;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    border-radius: 0.25rem;
+    transition: color 0.15s;
+  }
+
+  .refresh-button:hover:not(:disabled) {
+    color: hsl(var(--foreground));
+  }
+
+  .refresh-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .refresh-icon {
+    transition: transform 0.2s;
+  }
+
+  .spinning {
+    animation: spin 0.7s linear infinite;
+  }
+
+  .sessions-body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sessions-empty {
+    padding: 1rem;
+    text-align: center;
+    font-size: 0.8125rem;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .session-row {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid hsl(var(--border) / 0.5);
+    transition: background 0.1s;
+  }
+
+  .session-row:last-child {
+    border-bottom: none;
+  }
+
+  .session-row.active {
+    background: hsl(var(--accent));
+  }
+
+  .session-select {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.625rem 0.875rem;
+    border: none;
+    background: none;
+    color: hsl(var(--foreground));
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.1s;
+  }
+
+  .session-select:hover {
+    background: hsl(var(--accent));
+  }
+
+  .session-agent {
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  .session-meta {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.6875rem;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .session-id {
+    font-family: monospace;
+  }
+
+  .terminate-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0.25rem;
+    border: none;
+    background: none;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    border-radius: 0.25rem;
+    flex-shrink: 0;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .terminate-button:hover:not(:disabled) {
+    color: hsl(0 72% 51%);
+    background: hsl(0 72% 51% / 0.1);
+  }
+
+  .terminate-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .spinner {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border: 1.5px solid hsl(var(--muted-foreground) / 0.3);
+    border-top-color: hsl(var(--muted-foreground));
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/agent/sessions-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/sessions-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { ptyListSessions, ptyTerminateSession, type PtySessionInfo } from '$lib/services/tauri-commands';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('SessionsPanel');
@@ -12,12 +12,6 @@
     'open-code': 'Open Code',
   };
 
-  interface SessionInfo {
-    sessionId: string;
-    agentType: string;
-    startedAt: number;
-  }
-
   let {
     activeSessionId = null,
     onSelectSession,
@@ -28,14 +22,14 @@
     onSessionTerminated: (_sessionId: string) => void;
   } = $props();
 
-  let sessions = $state<SessionInfo[]>([]);
+  let sessions = $state<PtySessionInfo[]>([]);
   let loading = $state(false);
   let terminatingIds = $state(new Set<string>());
 
   async function refresh() {
     loading = true;
     try {
-      const result = await invoke<{ sessions: SessionInfo[]; count: number }>('list_sessions');
+      const result = await ptyListSessions();
       sessions = result.sessions;
     } catch (e) {
       log.warn('Failed to list sessions', e);
@@ -47,7 +41,7 @@
   async function terminate(sessionId: string) {
     terminatingIds = new Set([...terminatingIds, sessionId]);
     try {
-      await invoke('terminate_session', { sessionId });
+      await ptyTerminateSession(sessionId);
       onSessionTerminated(sessionId);
       sessions = sessions.filter((s) => s.sessionId !== sessionId);
     } catch (e) {

--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -246,6 +246,27 @@
     }
   }
 
+  function handleAgentSessionsClick() {
+    const currentState = $tabState;
+    const existingTab = currentState.tabs.find((tab) => tab.type === 'agent-sessions');
+
+    if (existingTab) {
+      setActiveTab(existingTab.id, existingTab.paneId);
+    } else {
+      const targetPaneId = getTargetPaneId();
+      addTab(
+        {
+          id: 'agent-sessions',
+          title: 'Agent Sessions',
+          type: 'agent-sessions',
+          closeable: true,
+          paneId: targetPaneId
+        },
+        true
+      );
+    }
+  }
+
   // Handle navigation item clicks
   function handleNavItemClick(itemId: string) {
     // Close sub-panels when clicking non-collection nav items
@@ -261,6 +282,11 @@
     // Special handling for AI Chat
     if (itemId === 'ai-chat') {
       handleAiChatClick();
+    }
+
+    // Special handling for Agent Sessions
+    if (itemId === 'agent-sessions') {
+      handleAgentSessionsClick();
     }
 
     // Update active state in navigation items

--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -7,6 +7,7 @@
   import { createLogger } from '$lib/utils/logger';
   import SettingsPane from '$lib/components/settings/settings-pane.svelte';
   import ChatPanel from '$lib/components/chat/chat-panel.svelte';
+  import AgentSessionsPanel from '$lib/components/agent/agent-sessions-panel.svelte';
 
   const log = createLogger('PaneContent');
 
@@ -99,6 +100,8 @@
   <SettingsPane />
 {:else if activeTab?.type === 'chat'}
   <ChatPanel />
+{:else if activeTab?.type === 'agent-sessions'}
+  <AgentSessionsPanel />
 {:else if activeTab?.content}
   {@const content = activeTab.content}
   {@const nodeType = content.nodeType ?? 'text'}

--- a/packages/desktop-app/src/lib/services/tab-persistence-service.ts
+++ b/packages/desktop-app/src/lib/services/tab-persistence-service.ts
@@ -140,7 +140,7 @@ export class TabPersistenceService {
         return (
           typeof t.id === 'string' &&
           typeof t.title === 'string' &&
-          (t.type === 'node' || t.type === 'placeholder') &&
+          (t.type === 'node' || t.type === 'placeholder' || t.type === 'settings' || t.type === 'chat' || t.type === 'agent-sessions') &&
           typeof t.closeable === 'boolean' &&
           typeof t.paneId === 'string'
         );

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -390,3 +390,59 @@ export async function acpRefreshAgents(): Promise<AcpAgentInfo[]> {
   return [];
 }
 
+// ============================================================================
+// PTY Agent Session Commands (Issue #1120)
+// ============================================================================
+
+export interface PtyLaunchInput {
+  agentType: string;
+  prompt?: string | null;
+  cols: number;
+  rows: number;
+}
+
+export interface PtyLaunchResult {
+  sessionId: string;
+  createdAt: number;
+}
+
+export interface PtySessionInfo {
+  sessionId: string;
+  agentType: string;
+  startedAt: number;
+}
+
+export interface PtyListSessionsResult {
+  sessions: PtySessionInfo[];
+  count: number;
+}
+
+export interface PtyTerminateResult {
+  sessionId: string;
+  wasRunning: boolean;
+}
+
+export async function ptyLaunchSession(input: PtyLaunchInput): Promise<PtyLaunchResult> {
+  return invoke<PtyLaunchResult>('launch_session', { input });
+}
+
+export async function ptyWriteInput(sessionId: string, data: number[]): Promise<number> {
+  return invoke<number>('write_input', { sessionId, data });
+}
+
+export async function ptyResizeTerminal(
+  sessionId: string,
+  cols: number,
+  rows: number
+): Promise<void> {
+  return invoke<void>('resize_terminal', { sessionId, cols, rows });
+}
+
+export async function ptyTerminateSession(sessionId: string): Promise<PtyTerminateResult> {
+  return invoke<PtyTerminateResult>('terminate_session', { sessionId });
+}
+
+export async function ptyListSessions(): Promise<PtyListSessionsResult> {
+  return invoke<PtyListSessionsResult>('list_sessions');
+}
+

--- a/packages/desktop-app/src/lib/stores/layout.ts
+++ b/packages/desktop-app/src/lib/stores/layout.ts
@@ -91,6 +91,13 @@ export const navigationItems = writable<NavigationItem[]>([
     type: 'link'
   },
   {
+    id: 'agent-sessions',
+    label: 'Agent Sessions',
+    icon: 'M4 17L10 11L4 5M12 19H20', // terminal icon
+    active: false,
+    type: 'link'
+  },
+  {
     id: 'search',
     label: 'Search',
     icon: 'M11 11m-8 0a8 8 0 1 0 16 0a8 8 0 1 0-16 0M21 21l-4.35-4.35', // search icon

--- a/packages/desktop-app/src/lib/stores/navigation.ts
+++ b/packages/desktop-app/src/lib/stores/navigation.ts
@@ -10,7 +10,7 @@ const log = createLogger('Navigation');
 export interface Tab {
   id: string;
   title: string;
-  type: 'node' | 'placeholder' | 'settings' | 'chat';
+  type: 'node' | 'placeholder' | 'settings' | 'chat' | 'agent-sessions';
   content?: {
     nodeId: string;
     nodeType?: string;

--- a/packages/desktop-app/src/tests/stores/layout.test.ts
+++ b/packages/desktop-app/src/tests/stores/layout.test.ts
@@ -67,8 +67,8 @@ describe('Layout Store - Layout State Management', () => {
       const items = get(navigationItems);
 
       // Note: Collections section is rendered separately in NavigationSidebar, not in this store
-      // Items: daily-journal, ai-chat, search, favorites (Dashboard removed)
-      expect(items).toHaveLength(4);
+      // Items: daily-journal, ai-chat, agent-sessions, search, favorites (Dashboard removed)
+      expect(items).toHaveLength(5);
       expect(items[0].id).toBe('daily-journal');
       expect(items[0].active).toBe(false); // No default active state - nav items just navigate
       expect(items[0].type).toBe('link');


### PR DESCRIPTION
## Summary

- Wires `AgentSessionService` into the in-process gRPC server alongside the existing Node/Import/Embeddings services
- Adds `agent_session.rs` Tauri commands (`launch_session`, `write_input`, `resize_terminal`, `terminate_session`, `list_sessions`) — `launch_session` spawns a background tokio task that bridges `StreamOutput` to `pty-output-{sessionId}` Tauri events
- Adds `pty-terminal.svelte` wrapping xterm.js with FitAddon + ResizeObserver, subscribing to output events and forwarding keystrokes
- Adds `agent-launch-panel.svelte` (agent selector + prompt + Launch button) and `sessions-panel.svelte` (active sessions list with Terminate buttons)
- Adds `agent-sessions-panel.svelte` composite pane combining the above with a terminal area
- Wires a new `agent-sessions` tab type into navigation sidebar, pane-content, and tab-persistence

## Test plan

- [x] Frontend: 128 files / 3916 tests passing (`bun run test`)
- [x] Lint + type-check: `bun run quality:fix` exits 0 (svelte-check: 0 errors)
- [x] Rust: `cargo check -p nodespace-app` exits clean

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)