### PR TITLE
Normalize RelationshipEvent.from_id / to_id to node:<id>

### DIFF
--- a/packages/core/src/db/events.rs
+++ b/packages/core/src/db/events.rs
@@ -61,15 +61,14 @@ pub struct RelationshipEvent {
 }
 
 impl RelationshipEvent {
-    /// Construct an event with `from_id` / `to_id` normalized to
-    /// `node:<id>` form. Callers in `NodeService` hold raw node ids
-    /// (e.g. `"2026-05-20"` for date pages, bare UUIDs for normal
-    /// nodes) and the contract for `RelationshipEvent` requires the
-    /// table-prefixed `<table>:<key>` form (see the serialization
-    /// contract test below). Downstream consumers parse on `:` and
-    /// reject bare ids — most notably the Pro sync push consumer's
-    /// `parse_node_thing`, which gets bare date-page ids today and
-    /// fails the cloud RELATE.
+    /// Construct an event with `from_id` / `to_id` normalized to the
+    /// full SurrealDB Thing form (`node:<key>`). Required by the
+    /// serialization-contract test below — every consumer that
+    /// parses these fields splits on `:` and rejects bare ids.
+    /// Callers in `NodeService` often hold bare ids (date-page
+    /// nodes use `"2026-05-20"`, regular nodes use bare UUIDs), so
+    /// this constructor is the single normalization point producers
+    /// should go through.
     pub fn new(
         id: String,
         from_id: &str,
@@ -89,7 +88,10 @@ impl RelationshipEvent {
 
 /// Normalize a node id to its full SurrealDB Thing form
 /// (`node:<key>`). Pass-through if the input already contains `:`.
-fn node_thing(id: &str) -> String {
+/// `pub(crate)` so the `RelationshipDeleted` inline-field variant
+/// can use the same normalization at its emit sites in
+/// `services::node_service` without duplicating the helper.
+pub(crate) fn node_thing(id: &str) -> String {
     if id.contains(':') {
         id.to_string()
     } else {
@@ -221,6 +223,38 @@ pub enum DomainEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Locks in the `node_thing` normalizer contract: bare ids (date
+    /// pages, raw UUIDs) get prefixed; anything already containing
+    /// `:` passes through unchanged. The producer-side
+    /// `RelationshipEvent::new` and the
+    /// `RelationshipDeleted`-emit-sites both rely on this shape.
+    #[test]
+    fn node_thing_normalizes_bare_ids_and_passes_through_prefixed() {
+        assert_eq!(node_thing("2026-05-20"), "node:2026-05-20");
+        assert_eq!(node_thing("some-uuid"), "node:some-uuid");
+        assert_eq!(node_thing("node:already-prefixed"), "node:already-prefixed");
+        // Edge case: any `:` makes it pass-through, even foreign
+        // tables. Producers are expected to pass ids in the
+        // `<table>:<key>` form when crossing table boundaries.
+        assert_eq!(node_thing("relationship:abc"), "relationship:abc");
+    }
+
+    /// `RelationshipEvent::new` normalizes both endpoint ids through
+    /// `node_thing`. Locks the contract so producers can pass bare
+    /// ids and rely on the constructor for the prefix.
+    #[test]
+    fn relationship_event_new_normalizes_both_endpoints() {
+        let rel = RelationshipEvent::new(
+            "relationship:abc:def".to_string(),
+            "abc",
+            "def",
+            "has_child",
+            serde_json::json!({"order": 1.0}),
+        );
+        assert_eq!(rel.from_id, "node:abc");
+        assert_eq!(rel.to_id, "node:def");
+    }
 
     /// Contract test: Documents and enforces the exact JSON format for RelationshipEvent (Issue #811)
     ///

--- a/packages/core/src/db/events.rs
+++ b/packages/core/src/db/events.rs
@@ -60,6 +60,43 @@ pub struct RelationshipEvent {
     pub properties: serde_json::Value,
 }
 
+impl RelationshipEvent {
+    /// Construct an event with `from_id` / `to_id` normalized to
+    /// `node:<id>` form. Callers in `NodeService` hold raw node ids
+    /// (e.g. `"2026-05-20"` for date pages, bare UUIDs for normal
+    /// nodes) and the contract for `RelationshipEvent` requires the
+    /// table-prefixed `<table>:<key>` form (see the serialization
+    /// contract test below). Downstream consumers parse on `:` and
+    /// reject bare ids — most notably the Pro sync push consumer's
+    /// `parse_node_thing`, which gets bare date-page ids today and
+    /// fails the cloud RELATE.
+    pub fn new(
+        id: String,
+        from_id: &str,
+        to_id: &str,
+        relationship_type: impl Into<String>,
+        properties: serde_json::Value,
+    ) -> Self {
+        Self {
+            id,
+            from_id: node_thing(from_id),
+            to_id: node_thing(to_id),
+            relationship_type: relationship_type.into(),
+            properties,
+        }
+    }
+}
+
+/// Normalize a node id to its full SurrealDB Thing form
+/// (`node:<key>`). Pass-through if the input already contains `:`.
+fn node_thing(id: &str) -> String {
+    if id.contains(':') {
+        id.to_string()
+    } else {
+        format!("node:{id}")
+    }
+}
+
 /// Describes a single property change for playbook trigger matching (Issue #995)
 ///
 /// Computed by diffing pre-mutation and post-mutation node properties.

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -825,7 +825,16 @@ impl NodeService {
                     },
                 };
 
-                // Send to broadcast channel (ignore if no subscribers)
+                // Send to broadcast channel (ignore if no subscribers).
+                // Trace each emission so duplicate-CREATE investigations
+                // (see Pro sync demo: same node id arrived 3× at the push
+                // consumer) can grep the daemon log and tell whether the
+                // dup originates here or downstream of the receiver.
+                tracing::debug!(
+                    op = ?envelope.event,
+                    source = ?envelope.metadata.source_client_id,
+                    "broadcast emit"
+                );
                 let _ = tx.send(envelope);
             });
 
@@ -2398,13 +2407,13 @@ impl NodeService {
         // Emit event if relationship was created (not already existing)
         if let Some(rel_id) = relationship_id {
             self.emit_event(DomainEvent::RelationshipCreated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: rel_id,
-                    from_id: mentioning_node_id.to_string(),
-                    to_id: mentioned_node_id.to_string(),
-                    relationship_type: "mentions".to_string(),
-                    properties: serde_json::json!({}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    rel_id,
+                    mentioning_node_id,
+                    mentioned_node_id,
+                    "mentions",
+                    serde_json::json!({}),
+                ),
             });
         }
 
@@ -4313,13 +4322,13 @@ impl NodeService {
         // Emit RelationshipUpdated event (Issue #811: unified relationship events)
         if let Some(parent_id) = new_parent {
             self.emit_event(DomainEvent::RelationshipUpdated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: format!("relationship:{}:{}", parent_id, node_id),
-                    from_id: parent_id.to_string(),
-                    to_id: node_id.to_string(),
-                    relationship_type: "has_child".to_string(),
-                    properties: serde_json::json!({"order": actual_order}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    format!("relationship:{}:{}", parent_id, node_id),
+                    parent_id,
+                    node_id,
+                    "has_child",
+                    serde_json::json!({"order": actual_order}),
+                ),
             });
         }
 
@@ -4420,13 +4429,13 @@ impl NodeService {
         // Emit RelationshipUpdated event (Issue #811: unified relationship events)
         if let Some(parent_id) = new_parent {
             self.emit_event(DomainEvent::RelationshipUpdated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: format!("relationship:{}:{}", parent_id, node_id),
-                    from_id: parent_id.to_string(),
-                    to_id: node_id.to_string(),
-                    relationship_type: "has_child".to_string(),
-                    properties: serde_json::json!({"order": actual_order}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    format!("relationship:{}:{}", parent_id, node_id),
+                    parent_id,
+                    node_id,
+                    "has_child",
+                    serde_json::json!({"order": actual_order}),
+                ),
             });
         }
 
@@ -4690,13 +4699,13 @@ impl NodeService {
             start.elapsed().as_millis()
         );
         self.emit_event(DomainEvent::RelationshipCreated {
-            relationship: crate::db::events::RelationshipEvent {
-                id: format!("relationship:{}:{}", parent_id, child_id),
-                from_id: parent_id.to_string(),
-                to_id: child_id.to_string(),
-                relationship_type: "has_child".to_string(),
-                properties: serde_json::json!({"order": actual_order}),
-            },
+            relationship: crate::db::events::RelationshipEvent::new(
+                format!("relationship:{}:{}", parent_id, child_id),
+                parent_id,
+                child_id,
+                "has_child",
+                serde_json::json!({"order": actual_order}),
+            ),
         });
 
         tracing::debug!(
@@ -4772,13 +4781,13 @@ impl NodeService {
         // Reordering updates the hierarchy edge's order field
         if let Some(ref parent_id) = parent_id {
             self.emit_event(DomainEvent::RelationshipUpdated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: format!("relationship:{}:{}", parent_id, node_id),
-                    from_id: parent_id.clone(),
-                    to_id: node_id.to_string(),
-                    relationship_type: "has_child".to_string(),
-                    properties: serde_json::json!({"order": actual_order}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    format!("relationship:{}:{}", parent_id, node_id),
+                    parent_id,
+                    node_id,
+                    "has_child",
+                    serde_json::json!({"order": actual_order}),
+                ),
             });
         }
 
@@ -5869,13 +5878,13 @@ impl NodeService {
 
             // Emit RelationshipUpdated event (Issue #811: unified relationship events)
             self.emit_event(DomainEvent::RelationshipUpdated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: format!("relationship:{}:{}", parent_id, node_id),
-                    from_id: parent_id.to_string(),
-                    to_id: node_id.to_string(),
-                    relationship_type: "has_child".to_string(),
-                    properties: serde_json::json!({"order": actual_order}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    format!("relationship:{}:{}", parent_id, node_id),
+                    parent_id,
+                    node_id,
+                    "has_child",
+                    serde_json::json!({"order": actual_order}),
+                ),
             });
         } else {
             // Create new node
@@ -5912,13 +5921,13 @@ impl NodeService {
 
             // Emit RelationshipCreated event (Issue #811: unified relationship events)
             self.emit_event(DomainEvent::RelationshipCreated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: format!("relationship:{}:{}", parent_id, node_id),
-                    from_id: parent_id.to_string(),
-                    to_id: node_id.to_string(),
-                    relationship_type: "has_child".to_string(),
-                    properties: serde_json::json!({"order": actual_order}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    format!("relationship:{}:{}", parent_id, node_id),
+                    parent_id,
+                    node_id,
+                    "has_child",
+                    serde_json::json!({"order": actual_order}),
+                ),
             });
         }
 
@@ -6023,13 +6032,13 @@ impl NodeService {
         // Emit event if relationship was created (not already existing)
         if let Some(rel_id) = relationship_id {
             self.emit_event(DomainEvent::RelationshipCreated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: rel_id,
-                    from_id: source_id.to_string(),
-                    to_id: target_id.to_string(),
-                    relationship_type: "mentions".to_string(),
-                    properties: serde_json::json!({}),
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    rel_id,
+                    source_id,
+                    target_id,
+                    "mentions",
+                    serde_json::json!({}),
+                ),
             });
         }
 
@@ -6403,13 +6412,13 @@ impl NodeService {
                     let order = order_result.first().and_then(|r| r.order).unwrap_or(1.0);
 
                     self.emit_event(DomainEvent::RelationshipCreated {
-                        relationship: crate::db::events::RelationshipEvent {
+                        relationship: crate::db::events::RelationshipEvent::new(
                             id,
-                            from_id: source_id.to_string(),
-                            to_id: target_id.to_string(),
-                            relationship_type: "member_of".to_string(),
-                            properties: json!({"order": order}),
-                        },
+                            source_id,
+                            target_id,
+                            "member_of",
+                            json!({"order": order}),
+                        ),
                     });
                 }
                 return Ok(());
@@ -6508,13 +6517,13 @@ impl NodeService {
 
         if let Some(rel_result) = results.first() {
             self.emit_event(DomainEvent::RelationshipCreated {
-                relationship: crate::db::events::RelationshipEvent {
-                    id: extract_record_id_string(&rel_result.id),
-                    from_id: source_id.to_string(),
-                    to_id: target_id.to_string(),
-                    relationship_type: relationship_name.to_string(),
-                    properties: final_edge_data,
-                },
+                relationship: crate::db::events::RelationshipEvent::new(
+                    extract_record_id_string(&rel_result.id),
+                    source_id,
+                    target_id,
+                    relationship_name,
+                    final_edge_data,
+                ),
             });
         }
 

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -826,15 +826,6 @@ impl NodeService {
                 };
 
                 // Send to broadcast channel (ignore if no subscribers).
-                // Trace each emission so duplicate-CREATE investigations
-                // (see Pro sync demo: same node id arrived 3× at the push
-                // consumer) can grep the daemon log and tell whether the
-                // dup originates here or downstream of the receiver.
-                tracing::debug!(
-                    op = ?envelope.event,
-                    source = ?envelope.metadata.source_client_id,
-                    "broadcast emit"
-                );
                 let _ = tx.send(envelope);
             });
 
@@ -2460,12 +2451,15 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Emit event if relationship was deleted (existed)
+        // Emit event if relationship was deleted (existed). Normalize
+        // ids the same way `RelationshipEvent::new` does for the
+        // created/updated variants — see `db::events::node_thing` for
+        // the rationale (consumers parse on `:` and reject bare ids).
         if let Some(rel_id) = relationship_id {
             self.emit_event(DomainEvent::RelationshipDeleted {
                 id: rel_id,
-                from_id: mentioning_node_id.to_string(),
-                to_id: mentioned_node_id.to_string(),
+                from_id: crate::db::events::node_thing(mentioning_node_id),
+                to_id: crate::db::events::node_thing(mentioned_node_id),
                 relationship_type: "mentions".to_string(),
             });
         }
@@ -6083,12 +6077,14 @@ impl NodeService {
                 NodeServiceError::query_failed(format!("Failed to delete mention: {}", e))
             })?;
 
-        // Emit event if relationship was deleted (existed)
+        // Emit event if relationship was deleted (existed). Normalize
+        // ids — same rationale as the other `RelationshipDeleted`
+        // sites; see `db::events::node_thing`.
         if let Some(rel_id) = relationship_id {
             self.emit_event(DomainEvent::RelationshipDeleted {
                 id: rel_id,
-                from_id: source_id.to_string(),
-                to_id: target_id.to_string(),
+                from_id: crate::db::events::node_thing(source_id),
+                to_id: crate::db::events::node_thing(target_id),
                 relationship_type: "mentions".to_string(),
             });
         }
@@ -6614,12 +6610,14 @@ impl NodeService {
                 NodeServiceError::query_failed(format!("Failed to delete relationship: {}", e))
             })?;
 
-        // Emit RelationshipDeleted event
+        // Emit RelationshipDeleted event. Normalize ids — same
+        // rationale as the other `RelationshipDeleted` sites; see
+        // `db::events::node_thing`.
         if let Some(rel_id) = existing_ids.first() {
             self.emit_event(DomainEvent::RelationshipDeleted {
                 id: extract_record_id_string(rel_id),
-                from_id: source_id.to_string(),
-                to_id: target_id.to_string(),
+                from_id: crate::db::events::node_thing(source_id),
+                to_id: crate::db::events::node_thing(target_id),
                 relationship_type: relationship_name.to_string(),
             });
         }


### PR DESCRIPTION
Closes #1201. Slice 1 of NodeSpaceAI/nodespace-sync#49.

## Summary

`RelationshipEvent.from_id` / `to_id` were emitted as bare node ids (e.g. `"2026-05-20"`) at eight emit sites in `NodeService`. This violated the serialization-contract test in `db/events.rs:194-210` which asserts the prefixed `"node:<key>"` form — emit sites had drifted from the contract.

Most visible symptom: downstream consumers that parse on `:` (e.g. the Pro sync push consumer's `parse_node_thing`) rightly reject bare ids, breaking cloud RELATE for every node created under a date page.

## What changes

- `packages/core/src/db/events.rs` — adds `RelationshipEvent::new` constructor + a small `node_thing()` helper (pass-through if `:` present, prepend `node:` otherwise).
- `packages/core/src/services/node_service.rs` — converts all 8 production emit sites:
  - `create_parent_edge` (the date-page case that surfaced the bug)
  - `reorder_child`
  - two `move_node` paths
  - two `create_or_update` paths
  - `create_mention` + `create_mention_with_source`
  - the collection `member_of` emit site
  - the custom-relationship emit site

The contract test in `events.rs` is unchanged — it was already asserting the prefixed form; this PR is the producer side catching up.

## Background

This commit was originally validated as part of the two-window Pro PoC (closed PRs #1200/#1204/#1205, archived at `/Users/mayanktomar/nodespace/two-window-poc/` per the restart plan in NodeSpaceAI/nodespace-sync#49). Lifted forward unchanged onto current main — the fix is transport-agnostic.

## Verification

- `cargo check -p nodespace-core` — clean
- `cargo clippy -p nodespace-core --lib -- -D warnings` — clean
- `cargo fmt -p nodespace-core -- --check` — clean