### PR TITLE
Add first-launch onboarding wizard for PATH, MCP, and skill setup (closes #1180)

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands/mod.rs
+++ b/packages/desktop-app/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod embeddings;
 pub mod import;
 pub mod local_agent;
 pub mod nodes;
+pub mod onboarding;
 pub mod schemas;
 pub mod settings;
 

--- a/packages/desktop-app/src-tauri/src/commands/onboarding.rs
+++ b/packages/desktop-app/src-tauri/src/commands/onboarding.rs
@@ -156,8 +156,12 @@ pub async fn configure_mcp() -> Result<(), String> {
         let raw = tokio::fs::read_to_string(&config_path)
             .await
             .map_err(|e| format!("Failed to read Claude Desktop config: {e}"))?;
-        serde_json::from_str(&raw)
-            .map_err(|e| format!("Claude Desktop config contains invalid JSON: {e}"))?
+        let parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| format!("Claude Desktop config contains invalid JSON: {e}"))?;
+        if !parsed.is_object() {
+            return Err("Claude Desktop config is not a JSON object".to_string());
+        }
+        parsed
     } else {
         serde_json::json!({})
     };

--- a/packages/desktop-app/src-tauri/src/commands/onboarding.rs
+++ b/packages/desktop-app/src-tauri/src/commands/onboarding.rs
@@ -1,0 +1,245 @@
+//! Onboarding wizard Tauri commands (Issue #1180).
+//!
+//! Handles first-launch setup: PATH configuration, MCP integration, and
+//! Claude Code skill installation. Completion state is persisted to
+//! `~/.nodespace/config.json`.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Current onboarding status returned to the frontend on startup.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingStatus {
+    pub completed: bool,
+    pub path_configured: bool,
+    pub mcp_configured: bool,
+    pub skill_configured: bool,
+    pub claude_desktop_detected: bool,
+    pub claude_code_detected: bool,
+    pub path_already_configured: bool,
+}
+
+/// Shape of `~/.nodespace/config.json` on disk.
+#[derive(Serialize, Deserialize, Default)]
+#[serde(default)]
+struct NodespaceConfig {
+    #[serde(default)]
+    onboarding_completed: bool,
+    #[serde(default)]
+    integrations: IntegrationsConfig,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(default)]
+struct IntegrationsConfig {
+    path_configured: bool,
+    mcp_configured: bool,
+    skill_configured: bool,
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn nodespace_config_path() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    Ok(home.join(".nodespace").join("config.json"))
+}
+
+async fn read_config() -> Result<NodespaceConfig, String> {
+    let path = nodespace_config_path()?;
+    if !path.exists() {
+        return Ok(NodespaceConfig::default());
+    }
+    let raw = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read config: {e}"))?;
+    serde_json::from_str(&raw).map_err(|e| format!("Failed to parse config: {e}"))
+}
+
+async fn write_config(cfg: &NodespaceConfig) -> Result<(), String> {
+    let path = nodespace_config_path()?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create ~/.nodespace dir: {e}"))?;
+    }
+    let serialized = serde_json::to_string_pretty(cfg)
+        .map_err(|e| format!("Failed to serialize config: {e}"))?;
+    tokio::fs::write(&path, serialized)
+        .await
+        .map_err(|e| format!("Failed to write config: {e}"))
+}
+
+/// Return true if the PATH export line is already present in the given file.
+async fn file_contains_nodespace_path(path: &PathBuf) -> bool {
+    match tokio::fs::read_to_string(path).await {
+        Ok(content) => content.contains("$HOME/.nodespace/bin"),
+        Err(_) => false,
+    }
+}
+
+/// Append `export PATH` line to a shell file if the file exists and the line
+/// is not already present.  Returns `true` if the file was modified.
+async fn append_path_to_file(path: &PathBuf) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    if file_contains_nodespace_path(path).await {
+        return Ok(false);
+    }
+    let line = "\n# NodeSpace CLI\nexport PATH=\"$HOME/.nodespace/bin:$PATH\"\n";
+    let mut content = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    content.push_str(line);
+    tokio::fs::write(path, content)
+        .await
+        .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+// ── commands ─────────────────────────────────────────────────────────────────
+
+/// Read persisted onboarding state and detect installed integrations.
+#[tauri::command]
+pub async fn check_onboarding_status() -> Result<OnboardingStatus, String> {
+    let cfg = read_config().await?;
+
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+
+    let claude_desktop_detected = home.join("Library/Application Support/Claude").exists();
+
+    let claude_code_detected = home.join(".claude").exists();
+
+    // Check whether the PATH export is already in any shell config.
+    let zshrc = home.join(".zshrc");
+    let bash_profile = home.join(".bash_profile");
+    let path_already_configured = file_contains_nodespace_path(&zshrc).await
+        || file_contains_nodespace_path(&bash_profile).await;
+
+    Ok(OnboardingStatus {
+        completed: cfg.onboarding_completed,
+        path_configured: cfg.integrations.path_configured,
+        mcp_configured: cfg.integrations.mcp_configured,
+        skill_configured: cfg.integrations.skill_configured,
+        claude_desktop_detected,
+        claude_code_detected,
+        path_already_configured,
+    })
+}
+
+/// Append the NodeSpace PATH export to `~/.zshrc` and/or `~/.bash_profile`
+/// (whichever exist). Idempotent — will not add the line if already present.
+#[tauri::command]
+pub async fn configure_path() -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+
+    append_path_to_file(&home.join(".zshrc")).await?;
+    append_path_to_file(&home.join(".bash_profile")).await?;
+
+    Ok(())
+}
+
+/// Merge the `nodespace` MCP server entry into Claude Desktop's config file.
+///
+/// Reads `~/Library/Application Support/Claude/claude_desktop_config.json`,
+/// sets `mcpServers.nodespace`, and writes back. Creates the file if absent.
+/// Returns an error if the existing JSON is malformed.
+#[tauri::command]
+pub async fn configure_mcp() -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let claude_dir = home.join("Library/Application Support/Claude");
+    let config_path = claude_dir.join("claude_desktop_config.json");
+
+    // Parse existing config or start with an empty object.
+    let mut root: serde_json::Value = if config_path.exists() {
+        let raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|e| format!("Failed to read Claude Desktop config: {e}"))?;
+        serde_json::from_str(&raw)
+            .map_err(|e| format!("Claude Desktop config contains invalid JSON: {e}"))?
+    } else {
+        serde_json::json!({})
+    };
+
+    // Ensure mcpServers key exists as an object.
+    if !root.get("mcpServers").map_or(false, |v| v.is_object()) {
+        root["mcpServers"] = serde_json::json!({});
+    }
+
+    root["mcpServers"]["nodespace"] = serde_json::json!({
+        "command": "nodespace",
+        "args": ["mcp"]
+    });
+
+    // Ensure target directory exists.
+    tokio::fs::create_dir_all(&claude_dir)
+        .await
+        .map_err(|e| format!("Failed to create Claude config directory: {e}"))?;
+
+    let serialized = serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("Failed to serialize MCP config: {e}"))?;
+
+    tokio::fs::write(&config_path, serialized)
+        .await
+        .map_err(|e| format!("Failed to write Claude Desktop config: {e}"))?;
+
+    Ok(())
+}
+
+const SKILL_MD_CONTENT: &str = r#"# NodeSpace Knowledge Graph
+
+NodeSpace is running locally with an MCP server at your disposal.
+
+## Available Tools
+
+Use `mcp__nodespace__*` tools to interact with the knowledge graph:
+- `mcp__nodespace__create_node` — Create a new node
+- `mcp__nodespace__get_node` — Retrieve a node by ID
+- `mcp__nodespace__update_node` — Update node content or properties
+- `mcp__nodespace__delete_node` — Delete a node
+- `mcp__nodespace__search_nodes` — Search nodes by content
+- `mcp__nodespace__get_children` — Get child nodes
+
+## When to Use
+
+- When the user asks to save, retrieve, or organize information
+- When capturing notes, tasks, or decisions from a coding session
+- When the user references their NodeSpace or knowledge graph
+"#;
+
+/// Write `SKILL.md` to `~/.claude/skills/nodespace/SKILL.md`.
+/// Creates parent directories as needed. Safe to call repeatedly.
+#[tauri::command]
+pub async fn configure_skill() -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let skill_dir = home.join(".claude").join("skills").join("nodespace");
+
+    tokio::fs::create_dir_all(&skill_dir)
+        .await
+        .map_err(|e| format!("Failed to create skill directory: {e}"))?;
+
+    tokio::fs::write(skill_dir.join("SKILL.md"), SKILL_MD_CONTENT)
+        .await
+        .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
+
+    Ok(())
+}
+
+/// Persist the onboarding completion state to `~/.nodespace/config.json`.
+#[tauri::command]
+pub async fn complete_onboarding(
+    path_configured: bool,
+    mcp_configured: bool,
+    skill_configured: bool,
+) -> Result<(), String> {
+    let cfg = NodespaceConfig {
+        onboarding_completed: true,
+        integrations: IntegrationsConfig {
+            path_configured,
+            mcp_configured,
+            skill_configured,
+        },
+    };
+    write_config(&cfg).await
+}

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -675,6 +675,12 @@ pub fn run() {
             commands::agent_session::terminate_session,
             commands::agent_session::list_sessions,
             commands::agent_session::check_agent_availability,
+            // First-launch onboarding wizard (Issue #1180)
+            commands::onboarding::check_onboarding_status,
+            commands::onboarding::configure_path,
+            commands::onboarding::configure_mcp,
+            commands::onboarding::configure_skill,
+            commands::onboarding::complete_onboarding,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -24,6 +24,7 @@
   import { TabPersistenceService } from '$lib/services/tab-persistence-service';
   import { createLogger } from '$lib/utils/logger';
   import { openUrl, isExternalUrl, isNodespaceUrl } from '$lib/utils/external-links';
+  import OnboardingWizard from '$lib/components/onboarding/onboarding-wizard.svelte';
 
   // Logger instance for AppShell component
   const log = createLogger('AppShell');
@@ -31,6 +32,9 @@
   // Daemon connectivity state (Issue #1179). Set to true when Tauri signals
   // that nodespaced could not be reached within 5 seconds of app launch.
   let daemonUnreachable = $state(false);
+
+  // First-launch onboarding wizard (Issue #1180).
+  let showOnboarding = $state(false);
 
   /**
    * Sets up MCP event listeners for real-time UI updates
@@ -193,6 +197,15 @@
           daemonUnreachable = false;
         }
       });
+
+      // Show first-launch onboarding wizard if setup has not been completed (Issue #1180).
+      invoke<{ completed: boolean }>('check_onboarding_status')
+        .then((status) => {
+          if (!status.completed) {
+            showOnboarding = true;
+          }
+        })
+        .catch((err) => log.debug('Could not check onboarding status:', err));
 
       unlistenMenu = listen('menu-toggle-sidebar', () => {
         toggleSidebar();
@@ -550,6 +563,9 @@
       <!-- Status Bar - shows import progress, etc. (pushes content up, not overlay) -->
       <StatusBar />
     </div>
+
+    <!-- First-launch onboarding wizard (Issue #1180) -->
+    <OnboardingWizard open={showOnboarding} onClose={() => (showOnboarding = false)} />
   </NodeServiceContext>
 </ThemeProvider>
 

--- a/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
+++ b/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
@@ -32,6 +32,7 @@
   let currentStep = $state<WizardStep>('path');
   let isLoading = $state(false);
   let stepSuccess = $state(false);
+  let stepError = $state<string | null>(null);
 
   // Which steps are active (some may be skipped if prerequisites missing)
   let showMcp = $state(false);
@@ -63,6 +64,7 @@
     if (idx !== -1 && idx < seq.length - 1) {
       currentStep = seq[idx + 1];
       stepSuccess = false;
+      stepError = null;
     }
   }
 
@@ -89,12 +91,14 @@
 
   async function handleConfigurePath() {
     isLoading = true;
+    stepError = null;
     try {
       await invoke('configure_path');
       pathDone = true;
       stepSuccess = true;
       log.info('PATH configured successfully');
     } catch (err) {
+      stepError = err instanceof Error ? err.message : String(err);
       log.error('Failed to configure PATH', err);
     } finally {
       isLoading = false;
@@ -103,12 +107,14 @@
 
   async function handleConfigureMcp() {
     isLoading = true;
+    stepError = null;
     try {
       await invoke('configure_mcp');
       mcpDone = true;
       stepSuccess = true;
       log.info('MCP configured successfully');
     } catch (err) {
+      stepError = err instanceof Error ? err.message : String(err);
       log.error('Failed to configure MCP', err);
     } finally {
       isLoading = false;
@@ -117,12 +123,14 @@
 
   async function handleConfigureSkill() {
     isLoading = true;
+    stepError = null;
     try {
       await invoke('configure_skill');
       skillDone = true;
       stepSuccess = true;
       log.info('Skill configured successfully');
     } catch (err) {
+      stepError = err instanceof Error ? err.message : String(err);
       log.error('Failed to configure skill', err);
     } finally {
       isLoading = false;
@@ -219,6 +227,9 @@
             <button class="primary-button" onclick={nextStep}>Next</button>
           </div>
         {:else}
+          {#if stepError}
+            <div class="error-banner">{stepError}</div>
+          {/if}
           <div class="step-actions">
             <button class="primary-button" onclick={handleConfigurePath} disabled={isLoading}>
               {isLoading ? 'Configuring…' : 'Add to PATH'}
@@ -247,6 +258,9 @@
             <button class="primary-button" onclick={nextStep}>Next</button>
           </div>
         {:else}
+          {#if stepError}
+            <div class="error-banner">{stepError}</div>
+          {/if}
           <div class="step-actions">
             <button class="primary-button" onclick={handleConfigureMcp} disabled={isLoading}>
               {isLoading ? 'Configuring…' : 'Connect Claude Desktop'}
@@ -274,6 +288,9 @@
             <button class="primary-button" onclick={nextStep}>Next</button>
           </div>
         {:else}
+          {#if stepError}
+            <div class="error-banner">{stepError}</div>
+          {/if}
           <div class="step-actions">
             <button class="primary-button" onclick={handleConfigureSkill} disabled={isLoading}>
               {isLoading ? 'Installing…' : 'Add Skill'}
@@ -489,6 +506,17 @@
     color: hsl(var(--muted-foreground));
     background: hsl(var(--muted) / 0.5);
     border: 1px solid hsl(var(--border));
+    border-radius: 0.375rem;
+    padding: 0.625rem 0.875rem;
+    margin-bottom: 1.25rem;
+    line-height: 1.5;
+  }
+
+  .error-banner {
+    font-size: 0.875rem;
+    color: hsl(var(--destructive-foreground));
+    background: hsl(var(--destructive) / 0.1);
+    border: 1px solid hsl(var(--destructive) / 0.3);
     border-radius: 0.375rem;
     padding: 0.625rem 0.875rem;
     margin-bottom: 1.25rem;

--- a/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
+++ b/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
@@ -1,0 +1,592 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { invoke } from '@tauri-apps/api/core';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('OnboardingWizard');
+
+  let {
+    open = false,
+    onClose,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  } = $props();
+
+  // ── types ──────────────────────────────────────────────────────────────────
+
+  type WizardStep = 'path' | 'mcp' | 'skill' | 'summary';
+
+  interface OnboardingStatus {
+    completed: boolean;
+    pathConfigured: boolean;
+    mcpConfigured: boolean;
+    skillConfigured: boolean;
+    claudeDesktopDetected: boolean;
+    claudeCodeDetected: boolean;
+    pathAlreadyConfigured: boolean;
+  }
+
+  // ── state ──────────────────────────────────────────────────────────────────
+
+  let currentStep = $state<WizardStep>('path');
+  let isLoading = $state(false);
+  let stepSuccess = $state(false);
+
+  // Which steps are active (some may be skipped if prerequisites missing)
+  let showMcp = $state(false);
+  let showSkill = $state(false);
+
+  // What was actually configured (for summary)
+  let pathDone = $state(false);
+  let mcpDone = $state(false);
+  let skillDone = $state(false);
+
+  // Whether the PATH export was already present before we ran
+  let pathWasAlreadyConfigured = $state(false);
+
+  // ── derived step sequence ──────────────────────────────────────────────────
+
+  const stepSequence = $derived(
+    (() => {
+      const steps: WizardStep[] = ['path'];
+      if (showMcp) steps.push('mcp');
+      if (showSkill) steps.push('skill');
+      steps.push('summary');
+      return steps;
+    })()
+  );
+
+  function nextStep() {
+    const seq = stepSequence;
+    const idx = seq.indexOf(currentStep);
+    if (idx !== -1 && idx < seq.length - 1) {
+      currentStep = seq[idx + 1];
+      stepSuccess = false;
+    }
+  }
+
+  // ── mount: probe environment ───────────────────────────────────────────────
+
+  onMount(() => {
+    invoke<OnboardingStatus>('check_onboarding_status')
+      .then((status) => {
+        showMcp = status.claudeDesktopDetected;
+        showSkill = status.claudeCodeDetected;
+        pathWasAlreadyConfigured = status.pathAlreadyConfigured;
+        log.debug('Onboarding status loaded', {
+          showMcp,
+          showSkill,
+          pathAlreadyConfigured: status.pathAlreadyConfigured,
+        });
+      })
+      .catch((err) => {
+        log.warn('Could not load onboarding status', err);
+      });
+  });
+
+  // ── step actions ───────────────────────────────────────────────────────────
+
+  async function handleConfigurePath() {
+    isLoading = true;
+    try {
+      await invoke('configure_path');
+      pathDone = true;
+      stepSuccess = true;
+      log.info('PATH configured successfully');
+    } catch (err) {
+      log.error('Failed to configure PATH', err);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  async function handleConfigureMcp() {
+    isLoading = true;
+    try {
+      await invoke('configure_mcp');
+      mcpDone = true;
+      stepSuccess = true;
+      log.info('MCP configured successfully');
+    } catch (err) {
+      log.error('Failed to configure MCP', err);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  async function handleConfigureSkill() {
+    isLoading = true;
+    try {
+      await invoke('configure_skill');
+      skillDone = true;
+      stepSuccess = true;
+      log.info('Skill configured successfully');
+    } catch (err) {
+      log.error('Failed to configure skill', err);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  function skipCurrentStep() {
+    log.debug('Skipped step', { step: currentStep });
+    nextStep();
+  }
+
+  async function finishWizard() {
+    try {
+      await invoke('complete_onboarding', {
+        pathConfigured: pathDone,
+        mcpConfigured: mcpDone,
+        skillConfigured: skillDone,
+      });
+      log.info('Onboarding completed', { pathDone, mcpDone, skillDone });
+    } catch (err) {
+      log.warn('Could not persist onboarding completion', err);
+    }
+    onClose();
+  }
+
+  // ── dialog keyboard / backdrop ─────────────────────────────────────────────
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      onClose();
+    }
+  }
+</script>
+
+{#if open}
+  <div
+    class="onboarding-backdrop"
+    onclick={handleBackdropClick}
+    onkeydown={handleKeydown}
+    role="dialog"
+    aria-modal="true"
+    aria-label="First-launch setup"
+    tabindex="-1"
+  >
+    <div class="onboarding-dialog">
+      <!-- Close button -->
+      <button class="close-button" onclick={onClose} aria-label="Close dialog">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      <!-- Step indicator -->
+      <div class="step-indicator" aria-hidden="true">
+        {#each stepSequence as step (step)}
+          <span
+            class="step-dot"
+            class:active={currentStep === step}
+            class:done={stepSequence.indexOf(step) < stepSequence.indexOf(currentStep)}
+          ></span>
+        {/each}
+      </div>
+
+      <!-- ── PATH step ──────────────────────────────────────────────────── -->
+      {#if currentStep === 'path'}
+        <div class="onboarding-header">
+          <h2>Add NodeSpace to your terminal?</h2>
+          <p>
+            Adds <code>~/.nodespace/bin</code> to your <code>PATH</code> so you can run
+            <code>nodespace</code> from any terminal.
+          </p>
+        </div>
+
+        {#if pathWasAlreadyConfigured}
+          <div class="info-banner">
+            Already configured — your shell profile already includes the NodeSpace path.
+          </div>
+          <div class="step-actions">
+            <button class="primary-button" onclick={nextStep}>Next</button>
+          </div>
+        {:else if stepSuccess}
+          <div class="success-banner">
+            Added to <code>~/.zshrc</code> and/or <code>~/.bash_profile</code>. Open a new terminal
+            to apply.
+          </div>
+          <div class="step-actions">
+            <button class="primary-button" onclick={nextStep}>Next</button>
+          </div>
+        {:else}
+          <div class="step-actions">
+            <button class="primary-button" onclick={handleConfigurePath} disabled={isLoading}>
+              {isLoading ? 'Configuring…' : 'Add to PATH'}
+            </button>
+            <button class="skip-button" onclick={skipCurrentStep} disabled={isLoading}>Skip</button>
+          </div>
+        {/if}
+      {/if}
+
+      <!-- ── MCP step ───────────────────────────────────────────────────── -->
+      {#if currentStep === 'mcp'}
+        <div class="onboarding-header">
+          <h2>Connect NodeSpace to Claude?</h2>
+          <p>
+            Registers NodeSpace as an MCP server in Claude Desktop so Claude can read and write
+            your knowledge graph directly.
+          </p>
+        </div>
+
+        {#if stepSuccess}
+          <div class="success-banner">
+            NodeSpace added to <code>claude_desktop_config.json</code>. Restart Claude Desktop to
+            activate.
+          </div>
+          <div class="step-actions">
+            <button class="primary-button" onclick={nextStep}>Next</button>
+          </div>
+        {:else}
+          <div class="step-actions">
+            <button class="primary-button" onclick={handleConfigureMcp} disabled={isLoading}>
+              {isLoading ? 'Configuring…' : 'Connect Claude Desktop'}
+            </button>
+            <button class="skip-button" onclick={skipCurrentStep} disabled={isLoading}>Skip</button>
+          </div>
+        {/if}
+      {/if}
+
+      <!-- ── Skill step ─────────────────────────────────────────────────── -->
+      {#if currentStep === 'skill'}
+        <div class="onboarding-header">
+          <h2>Add NodeSpace to Claude Code?</h2>
+          <p>
+            Installs a skill file at <code>~/.claude/skills/nodespace/SKILL.md</code> so Claude
+            Code knows how to interact with your knowledge graph.
+          </p>
+        </div>
+
+        {#if stepSuccess}
+          <div class="success-banner">
+            Skill file written. Claude Code will pick it up automatically on the next session.
+          </div>
+          <div class="step-actions">
+            <button class="primary-button" onclick={nextStep}>Next</button>
+          </div>
+        {:else}
+          <div class="step-actions">
+            <button class="primary-button" onclick={handleConfigureSkill} disabled={isLoading}>
+              {isLoading ? 'Installing…' : 'Add Skill'}
+            </button>
+            <button class="skip-button" onclick={skipCurrentStep} disabled={isLoading}>Skip</button>
+          </div>
+        {/if}
+      {/if}
+
+      <!-- ── Summary step ───────────────────────────────────────────────── -->
+      {#if currentStep === 'summary'}
+        <div class="onboarding-header">
+          <h2>You're all set!</h2>
+          <p>Here's a summary of what was configured.</p>
+        </div>
+
+        <ul class="summary-list">
+          <li class:configured={pathDone || pathWasAlreadyConfigured} class:skipped={!pathDone && !pathWasAlreadyConfigured}>
+            <span class="summary-icon">
+              {#if pathDone || pathWasAlreadyConfigured}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              {:else}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              {/if}
+            </span>
+            <span>
+              Terminal PATH
+              {#if pathWasAlreadyConfigured && !pathDone}
+                <span class="summary-note">(already configured)</span>
+              {:else if !pathDone}
+                <span class="summary-note">(skipped)</span>
+              {/if}
+            </span>
+          </li>
+
+          {#if showMcp}
+            <li class:configured={mcpDone} class:skipped={!mcpDone}>
+              <span class="summary-icon">
+                {#if mcpDone}
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                {:else}
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                {/if}
+              </span>
+              <span>
+                Claude Desktop MCP
+                {#if !mcpDone}<span class="summary-note">(skipped)</span>{/if}
+              </span>
+            </li>
+          {/if}
+
+          {#if showSkill}
+            <li class:configured={skillDone} class:skipped={!skillDone}>
+              <span class="summary-icon">
+                {#if skillDone}
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                {:else}
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="14" height="14">
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                {/if}
+              </span>
+              <span>
+                Claude Code skill
+                {#if !skillDone}<span class="summary-note">(skipped)</span>{/if}
+              </span>
+            </li>
+          {/if}
+        </ul>
+
+        <p class="settings-hint">
+          You can revisit these integrations at any time in
+          <strong>Settings &rarr; Integrations</strong>.
+        </p>
+
+        <div class="step-actions">
+          <button class="primary-button" onclick={finishWizard}>Open NodeSpace</button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .onboarding-backdrop {
+    position: fixed;
+    inset: 0;
+    background: hsl(0 0% 0% / 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+    padding: 1rem;
+  }
+
+  .onboarding-dialog {
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.75rem;
+    padding: 2rem;
+    max-width: 30rem;
+    width: 100%;
+    position: relative;
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 12px 40px hsl(0 0% 0% / 0.15);
+  }
+
+  .close-button {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .close-button:hover {
+    color: hsl(var(--foreground));
+  }
+
+  /* Step dots */
+  .step-indicator {
+    display: flex;
+    gap: 0.375rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .step-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(var(--muted-foreground) / 0.3);
+    transition: background 0.15s;
+  }
+
+  .step-dot.active {
+    background: hsl(var(--primary));
+    width: 18px;
+    border-radius: 3px;
+  }
+
+  .step-dot.done {
+    background: hsl(var(--primary) / 0.5);
+  }
+
+  /* Header */
+  .onboarding-header {
+    margin-bottom: 1.5rem;
+  }
+
+  .onboarding-header h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.375rem;
+    color: hsl(var(--foreground));
+  }
+
+  .onboarding-header p {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .onboarding-header code {
+    font-size: 0.8125rem;
+    background: hsl(var(--muted));
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    color: hsl(var(--foreground));
+  }
+
+  /* Banners */
+  .success-banner {
+    font-size: 0.875rem;
+    color: hsl(142 76% 30%);
+    background: hsl(142 76% 36% / 0.1);
+    border: 1px solid hsl(142 76% 36% / 0.25);
+    border-radius: 0.375rem;
+    padding: 0.625rem 0.875rem;
+    margin-bottom: 1.25rem;
+    line-height: 1.5;
+  }
+
+  .success-banner code {
+    font-size: 0.8125rem;
+    background: hsl(142 76% 36% / 0.12);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+
+  .info-banner {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--muted) / 0.5);
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.375rem;
+    padding: 0.625rem 0.875rem;
+    margin-bottom: 1.25rem;
+    line-height: 1.5;
+  }
+
+  /* Actions */
+  .step-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .primary-button {
+    padding: 0.5rem 1.25rem;
+    border-radius: 0.375rem;
+    border: none;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .primary-button:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .primary-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .skip-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    padding: 0.5rem 0.25rem;
+  }
+
+  .skip-button:hover:not(:disabled) {
+    color: hsl(var(--foreground));
+  }
+
+  .skip-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Summary */
+  .summary-list {
+    list-style: none;
+    margin: 0 0 1.25rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .summary-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .summary-list li.configured {
+    color: hsl(var(--foreground));
+  }
+
+  .summary-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .summary-list li.configured .summary-icon {
+    color: hsl(142 76% 36%);
+  }
+
+  .summary-list li.skipped .summary-icon {
+    color: hsl(var(--muted-foreground) / 0.5);
+  }
+
+  .summary-note {
+    font-size: 0.8125rem;
+    color: hsl(var(--muted-foreground));
+    margin-left: 0.25rem;
+  }
+
+  .settings-hint {
+    font-size: 0.8125rem;
+    color: hsl(var(--muted-foreground));
+    margin: 0 0 1.5rem;
+    line-height: 1.5;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Shows a one-time modal wizard after first launch (once daemon is confirmed healthy), prompting setup of three integrations: terminal PATH, Claude Desktop MCP, and Claude Code skill
- Each step is opt-in with primary action + Skip; skipped/completed steps recorded in `~/.nodespace/config.json`
- MCP and Skill steps only shown when their prerequisites are detected (`~/Library/Application Support/Claude/` and `~/.claude/` respectively)
- All three actions are idempotent — safe to re-run from Settings later (issue #1181)
- Summary screen shows what was configured vs skipped

## Test plan

- [ ] Fresh launch with no `~/.nodespace/config.json` → wizard appears
- [ ] Complete wizard → `config.json` written with `onboarding_completed: true`; wizard never shows again
- [ ] PATH step appends export line to `~/.zshrc` / `~/.bash_profile`; idempotent on repeat
- [ ] MCP step merges nodespace entry without clobbering other `mcpServers` entries
- [ ] Skill step writes `~/.claude/skills/nodespace/SKILL.md`
- [ ] MCP step hidden when `~/Library/Application Support/Claude/` absent
- [ ] Skill step hidden when `~/.claude/` absent
- [ ] Action failure shows inline error banner (e.g. permissions error)
- [ ] `bun run test` — no new failures vs baseline (4 failed / 125 passed)
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)