### PR TITLE
Add hardware requirement labels to model selection UI (closes #1140)

### DIFF
--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -388,6 +388,9 @@ pub struct ModelInfo {
     pub backend: ModelBackend,
     /// Current download / load status.
     pub status: ModelStatus,
+    /// Minimum system RAM (in GiB) required to run this model comfortably.
+    /// Zero means unknown (e.g. for Ollama-managed models).
+    pub min_memory_gb: u8,
 }
 
 /// Specification of a chat model's capabilities.

--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -55,6 +55,8 @@ struct CatalogEntry {
     sha256: &'static str,
     context_window: u32,
     default_temperature: f32,
+    /// Minimum system RAM (in GiB) required to run this model comfortably.
+    min_memory_gb: u8,
 }
 
 /// Ministral 3B -- fast, lightweight, identical tool reliability.
@@ -69,6 +71,7 @@ const MINISTRAL_3B: CatalogEntry = CatalogEntry {
     sha256: "", // Skip verification — official Mistral repo, Xet storage
     context_window: 32_768,
     default_temperature: 0.3,
+    min_memory_gb: 8,
 };
 
 /// Ministral 8B -- deeper reasoning, vision capable.
@@ -83,6 +86,7 @@ const MINISTRAL_8B: CatalogEntry = CatalogEntry {
     sha256: "", // Skip verification — official Mistral repo, Xet storage
     context_window: 32_768,
     default_temperature: 0.3,
+    min_memory_gb: 16,
 };
 
 /// Gemma 4 E4B -- Google's efficient ~4B-effective model; stronger reasoning
@@ -98,6 +102,7 @@ const GEMMA_4_E4B: CatalogEntry = CatalogEntry {
     sha256: "", // Skip verification — official ggml-org repo (llama.cpp team), Xet storage
     context_window: 32_768,
     default_temperature: 0.3,
+    min_memory_gb: 16,
 };
 
 /// Gemma 4 31B -- Google's larger dense quality-tier option (24GB+ Apple
@@ -114,6 +119,7 @@ const GEMMA_4_31B: CatalogEntry = CatalogEntry {
     sha256: "", // Skip verification — official ggml-org repo (llama.cpp team), Xet storage
     context_window: 32_768,
     default_temperature: 0.3,
+    min_memory_gb: 24,
 };
 
 /// All catalog entries, in preference order.
@@ -303,6 +309,7 @@ impl ModelManager for GgufModelManager {
                 sha256: Some(entry.sha256.to_string()),
                 backend: ModelBackend::Gguf,
                 status,
+                min_memory_gb: entry.min_memory_gb,
             });
         }
 
@@ -826,7 +833,7 @@ fn find_catalog_entry(model_id: &str) -> Result<&'static CatalogEntry, ModelErro
 }
 
 /// Detect total system RAM in bytes using `sysinfo`.
-fn detect_system_ram() -> u64 {
+pub fn detect_system_ram() -> u64 {
     let mut sys = sysinfo::System::new();
     sys.refresh_memory();
     sys.total_memory()
@@ -904,6 +911,7 @@ mod tests {
             .url
             .as_ref()
             .is_some_and(|u| u.contains("ggml-org/gemma-4-E4B-it-GGUF")));
+        assert_eq!(e4b.min_memory_gb, 16);
 
         let g31 = models.iter().find(|m| m.id == "gemma-4-31b-q4km").unwrap();
         assert_eq!(g31.family, ModelFamily::Gemma4);
@@ -913,6 +921,7 @@ mod tests {
             .url
             .as_ref()
             .is_some_and(|u| u.contains("ggml-org/gemma-4-31B-it-GGUF")));
+        assert_eq!(g31.min_memory_gb, 24);
     }
 
     #[tokio::test]
@@ -926,6 +935,10 @@ mod tests {
         assert!(m3b.url.as_ref().is_some_and(|u| !u.is_empty()));
         // sha256 may be empty when verification is skipped (official repos)
         assert!(m3b.size_bytes > 0);
+        assert_eq!(m3b.min_memory_gb, 8);
+
+        let m8b = models.iter().find(|m| m.id == "ministral-8b-q4km").unwrap();
+        assert_eq!(m8b.min_memory_gb, 16);
     }
 
     #[tokio::test]

--- a/packages/agent/src/local_agent/ollama_model_manager.rs
+++ b/packages/agent/src/local_agent/ollama_model_manager.rs
@@ -175,6 +175,7 @@ impl ModelManager for OllamaModelManager {
                 sha256: None,
                 backend: ModelBackend::Ollama,
                 status: ModelStatus::Ready,
+                min_memory_gb: 0,
             })
             .collect();
 

--- a/packages/agent/src/local_agent/ollama_model_manager.rs
+++ b/packages/agent/src/local_agent/ollama_model_manager.rs
@@ -175,6 +175,7 @@ impl ModelManager for OllamaModelManager {
                 sha256: None,
                 backend: ModelBackend::Ollama,
                 status: ModelStatus::Ready,
+                // Ollama manages its own model files; RAM requirement is unknown.
                 min_memory_gb: 0,
             })
             .collect();

--- a/packages/daemon/proto/local_agent_service.proto
+++ b/packages/daemon/proto/local_agent_service.proto
@@ -171,6 +171,8 @@ message ModelEntry {
   string status_json = 4;
   int64 size_bytes = 5;
   string quantization = 6;
+  // Minimum system RAM (GiB) required; 0 means unknown.
+  uint32 min_memory_gb = 7;
 }
 
 message ListModelsResponse {

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -387,6 +387,7 @@ impl GrpcLocalAgentService for LocalAgentServiceImpl {
                     status_json,
                     size_bytes: m.size_bytes as i64,
                     quantization: m.quantization,
+                    min_memory_gb: m.min_memory_gb as u32,
                 }
             })
             .collect();

--- a/packages/desktop-app/src-tauri/src/commands/chat_models.rs
+++ b/packages/desktop-app/src-tauri/src/commands/chat_models.rs
@@ -11,6 +11,7 @@ use crate::agent_events;
 use crate::commands::nodes::CommandError;
 use nodespace_agent::agent_types::{DownloadEvent, ModelInfo, ModelManager};
 use nodespace_agent::local_agent::composite_model_manager::CompositeModelManager;
+use nodespace_agent::local_agent::model_manager::detect_system_ram;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
@@ -137,4 +138,13 @@ pub async fn ollama_available(
     manager: State<'_, Arc<CompositeModelManager>>,
 ) -> Result<bool, CommandError> {
     Ok(manager.ollama_available().await)
+}
+
+/// Return total system RAM in GiB (rounded down).
+///
+/// Used by the model manager UI to dim cards for models that exceed the
+/// machine's available RAM.
+#[tauri::command]
+pub fn get_system_ram_gb() -> u64 {
+    detect_system_ram() / (1024 * 1024 * 1024)
 }

--- a/packages/desktop-app/src-tauri/src/commands/local_agent.rs
+++ b/packages/desktop-app/src-tauri/src/commands/local_agent.rs
@@ -386,6 +386,7 @@ pub async fn list_local_models(
                 sha256: None,
                 backend,
                 status,
+                min_memory_gb: entry.min_memory_gb as u8,
             })
         })
         .collect();

--- a/packages/desktop-app/src-tauri/src/commands/local_agent.rs
+++ b/packages/desktop-app/src-tauri/src/commands/local_agent.rs
@@ -386,7 +386,7 @@ pub async fn list_local_models(
                 sha256: None,
                 backend,
                 status,
-                min_memory_gb: entry.min_memory_gb as u8,
+                min_memory_gb: entry.min_memory_gb.min(u8::MAX as u32) as u8,
             })
         })
         .collect();

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -464,6 +464,7 @@ pub fn run() {
             commands::chat_models::chat_model_load,
             commands::chat_models::chat_model_unload,
             commands::chat_models::ollama_available,
+            commands::chat_models::get_system_ram_gb,
             // PTY agent session commands (Issue #1120)
             commands::agent_session::launch_session,
             commands::agent_session::write_input,

--- a/packages/desktop-app/src/lib/components/settings/model-manager.svelte
+++ b/packages/desktop-app/src/lib/components/settings/model-manager.svelte
@@ -10,6 +10,7 @@
   const loadedModelId = $derived(modelStore.loadedModelId);
   const recommendedModel = $derived(modelStore.recommendedModel);
   const isLoading = $derived(modelStore.isLoading);
+  const systemRamGb = $derived(modelStore.systemRamGb);
 
   onMount(() => {
     if (models.length === 0) {
@@ -79,7 +80,8 @@
         {@const isLoaded = model.id === loadedModelId}
         {@const progress = downloadProgress[model.id]}
 
-        <div class="model-card" class:model-loaded={isLoaded}>
+        {@const insufficientRam = systemRamGb > 0 && model.min_memory_gb > 0 && systemRamGb < model.min_memory_gb}
+        <div class="model-card" class:model-loaded={isLoaded} class:model-insufficient-ram={insufficientRam}>
           <div class="model-card-header">
             <div class="model-card-title">
               <span class="model-name">{model.name}</span>
@@ -96,6 +98,13 @@
             <span>{formatBytes(model.size_bytes)}</span>
             <span>&middot;</span>
             <span>{model.quantization}</span>
+            {#if model.min_memory_gb > 0}
+              <span>&middot;</span>
+              <span>Requires {model.min_memory_gb} GB RAM</span>
+              {#if insufficientRam}
+                <span class="ram-warning-chip">Insufficient RAM</span>
+              {/if}
+            {/if}
           </div>
 
           {#if progress !== undefined}
@@ -223,6 +232,10 @@
     background: hsl(var(--primary) / 0.03);
   }
 
+  .model-insufficient-ram {
+    opacity: 0.6;
+  }
+
   .model-card-header {
     display: flex;
     align-items: center;
@@ -285,9 +298,20 @@
 
   .model-card-meta {
     display: flex;
+    align-items: center;
     gap: 0.375rem;
     font-size: 0.8125rem;
     color: hsl(var(--muted-foreground));
+    flex-wrap: wrap;
+  }
+
+  .ram-warning-chip {
+    font-size: 0.6875rem;
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+    padding: 0.0625rem 0.375rem;
+    border-radius: 9999px;
+    font-weight: 500;
   }
 
   .model-progress {

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -349,6 +349,12 @@ export async function chatModelUnload(): Promise<void> {
   return invoke<void>('chat_model_unload');
 }
 
+/** Return total system RAM in GiB (rounded down). Returns 0 outside Tauri. */
+export function getSystemRamGb(): Promise<number> {
+  if (!isTauri()) return Promise.resolve(0);
+  return invoke<number>('get_system_ram_gb');
+}
+
 /**
  * Ensure a model is downloaded, loaded, and the inference engine is ready.
  * Handles full lifecycle: download → load → engine swap.

--- a/packages/desktop-app/src/lib/stores/model-store.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/model-store.svelte.ts
@@ -123,6 +123,7 @@ class ModelStore {
         await new Promise((resolve) => setTimeout(resolve, 200));
         if (this.models.length === 0) {
           this.models = createMockModels();
+          this.systemRamGb = 8; // Simulate a low-RAM machine so the warning chip is visible in dev
         }
       }
       log.info('Models refreshed', { count: this.models.length });

--- a/packages/desktop-app/src/lib/stores/model-store.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/model-store.svelte.ts
@@ -43,6 +43,7 @@ function createMockModels(): ModelInfo[] {
       url: 'https://huggingface.co/ministral/ministral-8b-instruct-2410-GGUF',
       sha256: 'abc123',
       status: { status: 'not_downloaded' },
+      min_memory_gb: 16,
     },
     {
       id: 'ministral-3b-q4',
@@ -54,6 +55,7 @@ function createMockModels(): ModelInfo[] {
       url: 'https://huggingface.co/ministral/ministral-3b-instruct-GGUF',
       sha256: 'def456',
       status: { status: 'not_downloaded' },
+      min_memory_gb: 8,
     },
     {
       id: 'ministral-8b-q8',
@@ -65,6 +67,7 @@ function createMockModels(): ModelInfo[] {
       url: 'https://huggingface.co/ministral/ministral-8b-instruct-2410-GGUF',
       sha256: 'ghi789',
       status: { status: 'not_downloaded' },
+      min_memory_gb: 16,
     },
   ];
 }
@@ -74,6 +77,8 @@ class ModelStore {
   downloadProgress = $state<Record<string, number>>({});
   loadedModelId = $state<string | null>(null);
   isLoading = $state(false);
+  /** Total system RAM in GiB. 0 means unknown (non-Tauri or not yet loaded). */
+  systemRamGb = $state(0);
 
   private downloadAbortControllers = new Map<string, AbortController>();
   private eventUnlisteners: Array<() => void> = [];
@@ -107,7 +112,10 @@ class ModelStore {
     this.isLoading = true;
     try {
       if (isTauri()) {
-        this.models = await tauriCommands.chatModelList();
+        [this.models, this.systemRamGb] = await Promise.all([
+          tauriCommands.chatModelList(),
+          tauriCommands.getSystemRamGb(),
+        ]);
         // Detect which model is loaded
         const loaded = this.models.find((m) => m.status.status === 'loaded');
         this.loadedModelId = loaded?.id ?? null;
@@ -398,6 +406,7 @@ class ModelStore {
     this.downloadProgress = {};
     this.loadedModelId = null;
     this.isLoading = false;
+    this.systemRamGb = 0;
   }
 
   /** Internal helper to update a model's status immutably. */

--- a/packages/desktop-app/src/lib/types/agent-types.ts
+++ b/packages/desktop-app/src/lib/types/agent-types.ts
@@ -291,6 +291,8 @@ export interface ModelInfo {
 	readonly url: string;
 	readonly sha256: string;
 	readonly status: ModelStatus;
+	/** Minimum system RAM (GiB) required to run this model. 0 means unknown. */
+	readonly min_memory_gb: number;
 }
 
 /** Specification of a chat model's capabilities. */

--- a/packages/desktop-app/src/tests/stores/model-store.test.ts
+++ b/packages/desktop-app/src/tests/stores/model-store.test.ts
@@ -75,6 +75,7 @@ describe('ModelStore', () => {
         expect(model.quantization).toBeTruthy();
         expect(model.status).toBeDefined();
         expect(model.status.status).toBe('not_downloaded');
+        expect(model.min_memory_gb).toBeGreaterThan(0);
       }
     });
   });


### PR DESCRIPTION
## Summary

- Adds `min_memory_gb` field to `CatalogEntry` and `ModelInfo` (8 GB Ministral 3B, 16 GB Ministral 8B / Gemma 4 E4B, 24 GB Gemma 4 31B)
- Propagates the field through `GgufModelManager::list()`, `OllamaModelManager::list()` (0 = unknown), daemon gRPC `ModelEntry` proto, and TypeScript `ModelInfo` interface
- Adds `get_system_ram_gb` Tauri command using the existing `detect_system_ram()` function (now public)
- Model manager UI shows "Requires X GB RAM" on every card; dims card and shows "Insufficient RAM" chip when system RAM is below the model's requirement
- Extends `list_models_have_correct_metadata` and `list_includes_gemma4_entries_with_correct_metadata` tests with `min_memory_gb` assertions

## Test plan

- [ ] Frontend: 128 files, 3916 tests passed (no regressions)
- [ ] Rust `model_manager` tests: 33 passed, 0 failed
- [ ] `bun run quality:fix` passed clean
- [ ] Rust crates `nodespace-agent` and `nodespace-daemon` compile clean (`cargo check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)