### PR TITLE
Forward RelationshipEvent variants on WatchNodes stream

### DIFF
--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -40,9 +40,10 @@ use crate::nodespace::{
     MentionResponse, MentionTargetRequest, MoveNodeRequest, NodeCollectionsRequest, NodeData,
     NodeDeleted, NodeEvent, NodeListResponse, NodeReference, NodeReferenceListResponse,
     NodeResponse, NodeTreeResponse, OptionalNodeResponse, OptionalStringClear,
-    OptionalTimestampClear, QueryNodesSimpleRequest, RemoveNodeFromCollectionRequest,
-    RenameCollectionRequest, ReorderNodeRequest, ReorderNodeResponse, SearchRequest,
-    UpdateNodeRequest, UpdateTaskNodeRequest, UpsertNodeWithParentRequest, WatchRequest,
+    OptionalTimestampClear, QueryNodesSimpleRequest, RelationshipDeletedPayload,
+    RelationshipPayload, RemoveNodeFromCollectionRequest, RenameCollectionRequest,
+    ReorderNodeRequest, ReorderNodeResponse, SearchRequest, UpdateNodeRequest,
+    UpdateTaskNodeRequest, UpsertNodeWithParentRequest, WatchRequest,
 };
 
 /// gRPC adapter that owns shared handles to the core services.
@@ -1203,9 +1204,48 @@ async fn convert_domain_event(
                 node_type: node_type.clone(),
             })),
         }),
-        DomainEvent::RelationshipCreated { .. }
-        | DomainEvent::RelationshipUpdated { .. }
-        | DomainEvent::RelationshipDeleted { .. } => None,
+        DomainEvent::RelationshipCreated { relationship } => Some(NodeEvent {
+            event: Some(NodeEventKind::RelationshipCreated(relationship_to_proto(
+                relationship,
+            ))),
+        }),
+        DomainEvent::RelationshipUpdated { relationship } => Some(NodeEvent {
+            event: Some(NodeEventKind::RelationshipUpdated(relationship_to_proto(
+                relationship,
+            ))),
+        }),
+        DomainEvent::RelationshipDeleted {
+            id,
+            from_id,
+            to_id,
+            relationship_type,
+        } => Some(NodeEvent {
+            event: Some(NodeEventKind::RelationshipDeleted(
+                RelationshipDeletedPayload {
+                    id: id.clone(),
+                    from_id: from_id.clone(),
+                    to_id: to_id.clone(),
+                    relationship_type: relationship_type.clone(),
+                },
+            )),
+        }),
+    }
+}
+
+/// Translate a `RelationshipEvent` from the in-process domain channel
+/// into the proto wire form. `properties` is JSON-encoded as a string
+/// so the proto schema stays stable across additions to the
+/// underlying `serde_json::Value` payload — the desktop watcher
+/// re-parses it back to JSON before emitting the Tauri event.
+fn relationship_to_proto(
+    rel: &nodespace_core::db::events::RelationshipEvent,
+) -> RelationshipPayload {
+    RelationshipPayload {
+        id: rel.id.clone(),
+        from_id: rel.from_id.clone(),
+        to_id: rel.to_id.clone(),
+        relationship_type: rel.relationship_type.clone(),
+        properties: rel.properties.to_string(),
     }
 }
 

--- a/packages/desktop-app/src-tauri/src/watcher.rs
+++ b/packages/desktop-app/src-tauri/src/watcher.rs
@@ -197,5 +197,72 @@ fn forward(app: &AppHandle, event: nodespace_proto::nodespace::NodeEvent) {
                 error!("Failed to emit node:deleted for {}: {e}", d.node_id);
             }
         }
+        // Relationship variants — added so cloud-sync / cross-window
+        // hierarchy changes reach the frontend's reactiveStructureTree
+        // (issue #1202). Payload shape mirrors the in-process
+        // DomainEventForwarder's `relationship:*` Tauri events so
+        // `tauri-sync-listener.ts` works unchanged. `properties`
+        // arrives JSON-encoded on the wire (proto schema is stable);
+        // re-parse it here before emitting so the frontend gets a
+        // real object (the `has_child` listener reads
+        // `properties.order`).
+        NodeEventKind::RelationshipCreated(r) => emit_relationship(app, "relationship:created", r),
+        NodeEventKind::RelationshipUpdated(r) => emit_relationship(app, "relationship:updated", r),
+        NodeEventKind::RelationshipDeleted(r) => {
+            let payload = RelationshipDeletedOut {
+                id: r.id.clone(),
+                from_id: r.from_id,
+                to_id: r.to_id,
+                relationship_type: r.relationship_type,
+            };
+            if let Err(e) = app.emit("relationship:deleted", &payload) {
+                error!("Failed to emit relationship:deleted for {}: {e}", r.id);
+            }
+        }
+    }
+}
+
+/// Frontend payload for `relationship:created` / `relationship:updated`.
+/// Must stay structurally identical to the in-process
+/// `DomainEventForwarder`'s emission of the core `RelationshipEvent`
+/// struct (camelCase via serde rename), so `tauri-sync-listener.ts`
+/// works unchanged across the two forwarding paths.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RelationshipPayloadOut {
+    id: String,
+    from_id: String,
+    to_id: String,
+    relationship_type: String,
+    properties: serde_json::Value,
+}
+
+/// Frontend payload for `relationship:deleted` — mirrors the
+/// `DomainEventForwarder` shape (no `properties` field).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RelationshipDeletedOut {
+    id: String,
+    from_id: String,
+    to_id: String,
+    relationship_type: String,
+}
+
+fn emit_relationship(
+    app: &AppHandle,
+    name: &str,
+    r: nodespace_proto::nodespace::RelationshipPayload,
+) {
+    let props = serde_json::from_str(&r.properties)
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+    let payload = RelationshipPayloadOut {
+        id: r.id.clone(),
+        from_id: r.from_id,
+        to_id: r.to_id,
+        relationship_type: r.relationship_type,
+        properties: props,
+    };
+    if let Err(e) = app.emit(name, &payload) {
+        error!("Failed to emit {name} for {}: {e}", r.id);
     }
 }

--- a/packages/desktop-app/src-tauri/src/watcher.rs
+++ b/packages/desktop-app/src-tauri/src/watcher.rs
@@ -253,8 +253,26 @@ fn emit_relationship(
     name: &str,
     r: nodespace_proto::nodespace::RelationshipPayload,
 ) {
-    let props = serde_json::from_str(&r.properties)
-        .unwrap_or(serde_json::Value::Object(Default::default()));
+    // `r.properties` arrives JSON-encoded as a string on the wire so
+    // the proto schema stays stable across additions to the
+    // underlying `serde_json::Value`. If parsing fails, we still
+    // emit the event with an empty `{}` so the frontend's
+    // `has_child` listener can fall back via `Date.now()` — but
+    // surface the parse failure as a warning so the silent
+    // ordering-corruption case is visible in logs instead of just
+    // showing up as nodes sorted to the tail of their parent.
+    let props = match serde_json::from_str(&r.properties) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                rel_id = %r.id,
+                rel_type = %r.relationship_type,
+                error = %e,
+                "Failed to parse relationship properties JSON; emitting empty object"
+            );
+            serde_json::Value::Object(Default::default())
+        }
+    };
     let payload = RelationshipPayloadOut {
         id: r.id.clone(),
         from_id: r.from_id,

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -35,6 +35,19 @@ import { registerSchemaPlugin, unregisterSchemaPlugin } from '$lib/plugins/schem
 const log = createLogger('TauriSync');
 
 /**
+ * Strip the `node:` table prefix from a SurrealDB Thing id so it
+ * matches the bare-id key shape `reactiveStructureTree` uses
+ * elsewhere in the app (the date-page route, the outliner's
+ * local-action `addChild` path, and `sharedNodeStore` all key by
+ * bare ids). Backend `RelationshipEvent` payloads carry the
+ * prefixed form per the serialization contract; the frontend's
+ * tree-keyspace is historically bare, so normalize at the boundary.
+ */
+function stripNodePrefix(id: string): string {
+  return id.startsWith('node:') ? id.slice('node:'.length) : id;
+}
+
+/**
  * Normalize node data from domain events to type-specific format
  *
  * Domain events send generic Node objects where type-specific fields (like task status)
@@ -153,9 +166,16 @@ export async function initializeTauriSyncListeners(): Promise<void> {
         // updates the order and re-sorts rather than inserting a duplicate.
         if (structureTree) {
           const order = (rel.properties?.order as number) ?? Date.now();
+          // structureTree is keyed by bare node ids (e.g. the date-
+          // page route uses `2026-05-20`, not `node:2026-05-20`).
+          // Backend events carry the table-prefixed form per the
+          // RelationshipEvent serialization contract — strip the
+          // `node:` prefix here so the local-action path (which
+          // writes bare ids via the outliner) and the sync-event
+          // path agree on the key shape.
           structureTree.addChild({
-            parentId: rel.fromId,
-            childId: rel.toId,
+            parentId: stripNodePrefix(rel.fromId),
+            childId: stripNodePrefix(rel.toId),
             order
           });
         }
@@ -186,7 +206,11 @@ export async function initializeTauriSyncListeners(): Promise<void> {
         // far outside the normal fractional order range and will sort the node to the end.
         // In practice, relationship:updated events from the backend always include order.
         const order = (rel.properties?.order as number) ?? Date.now();
-        structureTree.updateChildOrder(rel.fromId, rel.toId, order);
+        structureTree.updateChildOrder(
+          stripNodePrefix(rel.fromId),
+          stripNodePrefix(rel.toId),
+          order
+        );
       }
     });
 
@@ -198,8 +222,8 @@ export async function initializeTauriSyncListeners(): Promise<void> {
         // Hierarchy deletion - update ReactiveStructureTree
         if (structureTree) {
           structureTree.removeChild({
-            parentId: fromId,
-            childId: toId,
+            parentId: stripNodePrefix(fromId),
+            childId: stripNodePrefix(toId),
             order: 0 // Order doesn't matter for removal
           });
         }

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -180,14 +180,23 @@ export async function initializeTauriSyncListeners(): Promise<void> {
           });
         }
       } else if (rel.relationshipType === 'member_of') {
-        // Collection membership changed - refresh collections sidebar
-        log.debug(`Member added: ${rel.fromId} to collection ${rel.toId}`);
-        scheduleCollectionRefresh(rel.toId);
+        // Collection membership changed - refresh collections sidebar.
+        // `scheduleCollectionRefresh` compares the passed id against
+        // `state.selectedCollectionId`, which is keyed by bare ids
+        // elsewhere in the app — strip the `node:` prefix the
+        // serialization contract requires.
+        const toId = stripNodePrefix(rel.toId);
+        log.debug(`Member added: ${rel.fromId} to collection ${toId}`);
+        scheduleCollectionRefresh(toId);
       } else if (rel.relationshipType === 'mentions') {
         // Mention relationship created - target node's mentionedIn needs refresh
         // mentionedIn is populated by get_children_tree, so we need to refetch the tree
-        // for the target node to get updated backlinks
-        log.debug(`Mention created: ${rel.fromId} mentions ${rel.toId}`);
+        // for the target node to get updated backlinks. Strip prefix for log clarity;
+        // when this branch grows to call `loadChildrenTree`, normalization will be
+        // necessary for the lookup to hit the bare-id keyspace.
+        log.debug(
+          `Mention created: ${stripNodePrefix(rel.fromId)} mentions ${stripNodePrefix(rel.toId)}`
+        );
 
         // If the target node is currently displayed, its mentionedIn will update
         // on next tree load. For immediate reactivity, the user can refresh the view.
@@ -228,12 +237,17 @@ export async function initializeTauriSyncListeners(): Promise<void> {
           });
         }
       } else if (relationshipType === 'member_of') {
-        // Collection membership removed - refresh collections sidebar
+        // Collection membership removed - refresh collections sidebar.
+        // Bare-id keyspace, same rationale as `relationship:created`
+        // above.
+        const bareToId = stripNodePrefix(toId);
         log.debug(`Member removed from collection: ${id}`);
-        scheduleCollectionRefresh(toId);
+        scheduleCollectionRefresh(bareToId);
       } else if (relationshipType === 'mentions') {
-        // Mention relationship deleted - target node's mentionedIn needs refresh
-        log.debug(`Mention deleted: ${id} (${fromId} -> ${toId})`);
+        // Mention relationship deleted - target node's mentionedIn needs refresh.
+        log.debug(
+          `Mention deleted: ${id} (${stripNodePrefix(fromId)} -> ${stripNodePrefix(toId)})`
+        );
 
         // Same as creation: mentionedIn updates on next tree load for toId.
         // Future enhancement: call loadChildrenTree for toId if it's the current view.

--- a/packages/proto/proto/node_service.proto
+++ b/packages/proto/proto/node_service.proto
@@ -227,6 +227,14 @@ message NodeEvent {
     NodeData created = 1;
     NodeData updated = 2;
     NodeDeleted deleted = 3;
+    // Relationship events (added so cross-window / cloud-sync hierarchy
+    // changes reach the frontend's structureTree — without these, a
+    // pulled child node arrives but never attaches to its parent's
+    // children list and the outliner can't render it. Mirrors the
+    // in-process DomainEventForwarder's `relationship:*` Tauri events.)
+    RelationshipPayload relationship_created = 4;
+    RelationshipPayload relationship_updated = 5;
+    RelationshipDeletedPayload relationship_deleted = 6;
   }
 }
 
@@ -237,6 +245,25 @@ message NodeDeleted {
   // node. Carries the same value as DomainEvent::NodeDeleted::node_type from
   // the core event channel.
   string node_type = 2;
+}
+
+// Mirrors nodespace_core::db::events::RelationshipEvent. `properties`
+// is JSON-encoded as a string (same shape as `NodeData.properties`)
+// so the proto stays stable across additions to the underlying
+// serde_json::Value payload.
+message RelationshipPayload {
+  string id = 1;
+  string from_id = 2;
+  string to_id = 3;
+  string relationship_type = 4;
+  string properties = 5; // JSON
+}
+
+message RelationshipDeletedPayload {
+  string id = 1;
+  string from_id = 2;
+  string to_id = 3;
+  string relationship_type = 4;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Slice 4 of NodeSpaceAI/nodespace-sync#49.

`watcher.rs` (post-#1196) already streams `node:created` / `node:updated` / `node:deleted` from `nodespaced` to the frontend. It dropped relationship events, so a cloud-pulled `has_child` edge never reached the frontend's `reactiveStructureTree` — child nodes arrived but never attached to their parent in the outliner.

This wires the relationship pipeline end-to-end.

## What changes

- **`packages/proto/proto/node_service.proto`** — extends `NodeEvent` with three new oneof variants (`relationship_created`, `relationship_updated`, `relationship_deleted`) and adds `RelationshipPayload` + `RelationshipDeletedPayload` messages. Backwards-compatible: older clients ignore unknown tags. `properties` is JSON-encoded as a string so the proto schema stays stable across additions to the underlying `serde_json::Value`.

- **`packages/daemon/src/services/node_service.rs::convert_domain_event`** — extends the match to map `DomainEvent::Relationship*` into the new proto variants via a small `relationship_to_proto` helper.

- **`packages/desktop-app/src-tauri/src/watcher.rs::forward()`** — adds the three match arms; payload shape mirrors the in-process `DomainEventForwarder` exactly (camelCase via serde rename, JSON `properties` re-parsed from the wire string). The frontend `tauri-sync-listener.ts` needs no contract change.

- **`packages/desktop-app/src/lib/services/tauri-sync-listener.ts`** — adds a `stripNodePrefix` helper and applies it at the three `structureTree` call sites (`addChild`, `updateChildOrder`, `removeChild`). The structure tree is keyed by bare ids throughout the app; backend events carry the table-prefixed `"node:<key>"` form per the `RelationshipEvent` serialization contract. Normalize at the boundary so the two key spaces agree.

## Verified

- `cargo check -p nodespace-proto` clean (regenerates Rust bindings from the new variants)
- `cargo check -p nodespace-daemon` clean
- `cargo check --manifest-path packages/desktop-app/src-tauri/Cargo.toml --no-default-features` clean
- `cargo clippy --no-default-features --lib -- -D warnings` clean (desktop-app)
- `cargo clippy -p nodespace-daemon -- -D warnings` clean
- `bunx svelte-check --threshold error` — 0 errors, 0 warnings (1639 files)

## Background

Validated end-to-end during the two-window Pro PoC. Adapted to fold the relationship forwarding into the existing `watcher.rs` rather than the PoC's separate `external_event_forwarder` module (post-#1196's watcher path is the single forwarder for external-daemon mode now).

## Stack

- **#1206** — Slice 1 (`RelationshipEvent` id normalization, closes #1201)
- **#1207** — Slice 3 (Pro Tauri client base)
- **(this PR)** — Slice 4
- Slice 5 (sync pull-path relationship subscription, closes NodeSpaceAI/nodespace-sync#46) and Slice 6 (nodespaced-pro on UDS) coming next.

Parent: NodeSpaceAI/nodespace-sync#49.