### PR TITLE
Replace nodespace_core type imports in Tauri commands with local types (closes #1172)

### DIFF
--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -1951,9 +1951,7 @@ impl SurrealStore {
         if let Some(off) = offset {
             query_builder = query_builder.bind(("offset", off as i64));
         }
-        let mut response = query_builder
-            .await
-            .context("Failed to get root nodes")?;
+        let mut response = query_builder.await.context("Failed to get root nodes")?;
 
         let surreal_nodes: Vec<SurrealNode> = response
             .take(0)
@@ -8104,13 +8102,25 @@ mod tests {
         let (store, _temp_dir) = create_test_store().await?;
 
         let r1 = store
-            .create_node(Node::new("text".to_string(), "Root 1".to_string(), json!({})), None, None)
+            .create_node(
+                Node::new("text".to_string(), "Root 1".to_string(), json!({})),
+                None,
+                None,
+            )
             .await?;
         let r2 = store
-            .create_node(Node::new("text".to_string(), "Root 2".to_string(), json!({})), None, None)
+            .create_node(
+                Node::new("text".to_string(), "Root 2".to_string(), json!({})),
+                None,
+                None,
+            )
             .await?;
         let r3 = store
-            .create_node(Node::new("text".to_string(), "Root 3".to_string(), json!({})), None, None)
+            .create_node(
+                Node::new("text".to_string(), "Root 3".to_string(), json!({})),
+                None,
+                None,
+            )
             .await?;
         // Child should NOT appear in roots
         store
@@ -8132,14 +8142,22 @@ mod tests {
 
         for i in 0..5 {
             store
-                .create_node(Node::new("text".to_string(), format!("Root {i}"), json!({})), None, None)
+                .create_node(
+                    Node::new("text".to_string(), format!("Root {i}"), json!({})),
+                    None,
+                    None,
+                )
                 .await?;
         }
 
         let roots = store.get_roots(Some(3), None).await?;
         // Schema nodes are also roots; just verify we got at most 3 *extra* nodes.
         // The point is that LIMIT is applied in DB, not in memory.
-        assert!(roots.len() <= 3, "limit=3 should return at most 3 nodes, got {}", roots.len());
+        assert!(
+            roots.len() <= 3,
+            "limit=3 should return at most 3 nodes, got {}",
+            roots.len()
+        );
 
         Ok(())
     }
@@ -8154,7 +8172,11 @@ mod tests {
 
         for i in 0..4 {
             store
-                .create_node(Node::new("text".to_string(), format!("Page root {i}"), json!({})), None, None)
+                .create_node(
+                    Node::new("text".to_string(), format!("Page root {i}"), json!({})),
+                    None,
+                    None,
+                )
                 .await?;
         }
 

--- a/packages/core/src/mcp/handlers/schema.rs
+++ b/packages/core/src/mcp/handlers/schema.rs
@@ -577,7 +577,10 @@ pub async fn handle_update_schema(
         .await
         .map_err(|e| MCPError::internal_error(format!("Failed to get schema: {}", e)))?
         .ok_or_else(|| {
-            MCPError::invalid_params(format!("Schema '{}' not found after renames", params.schema_id))
+            MCPError::invalid_params(format!(
+                "Schema '{}' not found after renames",
+                params.schema_id
+            ))
         })?;
 
     // Process fields

--- a/packages/desktop-app/src-tauri/src/commands/collections.rs
+++ b/packages/desktop-app/src-tauri/src/commands/collections.rs
@@ -3,7 +3,7 @@
 //! As of Issue #1113, all commands proxy through the in-process gRPC server
 //! (nodespace-daemon) instead of calling `packages/core` directly.
 
-use nodespace_core::Node;
+use crate::types::Node;
 use nodespace_daemon::nodespace::{
     AddNodeToCollectionByPathRequest, AddNodeToCollectionRequest, CollectionMembersRequest,
     CreateCollectionRequest, DeleteCollectionRequest, FindCollectionByPathRequest,

--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -5,7 +5,7 @@
 
 use crate::commands::nodes::CommandError;
 use crate::services::GrpcClient;
-use nodespace_core::models::Node;
+use crate::types::Node;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 

--- a/packages/desktop-app/src-tauri/src/commands/nodes.rs
+++ b/packages/desktop-app/src-tauri/src/commands/nodes.rs
@@ -3,9 +3,12 @@
 //! As of Issue #1113, all commands proxy through the in-process gRPC server
 //! (nodespace-daemon) instead of calling `packages/core` directly.
 
+use crate::types::{
+    node_to_typed_value as types_node_to_typed_value,
+    nodes_to_typed_values as types_nodes_to_typed_values, DeleteResult, Node, NodeQuery,
+    NodeReference, NodeUpdate, TaskNodeUpdate,
+};
 use chrono::{DateTime, Utc};
-use nodespace_core::models::{self, DeleteResult, NodeReference, TaskNodeUpdate};
-use nodespace_core::{Node, NodeQuery, NodeUpdate};
 use nodespace_daemon::nodespace::{
     CreateMentionRequest, CreateNodeRequest, DeleteMentionRequest, DeleteNodeRequest,
     GetChildrenRequest, GetChildrenTreeRequest, GetNodeRequest, GetSchemaDefinitionRequest,
@@ -141,10 +144,8 @@ async fn validate_node_type(
 }
 
 /// Convert a Node to its strongly-typed JSON representation (Issue #673)
-///
-/// Delegates to the canonical `models::node_to_typed_value` and maps errors to CommandError.
 pub fn node_to_typed_value(node: Node) -> Result<Value, CommandError> {
-    models::node_to_typed_value(node).map_err(|e| CommandError {
+    types_node_to_typed_value(node).map_err(|e| CommandError {
         message: e.clone(),
         code: "CONVERSION_ERROR".to_string(),
         details: Some(e),
@@ -153,7 +154,7 @@ pub fn node_to_typed_value(node: Node) -> Result<Value, CommandError> {
 
 /// Convert a list of Nodes to their strongly-typed JSON representations (Issue #673)
 pub fn nodes_to_typed_values(nodes: Vec<Node>) -> Result<Vec<Value>, CommandError> {
-    models::nodes_to_typed_values(nodes).map_err(|e| CommandError {
+    types_nodes_to_typed_values(nodes).map_err(|e| CommandError {
         message: e.clone(),
         code: "CONVERSION_ERROR".to_string(),
         details: Some(e),

--- a/packages/desktop-app/src-tauri/src/commands/schemas.rs
+++ b/packages/desktop-app/src-tauri/src/commands/schemas.rs
@@ -7,7 +7,7 @@
 //! - `get_all_schemas` - List all schema nodes (returns SchemaNode[] with typed fields)
 //! - `get_schema_definition` - Get a specific schema by ID (returns SchemaNode with typed fields)
 
-use nodespace_core::SchemaNode;
+use crate::types::SchemaNode;
 use nodespace_daemon::nodespace::{GetAllSchemasRequest, GetSchemaDefinitionRequest};
 use tauri::State;
 use tonic::Request;

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ pub mod agent_events;
 // Tauri commands module (public for dev-server access)
 pub mod commands;
 
+// Local type mirrors for command layer (severs nodespace_core dep from commands/)
+pub mod types;
+
 // Application preferences management
 pub mod preferences;
 

--- a/packages/desktop-app/src-tauri/src/types.rs
+++ b/packages/desktop-app/src-tauri/src/types.rs
@@ -1,0 +1,602 @@
+//! Local type mirrors for Tauri command layer.
+//!
+//! These structs replicate the shapes used by `packages/core` that the commands need
+//! for deserialization (inputs from Svelte) and serialization (outputs to Svelte).
+//! Defining them here severs the direct `nodespace_core` dependency from the command
+//! files while keeping the wire format identical.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+// ---------------------------------------------------------------------------
+// Node
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeReference {
+    pub id: String,
+    pub title: Option<String>,
+    pub node_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Node {
+    pub id: String,
+    pub node_type: String,
+    pub content: String,
+    #[serde(default = "default_version")]
+    pub version: i64,
+    pub created_at: DateTime<Utc>,
+    pub modified_at: DateTime<Utc>,
+    pub properties: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mentions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mentioned_in: Vec<NodeReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(
+        default = "default_lifecycle_status",
+        skip_serializing_if = "is_active_lifecycle"
+    )]
+    pub lifecycle_status: String,
+}
+
+fn default_version() -> i64 {
+    1
+}
+
+fn default_lifecycle_status() -> String {
+    "active".to_string()
+}
+
+fn is_active_lifecycle(s: &str) -> bool {
+    s == "active"
+}
+
+// ---------------------------------------------------------------------------
+// NodeQuery
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mentioned_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// NodeUpdate
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_status: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// DeleteResult
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeleteResult {
+    pub existed: bool,
+}
+
+// ---------------------------------------------------------------------------
+// TaskStatus / TaskPriority / TaskNodeUpdate
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum TaskStatus {
+    #[default]
+    Open,
+    InProgress,
+    Done,
+    Cancelled,
+    User(String),
+}
+
+impl FromStr for TaskStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "open" => Self::Open,
+            "in_progress" => Self::InProgress,
+            "done" => Self::Done,
+            "cancelled" => Self::Cancelled,
+            other => Self::User(other.to_string()),
+        })
+    }
+}
+
+impl TaskStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Open => "open",
+            Self::InProgress => "in_progress",
+            Self::Done => "done",
+            Self::Cancelled => "cancelled",
+            Self::User(s) => s.as_str(),
+        }
+    }
+}
+
+impl Serialize for TaskStatus {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskStatus {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Ok(Self::from_str(&s).unwrap())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum TaskPriority {
+    Low,
+    #[default]
+    Medium,
+    High,
+    User(String),
+}
+
+impl FromStr for TaskPriority {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "low" => Self::Low,
+            "medium" => Self::Medium,
+            "high" => Self::High,
+            other => Self::User(other.to_string()),
+        })
+    }
+}
+
+impl TaskPriority {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::User(s) => s.as_str(),
+        }
+    }
+}
+
+impl Serialize for TaskPriority {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskPriority {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Ok(Self::from_str(&s).unwrap())
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskNodeUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<TaskStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<Option<TaskPriority>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "flexible_date::deserialize_with_null"
+    )]
+    pub due_date: Option<Option<DateTime<Utc>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "flexible_date::deserialize_with_null"
+    )]
+    pub started_at: Option<Option<DateTime<Utc>>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "flexible_date::deserialize_with_null"
+    )]
+    pub completed_at: Option<Option<DateTime<Utc>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+mod flexible_date {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize_with_null<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<Option<DateTime<Utc>>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<Option<String>> = Option::deserialize(deserializer)?;
+        match opt {
+            None => Ok(None),
+            Some(None) => Ok(Some(None)),
+            Some(Some(s)) => {
+                let dt = DateTime::parse_from_rfc3339(&s)
+                    .map(|d| d.with_timezone(&Utc))
+                    .or_else(|_| {
+                        chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d")
+                            .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc())
+                    })
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Some(Some(dt)))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SchemaNode and related types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnumValue {
+    pub value: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemaProtectionLevel {
+    Core,
+    User,
+    System,
+}
+
+fn default_protection_level() -> SchemaProtectionLevel {
+    SchemaProtectionLevel::User
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub field_type: String,
+    #[serde(default = "default_protection_level")]
+    pub protection: SchemaProtectionLevel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub core_values: Option<Vec<EnumValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_values: Option<Vec<EnumValue>>,
+    #[serde(default)]
+    pub indexed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensible: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<SchemaField>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_fields: Option<Vec<SchemaField>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RelationshipDirection {
+    Out,
+    In,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RelationshipCardinality {
+    One,
+    Many,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub field_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaRelationship {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub target_type: Option<String>,
+    pub direction: RelationshipDirection,
+    pub cardinality: RelationshipCardinality,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverse_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverse_cardinality: Option<RelationshipCardinality>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge_table: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge_fields: Option<Vec<EdgeField>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaNode {
+    pub id: String,
+    pub content: String,
+    #[serde(default = "default_version")]
+    pub version: i64,
+    pub created_at: DateTime<Utc>,
+    pub modified_at: DateTime<Utc>,
+    #[serde(default)]
+    pub is_core: bool,
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub fields: Vec<SchemaField>,
+    #[serde(default)]
+    pub relationships: Vec<SchemaRelationship>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties_header_summary_template: Option<String>,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+impl SchemaNode {
+    pub fn from_node(node: Node) -> Result<Self, String> {
+        if node.node_type != "schema" {
+            return Err(format!("Expected 'schema', got '{}'", node.node_type));
+        }
+
+        let is_core = node
+            .properties
+            .get("isCore")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let schema_version = node
+            .properties
+            .get("schemaVersion")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32)
+            .unwrap_or(1);
+
+        let description = node
+            .properties
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+
+        let fields: Vec<SchemaField> = node
+            .properties
+            .get("fields")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        let relationships: Vec<SchemaRelationship> = node
+            .properties
+            .get("relationships")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        let title_template = node
+            .properties
+            .get("titleTemplate")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let properties_header_summary_template = node
+            .properties
+            .get("propertiesHeaderSummaryTemplate")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        Ok(Self {
+            id: node.id,
+            content: node.content,
+            version: node.version,
+            created_at: node.created_at,
+            modified_at: node.modified_at,
+            is_core,
+            schema_version,
+            description,
+            fields,
+            relationships,
+            title_template,
+            properties_header_summary_template,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// node_to_typed_value — converts Node → strongly-typed JSON for the frontend
+// ---------------------------------------------------------------------------
+
+pub fn node_to_typed_value(node: Node) -> Result<serde_json::Value, String> {
+    let mut node = node;
+    flatten_properties_for_api(&mut node);
+
+    let node_id = node.id.clone();
+    let mut value = match node.node_type.as_str() {
+        "task" => task_node_to_value(node),
+        "schema" => SchemaNode::from_node(node).and_then(|s| {
+            serde_json::to_value(s).map_err(|e| format!("Failed to serialize schema: {}", e))
+        }),
+        _ => serde_json::to_value(node).map_err(|e| format!("Failed to serialize node: {}", e)),
+    }?;
+
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "uri".to_string(),
+            serde_json::Value::String(format!("nodespace://{}", node_id)),
+        );
+    }
+
+    Ok(value)
+}
+
+pub fn nodes_to_typed_values(nodes: Vec<Node>) -> Result<Vec<serde_json::Value>, String> {
+    nodes.into_iter().map(node_to_typed_value).collect()
+}
+
+fn flatten_properties_for_api(node: &mut Node) {
+    let node_type = node.node_type.clone();
+
+    let Some(props_obj) = node.properties.as_object() else {
+        return;
+    };
+
+    if let Some(type_namespace) = props_obj.get(&node_type) {
+        if let Some(type_props) = type_namespace.as_object() {
+            let flat: serde_json::Map<String, serde_json::Value> = type_props
+                .iter()
+                .filter(|(k, _)| !k.starts_with('_'))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            node.properties = serde_json::Value::Object(flat);
+            return;
+        }
+    }
+
+    let flat: serde_json::Map<String, serde_json::Value> = props_obj
+        .iter()
+        .filter(|(k, v)| !v.is_object() && !k.starts_with('_'))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    node.properties = serde_json::Value::Object(flat);
+}
+
+fn task_node_to_value(node: Node) -> Result<serde_json::Value, String> {
+    let task_props = node
+        .properties
+        .get("task")
+        .and_then(|v| v.as_object())
+        .map(|obj| serde_json::Value::Object(obj.clone()));
+    let props = task_props.as_ref().unwrap_or(&node.properties);
+
+    let status: TaskStatus = props
+        .get("status")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default();
+
+    let priority = props
+        .get("priority")
+        .and_then(|v| v.as_str())
+        .map(|s| TaskPriority::from_str(s).unwrap_or_default());
+
+    let due_date = props
+        .get("due_date")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    let assignee = props
+        .get("assignee_id")
+        .or_else(|| props.get("assignee"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let started_at = props
+        .get("started_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    let completed_at = props
+        .get("completed_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    let mut task_props_map = serde_json::Map::new();
+    task_props_map.insert("status".to_string(), serde_json::json!(status.as_str()));
+    if let Some(ref p) = priority {
+        task_props_map.insert("priority".to_string(), serde_json::json!(p.as_str()));
+    }
+    if let Some(ref d) = due_date {
+        task_props_map.insert("dueDate".to_string(), serde_json::json!(d.to_rfc3339()));
+    }
+    if let Some(ref a) = assignee {
+        task_props_map.insert("assignee".to_string(), serde_json::json!(a));
+    }
+    if let Some(ref s) = started_at {
+        task_props_map.insert("startedAt".to_string(), serde_json::json!(s.to_rfc3339()));
+    }
+    if let Some(ref c) = completed_at {
+        task_props_map.insert("completedAt".to_string(), serde_json::json!(c.to_rfc3339()));
+    }
+
+    let task_node = serde_json::json!({
+        "id": node.id,
+        "nodeType": node.node_type,
+        "content": node.content,
+        "version": node.version,
+        "createdAt": node.created_at,
+        "modifiedAt": node.modified_at,
+        "properties": task_props_map,
+        "lifecycleStatus": node.lifecycle_status,
+    });
+
+    Ok(task_node)
+}

--- a/packages/desktop-app/src-tauri/src/types.rs
+++ b/packages/desktop-app/src-tauri/src/types.rs
@@ -526,13 +526,40 @@ fn flatten_properties_for_api(node: &mut Node) {
     node.properties = serde_json::Value::Object(flat);
 }
 
+/// Local mirror of core's TaskNode — produces the flat top-level field shape
+/// the frontend TypeScript interface expects:
+/// { id, nodeType, content, version, ..., status, priority, dueDate, ... }
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskNode {
+    id: String,
+    #[serde(rename = "nodeType")]
+    node_type: String,
+    content: String,
+    #[serde(default = "default_version")]
+    version: i64,
+    created_at: DateTime<Utc>,
+    modified_at: DateTime<Utc>,
+    properties: serde_json::Value,
+    #[serde(default, skip_serializing_if = "is_active_lifecycle")]
+    lifecycle_status: String,
+    // Task-specific fields at top level (mirrors core TaskNode layout)
+    status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priority: Option<TaskPriority>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    due_date: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assignee: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completed_at: Option<DateTime<Utc>>,
+}
+
 fn task_node_to_value(node: Node) -> Result<serde_json::Value, String> {
-    let task_props = node
-        .properties
-        .get("task")
-        .and_then(|v| v.as_object())
-        .map(|obj| serde_json::Value::Object(obj.clone()));
-    let props = task_props.as_ref().unwrap_or(&node.properties);
+    // Properties are already flattened by flatten_properties_for_api before this call.
+    let props = &node.properties;
 
     let status: TaskStatus = props
         .get("status")
@@ -546,57 +573,49 @@ fn task_node_to_value(node: Node) -> Result<serde_json::Value, String> {
         .map(|s| TaskPriority::from_str(s).unwrap_or_default());
 
     let due_date = props
-        .get("due_date")
+        .get("dueDate")
+        .or_else(|| props.get("due_date"))
         .and_then(|v| v.as_str())
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc));
 
     let assignee = props
-        .get("assignee_id")
-        .or_else(|| props.get("assignee"))
+        .get("assignee")
+        .or_else(|| props.get("assignee_id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
     let started_at = props
-        .get("started_at")
+        .get("startedAt")
+        .or_else(|| props.get("started_at"))
         .and_then(|v| v.as_str())
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc));
 
     let completed_at = props
-        .get("completed_at")
+        .get("completedAt")
+        .or_else(|| props.get("completed_at"))
         .and_then(|v| v.as_str())
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc));
 
-    let mut task_props_map = serde_json::Map::new();
-    task_props_map.insert("status".to_string(), serde_json::json!(status.as_str()));
-    if let Some(ref p) = priority {
-        task_props_map.insert("priority".to_string(), serde_json::json!(p.as_str()));
-    }
-    if let Some(ref d) = due_date {
-        task_props_map.insert("dueDate".to_string(), serde_json::json!(d.to_rfc3339()));
-    }
-    if let Some(ref a) = assignee {
-        task_props_map.insert("assignee".to_string(), serde_json::json!(a));
-    }
-    if let Some(ref s) = started_at {
-        task_props_map.insert("startedAt".to_string(), serde_json::json!(s.to_rfc3339()));
-    }
-    if let Some(ref c) = completed_at {
-        task_props_map.insert("completedAt".to_string(), serde_json::json!(c.to_rfc3339()));
-    }
+    let lifecycle_status = node.lifecycle_status.clone();
+    let task = TaskNode {
+        id: node.id,
+        node_type: node.node_type,
+        content: node.content,
+        version: node.version,
+        created_at: node.created_at,
+        modified_at: node.modified_at,
+        properties: node.properties,
+        lifecycle_status,
+        status,
+        priority,
+        due_date,
+        assignee,
+        started_at,
+        completed_at,
+    };
 
-    let task_node = serde_json::json!({
-        "id": node.id,
-        "nodeType": node.node_type,
-        "content": node.content,
-        "version": node.version,
-        "createdAt": node.created_at,
-        "modifiedAt": node.modified_at,
-        "properties": task_props_map,
-        "lifecycleStatus": node.lifecycle_status,
-    });
-
-    Ok(task_node)
+    serde_json::to_value(&task).map_err(|e| format!("Failed to serialize task node: {}", e))
 }


### PR DESCRIPTION
## Summary

- Creates `packages/desktop-app/src-tauri/src/types.rs` with local mirror structs for all types previously imported from `nodespace_core` in the commands layer: `Node`, `NodeQuery`, `NodeUpdate`, `DeleteResult`, `NodeReference`, `TaskNodeUpdate`, `TaskStatus`, `TaskPriority`, `SchemaNode`, and supporting schema types
- Moves `node_to_typed_value`/`nodes_to_typed_values`/`flatten_properties_for_api` logic locally (previously called into `nodespace_core::models::*`)
- Removes all `use nodespace_core` imports from `commands/{nodes,collections,schemas,embeddings}.rs`
- Adds `pub mod types;` declaration to `lib.rs`

**Note on Cargo.toml**: The `nodespace-core` dep in `Cargo.toml` cannot yet be removed — `lib.rs` and `services/` still use `NodeService`, `SurrealStore`, `PlaybookEngine`, etc. for app initialization. That cleanup is a separate issue.

## Test plan

- [x] No `use nodespace_core` imports remain in `packages/desktop-app/src-tauri/src/commands/`
- [x] `cargo build -p nodespace-app` succeeds with no errors or warnings
- [x] `cargo clippy -p nodespace-app -- -D warnings` passes
- [x] `bun run test` passes (129 files, 3921 tests)
- [x] Frontend wire formats preserved (serde shapes identical to core originals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)