### PR TITLE
Add schema field rename with property data migration

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -498,7 +498,7 @@ fn def_create_schema() -> ToolDefinition {
 fn def_update_schema() -> ToolDefinition {
     ToolDefinition {
         name: "update_schema".into(),
-        description: "Modify an existing schema type: add/remove/rename fields, add/remove relationships, update description or title_template. Use rename_fields to safely rename a field — it migrates all existing node property data to the new key and updates the schema definition atomically.".into(),
+        description: "Modify an existing schema type: add/remove/rename fields, add/remove relationships, update description or title_template. Use rename_fields to safely rename a field — it migrates all existing node property data to the new key and updates the schema definition.".into(),
         parameters_schema: json!({
             "type": "object",
             "properties": {
@@ -546,7 +546,8 @@ fn def_update_schema() -> ToolDefinition {
                             "from": { "type": "string", "description": "Current field name" },
                             "to": { "type": "string", "description": "New field name" }
                         },
-                        "required": ["from", "to"]
+                        "required": ["from", "to"],
+                        "additionalProperties": false
                     }
                 },
                 "add_relationships": {

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -498,7 +498,7 @@ fn def_create_schema() -> ToolDefinition {
 fn def_update_schema() -> ToolDefinition {
     ToolDefinition {
         name: "update_schema".into(),
-        description: "Modify an existing schema type: add/remove fields, add/remove relationships, update description or title_template.".into(),
+        description: "Modify an existing schema type: add/remove/rename fields, add/remove relationships, update description or title_template. Use rename_fields to safely rename a field — it migrates all existing node property data to the new key and updates the schema definition atomically.".into(),
         parameters_schema: json!({
             "type": "object",
             "properties": {
@@ -536,6 +536,18 @@ fn def_update_schema() -> ToolDefinition {
                     "type": "array",
                     "description": "Field names to remove",
                     "items": { "type": "string" }
+                },
+                "rename_fields": {
+                    "type": "array",
+                    "description": "Fields to rename. Each entry rekeys property data on ALL existing nodes of this schema type and updates the schema definition. Renaming to an existing field name is rejected. Processed before add_fields/remove_fields.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "from": { "type": "string", "description": "Current field name" },
+                            "to": { "type": "string", "description": "New field name" }
+                        },
+                        "required": ["from", "to"]
+                    }
                 },
                 "add_relationships": {
                     "type": "array",

--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -3232,6 +3232,97 @@ impl SurrealStore {
         Ok(())
     }
 
+    /// Rekey a property field for all nodes of a given type (Issue #1088).
+    ///
+    /// Fetches all nodes of the given type, renames the field in the namespace
+    /// object in Rust, then writes back each updated node. This avoids SurrealDB
+    /// query syntax issues with dynamic property paths and is correct for all
+    /// field name formats including `custom:field`.
+    ///
+    /// # Errors
+    /// Returns an error if `from == to`, if either name is empty, or if any DB operation fails.
+    pub async fn rename_schema_field(&self, type_id: &str, from: &str, to: &str) -> Result<u64> {
+        if from.is_empty() || to.is_empty() {
+            return Err(anyhow::anyhow!("Field names must not be empty"));
+        }
+        if from == to {
+            return Err(anyhow::anyhow!(
+                "Source and destination field names are the same: '{}'",
+                from
+            ));
+        }
+
+        // Fetch all nodes of the given type
+        let query = "SELECT * FROM node WHERE node_type = $type_id;";
+        let mut response = self
+            .db
+            .query(query)
+            .bind(("type_id", type_id.to_string()))
+            .await
+            .context(format!(
+                "Failed to fetch nodes for type '{}' during field rename",
+                type_id
+            ))?;
+
+        let nodes: Vec<SurrealNode> = response
+            .take(0)
+            .context("Failed to take node results during field rename")?;
+
+        let mut affected: u64 = 0;
+
+        for node in nodes {
+            let node_id = extract_record_key(&node.id);
+            let mut properties = node.properties.clone();
+
+            // Rename the field in the type's namespace object
+            let had_field = if let Some(ns_obj) = properties
+                .as_object_mut()
+                .and_then(|p| p.get_mut(type_id))
+                .and_then(|ns| ns.as_object_mut())
+            {
+                if let Some(value) = ns_obj.remove(from) {
+                    ns_obj.insert(to.to_string(), value);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
+            if had_field {
+                let update_query =
+                    "UPDATE type::record('node', $id) SET properties = $properties, modified_at = time::now();";
+                self.db
+                    .query(update_query)
+                    .bind(("id", node_id.clone()))
+                    .bind(("properties", properties))
+                    .await
+                    .context(format!(
+                        "Failed to update node '{}' during field rename '{}' -> '{}'",
+                        node_id, from, to
+                    ))?
+                    .check()
+                    .context(format!(
+                        "Update query failed for node '{}' during field rename '{}' -> '{}'",
+                        node_id, from, to
+                    ))?;
+                affected += 1;
+            }
+        }
+
+        tracing::info!(
+            type_id = %type_id,
+            from = %from,
+            to = %to,
+            affected = affected,
+            "rename_schema_field: migrated {} node(s)",
+            affected
+        );
+
+        Ok(affected)
+    }
+
     // NOTE: Old node-based embedding methods REMOVED (Issue #729)
     // The following methods operated on node.embedding_vector and node.embedding_stale:
     // - get_nodes_without_embeddings() - queried node WHERE embedding_vector IS NONE

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -490,10 +490,21 @@ pub async fn handle_update_schema(
     let params: UpdateSchemaParams = serde_json::from_value(params)
         .map_err(|e| MCPError::invalid_params(format!("Invalid parameters: {}", e)))?;
 
-    // --- Phase 1: Process renames first (each rename migrates data + updates schema definition) ---
-    let mut fields_renamed = 0;
+    // --- Phase 0: Verify schema exists, validate renames, run playbook impact check ---
+    // Schema existence is verified upfront so rename/playbook validation errors are reported
+    // before any mutations execute.
+    node_service
+        .get_schema_node(&params.schema_id)
+        .await
+        .map_err(|e| MCPError::internal_error(format!("Failed to get schema: {}", e)))?
+        .ok_or_else(|| {
+            MCPError::invalid_params(format!("Schema '{}' not found", params.schema_id))
+        })?;
+
+    // Validate renames before executing any mutations (including the playbook guard below)
     if let Some(ref renames) = params.rename_fields {
-        // Validate all renames upfront before executing any
+        let mut seen_sources = std::collections::HashSet::new();
+        let mut seen_destinations = std::collections::HashSet::new();
         for rename in renames {
             if rename.from.trim().is_empty() || rename.to.trim().is_empty() {
                 return Err(MCPError::invalid_params(
@@ -506,10 +517,12 @@ pub async fn handle_update_schema(
                     rename.from
                 )));
             }
-        }
-        // Check for duplicate destinations within the rename list itself
-        let mut seen_destinations = std::collections::HashSet::new();
-        for rename in renames {
+            if !seen_sources.insert(&rename.from) {
+                return Err(MCPError::invalid_params(format!(
+                    "rename_fields: duplicate source field name '{}'",
+                    rename.from
+                )));
+            }
             if !seen_destinations.insert(&rename.to) {
                 return Err(MCPError::invalid_params(format!(
                     "rename_fields: duplicate destination field name '{}'",
@@ -517,6 +530,38 @@ pub async fn handle_update_schema(
                 )));
             }
         }
+    }
+
+    // Issue #1012: Check if any active playbooks would be affected by this schema change.
+    // Done before any mutations so a blocked rename doesn't partially execute.
+    let affected =
+        crate::playbook::validation::check_schema_change_impact(&params.schema_id, node_service)
+            .await
+            .map_err(|e| MCPError::internal_error(format!("Impact analysis failed: {}", e)))?;
+
+    if !affected.is_empty() && !params.force {
+        let names: Vec<String> = affected.iter().map(|a| a.to_string()).collect();
+        return Err(MCPError::invalid_params(format!(
+            "Schema change would affect {} active playbook(s): {}. Use force=true to proceed.",
+            affected.len(),
+            names.join("; ")
+        )));
+    }
+
+    let affected_names: Option<Vec<String>> = if !affected.is_empty() {
+        Some(
+            affected
+                .iter()
+                .map(|a| format!("{} ({})", a.playbook_name, a.playbook_id))
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    // --- Phase 1: Process renames (each rename migrates data + updates schema definition) ---
+    let mut fields_renamed = 0;
+    if let Some(ref renames) = params.rename_fields {
         for rename in renames {
             node_service
                 .rename_schema_field(&params.schema_id, &rename.from, &rename.to)
@@ -526,13 +571,13 @@ pub async fn handle_update_schema(
         }
     }
 
-    // --- Phase 2: Re-fetch schema (may have been updated by renames above) ---
+    // --- Phase 2: Re-fetch schema (reflects any renames applied above) ---
     let schema = node_service
         .get_schema_node(&params.schema_id)
         .await
         .map_err(|e| MCPError::internal_error(format!("Failed to get schema: {}", e)))?
         .ok_or_else(|| {
-            MCPError::invalid_params(format!("Schema '{}' not found", params.schema_id))
+            MCPError::invalid_params(format!("Schema '{}' not found after renames", params.schema_id))
         })?;
 
     // Process fields
@@ -624,32 +669,6 @@ pub async fn handle_update_schema(
     SchemaNodeBehavior
         .validate_schema_node(&updated_schema)
         .map_err(|e| MCPError::invalid_params(format!("Schema validation failed: {}", e)))?;
-
-    // Issue #1012: Check if any active playbooks would be affected by this schema change
-    let affected =
-        crate::playbook::validation::check_schema_change_impact(&params.schema_id, node_service)
-            .await
-            .map_err(|e| MCPError::internal_error(format!("Impact analysis failed: {}", e)))?;
-
-    if !affected.is_empty() && !params.force {
-        let names: Vec<String> = affected.iter().map(|a| a.to_string()).collect();
-        return Err(MCPError::invalid_params(format!(
-            "Schema change would affect {} active playbook(s): {}. Use force=true to proceed.",
-            affected.len(),
-            names.join("; ")
-        )));
-    }
-
-    let affected_names: Option<Vec<String>> = if !affected.is_empty() {
-        Some(
-            affected
-                .iter()
-                .map(|a| format!("{} ({})", a.playbook_name, a.playbook_id))
-                .collect(),
-        )
-    } else {
-        None
-    };
 
     let update = NodeUpdate {
         properties: Some(properties),

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -257,6 +257,15 @@ pub struct RemoveSchemaRelationshipParams {
     pub relationship_name: String,
 }
 
+/// A single field rename operation within update_schema
+#[derive(Debug, Deserialize)]
+pub struct FieldRename {
+    /// Current field name
+    pub from: String,
+    /// New field name
+    pub to: String,
+}
+
 /// Parameters for update_schema (batch operations)
 #[derive(Debug, Deserialize)]
 pub struct UpdateSchemaParams {
@@ -268,6 +277,10 @@ pub struct UpdateSchemaParams {
     /// Field names to remove
     #[serde(default)]
     pub remove_fields: Option<Vec<String>>,
+    /// Field renames — rekeys property data on all existing nodes of this type
+    /// and updates the schema definition atomically.
+    #[serde(default)]
+    pub rename_fields: Option<Vec<FieldRename>>,
     /// Relationships to add
     #[serde(default)]
     pub add_relationships: Option<Vec<crate::models::schema::SchemaRelationship>>,
@@ -303,6 +316,8 @@ pub struct SchemaUpdateOutput {
     pub fields_added: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields_removed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields_renamed: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relationships_added: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -475,7 +490,43 @@ pub async fn handle_update_schema(
     let params: UpdateSchemaParams = serde_json::from_value(params)
         .map_err(|e| MCPError::invalid_params(format!("Invalid parameters: {}", e)))?;
 
-    // Get existing schema
+    // --- Phase 1: Process renames first (each rename migrates data + updates schema definition) ---
+    let mut fields_renamed = 0;
+    if let Some(ref renames) = params.rename_fields {
+        // Validate all renames upfront before executing any
+        for rename in renames {
+            if rename.from.trim().is_empty() || rename.to.trim().is_empty() {
+                return Err(MCPError::invalid_params(
+                    "rename_fields entries must have non-empty 'from' and 'to'".to_string(),
+                ));
+            }
+            if rename.from == rename.to {
+                return Err(MCPError::invalid_params(format!(
+                    "rename_fields: 'from' and 'to' are the same: '{}'",
+                    rename.from
+                )));
+            }
+        }
+        // Check for duplicate destinations within the rename list itself
+        let mut seen_destinations = std::collections::HashSet::new();
+        for rename in renames {
+            if !seen_destinations.insert(&rename.to) {
+                return Err(MCPError::invalid_params(format!(
+                    "rename_fields: duplicate destination field name '{}'",
+                    rename.to
+                )));
+            }
+        }
+        for rename in renames {
+            node_service
+                .rename_schema_field(&params.schema_id, &rename.from, &rename.to)
+                .await
+                .map_err(|e| MCPError::invalid_params(format!("Field rename failed: {}", e)))?;
+            fields_renamed += 1;
+        }
+    }
+
+    // --- Phase 2: Re-fetch schema (may have been updated by renames above) ---
     let schema = node_service
         .get_schema_node(&params.schema_id)
         .await
@@ -620,6 +671,11 @@ pub async fn handle_update_schema(
         },
         fields_removed: if fields_removed > 0 {
             Some(fields_removed)
+        } else {
+            None
+        },
+        fields_renamed: if fields_renamed > 0 {
+            Some(fields_renamed)
         } else {
             None
         },

--- a/packages/core/src/mcp/handlers/schema_test.rs
+++ b/packages/core/src/mcp/handlers/schema_test.rs
@@ -300,3 +300,207 @@ async fn test_update_schema_remove_unrelated_field_with_template_succeeds() {
         update_result
     );
 }
+
+// ============================================================================
+// rename_fields
+// ============================================================================
+
+#[tokio::test]
+async fn test_rename_field_updates_schema_definition() {
+    let (svc, _tmp) = create_test_service().await;
+
+    // Create a schema with a field to rename
+    let create_result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "RenameTest",
+            "fields": [
+                { "name": "old_name", "type": "string", "protection": "user", "indexed": false },
+                { "name": "keep_me",  "type": "string", "protection": "user", "indexed": false }
+            ]
+        }),
+    )
+    .await
+    .expect("Schema creation failed");
+    let schema_id = create_result["schemaId"]
+        .as_str()
+        .expect("schemaId missing");
+
+    let result = handle_update_schema(
+        &svc,
+        json!({
+            "schema_id": schema_id,
+            "rename_fields": [{ "from": "old_name", "to": "new_name" }]
+        }),
+    )
+    .await;
+
+    assert!(result.is_ok(), "rename_fields should succeed: {:?}", result);
+    let output = result.unwrap();
+    assert_eq!(output["fieldsRenamed"], serde_json::json!(1));
+
+    // Schema definition should reflect the rename
+    let schema = svc
+        .get_schema_node(schema_id)
+        .await
+        .expect("get_schema_node failed")
+        .expect("schema not found");
+
+    let field_names: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(
+        field_names.contains(&"new_name"),
+        "new_name should exist in schema fields: {:?}",
+        field_names
+    );
+    assert!(
+        !field_names.contains(&"old_name"),
+        "old_name should no longer exist in schema fields: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&"keep_me"),
+        "keep_me should be unchanged: {:?}",
+        field_names
+    );
+}
+
+#[tokio::test]
+async fn test_rename_field_not_found_returns_error() {
+    let (svc, _tmp) = create_test_service().await;
+
+    let create_result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "RenameErrorTest",
+            "fields": [
+                { "name": "existing", "type": "string", "protection": "user", "indexed": false }
+            ]
+        }),
+    )
+    .await
+    .expect("Schema creation failed");
+    let schema_id = create_result["schemaId"]
+        .as_str()
+        .expect("schemaId missing");
+
+    let result = handle_update_schema(
+        &svc,
+        json!({
+            "schema_id": schema_id,
+            "rename_fields": [{ "from": "does_not_exist", "to": "new_name" }]
+        }),
+    )
+    .await;
+
+    assert!(result.is_err(), "Renaming a nonexistent field should fail");
+}
+
+#[tokio::test]
+async fn test_rename_field_to_existing_field_returns_error() {
+    let (svc, _tmp) = create_test_service().await;
+
+    let create_result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "RenameConflictTest",
+            "fields": [
+                { "name": "field_a", "type": "string", "protection": "user", "indexed": false },
+                { "name": "field_b", "type": "string", "protection": "user", "indexed": false }
+            ]
+        }),
+    )
+    .await
+    .expect("Schema creation failed");
+    let schema_id = create_result["schemaId"]
+        .as_str()
+        .expect("schemaId missing");
+
+    let result = handle_update_schema(
+        &svc,
+        json!({
+            "schema_id": schema_id,
+            "rename_fields": [{ "from": "field_a", "to": "field_b" }]
+        }),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Renaming to an existing field name should fail"
+    );
+}
+
+#[tokio::test]
+async fn test_rename_field_migrates_node_data() {
+    use crate::services::CreateNodeParams;
+
+    let (svc, _tmp) = create_test_service().await;
+
+    // Create a schema type
+    let create_result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "DataMigrateTest",
+            "fields": [
+                { "name": "old_field", "type": "string", "protection": "user", "indexed": false }
+            ]
+        }),
+    )
+    .await
+    .expect("Schema creation failed");
+    let schema_id = create_result["schemaId"]
+        .as_str()
+        .expect("schemaId missing")
+        .to_string();
+
+    // Create a node instance with data in old_field
+    let node_params = CreateNodeParams {
+        id: None,
+        node_type: schema_id.clone(),
+        content: "test node".to_string(),
+        parent_id: None,
+        insert_after_node_id: None,
+        properties: serde_json::json!({
+            &schema_id: { "old_field": "my_value" }
+        }),
+    };
+    let node_id = svc
+        .create_node_with_parent(node_params)
+        .await
+        .expect("create_node_with_parent failed");
+
+    // Rename the field
+    handle_update_schema(
+        &svc,
+        json!({
+            "schema_id": schema_id,
+            "rename_fields": [{ "from": "old_field", "to": "new_field" }]
+        }),
+    )
+    .await
+    .expect("rename_fields should succeed");
+
+    // Verify the node data was migrated
+    let node = svc
+        .get_node(&node_id)
+        .await
+        .expect("get_node failed")
+        .expect("node not found");
+
+    let ns_props = node.properties.get(&schema_id);
+    assert!(
+        ns_props.is_some(),
+        "Namespaced properties should exist after rename"
+    );
+    let ns_props = ns_props.unwrap();
+    assert_eq!(
+        ns_props.get("new_field").and_then(|v| v.as_str()),
+        Some("my_value"),
+        "Value should be migrated to new_field"
+    );
+    assert!(
+        ns_props.get("old_field").is_none()
+            || ns_props.get("old_field").is_some_and(|v| v.is_null()),
+        "old_field should be removed after rename"
+    );
+}

--- a/packages/core/src/mcp/handlers/schema_test.rs
+++ b/packages/core/src/mcp/handlers/schema_test.rs
@@ -499,8 +499,7 @@ async fn test_rename_field_migrates_node_data() {
         "Value should be migrated to new_field"
     );
     assert!(
-        ns_props.get("old_field").is_none()
-            || ns_props.get("old_field").is_some_and(|v| v.is_null()),
+        ns_props.get("old_field").is_none(),
         "old_field should be removed after rename"
     );
 }

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -2715,6 +2715,101 @@ impl NodeService {
         })
     }
 
+    /// Rename a field across all node instances and update the schema definition atomically (Issue #1088).
+    ///
+    /// Steps performed in order:
+    ///   1. Validate the schema exists, the source field exists, and the destination does not.
+    ///   2. Migrate all node instances via `SurrealStore::rename_schema_field`.
+    ///   3. Update the schema definition (rename the field entry in `fields`).
+    ///
+    /// Steps 2 and 3 are executed sequentially. If step 3 fails after step 2 has already
+    /// migrated data, the error is returned and the caller should retry only the schema
+    /// definition update (data is already correct).
+    pub async fn rename_schema_field(
+        &self,
+        type_id: &str,
+        from: &str,
+        to: &str,
+    ) -> Result<u64, NodeServiceError> {
+        // Validate schema exists
+        let schema = self
+            .get_schema_node(type_id)
+            .await?
+            .ok_or_else(|| NodeServiceError::node_not_found(type_id))?;
+
+        // Validate source field exists in schema
+        if !schema.fields.iter().any(|f| f.name == from) {
+            return Err(NodeServiceError::invalid_update(format!(
+                "Field '{}' not found in schema '{}'",
+                from, type_id
+            )));
+        }
+
+        // Validate destination field does not already exist
+        if schema.fields.iter().any(|f| f.name == to) {
+            return Err(NodeServiceError::invalid_update(format!(
+                "Field '{}' already exists in schema '{}'; cannot rename to an existing field",
+                to, type_id
+            )));
+        }
+
+        // Step 1: Migrate all node property data
+        let affected = self
+            .store
+            .rename_schema_field(type_id, from, to)
+            .await
+            .map_err(|e| {
+                NodeServiceError::DatabaseError(crate::db::DatabaseError::SqlExecutionError {
+                    context: format!(
+                        "Failed to migrate field data '{}' -> '{}' for type '{}': {}",
+                        from, to, type_id, e
+                    ),
+                })
+            })?;
+
+        // Step 2: Update schema definition — rename field in the fields list
+        let updated_fields: Vec<crate::models::schema::SchemaField> = schema
+            .fields
+            .into_iter()
+            .map(|mut f| {
+                if f.name == from {
+                    f.name = to.to_string();
+                }
+                f
+            })
+            .collect();
+
+        let mut properties = serde_json::json!({
+            "isCore": schema.is_core,
+            "schemaVersion": schema.schema_version,
+            "description": schema.description,
+            "fields": updated_fields,
+            "relationships": schema.relationships,
+        });
+        if let Some(ref t) = schema.title_template {
+            properties["titleTemplate"] = serde_json::Value::String(t.clone());
+        }
+        if let Some(ref t) = schema.properties_header_summary_template {
+            properties["propertiesHeaderSummaryTemplate"] = serde_json::Value::String(t.clone());
+        }
+
+        let update = crate::models::NodeUpdate {
+            properties: Some(properties),
+            ..Default::default()
+        };
+
+        self.update_node_unchecked(type_id, update)
+            .await
+            .map_err(|e| NodeServiceError::DatabaseError(crate::db::DatabaseError::SqlExecutionError {
+                context: format!(
+                    "Failed to update schema definition after field rename '{}' -> '{}' for type '{}': {}",
+                    from, to, type_id, e
+                ),
+            }))?;
+
+        Ok(affected)
+    }
+
     /// Compute the indexed title for a node (Issue #824).
     ///
     /// Priority:

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -2715,16 +2715,16 @@ impl NodeService {
         })
     }
 
-    /// Rename a field across all node instances and update the schema definition atomically (Issue #1088).
+    /// Rename a field across all node instances and update the schema definition (Issue #1088).
     ///
     /// Steps performed in order:
     ///   1. Validate the schema exists, the source field exists, and the destination does not.
     ///   2. Migrate all node instances via `SurrealStore::rename_schema_field`.
     ///   3. Update the schema definition (rename the field entry in `fields`).
     ///
-    /// Steps 2 and 3 are executed sequentially. If step 3 fails after step 2 has already
-    /// migrated data, the error is returned and the caller should retry only the schema
-    /// definition update (data is already correct).
+    /// Steps 2 and 3 are executed sequentially but are not atomic. If step 3 fails after
+    /// step 2 has already migrated data, the error is returned and the caller should retry
+    /// only the schema definition update (data is already correct).
     pub async fn rename_schema_field(
         &self,
         type_id: &str,

--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -109,7 +109,6 @@ impl AgentSessionService for AgentSessionHandler {
             }
         }
 
-
         let id = self
             .manager
             .launch(agent_type, req.prompt, &self.assembler)


### PR DESCRIPTION
## Summary

- Adds `SurrealStore::rename_schema_field` that fetches all nodes of a type, rekeys the field in the namespace object in Rust, and writes each updated node back individually
- Adds `NodeService::rename_schema_field` that validates source/destination field existence, runs data migration, then updates the schema definition
- Adds `rename_fields: [{from, to}]` to `UpdateSchemaParams` (processed before add/remove so subsequent operations see post-rename schema state) and to the `update_schema` agent tool
- 4 integration tests covering: schema definition update, source-field-not-found error, rename-to-existing-field error, and node data migration

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)