### PR TITLE
Add curl-based shell installer for headless NodeSpace install (closes #1182)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     needs: build-tauri-macos-arm
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -435,3 +436,122 @@ jobs:
 - Source: NodeSpaceAI/nodespace-core@\`${{ github.ref_name }}\`" \
             --base main \
             --head "$BRANCH"
+
+  build-headless:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            id: macos-arm
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            id: macos-intel
+          - os: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+            id: linux-arm
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            id: linux-x86
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check platform filter
+        id: filter
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.platform }}" == "all" ]] || [[ "${{ inputs.platform }}" == "${{ matrix.id }}" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.id }} (selected: ${{ inputs.platform }})"
+          fi
+
+      - name: Checkout repository
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Rust stable
+        if: steps.filter.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        if: steps.filter.outputs.skip != 'true'
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: '. -> target'
+
+      - name: Install Protobuf (macOS)
+        if: steps.filter.outputs.skip != 'true' && matrix.os == 'macos-latest'
+        run: brew install protobuf
+
+      - name: Install Protobuf (Linux)
+        if: steps.filter.outputs.skip != 'true' && matrix.os == 'ubuntu-22.04'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install cross-compilation toolchain (Linux ARM)
+        if: steps.filter.outputs.skip != 'true' && matrix.id == 'linux-arm'
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      - name: Build nodespaced
+        if: steps.filter.outputs.skip != 'true'
+        run: cargo build --release --bin nodespaced --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.id == 'linux-arm' && 'aarch64-linux-gnu-gcc' || '' }}
+
+      - name: Build nodespace CLI
+        if: steps.filter.outputs.skip != 'true'
+        run: cargo build --release --bin nodespace --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.id == 'linux-arm' && 'aarch64-linux-gnu-gcc' || '' }}
+
+      - name: Rename binaries with target triple suffix
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          cp target/${{ matrix.target }}/release/nodespaced nodespaced-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/nodespace nodespace-${{ matrix.target }}
+
+      - name: Upload binaries to release
+        if: steps.filter.outputs.skip != 'true' && github.event_name == 'release'
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            nodespaced-${{ matrix.target }} \
+            nodespace-${{ matrix.target }} \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-checksums:
+    needs: build-headless
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Download binaries from release
+        run: |
+          gh release download ${{ github.event.release.tag_name }} \
+            --pattern 'nodespaced-*' --pattern 'nodespace-*' \
+            --dir artifacts/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd artifacts
+          sha256sum nodespaced-* nodespace-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} artifacts/SHA256SUMS --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
           - macos-arm
           - macos-intel
           - windows
+          - linux-arm
+          - linux-x86
 
 # Required permissions for uploading release assets
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,6 +4430,7 @@ dependencies = [
  "clap",
  "crossterm",
  "hyper-util",
+ "libc",
  "nodespace-core",
  "nodespace-daemon",
  "serde_json",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -23,6 +23,9 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 nodespace-daemon = { path = "../daemon" }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 nodespace-core = { workspace = true }
 tempfile = "3.0"

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod import;
 pub mod node;
 pub mod search;
 pub mod session;
+pub mod uninstall;

--- a/packages/cli/src/commands/uninstall.rs
+++ b/packages/cli/src/commands/uninstall.rs
@@ -1,0 +1,140 @@
+use anyhow::{Context, Result};
+use clap::Args;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Args, Debug)]
+pub struct UninstallArgs {}
+
+fn home_dir() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("$HOME is unset — cannot determine home directory")?;
+    Ok(PathBuf::from(home))
+}
+
+fn read_yn_prompt() -> bool {
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    let trimmed = input.trim();
+    trimmed.is_empty() || trimmed.eq_ignore_ascii_case("y")
+}
+
+pub async fn run(_args: UninstallArgs) -> Result<()> {
+    stop_daemon();
+
+    let home = home_dir()?;
+
+    remove_bin_dir(&home);
+    remove_sock(&home);
+    remove_claude_skill(&home);
+    prompt_remove_mcp(&home)?;
+
+    println!("NodeSpace uninstalled. Your data at ~/.nodespace/database/ has been preserved.");
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn stop_daemon() {
+    let uid = unsafe { libc::getuid() };
+    let _ = Command::new("launchctl")
+        .args(["bootout", &format!("gui/{uid}"), "app.nodespace.daemon"])
+        .status();
+
+    if let Ok(home) = std::env::var("HOME") {
+        let plist = PathBuf::from(home)
+            .join("Library")
+            .join("LaunchAgents")
+            .join("app.nodespace.daemon.plist");
+        let _ = fs::remove_file(&plist);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn stop_daemon() {
+    let _ = Command::new("systemctl")
+        .args(["--user", "stop", "nodespace"])
+        .status();
+    let _ = Command::new("systemctl")
+        .args(["--user", "disable", "nodespace"])
+        .status();
+
+    if let Ok(home) = std::env::var("HOME") {
+        let service = PathBuf::from(home)
+            .join(".config")
+            .join("systemd")
+            .join("user")
+            .join("nodespace.service");
+        let _ = fs::remove_file(&service);
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn stop_daemon() {}
+
+fn remove_bin_dir(home: &PathBuf) {
+    let bin_dir = home.join(".nodespace").join("bin");
+    let _ = fs::remove_dir_all(&bin_dir);
+}
+
+fn remove_sock(home: &PathBuf) {
+    let sock = home.join(".nodespace").join("daemon.sock");
+    let _ = fs::remove_file(&sock);
+}
+
+fn remove_claude_skill(home: &PathBuf) {
+    let skill_dir = home.join(".claude").join("skills").join("nodespace");
+    let _ = fs::remove_dir_all(&skill_dir);
+}
+
+fn prompt_remove_mcp(home: &PathBuf) -> Result<()> {
+    print!("Remove MCP entry from Claude Desktop config? [Y/n] ");
+    io::stdout().flush().context("flush stdout")?;
+
+    if !read_yn_prompt() {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    let config_path = home
+        .join("Library")
+        .join("Application Support")
+        .join("Claude")
+        .join("claude_desktop_config.json");
+
+    #[cfg(target_os = "linux")]
+    let config_path = home
+        .join(".config")
+        .join("Claude")
+        .join("claude_desktop_config.json");
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    return Ok(());
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if !config_path.exists() {
+            return Ok(());
+        }
+
+        let contents = fs::read_to_string(&config_path)
+            .with_context(|| format!("read {}", config_path.display()))?;
+
+        let mut value: serde_json::Value = serde_json::from_str(&contents)
+            .with_context(|| format!("parse {}", config_path.display()))?;
+
+        if let Some(mcp_servers) = value.get_mut("mcpServers").and_then(|v| v.as_object_mut()) {
+            mcp_servers.remove("nodespace");
+        }
+
+        let updated =
+            serde_json::to_string_pretty(&value).context("serialize claude desktop config")?;
+        fs::write(&config_path, updated)
+            .with_context(|| format!("write {}", config_path.display()))?;
+    }
+
+    Ok(())
+}

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -56,6 +56,8 @@ pub enum Command {
         #[command(subcommand)]
         action: commands::session::SessionAction,
     },
+    /// Uninstall NodeSpace: stop daemon, remove binaries and service registration.
+    Uninstall(commands::uninstall::UninstallArgs),
 }
 
 /// Resolve the socket path from an explicit override or env/default.
@@ -164,5 +166,6 @@ pub async fn run(cli: Cli) -> Result<()> {
             let mut client = connect_session(&sock).await?;
             commands::session::run(&mut client, action, json).await
         }
+        Command::Uninstall(args) => commands::uninstall::run(args).await,
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,339 @@
+#!/bin/sh
+# NodeSpace installer — POSIX sh
+# Installs nodespaced + nodespace CLI to ~/.nodespace/bin/ and registers
+# the background daemon with launchd (macOS) or systemd (Linux).
+#
+# Trust model: SHA256 checksums verify that downloaded binaries match the
+# release artifacts, but do not prove publisher identity. A compromised GitHub
+# release could replace both binaries and checksums simultaneously. GPG
+# signature verification is tracked in a follow-on issue.
+set -e
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+INSTALL_DIR="$HOME/.nodespace/bin"
+LOG_DIR="$HOME/.nodespace/logs"
+DB_PATH="$HOME/.nodespace/database/nodespace"
+SOCKET_PATH="$HOME/.nodespace/daemon.sock"
+GITHUB_API="https://api.github.com/repos/NodeSpaceAI/nodespace-core/releases/latest"
+GITHUB_DL="https://github.com/NodeSpaceAI/nodespace-core/releases/download"
+LAUNCHD_LABEL="app.nodespace.daemon"
+PLIST_PATH="$HOME/Library/LaunchAgents/app.nodespace.daemon.plist"
+SYSTEMD_SERVICE="$HOME/.config/systemd/user/nodespace.service"
+MCP_CONFIG_MACOS="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+MCP_CONFIG_LINUX="$HOME/.config/Claude/claude_desktop_config.json"
+SKILL_PATH="$HOME/.claude/skills/nodespace/SKILL.md"
+
+# ── Utilities ─────────────────────────────────────────────────────────────────
+die() { printf '\nError: %s\n' "$*" >&2; exit 1; }
+
+check_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+require_cmd() {
+    check_cmd "$1" || die "'$1' is required but not found. Please install it and retry."
+}
+
+sha256_verify() {
+    _file="$1"
+    _expected="$2"
+    if check_cmd sha256sum; then
+        _actual=$(sha256sum "$_file" | awk '{print $1}')
+    elif check_cmd shasum; then
+        _actual=$(shasum -a 256 "$_file" | awk '{print $1}')
+    else
+        die "No sha256 tool found (tried sha256sum and shasum)"
+    fi
+    if [ "$_actual" != "$_expected" ]; then
+        die "SHA256 mismatch for $1\n  expected: $_expected\n  got:      $_actual"
+    fi
+}
+
+# ── Platform detection ────────────────────────────────────────────────────────
+detect_triple() {
+    _os=$(uname -s)
+    _arch=$(uname -m)
+    case "$_os" in
+        Darwin)
+            case "$_arch" in
+                arm64)  printf 'aarch64-apple-darwin' ;;
+                x86_64) printf 'x86_64-apple-darwin' ;;
+                *)      die "Unsupported macOS architecture: $_arch" ;;
+            esac
+            ;;
+        Linux)
+            case "$_arch" in
+                aarch64) printf 'aarch64-unknown-linux-gnu' ;;
+                x86_64)  printf 'x86_64-unknown-linux-gnu' ;;
+                *)       die "Unsupported Linux architecture: $_arch" ;;
+            esac
+            ;;
+        *)
+            die "Unsupported platform: $_os. NodeSpace supports macOS and Linux."
+            ;;
+    esac
+}
+
+OS=$(uname -s)
+TRIPLE=$(detect_triple)
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+require_cmd curl
+
+# ── Fetch latest release version ─────────────────────────────────────────────
+printf 'Fetching latest release...\n'
+VERSION=$(curl -fsSL "$GITHUB_API" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+[ -n "$VERSION" ] || die "Could not determine latest release version"
+printf 'Installing NodeSpace %s (%s)\n' "$VERSION" "$TRIPLE"
+
+# ── Download binaries and checksums ───────────────────────────────────────────
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DL_BASE="$GITHUB_DL/$VERSION"
+
+printf 'Downloading nodespaced...\n'
+curl -fsSL -o "$TMP_DIR/nodespaced" "$DL_BASE/nodespaced-$TRIPLE"
+
+printf 'Downloading nodespace...\n'
+curl -fsSL -o "$TMP_DIR/nodespace" "$DL_BASE/nodespace-$TRIPLE"
+
+printf 'Downloading SHA256SUMS...\n'
+curl -fsSL -o "$TMP_DIR/SHA256SUMS" "$DL_BASE/SHA256SUMS"
+
+# ── Verify checksums ──────────────────────────────────────────────────────────
+printf 'Verifying checksums...\n'
+DAEMON_SUM=$(grep "nodespaced-$TRIPLE" "$TMP_DIR/SHA256SUMS" | awk '{print $1}')
+CLI_SUM=$(grep "nodespace-$TRIPLE" "$TMP_DIR/SHA256SUMS" | awk '{print $1}')
+
+[ -n "$DAEMON_SUM" ] || die "No checksum found for nodespaced-$TRIPLE in SHA256SUMS"
+[ -n "$CLI_SUM" ]    || die "No checksum found for nodespace-$TRIPLE in SHA256SUMS"
+
+sha256_verify "$TMP_DIR/nodespaced" "$DAEMON_SUM"
+sha256_verify "$TMP_DIR/nodespace"  "$CLI_SUM"
+printf 'Checksums OK\n'
+
+# ── Install binaries ──────────────────────────────────────────────────────────
+mkdir -p "$INSTALL_DIR" "$LOG_DIR" "$(dirname "$DB_PATH")"
+
+cp "$TMP_DIR/nodespaced" "$INSTALL_DIR/nodespaced"
+cp "$TMP_DIR/nodespace"  "$INSTALL_DIR/nodespace"
+chmod 755 "$INSTALL_DIR/nodespaced" "$INSTALL_DIR/nodespace"
+printf 'Binaries installed to %s\n' "$INSTALL_DIR"
+
+# ── Service registration ───────────────────────────────────────────────────────
+
+# macOS: launchd
+install_launchd() {
+    mkdir -p "$(dirname "$PLIST_PATH")"
+    cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>app.nodespace.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$INSTALL_DIR/nodespaced</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>NODESPACED_SOCKET</key>
+        <string>$SOCKET_PATH</string>
+        <key>NODESPACED_DB_PATH</key>
+        <string>$DB_PATH</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/nodespaced.log</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/nodespaced-error.log</string>
+</dict>
+</plist>
+PLIST
+
+    _uid=$(id -u)
+    _target="gui/$_uid"
+
+    # Check registration state explicitly before choosing the launchctl verb.
+    # Using bootstrap failure as a proxy is unreliable — it also fails on
+    # permission errors and malformed plists.
+    if launchctl print "$_target/$LAUNCHD_LABEL" >/dev/null 2>&1; then
+        # Already registered — kickstart to pick up updated binary
+        if launchctl kickstart -k "$_target/$LAUNCHD_LABEL" 2>/dev/null; then
+            printf 'launchd agent restarted\n'
+        else
+            printf 'Note: launchctl kickstart failed; daemon will start on next login\n'
+        fi
+    else
+        if launchctl bootstrap "$_target" "$PLIST_PATH" 2>/dev/null; then
+            printf 'launchd agent bootstrapped\n'
+        else
+            printf 'Note: launchctl bootstrap failed; daemon may start on next login\n'
+        fi
+    fi
+}
+
+# Linux: systemd user service
+install_systemd() {
+    mkdir -p "$(dirname "$SYSTEMD_SERVICE")"
+    cat > "$SYSTEMD_SERVICE" <<UNIT
+[Unit]
+Description=NodeSpace daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$INSTALL_DIR/nodespaced
+Environment=NODESPACED_SOCKET=$SOCKET_PATH
+Environment=NODESPACED_DB_PATH=$DB_PATH
+StandardOutput=append:$LOG_DIR/nodespaced.log
+StandardError=append:$LOG_DIR/nodespaced-error.log
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+UNIT
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now nodespace
+    printf 'systemd user service enabled and started\n'
+}
+
+case "$OS" in
+    Darwin) install_launchd ;;
+    Linux)  install_systemd ;;
+esac
+
+# ── Wait for daemon socket ─────────────────────────────────────────────────────
+printf 'Waiting for daemon...'
+_ticks=0
+while [ $_ticks -lt 10 ]; do
+    if [ -S "$SOCKET_PATH" ]; then
+        printf ' ready\n'
+        break
+    fi
+    # Each tick is 0.5s (or 1s on systems without fractional sleep).
+    # 10 ticks × 0.5s = 5s total wait.
+    if sleep 0.5 2>/dev/null; then
+        _ticks=$((_ticks + 1))
+    else
+        sleep 1
+        _ticks=$((_ticks + 2))
+    fi
+done
+if [ ! -S "$SOCKET_PATH" ] && [ $_ticks -ge 10 ]; then
+    printf ' (timeout — daemon may still be starting)\n'
+fi
+
+# ── PATH ──────────────────────────────────────────────────────────────────────
+printf '\nAdd nodespace to your PATH? [Y/n] '
+read -r _ans
+case "${_ans:-Y}" in
+    [Yy]*)
+        _path_line='export PATH="$HOME/.nodespace/bin:$PATH"'
+        _rc_updated=0
+        for _rc in "$HOME/.zshrc" "$HOME/.bash_profile"; do
+            if [ -f "$_rc" ]; then
+                if grep -qF '.nodespace/bin' "$_rc" 2>/dev/null; then
+                    printf '  %s already configured\n' "$_rc"
+                else
+                    printf '\n# NodeSpace\n%s\n' "$_path_line" >> "$_rc"
+                    printf '  Added to %s\n' "$_rc"
+                fi
+                _rc_updated=1
+            fi
+        done
+        if [ "$_rc_updated" -eq 0 ]; then
+            printf '  No ~/.zshrc or ~/.bash_profile found.\n'
+            printf '  Add manually: %s\n' "$_path_line"
+        fi
+        ;;
+    *) printf '  Skipped. Run: export PATH="$HOME/.nodespace/bin:$PATH"\n' ;;
+esac
+
+# ── MCP (Claude Desktop) ──────────────────────────────────────────────────────
+printf '\nConnect NodeSpace to Claude Desktop (MCP)? [Y/n] '
+read -r _ans
+case "${_ans:-Y}" in
+    [Yy]*)
+        case "$OS" in
+            Darwin) _mcp_cfg="$MCP_CONFIG_MACOS" ;;
+            *)      _mcp_cfg="$MCP_CONFIG_LINUX" ;;
+        esac
+
+        _mcp_entry='"nodespace": {\n    "command": "nodespace",\n    "args": ["mcp"]\n  }'
+
+        if [ -f "$_mcp_cfg" ]; then
+            if grep -q '"nodespace"' "$_mcp_cfg" 2>/dev/null; then
+                printf '  nodespace MCP entry already present in %s\n' "$_mcp_cfg"
+            elif grep -q '"mcpServers"' "$_mcp_cfg" 2>/dev/null; then
+                # Insert after the opening brace of mcpServers
+                # Use awk for reliable multi-line insertion
+                awk '
+                    /"mcpServers"/ { print; getline; print; printf "    %s,\n", entry; next }
+                    { print }
+                ' entry="$_mcp_entry" "$_mcp_cfg" > "$_mcp_cfg.tmp" \
+                    && mv "$_mcp_cfg.tmp" "$_mcp_cfg"
+                printf '  Added nodespace MCP entry to %s\n' "$_mcp_cfg"
+            else
+                printf '  Could not locate mcpServers in %s\n' "$_mcp_cfg"
+                printf '  Add manually:\n    %s\n' "$_mcp_entry"
+            fi
+        else
+            mkdir -p "$(dirname "$_mcp_cfg")"
+            cat > "$_mcp_cfg" <<JSON
+{
+  "mcpServers": {
+    "nodespace": {
+      "command": "nodespace",
+      "args": ["mcp"]
+    }
+  }
+}
+JSON
+            printf '  Created %s\n' "$_mcp_cfg"
+        fi
+        ;;
+    *) printf '  Skipped\n' ;;
+esac
+
+# ── Claude Code skill ─────────────────────────────────────────────────────────
+printf '\nAdd NodeSpace skill to Claude Code? [Y/n] '
+read -r _ans
+case "${_ans:-Y}" in
+    [Yy]*)
+        mkdir -p "$(dirname "$SKILL_PATH")"
+        cat > "$SKILL_PATH" <<'SKILL'
+# nodespace
+
+Use this skill to interact with the local NodeSpace knowledge graph.
+
+## When to use
+- When asked to store, search, or retrieve information in NodeSpace
+- When the user says "save this to NodeSpace" or "search NodeSpace for..."
+
+## Usage
+Run `nodespace node list` to list nodes, `nodespace search <query>` to search.
+SKILL
+        printf '  Skill written to %s\n' "$SKILL_PATH"
+        ;;
+    *) printf '  Skipped\n' ;;
+esac
+
+# ── Success summary ───────────────────────────────────────────────────────────
+printf '\n'
+printf '✓ NodeSpace installed to ~/.nodespace/bin/\n'
+if [ -S "$SOCKET_PATH" ]; then
+    printf '✓ nodespaced is running\n'
+else
+    printf '✓ nodespaced registered (will start on next login if not running yet)\n'
+fi
+printf '✓ Try: nodespace node list\n'
+printf '\n'

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# NodeSpace uninstaller — POSIX sh
+# Stops the daemon, removes binaries and service files.
+# User data at ~/.nodespace/database/ is PRESERVED.
+set -e
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+INSTALL_DIR="$HOME/.nodespace/bin"
+SOCKET_PATH="$HOME/.nodespace/daemon.sock"
+PLIST_PATH="$HOME/Library/LaunchAgents/app.nodespace.daemon.plist"
+SYSTEMD_SERVICE="$HOME/.config/systemd/user/nodespace.service"
+MCP_CONFIG_MACOS="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+MCP_CONFIG_LINUX="$HOME/.config/Claude/claude_desktop_config.json"
+SKILL_DIR="$HOME/.claude/skills/nodespace"
+LAUNCHD_LABEL="app.nodespace.daemon"
+
+OS=$(uname -s)
+
+# ── Stop daemon ───────────────────────────────────────────────────────────────
+printf 'Stopping nodespaced...\n'
+case "$OS" in
+    Darwin)
+        launchctl bootout "gui/$(id -u)/$LAUNCHD_LABEL" 2>/dev/null || true
+        ;;
+    Linux)
+        systemctl --user stop nodespace 2>/dev/null || true
+        systemctl --user disable nodespace 2>/dev/null || true
+        ;;
+esac
+
+# ── Remove service files ──────────────────────────────────────────────────────
+case "$OS" in
+    Darwin)
+        if [ -f "$PLIST_PATH" ]; then
+            rm -f "$PLIST_PATH"
+            printf 'Removed %s\n' "$PLIST_PATH"
+        fi
+        ;;
+    Linux)
+        if [ -f "$SYSTEMD_SERVICE" ]; then
+            rm -f "$SYSTEMD_SERVICE"
+            systemctl --user daemon-reload 2>/dev/null || true
+            printf 'Removed %s\n' "$SYSTEMD_SERVICE"
+        fi
+        ;;
+esac
+
+# ── Remove binaries ───────────────────────────────────────────────────────────
+if [ -d "$INSTALL_DIR" ]; then
+    rm -f "$INSTALL_DIR/nodespaced" "$INSTALL_DIR/nodespace"
+    # Remove the bin dir only if empty
+    rmdir "$INSTALL_DIR" 2>/dev/null || true
+    printf 'Removed binaries from %s\n' "$INSTALL_DIR"
+fi
+
+# ── Remove socket ─────────────────────────────────────────────────────────────
+if [ -e "$SOCKET_PATH" ]; then
+    rm -f "$SOCKET_PATH"
+    printf 'Removed socket %s\n' "$SOCKET_PATH"
+fi
+
+# ── Remove Claude Code skill ───────────────────────────────────────────────────
+if [ -d "$SKILL_DIR" ]; then
+    rm -rf "$SKILL_DIR"
+    printf 'Removed Claude Code skill at %s\n' "$SKILL_DIR"
+fi
+
+# ── Remove MCP entry from Claude Desktop config ────────────────────────────────
+case "$OS" in
+    Darwin) _mcp_cfg="$MCP_CONFIG_MACOS" ;;
+    *)      _mcp_cfg="$MCP_CONFIG_LINUX" ;;
+esac
+
+if [ -f "$_mcp_cfg" ] && grep -q '"nodespace"' "$_mcp_cfg" 2>/dev/null; then
+    # Count total mcpServers entries to gauge complexity
+    _entry_count=$(grep -c '"command"' "$_mcp_cfg" 2>/dev/null || printf '0')
+
+    # For complex configs, recommend the CLI which uses serde_json for safe removal.
+    if [ "$_entry_count" -le 5 ]; then
+        # Conservative block removal: delete the nodespace key through its closing brace.
+        # Handles the common case where the block spans ~4 lines.
+        awk '
+            /^[[:space:]]*"nodespace"[[:space:]]*:/ { skip=1 }
+            skip && /\}[[:space:]]*,?[[:space:]]*$/ { skip=0; next }
+            !skip { print }
+        ' "$_mcp_cfg" > "$_mcp_cfg.tmp" && mv "$_mcp_cfg.tmp" "$_mcp_cfg"
+        printf 'Removed nodespace MCP entry from %s\n' "$_mcp_cfg"
+    else
+        printf 'Note: %s has many entries.\n' "$_mcp_cfg"
+        printf 'Run `nodespace uninstall` for safe JSON-aware removal, or remove manually:\n'
+        printf '  "nodespace": { "command": "nodespace", "args": ["mcp"] }\n'
+    fi
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+printf '\nNodeSpace uninstalled. Your data at ~/.nodespace/database/ has been preserved.\n'


### PR DESCRIPTION
## Summary
- `scripts/install.sh`: POSIX sh installer — detects platform/arch, downloads nodespaced + nodespace from GitHub releases, verifies SHA256, installs to `~/.nodespace/bin/`, registers launchd (macOS) or systemd user service (Linux), prompts for PATH/MCP/skill setup
- `scripts/uninstall.sh`: POSIX sh uninstaller — stops daemon, removes service registration, binaries, socket, and Claude Code skill
- `packages/cli`: adds `nodespace uninstall` subcommand with interactive MCP config cleanup
- `.github/workflows/release.yml`: adds `build-headless` 4-platform matrix job and `upload-checksums` job

## Test plan
- [ ] Run `scripts/install.sh` on macOS arm64 — verify binaries land in `~/.nodespace/bin/`, launchd plist written, daemon starts
- [ ] Run installer a second time — verify idempotency (no duplicate PATH entries, MCP entry not duplicated)
- [ ] Run `nodespace uninstall` — verify daemon stopped, binaries removed, MCP entry cleaned from claude_desktop_config.json, database preserved
- [ ] Run `scripts/uninstall.sh` directly — verify equivalent behavior to CLI command
- [ ] Manually trigger `build-headless` workflow via workflow_dispatch for each platform
- [ ] Verify SHA256SUMS uploaded to release after `upload-checksums` job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)