### PR TITLE
Add PTY agent binary detection and CheckAgentAvailability RPC (closes #1124)

### DIFF
--- a/packages/agent/src/pty/detection.rs
+++ b/packages/agent/src/pty/detection.rs
@@ -52,7 +52,8 @@ pub fn detect_all_agents() -> Vec<AgentAvailability> {
 // ---------------------------------------------------------------------------
 
 fn detect_one(agent_type: AgentType, binary: &'static str, path: &OsString) -> AgentAvailability {
-    let binary_path = which::which_in(binary, Some(path), ".").ok();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let binary_path = which::which_in(binary, Some(path), &cwd).ok();
     let binary_found = binary_path.is_some();
     let auth_found = check_auth(agent_type);
     let install_hint = if binary_found {
@@ -186,10 +187,18 @@ fn path_helper_output() -> Option<OsString> {
         return None;
     }
     let stdout = String::from_utf8(output.stdout).ok()?;
-    // Extract the value between the first pair of double-quotes.
-    let start = stdout.find('"')? + 1;
-    let end = stdout[start..].find('"')? + start;
-    Some(OsString::from(&stdout[start..end]))
+    // Find the PATH= line and extract the quoted value defensively using
+    // strip_prefix/strip_suffix rather than positional find('"') so that
+    // unexpected whitespace or ordering doesn't silently yield a wrong path.
+    let path_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("PATH="))?;
+    let after_prefix = path_line.trim_start().strip_prefix("PATH=\"")?;
+    // Accept either `"…"; export PATH;` or a bare closing quote.
+    let value = after_prefix
+        .strip_suffix("\"; export PATH;")
+        .or_else(|| after_prefix.strip_suffix('"'))?;
+    Some(OsString::from(value))
 }
 
 // ---------------------------------------------------------------------------
@@ -203,7 +212,7 @@ mod tests {
     #[test]
     fn detect_all_returns_five_entries() {
         let results = detect_all_agents();
-        assert_eq!(results.len(), 5);
+        assert_eq!(results.len(), AGENT_CATALOG.len());
     }
 
     #[test]

--- a/packages/agent/src/pty/detection.rs
+++ b/packages/agent/src/pty/detection.rs
@@ -1,0 +1,261 @@
+//! Binary and auth detection for PTY agent CLIs (Issue #1124).
+//!
+//! `detect_all_agents()` iterates the static AGENT_CATALOG and checks two
+//! things per agent: (1) the binary is reachable on an augmented PATH, and
+//! (2) the user has configured an auth credential.
+//!
+//! PATH augmentation runs `/usr/libexec/path_helper` on macOS first so that
+//! shell-configured PATH entries (e.g. Homebrew, nvm) are visible even when
+//! the daemon was launched outside a login shell.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use crate::acp::registry::AGENT_CATALOG;
+use crate::agent_types::AgentType;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Per-agent availability status returned by `detect_all_agents`.
+#[derive(Debug, Clone)]
+pub struct AgentAvailability {
+    pub agent_type: AgentType,
+    /// Binary name (e.g. "claude").
+    pub binary: &'static str,
+    /// `true` when the binary was found on the augmented PATH.
+    pub binary_found: bool,
+    /// `true` when an auth credential (env var or config file) was found.
+    pub auth_found: bool,
+    /// Absolute path to the binary, when found.
+    pub binary_path: Option<PathBuf>,
+    /// Human-readable install hint shown in the UI when `binary_found` is `false`.
+    pub install_hint: Option<&'static str>,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run binary and auth checks for every agent in the catalog.
+pub fn detect_all_agents() -> Vec<AgentAvailability> {
+    let path = augmented_path();
+    AGENT_CATALOG
+        .iter()
+        .map(|def| detect_one(def.agent_type, def.binary, &path))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent detection
+// ---------------------------------------------------------------------------
+
+fn detect_one(agent_type: AgentType, binary: &'static str, path: &OsString) -> AgentAvailability {
+    let binary_path = which::which_in(binary, Some(path), ".").ok();
+    let binary_found = binary_path.is_some();
+    let auth_found = check_auth(agent_type);
+    let install_hint = if binary_found {
+        None
+    } else {
+        Some(install_hint_for(agent_type))
+    };
+
+    AgentAvailability {
+        agent_type,
+        binary,
+        binary_found,
+        auth_found,
+        binary_path,
+        install_hint,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth checks
+// ---------------------------------------------------------------------------
+
+fn check_auth(agent_type: AgentType) -> bool {
+    match agent_type {
+        AgentType::ClaudeCode => {
+            std::env::var("ANTHROPIC_API_KEY").is_ok() || claude_credentials_file_exists()
+        }
+        AgentType::Codex => std::env::var("OPENAI_API_KEY").is_ok(),
+        AgentType::GeminiCli => {
+            std::env::var("GEMINI_API_KEY").is_ok() || gemini_credentials_file_exists()
+        }
+        AgentType::Pi => std::env::var("PI_API_KEY").is_ok(),
+        AgentType::OpenCode => {
+            std::env::var("OPENCODE_API_KEY").is_ok() || opencode_provider_config_exists()
+        }
+    }
+}
+
+fn claude_credentials_file_exists() -> bool {
+    dirs::home_dir()
+        .map(|h| h.join(".claude").join("credentials").exists())
+        .unwrap_or(false)
+}
+
+fn gemini_credentials_file_exists() -> bool {
+    dirs::home_dir()
+        .map(|h| {
+            h.join(".config")
+                .join("gemini")
+                .join("credentials")
+                .exists()
+        })
+        .unwrap_or(false)
+}
+
+fn opencode_provider_config_exists() -> bool {
+    // opencode stores provider config in ~/.config/opencode/config.json or
+    // ~/.opencode/config.json; either presence counts as "configured".
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return false,
+    };
+    home.join(".config")
+        .join("opencode")
+        .join("config.json")
+        .exists()
+        || home.join(".opencode").join("config.json").exists()
+}
+
+// ---------------------------------------------------------------------------
+// Install hints
+// ---------------------------------------------------------------------------
+
+fn install_hint_for(agent_type: AgentType) -> &'static str {
+    match agent_type {
+        AgentType::ClaudeCode => {
+            "npm install -g @anthropic-ai/claude-code — https://claude.ai/code"
+        }
+        AgentType::Codex => "npm install -g @openai/codex — https://openai.com/codex",
+        AgentType::GeminiCli => {
+            "brew install gemini-cli — https://github.com/google-gemini/gemini-cli"
+        }
+        AgentType::Pi => "https://pi.dev",
+        AgentType::OpenCode => "https://opencode.ai",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PATH augmentation
+// ---------------------------------------------------------------------------
+
+/// Build an augmented PATH that includes common user-level install locations
+/// and, on macOS, the system-managed entries from `/usr/libexec/path_helper`.
+fn augmented_path() -> OsString {
+    let mut extra: Vec<PathBuf> = Vec::new();
+
+    // macOS: ask path_helper for the shell-configured PATH.
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(shell_path) = path_helper_output() {
+            extra.extend(std::env::split_paths(&shell_path));
+        }
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        extra.push(home.join(".npm-global").join("bin"));
+        extra.push(home.join(".local").join("bin"));
+        extra.push(home.join(".cargo").join("bin"));
+        extra.push(home.join("go").join("bin"));
+    }
+    extra.push(PathBuf::from("/opt/homebrew/bin"));
+    extra.push(PathBuf::from("/usr/local/bin"));
+
+    // Append existing PATH so user's configured entries are still searched.
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    extra.extend(std::env::split_paths(&existing));
+
+    std::env::join_paths(extra).unwrap_or(existing)
+}
+
+/// Run `/usr/libexec/path_helper -s` and extract the PATH value from its output.
+///
+/// Output looks like: `PATH="/usr/local/bin:/usr/bin:/bin"; export PATH;`
+#[cfg(target_os = "macos")]
+fn path_helper_output() -> Option<OsString> {
+    let output = std::process::Command::new("/usr/libexec/path_helper")
+        .arg("-s")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    // Extract the value between the first pair of double-quotes.
+    let start = stdout.find('"')? + 1;
+    let end = stdout[start..].find('"')? + start;
+    Some(OsString::from(&stdout[start..end]))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_all_returns_five_entries() {
+        let results = detect_all_agents();
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn binary_found_implies_path_present() {
+        for av in detect_all_agents() {
+            if av.binary_found {
+                assert!(
+                    av.binary_path.is_some(),
+                    "{}: binary_found but binary_path is None",
+                    av.binary
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn install_hint_absent_when_binary_found() {
+        for av in detect_all_agents() {
+            if av.binary_found {
+                assert!(
+                    av.install_hint.is_none(),
+                    "{}: binary_found but install_hint is still set",
+                    av.binary
+                );
+            } else {
+                assert!(
+                    av.install_hint.is_some(),
+                    "{}: binary missing but no install_hint",
+                    av.binary
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn augmented_path_is_non_empty() {
+        let p = augmented_path();
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn agent_types_match_catalog_order() {
+        let results = detect_all_agents();
+        let expected = [
+            AgentType::ClaudeCode,
+            AgentType::Codex,
+            AgentType::GeminiCli,
+            AgentType::Pi,
+            AgentType::OpenCode,
+        ];
+        for (av, expected_type) in results.iter().zip(expected.iter()) {
+            assert_eq!(av.agent_type, *expected_type);
+        }
+    }
+}

--- a/packages/agent/src/pty/mod.rs
+++ b/packages/agent/src/pty/mod.rs
@@ -16,9 +16,11 @@
 //!    [`tempfile::TempDir`] so the working directory is cleaned up.
 
 pub mod capture;
+pub mod detection;
 pub mod manager;
 pub mod session;
 
 pub use capture::SessionCapture;
+pub use detection::{detect_all_agents, AgentAvailability};
 pub use manager::{PtySessionManager, SessionMetadata};
 pub use session::{ExitStatus, OutputChunk, PtySession};

--- a/packages/daemon/proto/agent_session_service.proto
+++ b/packages/daemon/proto/agent_session_service.proto
@@ -15,6 +15,7 @@ service AgentSessionService {
   rpc ResizeTerminal(ResizeRequest) returns (ResizeResponse);
   rpc TerminateSession(TerminateSessionRequest) returns (TerminateSessionResponse);
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+  rpc CheckAgentAvailability(CheckAvailabilityRequest) returns (CheckAvailabilityResponse);
 }
 
 // ---------------------------------------------------------------------------
@@ -134,4 +135,29 @@ message SessionInfo {
 message ListSessionsResponse {
   repeated SessionInfo sessions = 1;
   uint32 count = 2;
+}
+
+// ---------------------------------------------------------------------------
+// CheckAgentAvailability
+// ---------------------------------------------------------------------------
+
+message CheckAvailabilityRequest {}
+
+message AgentAvailability {
+  // Catalogued agent identifier (kebab-case), e.g. "claude-code".
+  string agent_type = 1;
+  // Binary name that was searched on PATH (e.g. "claude").
+  string binary = 2;
+  // True when the binary was found on the augmented PATH.
+  bool binary_found = 3;
+  // True when an auth credential (env var or config file) was found.
+  bool auth_found = 4;
+  // Absolute path to the binary, when found.
+  optional string binary_path = 5;
+  // Human-readable install instruction shown when binary_found is false.
+  optional string install_hint = 6;
+}
+
+message CheckAvailabilityResponse {
+  repeated AgentAvailability agents = 1;
 }

--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -58,7 +58,8 @@ pub use nodespace::node_service_server::NodeServiceServer;
 pub use nodespace::settings_service_client::SettingsServiceClient;
 pub use nodespace::settings_service_server::SettingsServiceServer;
 pub use nodespace::{
-    CaptureContentLevel, CaptureSettingsResponse, GetCaptureSettingsRequest, LaunchSessionRequest,
+    AgentAvailability, CaptureContentLevel, CaptureSettingsResponse, CheckAvailabilityRequest,
+    CheckAvailabilityResponse, GetCaptureSettingsRequest, LaunchSessionRequest,
     LaunchSessionResponse, ListSessionsRequest, ListSessionsResponse, NodeData, ResizeRequest,
     ResizeResponse, SessionInfo, StreamOutputRequest, TerminateSessionRequest,
     TerminateSessionResponse, UpdateCaptureSettingsRequest, WriteInputRequest, WriteInputResponse,

--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -73,9 +73,17 @@ impl AgentSessionService for AgentSessionHandler {
         // The UI calls CheckAgentAvailability before showing the Launch button,
         // but the RPC guard ensures the daemon never spawns a doomed process
         // even if the UI check is skipped or stale.
-        let availability = detect_all_agents()
-            .into_iter()
-            .find(|a| a.agent_type == agent_type);
+        //
+        // detect_all_agents() spawns /usr/libexec/path_helper via
+        // std::process::Command on macOS — a blocking call that must not run
+        // on a Tokio executor thread.
+        let availability = tokio::task::spawn_blocking(move || {
+            detect_all_agents()
+                .into_iter()
+                .find(|a| a.agent_type == agent_type)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("agent detection task panicked: {e}")))?;
         if let Some(av) = availability {
             if !av.binary_found || !av.auth_found {
                 let reason = match (av.binary_found, av.auth_found) {
@@ -359,7 +367,12 @@ impl AgentSessionService for AgentSessionHandler {
         &self,
         _request: Request<CheckAvailabilityRequest>,
     ) -> Result<Response<CheckAvailabilityResponse>, Status> {
-        let results = detect_all_agents();
+        // detect_all_agents() spawns /usr/libexec/path_helper via
+        // std::process::Command on macOS — a blocking call that must not run
+        // on a Tokio executor thread.
+        let results = tokio::task::spawn_blocking(detect_all_agents)
+            .await
+            .map_err(|e| Status::internal(format!("agent detection task panicked: {e}")))?;
         let agents: Vec<AgentAvailability> = results
             .into_iter()
             .map(|av| AgentAvailability {

--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -18,17 +18,18 @@ use std::sync::Arc;
 use chrono::Utc;
 use nodespace_agent::acp::context_assembly::GraphContextAssembler;
 use nodespace_agent::agent_types::AgentType;
-use nodespace_agent::pty::{PtySession, PtySessionManager};
+use nodespace_agent::pty::{detect_all_agents, PtySession, PtySessionManager};
 use nodespace_core::services::NodeService as CoreNodeService;
 use tokio::sync::broadcast::error::RecvError;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
 use crate::nodespace::{
-    agent_session_service_server::AgentSessionService, LaunchSessionRequest, LaunchSessionResponse,
-    ListSessionsRequest, ListSessionsResponse, OutputChunk, ResizeRequest, ResizeResponse,
-    SessionInfo, StreamOutputRequest, TerminateSessionRequest, TerminateSessionResponse,
-    WriteInputRequest, WriteInputResponse,
+    agent_session_service_server::AgentSessionService, AgentAvailability, CheckAvailabilityRequest,
+    CheckAvailabilityResponse, LaunchSessionRequest, LaunchSessionResponse, ListSessionsRequest,
+    ListSessionsResponse, OutputChunk, ResizeRequest, ResizeResponse, SessionInfo,
+    StreamOutputRequest, TerminateSessionRequest, TerminateSessionResponse, WriteInputRequest,
+    WriteInputResponse,
 };
 use crate::services::capture_service::{finalize_capture, CompletedSession};
 use crate::services::settings_service::{read_capture_settings, CaptureConfig};
@@ -67,6 +68,40 @@ impl AgentSessionService for AgentSessionHandler {
 
         let agent_type = parse_agent_type(&req.agent_type).map_err(Status::invalid_argument)?;
         let agent_type_str = agent_type_to_string(agent_type);
+
+        // Defense-in-depth: reject the launch if the agent is not ready.
+        // The UI calls CheckAgentAvailability before showing the Launch button,
+        // but the RPC guard ensures the daemon never spawns a doomed process
+        // even if the UI check is skipped or stale.
+        let availability = detect_all_agents()
+            .into_iter()
+            .find(|a| a.agent_type == agent_type);
+        if let Some(av) = availability {
+            if !av.binary_found || !av.auth_found {
+                let reason = match (av.binary_found, av.auth_found) {
+                    (false, false) => format!(
+                        "agent '{}' is not ready: binary '{}' not found and auth not configured",
+                        req.agent_type, av.binary
+                    ),
+                    (false, _) => format!(
+                        "agent '{}' is not ready: binary '{}' not found on PATH{}",
+                        req.agent_type,
+                        av.binary,
+                        av.install_hint
+                            .map(|h| format!(" — {h}"))
+                            .unwrap_or_default()
+                    ),
+                    (_, false) => format!(
+                        "agent '{}' is not ready: auth credential not configured",
+                        req.agent_type
+                    ),
+                    _ => unreachable!(),
+                };
+                return Err(Status::failed_precondition(reason));
+            }
+        }
+
+
         let id = self
             .manager
             .launch(agent_type, req.prompt, &self.assembler)
@@ -318,6 +353,25 @@ impl AgentSessionService for AgentSessionHandler {
         // for clients that compare snapshots.
         let count = u32::try_from(sessions.len()).unwrap_or(u32::MAX);
         Ok(Response::new(ListSessionsResponse { sessions, count }))
+    }
+
+    async fn check_agent_availability(
+        &self,
+        _request: Request<CheckAvailabilityRequest>,
+    ) -> Result<Response<CheckAvailabilityResponse>, Status> {
+        let results = detect_all_agents();
+        let agents: Vec<AgentAvailability> = results
+            .into_iter()
+            .map(|av| AgentAvailability {
+                agent_type: agent_type_to_string(av.agent_type),
+                binary: av.binary.to_string(),
+                binary_found: av.binary_found,
+                auth_found: av.auth_found,
+                binary_path: av.binary_path.map(|p| p.to_string_lossy().into_owned()),
+                install_hint: av.install_hint.map(str::to_string),
+            })
+            .collect();
+        Ok(Response::new(CheckAvailabilityResponse { agents }))
     }
 }
 

--- a/packages/desktop-app/src-tauri/src/commands/agent_session.rs
+++ b/packages/desktop-app/src-tauri/src/commands/agent_session.rs
@@ -130,6 +130,7 @@ fn status_to_command_error(status: tonic::Status) -> CommandError {
     let code = match status.code() {
         tonic::Code::NotFound => "SESSION_NOT_FOUND",
         tonic::Code::InvalidArgument => "INVALID_ARGUMENT",
+        tonic::Code::FailedPrecondition => "AGENT_NOT_READY",
         _ => "GRPC_ERROR",
     }
     .to_string();

--- a/packages/desktop-app/src-tauri/src/commands/agent_session.rs
+++ b/packages/desktop-app/src-tauri/src/commands/agent_session.rs
@@ -17,8 +17,8 @@ use std::sync::Mutex;
 
 use futures::StreamExt;
 use nodespace_daemon::{
-    LaunchSessionRequest, ListSessionsRequest, ResizeRequest, TerminateSessionRequest,
-    WriteInputRequest,
+    CheckAvailabilityRequest, LaunchSessionRequest, ListSessionsRequest, ResizeRequest,
+    TerminateSessionRequest, WriteInputRequest,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -94,6 +94,23 @@ pub struct ListSessionsResult {
 pub struct TerminateSessionResult {
     pub session_id: String,
     pub was_running: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentAvailabilityInfo {
+    pub agent_type: String,
+    pub binary: String,
+    pub binary_found: bool,
+    pub auth_found: bool,
+    pub binary_path: Option<String>,
+    pub install_hint: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckAvailabilityResult {
+    pub agents: Vec<AgentAvailabilityInfo>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -316,4 +333,30 @@ pub async fn list_sessions(
         sessions,
         count: inner.count,
     })
+}
+
+/// Check which PTY agents have their binary and auth credentials configured.
+#[tauri::command]
+pub async fn check_agent_availability(
+    client: State<'_, GrpcClient>,
+) -> Result<CheckAvailabilityResult, CommandError> {
+    let mut c = client.agent_session_client().await;
+    let resp = c
+        .check_agent_availability(Request::new(CheckAvailabilityRequest {}))
+        .await
+        .map_err(status_to_command_error)?;
+    let inner = resp.into_inner();
+    let agents = inner
+        .agents
+        .into_iter()
+        .map(|a| AgentAvailabilityInfo {
+            agent_type: a.agent_type,
+            binary: a.binary,
+            binary_found: a.binary_found,
+            auth_found: a.auth_found,
+            binary_path: a.binary_path,
+            install_hint: a.install_hint,
+        })
+        .collect();
+    Ok(CheckAvailabilityResult { agents })
 }

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -472,6 +472,7 @@ pub fn run() {
             commands::agent_session::resize_terminal,
             commands::agent_session::terminate_session,
             commands::agent_session::list_sessions,
+            commands::agent_session::check_agent_availability,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import {
-    ptyLaunchSession,
     getCaptureSettings,
+    ptyCheckAgentAvailability,
+    ptyLaunchSession,
     updateCaptureSettings,
-    type CaptureContentLevel
+    type AgentAvailabilityInfo,
+    type CaptureContentLevel,
   } from '$lib/services/tauri-commands';
   import { createLogger } from '$lib/utils/logger';
-  import { onMount } from 'svelte';
 
   const log = createLogger('AgentLaunchPanel');
 
@@ -15,17 +17,24 @@
     { id: 'codex', label: 'Codex' },
     { id: 'gemini-cli', label: 'Gemini CLI' },
     { id: 'pi', label: 'Pi' },
-    { id: 'open-code', label: 'Open Code' }
+    { id: 'open-code', label: 'Open Code' },
   ];
 
   const CONTENT_LEVELS: { value: CaptureContentLevel; label: string }[] = [
     { value: 'metadata_only', label: 'Metadata only' },
     { value: 'summary', label: 'Summary' },
-    { value: 'full', label: 'Full transcript' }
+    { value: 'full', label: 'Full transcript' },
   ];
 
+  type AgentStatus =
+    | 'ready'
+    | 'binary_missing'
+    | 'auth_missing'
+    | 'binary_missing_and_auth_missing'
+    | 'unknown';
+
   let {
-    onSessionLaunched
+    onSessionLaunched,
   }: {
     onSessionLaunched: (_sessionId: string) => void;
   } = $props();
@@ -39,14 +48,27 @@
   let captureSync = $state(false);
   let captureContent = $state<CaptureContentLevel>('metadata_only');
 
+  let availability = $state<Record<string, AgentAvailabilityInfo>>({});
+  let availabilityLoading = $state(true);
+
   onMount(async () => {
     try {
-      const settings = await getCaptureSettings();
+      const [settings, availResult] = await Promise.all([
+        getCaptureSettings(),
+        ptyCheckAgentAvailability(),
+      ]);
       captureEnabled = settings.enabled;
       captureSync = settings.sync;
       captureContent = settings.content;
+      const map: Record<string, AgentAvailabilityInfo> = {};
+      for (const agent of availResult.agents) {
+        map[agent.agentType] = agent;
+      }
+      availability = map;
     } catch (e) {
-      log.warn('Failed to load capture settings', e);
+      log.warn('Failed to load panel settings', e);
+    } finally {
+      availabilityLoading = false;
     }
   });
 
@@ -55,11 +77,24 @@
       await updateCaptureSettings({
         enabled: captureEnabled,
         sync: captureSync,
-        content: captureContent
+        content: captureContent,
       });
     } catch (e) {
       log.error('Failed to save capture settings', e);
     }
+  }
+
+  function selectedAvailability(): AgentAvailabilityInfo | undefined {
+    return availability[selectedAgent];
+  }
+
+  function agentStatus(agentId: string): AgentStatus {
+    const av = availability[agentId];
+    if (!av) return 'unknown';
+    if (!av.binaryFound && !av.authFound) return 'binary_missing_and_auth_missing';
+    if (!av.binaryFound) return 'binary_missing';
+    if (!av.authFound) return 'auth_missing';
+    return 'ready';
   }
 
   async function launch() {
@@ -70,7 +105,7 @@
         agentType: selectedAgent,
         prompt: prompt.trim() || null,
         cols: 80,
-        rows: 24
+        rows: 24,
       });
       prompt = '';
       onSessionLaunched(result.sessionId);
@@ -104,10 +139,43 @@
         disabled={launching}
       >
         {#each AGENT_OPTIONS as option (option.id)}
-          <option value={option.id}>{option.label}</option>
+          {@const status = agentStatus(option.id)}
+          <option value={option.id}>
+            {option.label}{status === 'ready' || status === 'unknown' ? '' : ' ⚠'}
+          </option>
         {/each}
       </select>
     </div>
+
+    {#if !availabilityLoading}
+      {@const av = selectedAvailability()}
+      {@const status = agentStatus(selectedAgent)}
+      {#if av && status !== 'ready' && status !== 'unknown'}
+        <div class="availability-banner availability-banner--warning" role="alert">
+          {#if status === 'binary_missing' || status === 'binary_missing_and_auth_missing'}
+            <div class="availability-row">
+              <span class="availability-icon">⚠</span>
+              <span>
+                <strong>{av.binary}</strong> not found on PATH.
+                {#if av.installHint}
+                  <span class="install-hint">{av.installHint}</span>
+                {/if}
+              </span>
+            </div>
+          {/if}
+          {#if status === 'auth_missing' || status === 'binary_missing_and_auth_missing'}
+            <div class="availability-row">
+              <span class="availability-icon">⚠</span>
+              <span>Auth credential not configured for this agent.</span>
+            </div>
+          {/if}
+        </div>
+      {:else if av && status === 'ready'}
+        <div class="availability-banner availability-banner--ready" role="status">
+          <span class="availability-icon">✓</span> Ready
+        </div>
+      {/if}
+    {/if}
 
     <div class="field">
       <label class="field-label" for="prompt-input">
@@ -260,6 +328,51 @@
     font-size: 0.6875rem;
     color: hsl(var(--muted-foreground));
     align-self: flex-end;
+  }
+
+  .availability-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+  }
+
+  .availability-banner--warning {
+    background: hsl(38 92% 50% / 0.1);
+    border: 1px solid hsl(38 92% 50% / 0.35);
+    color: hsl(32 95% 44%);
+  }
+
+  .availability-banner--ready {
+    background: hsl(142 71% 45% / 0.1);
+    border: 1px solid hsl(142 71% 45% / 0.3);
+    color: hsl(142 71% 35%);
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .availability-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+
+  .availability-icon {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    margin-top: 0.05rem;
+  }
+
+  .install-hint {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.75rem;
+    opacity: 0.85;
+    font-family: ui-monospace, monospace;
+    word-break: break-all;
   }
 
   .capture-section {

--- a/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
+++ b/packages/desktop-app/src/lib/components/agent/agent-launch-panel.svelte
@@ -88,6 +88,7 @@
     return availability[selectedAgent];
   }
 
+
   function agentStatus(agentId: string): AgentStatus {
     const av = availability[agentId];
     if (!av) return 'unknown';

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -472,12 +472,34 @@ export async function updateCaptureSettings(
       enabled: false,
       sync: false,
       content: 'metadata_only',
-      ...settings
+      ...settings,
     } as CaptureSettings;
   }
   return invoke<CaptureSettings>('update_capture_settings', {
     enabled: settings.enabled ?? null,
     sync: settings.sync ?? null,
-    content: settings.content ?? null
+    content: settings.content ?? null,
   });
 }
+
+// ============================================================================
+// PTY Agent Availability Commands (Issue #1124)
+// ============================================================================
+
+export interface AgentAvailabilityInfo {
+  agentType: string;
+  binary: string;
+  binaryFound: boolean;
+  authFound: boolean;
+  binaryPath: string | null;
+  installHint: string | null;
+}
+
+export interface CheckAvailabilityResult {
+  agents: AgentAvailabilityInfo[];
+}
+
+export async function ptyCheckAgentAvailability(): Promise<CheckAvailabilityResult> {
+  return invoke<CheckAvailabilityResult>('check_agent_availability');
+}
+


### PR DESCRIPTION
## Summary

Implements binary and auth detection for all five PTY agent CLIs, exposes a `CheckAgentAvailability` RPC, and surfaces per-agent status in the `AgentLaunchPanel`.

- Adds `packages/agent/src/pty/detection.rs` with `detect_all_agents()`, augmented-PATH logic, and per-agent auth checks
- Adds `CheckAgentAvailability` RPC to `agent_session_service.proto` and implements handler
- Adds `FAILED_PRECONDITION` guard in `launch_session` for defense-in-depth
- Adds Tauri `check_agent_availability` command and `ptyCheckAgentAvailability()` frontend helper
- Wires availability badges into `AgentLaunchPanel.svelte`

## Test plan

- [ ] `cargo test -p nodespace-agent` passes (detection unit tests)
- [ ] `bun run test:all` passes
- [ ] Manual: launch panel shows ready/warning badges per-agent
- [ ] Manual: launching an agent with missing binary returns FAILED_PRECONDITION

🤖 Generated with [Claude Code](https://claude.com/claude-code)