### PR TITLE
chore: bump dev:tauri:frontend script vite port 1420 → 1422

### DIFF
--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -12,7 +12,7 @@
     "dev:browser": "bun run dev:check && bunx concurrently --success first --names 'Proxy,UI' --prefix-colors 'yellow,green' 'bun run dev:browser:proxy' 'sleep 2 && bun run dev:browser:frontend'",
     "dev:browser:prod": "bun run dev:check && bunx concurrently --success first --names 'Proxy,UI' --prefix-colors 'yellow,green' 'bun run dev:browser:proxy' 'sleep 2 && bun run dev:browser:frontend'",
     "demo:browser": "bun run dev:check && bunx concurrently --success first --names 'Proxy,UI' --prefix-colors 'yellow,green' 'bun run dev:browser:proxy' 'sleep 2 && bun run dev:browser:frontend'",
-    "dev:tauri:frontend": "bunx vite dev --port 1420",
+    "dev:tauri:frontend": "bunx vite dev --port 1422",
     "dev:tauri": "bunx tauri dev -- --bin nodespace-app",
     "demo:tauri": "NODESPACE_DB_PATH=~/.nodespace/database/demo-db bunx tauri dev -- --bin nodespace-app",
     "dev": "bun run dev:browser",


### PR DESCRIPTION
## Summary

`tauri.conf.json` was bumped to `devUrl: http://localhost:1422` in commit `1e7b940b` ("Fix block_on panic and auth detection; change dev port to 1422"), but the sibling `dev:tauri:frontend` npm script in the same `package.json` was left at port 1420. Anyone running:

```bash
bun run dev:tauri:frontend
```

starts vite on port 1420, which the Tauri binary (looking for 1422) never reaches.

## Discovery

Caught while reviewing `NodeSpaceAI/nodespace-sync#56` — that PR bumps the same port in the two-window runbook + script, and a cross-repo sweep surfaced this lingering reference here.

## Test plan

- [ ] CI green
- [ ] Spot-check: `cat packages/desktop-app/package.json | grep dev:tauri:frontend` shows `--port 1422`.
- [ ] `bun run dev:tauri` (the `beforeDevCommand` in `tauri.conf.json` already invokes the right port directly via `bunx vite dev --port 1422`, so the standard dev flow was never broken — this fixes only the script-invocation path).