### PR TITLE
Add GetRoots RPC and restore root_node_count to diagnostics

### DIFF
--- a/packages/cli/src/commands/diagnostics.rs
+++ b/packages/cli/src/commands/diagnostics.rs
@@ -107,7 +107,7 @@ pub async fn collect(client: &mut NodeServiceClient<Channel>, db_path: &Path) ->
         })
         .await
     {
-        Ok(response) => response.into_inner().nodes.len(),
+        Ok(response) => response.into_inner().count as usize,
         Err(e) => {
             errors.push(format!("GetRoots failed: {e}"));
             0

--- a/packages/cli/src/commands/diagnostics.rs
+++ b/packages/cli/src/commands/diagnostics.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Context, Result};
 use clap::Args;
-use nodespace_daemon::nodespace::{GetAllSchemasRequest, QueryNodesSimpleRequest};
+use nodespace_daemon::nodespace::{GetAllSchemasRequest, GetRootsRequest, QueryNodesSimpleRequest};
 use nodespace_daemon::{resolve_db_path, NodeServiceClient};
 use serde_json::json;
 use std::fs;
@@ -32,6 +32,7 @@ pub struct DiagnosticsReport {
     pub database_exists: bool,
     pub database_size_bytes: Option<u64>,
     pub total_node_count: usize,
+    pub root_node_count: usize,
     pub schema_count: i32,
     pub recent_node_ids: Vec<String>,
     pub errors: Vec<String>,
@@ -99,13 +100,19 @@ pub async fn collect(client: &mut NodeServiceClient<Channel>, db_path: &Path) ->
 
     let total_node_count = all_nodes.len();
 
-    // Root count is intentionally omitted from the report. Parentage is
-    // stored as a graph edge in SurrealDB, and the daemon's
-    // `query_nodes_simple` handler ships nodes back with `parent_id = None`
-    // for every row because the column doesn't exist — there is no honest
-    // way to distinguish a root from a child via the current RPC surface.
-    // Add a `GetRoots` RPC (or extend `NodeListResponse` with parent ids)
-    // before reporting this number.
+    let root_node_count = match client
+        .get_roots(GetRootsRequest {
+            limit: 0,
+            offset: 0,
+        })
+        .await
+    {
+        Ok(response) => response.into_inner().nodes.len(),
+        Err(e) => {
+            errors.push(format!("GetRoots failed: {e}"));
+            0
+        }
+    };
 
     // QueryNodesSimple doesn't expose ORDER BY, so we sort the in-memory
     // batch by created_at descending before slicing. O(n log n) on n ≤
@@ -138,6 +145,7 @@ pub async fn collect(client: &mut NodeServiceClient<Channel>, db_path: &Path) ->
         database_exists,
         database_size_bytes,
         total_node_count,
+        root_node_count,
         schema_count,
         recent_node_ids,
         errors,
@@ -223,6 +231,7 @@ fn print_human(r: &DiagnosticsReport) {
         None => println!("Database size:   n/a"),
     }
     println!("Total nodes:     {}", r.total_node_count);
+    println!("Root nodes:      {}", r.root_node_count);
     println!("Schemas:         {}", r.schema_count);
     if r.recent_node_ids.is_empty() {
         println!("Recent node IDs: (none)");
@@ -244,6 +253,7 @@ fn print_json(r: &DiagnosticsReport) -> Result<()> {
         "database_exists": r.database_exists,
         "database_size_bytes": r.database_size_bytes,
         "total_node_count": r.total_node_count,
+        "root_node_count": r.root_node_count,
         "schema_count": r.schema_count,
         "recent_node_ids": r.recent_node_ids,
         "errors": r.errors,

--- a/packages/cli/tests/cli_integration.rs
+++ b/packages/cli/tests/cli_integration.rs
@@ -342,6 +342,11 @@ async fn diagnostics_collect_reports_counts_and_recency() {
         baseline.total_node_count + 3,
         "expected three additional nodes vs baseline"
     );
+    assert_eq!(
+        report.root_node_count,
+        baseline.root_node_count + 1,
+        "expected one additional root node vs baseline"
+    );
     assert!(
         report.database_exists,
         "daemon-db directory must exist after node creation"

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -3603,6 +3603,7 @@ impl NodeService {
         Ok(children)
     }
 
+    /// Returns all root nodes — nodes with no parent edge in the graph.
     pub async fn get_roots(&self) -> Result<Vec<Node>, NodeServiceError> {
         self.store
             .get_children(None)

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -3603,6 +3603,13 @@ impl NodeService {
         Ok(children)
     }
 
+    pub async fn get_roots(&self) -> Result<Vec<Node>, NodeServiceError> {
+        self.store
+            .get_children(None)
+            .await
+            .map_err(|e| NodeServiceError::query_failed(e.to_string()))
+    }
+
     /// Get all descendants of a node (recursive children)
     ///
     /// Fetches all nodes in the subtree rooted at the specified node,

--- a/packages/daemon/proto/node_service.proto
+++ b/packages/daemon/proto/node_service.proto
@@ -173,7 +173,9 @@ message GetChildrenRequest {
 }
 
 message GetRootsRequest {
-  // 0 = use server default; returns all roots when unset
+  // limit/offset are applied in application memory, not at the store layer.
+  // 0 = no limit/offset; all roots are returned.
+  // Pushing pagination into the store is tracked in issue #1167.
   uint32 limit = 1;
   uint32 offset = 2;
 }

--- a/packages/daemon/proto/node_service.proto
+++ b/packages/daemon/proto/node_service.proto
@@ -38,6 +38,9 @@ service NodeService {
   // Type-specific updates
   rpc UpdateTaskNode(UpdateTaskNodeRequest) returns (NodeResponse);
 
+  // Roots
+  rpc GetRoots(GetRootsRequest) returns (NodeListResponse);
+
   // Schemas (read-only)
   rpc GetAllSchemas(GetAllSchemasRequest) returns (NodeListResponse);
   rpc GetSchemaDefinition(GetSchemaDefinitionRequest) returns (NodeResponse);
@@ -167,6 +170,12 @@ message DeleteNodeResponse {
 
 message GetChildrenRequest {
   string node_id = 1;
+}
+
+message GetRootsRequest {
+  // 0 = use server default; returns all roots when unset
+  uint32 limit = 1;
+  uint32 offset = 2;
 }
 
 message NodeListResponse {

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -36,13 +36,13 @@ use crate::nodespace::{
     DeleteCollectionRequest, DeleteMentionRequest, DeleteNodeRequest, DeleteNodeResponse, Empty,
     FindCollectionByPathRequest, GetAllCollectionsRequest, GetAllSchemasRequest,
     GetChildrenRequest, GetChildrenTreeRequest, GetCollectionByNameRequest, GetNodeRequest,
-    GetSchemaDefinitionRequest, MentionAutocompleteRequest, MentionIdsResponse, MentionResponse,
-    MentionTargetRequest, MoveNodeRequest, NodeCollectionsRequest, NodeData, NodeDeleted,
-    NodeEvent, NodeListResponse, NodeReference, NodeReferenceListResponse, NodeResponse,
-    NodeTreeResponse, OptionalNodeResponse, OptionalStringClear, OptionalTimestampClear,
-    QueryNodesSimpleRequest, RemoveNodeFromCollectionRequest, RenameCollectionRequest,
-    ReorderNodeRequest, ReorderNodeResponse, SearchRequest, UpdateNodeRequest,
-    UpdateTaskNodeRequest, UpsertNodeWithParentRequest, WatchRequest,
+    GetRootsRequest, GetSchemaDefinitionRequest, MentionAutocompleteRequest, MentionIdsResponse,
+    MentionResponse, MentionTargetRequest, MoveNodeRequest, NodeCollectionsRequest, NodeData,
+    NodeDeleted, NodeEvent, NodeListResponse, NodeReference, NodeReferenceListResponse,
+    NodeResponse, NodeTreeResponse, OptionalNodeResponse, OptionalStringClear,
+    OptionalTimestampClear, QueryNodesSimpleRequest, RemoveNodeFromCollectionRequest,
+    RenameCollectionRequest, ReorderNodeRequest, ReorderNodeResponse, SearchRequest,
+    UpdateNodeRequest, UpdateTaskNodeRequest, UpsertNodeWithParentRequest, WatchRequest,
 };
 
 /// gRPC adapter that owns shared handles to the core services.
@@ -294,6 +294,48 @@ impl GrpcNodeService for NodeServiceImpl {
 
         Ok(Response::new(NodeTreeResponse {
             tree_json: tree.to_string(),
+        }))
+    }
+
+    async fn get_roots(
+        &self,
+        request: Request<GetRootsRequest>,
+    ) -> Result<Response<NodeListResponse>, Status> {
+        let req = request.into_inner();
+        let limit = if req.limit == 0 {
+            None
+        } else {
+            Some(req.limit as usize)
+        };
+        let offset = if req.offset == 0 {
+            None
+        } else {
+            Some(req.offset as usize)
+        };
+
+        let mut roots = self
+            .node_service
+            .get_roots()
+            .await
+            .map_err(service_error_to_status)?;
+
+        if let Some(off) = offset {
+            roots = roots.into_iter().skip(off).collect();
+        }
+        if let Some(lim) = limit {
+            roots.truncate(lim);
+        }
+
+        let nodes: Vec<NodeData> = roots
+            .into_iter()
+            .map(|n| node_to_proto(n, None, None))
+            .collect();
+        let count = nodes.len() as i32;
+
+        Ok(Response::new(NodeListResponse {
+            nodes,
+            count,
+            collection_id: String::new(),
         }))
     }
 


### PR DESCRIPTION
## Summary
- Adds `GetRoots` RPC to `NodeService` proto with `GetRootsRequest` (limit/offset) returning `NodeListResponse`
- Implements daemon handler in `node_service.rs` wired to `CoreNodeService::get_roots()` → `SurrealStore::get_children(None)`
- Restores `root_node_count` to `DiagnosticsReport`, `print_human`, and `print_json` in the CLI diagnostics command
- Updates `diagnostics_collect_reports_counts_and_recency` integration test to assert `root_node_count == baseline + 1`

Closes #1153

## Test plan
- [x] `cargo build -p nodespace-daemon -p nodespace-cli` succeeds
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::unused-async` clean (pre-existing `nodespace-app` error unrelated to this PR)
- [x] `cargo test -p nodespace-cli` — all 5 tests pass including `diagnostics_collect_reports_counts_and_recency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)