### PR TITLE
Skip-while-editing guard in SharedNodeStore.setNode (fixes nodespace-sync#76)

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -525,9 +525,68 @@ export class SharedNodeStore {
   // Populated by the skip-while-editing guard in setNode() instead of
   // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
   // that remount the textarea and reset selectionStart — see
-  // nodespace-sync#77). Consumed by the UpdateNode persistence path so the
+  // nodespace-sync#76). Consumed by the UpdateNode persistence path so the
   // next OCC carries the freshest version.
   private serverConfirmedVersions = new Map<string, number>();
+
+  /**
+   * Test-only accessor for the non-reactive server-confirmed-version cache.
+   * Production code consumes this cache via the persistence path
+   * (UpdateNode OCC version selection). Tests use this to assert the cache
+   * was populated/cleared as expected — see
+   * `shared-node-store-skip-while-editing.test.ts`.
+   */
+  peekServerConfirmedVersion(nodeId: string): number | undefined {
+    return this.serverConfirmedVersions.get(nodeId);
+  }
+
+  /**
+   * Returns the version the next UpdateNode RPC would send for this node,
+   * applying the same lookup the persistence closure uses:
+   *
+   *   serverConfirmedVersions[nodeId] ?? localNode.version ?? 1
+   *
+   * Exposed so the skip-while-editing test suite can lock the contract in
+   * place — a future refactor that drops the cache read at the
+   * persistence call site would fail the corresponding test instead of
+   * silently re-introducing the OCC-defeat bug from nodespace-sync#76.
+   */
+  computeOccVersionForUpdate(nodeId: string): number {
+    const confirmed = this.serverConfirmedVersions.get(nodeId);
+    if (typeof confirmed === 'number') return confirmed;
+    const local = this.nodes.get(nodeId);
+    return local?.version ?? 1;
+  }
+
+  /**
+   * Heuristic for "is this database broadcast plausibly an echo of *this
+   * client's own* write?" Used by the skip-while-editing guard to decide
+   * whether to stash the broadcast's `node.version` for the next OCC.
+   *
+   * Returns `true` when the local optimistic content equals or extends the
+   * incoming content — i.e., the incoming is an older snapshot of what we
+   * already have. That covers both shapes the daemon's own confirmation
+   * loops back through:
+   *
+   *   - exact match: the broadcast is the just-confirmed write, no further
+   *     keystrokes since;
+   *   - local extension: the user typed more characters in the optimistic
+   *     state while the daemon was confirming the previous version.
+   *
+   * Returns `false` when the local content diverges from the incoming —
+   * which signals a *foreign* write (e.g., another client editing the
+   * same node concurrently). In that case the cache is intentionally left
+   * untouched so the next UpdateNode RPC uses the local `node.version`,
+   * conflicts with the server's newer version, and surfaces the
+   * divergence via the normal OCC path.
+   */
+  private isPlausibleOwnEcho(local: Node, incoming: Node): boolean {
+    const localContent = local.content ?? '';
+    const incomingContent = incoming.content ?? '';
+    if (localContent === incomingContent) return true;
+    // Local is an extension of incoming → user kept typing past the confirm.
+    return localContent.startsWith(incomingContent);
+  }
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
   private testErrors: Error[] = [];
@@ -1180,27 +1239,54 @@ export class SharedNodeStore {
     // remount the textarea (the `{#if isEditing}` block in base-node.svelte)
     // and reset selectionStart.
     //
+    // `source.type === 'database'` is the contract for "this update came from
+    // the daemon's domain-event broadcast" — see UpdateSource in
+    // `$lib/types/update-protocol`. Local user actions use `'viewer'`. The
+    // guard relies on no other producer of `'database'` events bypassing the
+    // intended skip behavior; the only consumers today are
+    // `tauri-sync-listener` and `browser-sync-service`.
+    //
     // Fixes nodespace-sync#76 (typing corruption: chars dropped/replaced
     // under sustained input as the optimistic store is clobbered by the
     // daemon's own confirmation looped back through the WatchNodes stream).
+    //
+    // Compute the predicates once into locals: (a) `hasPending` does three
+    // Map lookups, and (b) the coordinator transitions a node between its
+    // pending/executing/queued maps, so reading it twice can return
+    // different answers — the log message would otherwise contradict the
+    // branch taken.
+    const isFocused = focusManager.editingNodeId === node.id;
+    const hasPending = PersistenceCoordinator.getInstance().hasPending(node.id);
     if (
       source.type === 'database' &&
       existingNode &&
-      (focusManager.editingNodeId === node.id ||
-        PersistenceCoordinator.getInstance().hasPending(node.id))
+      (isFocused || hasPending)
     ) {
       log.debug(
         `setNode: skipping clobber of actively-edited node ${node.id} ` +
-        `(focused=${focusManager.editingNodeId === node.id}, ` +
-        `pending=${PersistenceCoordinator.getInstance().hasPending(node.id)})`
+          `(focused=${isFocused}, pending=${hasPending})`
       );
-      // Stash the server-confirmed version in the non-reactive cache so
-      // the next UpdateNode RPC carries the freshest version. The
-      // persistence path reads from this cache before falling back to the
-      // node's own .version field.
-      if (typeof node.version === 'number') {
+      // Only stash the server-confirmed version when the broadcast is
+      // plausibly an echo of *this client's own write* — otherwise the
+      // next UpdateNode RPC would carry the foreign writer's version
+      // against our content, defeating OCC and silently overwriting the
+      // foreign change.
+      //
+      // Heuristic: if the existing optimistic content equals or starts
+      // with the incoming content, the incoming is an older snapshot of
+      // OUR work (either an exact echo of our most-recent confirm, or a
+      // prefix from before the user typed more characters). Otherwise it
+      // is a foreign change — preserve OCC by leaving the cache empty so
+      // the next RPC uses our local `node.version`, which will conflict
+      // and surface the divergence.
+      if (typeof node.version === 'number' && this.isPlausibleOwnEcho(existingNode, node)) {
         this.serverConfirmedVersions.set(node.id, node.version);
       }
+      // `persistedNodeIds.add` is safe here precisely because the guard
+      // only runs when `existingNode` is truthy — a database event for a
+      // node we've already seen implies the node IS persisted server-side.
+      // Do not remove the `existingNode` check thinking the add is
+      // unconditional bookkeeping; it is not.
       this.persistedNodeIds.add(node.id);
       // Do NOT touch this.nodes or notify subscribers — there is no
       // observable change to the local view, and any reactive write here
@@ -1300,13 +1386,12 @@ export class SharedNodeStore {
 
                 try {
                   // Get current version for optimistic concurrency control.
-                  // Prefer the server-confirmed version stashed by the
-                  // skip-while-editing guard (see setNode) — that's the
-                  // freshest version we know about without having paid the
-                  // Svelte-reactivity cost of updating `currentNode.version`
-                  // in the reactive Map.
-                  const confirmedVersion = this.serverConfirmedVersions.get(nodeId);
-                  const currentVersion = confirmedVersion ?? currentNode.version ?? 1;
+                  // Routes through `computeOccVersionForUpdate` so the
+                  // skip-while-editing guard (see `setNode`) can stash a
+                  // server-confirmed version without mutating reactive
+                  // state. Test coverage:
+                  // `shared-node-store-skip-while-editing.test.ts`.
+                  const currentVersion = this.computeOccVersionForUpdate(nodeId);
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -529,6 +529,27 @@ export class SharedNodeStore {
   // next OCC carries the freshest version.
   private serverConfirmedVersions = new Map<string, number>();
 
+  // The content this client most-recently sent to the backend per node.
+  // Set by the UpdateNode/CreateNode persistence paths right before the RPC
+  // fires. Used by `isPlausibleOwnEcho` to recognise true own-write echoes
+  // (broadcast.content matches what WE just sent) rather than guessing
+  // from prefix relationships — the previous `local.startsWith(incoming)`
+  // heuristic mis-classified bob's `"hello"` write as alice's echo when
+  // alice's optimistic state was `"hello world"`.
+  private lastPersistedContent = new Map<string, string>();
+
+  /**
+   * Test-only helper to seed the "content this client last sent" cache
+   * without running the persistence path. Production code populates this
+   * cache from the UpdateNode/CreateNode RPC sites; tests don't have a
+   * tauriCommands mock running and need a way to assert the
+   * `isPlausibleOwnEcho` heuristic's gate on real own-write history.
+   * Marked `__test_` to keep it out of the production call surface.
+   */
+  __test_setLastPersistedContent(nodeId: string, content: string): void {
+    this.lastPersistedContent.set(nodeId, content);
+  }
+
   /**
    * Test-only accessor for the non-reactive server-confirmed-version cache.
    * Production code consumes this cache via the persistence path
@@ -559,33 +580,40 @@ export class SharedNodeStore {
   }
 
   /**
-   * Heuristic for "is this database broadcast plausibly an echo of *this
-   * client's own* write?" Used by the skip-while-editing guard to decide
-   * whether to stash the broadcast's `node.version` for the next OCC.
+   * Decide whether an incoming database broadcast is plausibly an echo of
+   * *this client's own* most-recent write. Used by the skip-while-editing
+   * guard to decide whether to stash the broadcast's `node.version` for
+   * the next OCC.
    *
-   * Returns `true` when the local optimistic content equals or extends the
-   * incoming content — i.e., the incoming is an older snapshot of what we
-   * already have. That covers both shapes the daemon's own confirmation
-   * loops back through:
+   * Returns `true` only when `incoming.content` matches the content this
+   * client last sent to the backend for this node (tracked in
+   * `lastPersistedContent`, populated by the persistence path right
+   * before the RPC fires). That covers the canonical case the guard
+   * exists for: our own write looping back through the daemon broadcast.
    *
-   *   - exact match: the broadcast is the just-confirmed write, no further
-   *     keystrokes since;
-   *   - local extension: the user typed more characters in the optimistic
-   *     state while the daemon was confirming the previous version.
+   * Returns `false` for everything else, including any incoming content
+   * we have no last-sent record for. This is deliberately conservative
+   * — false negatives just defer to OCC (the next UpdateNode RPC carries
+   * the local `node.version` and the backend's OCC surfaces any
+   * conflict), while false positives would silently overwrite a foreign
+   * writer's change. The earlier `local.startsWith(incoming)` heuristic
+   * had exactly that false-positive shape: alice with optimistic
+   * `"hello world"` + bob writes `"hello"` → bob's broadcast falsely
+   * classified as own-echo → bob's version stashed → alice's next RPC
+   * overwrites bob.
    *
-   * Returns `false` when the local content diverges from the incoming —
-   * which signals a *foreign* write (e.g., another client editing the
-   * same node concurrently). In that case the cache is intentionally left
-   * untouched so the next UpdateNode RPC uses the local `node.version`,
-   * conflicts with the server's newer version, and surfaces the
-   * divergence via the normal OCC path.
+   * Trade-off: a client that has never persisted this node before
+   * (initial-load path, no edits) reports false for all broadcasts —
+   * including legitimate own-echoes from the daemon's first confirmation
+   * after load. That's fine: with no last-sent record, the local
+   * `node.version` is the load-time version, OCC won't conflict against
+   * the daemon's confirm-of-the-same-state, and the next genuine edit
+   * populates the cache for subsequent echoes.
    */
-  private isPlausibleOwnEcho(local: Node, incoming: Node): boolean {
-    const localContent = local.content ?? '';
-    const incomingContent = incoming.content ?? '';
-    if (localContent === incomingContent) return true;
-    // Local is an extension of incoming → user kept typing past the confirm.
-    return localContent.startsWith(incomingContent);
+  private isPlausibleOwnEcho(_local: Node, incoming: Node): boolean {
+    const lastSent = this.lastPersistedContent.get(incoming.id);
+    if (lastSent === undefined) return false;
+    return lastSent === (incoming.content ?? '');
   }
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
@@ -1392,6 +1420,10 @@ export class SharedNodeStore {
                   // state. Test coverage:
                   // `shared-node-store-skip-while-editing.test.ts`.
                   const currentVersion = this.computeOccVersionForUpdate(nodeId);
+                  // Record the content we are about to send so the next
+                  // database broadcast for this node can be classified as
+                  // an own-echo (see `isPlausibleOwnEcho`).
+                  this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead
@@ -1408,6 +1440,7 @@ export class SharedNodeStore {
                     log.warn(
                       `Node ${nodeId} not found in database, creating instead of updating (error: ${errorMessage})`
                     );
+                    this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                     await tauriCommands.createNode(currentNode);
                     this.persistedNodeIds.add(nodeId);
                   } else {
@@ -1435,6 +1468,7 @@ export class SharedNodeStore {
                   }
                 }
 
+                this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                 await tauriCommands.createNode(currentNode);
                 this.persistedNodeIds.add(nodeId); // Track as persisted
 

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -31,6 +31,7 @@ import { isVersionConflict } from '$lib/types/errors';
 import { isValidDateId } from '$lib/types/date-node';
 import { createLogger } from '$lib/utils/logger';
 import { getPendingMoveOperation } from './pending-operations';
+import { focusManager } from './focus-manager.svelte';
 import { contentProcessor } from './content-processor';
 import { stripMarkdown } from './markdown-utils';
 import type { Node } from '$lib/types';
@@ -357,6 +358,21 @@ class SimplePersistenceCoordinator {
   }
 
   /**
+   * Returns true when a persistence operation for this node is either
+   * pending (debounced and not yet fired), executing (in-flight RPC), or
+   * queued behind an executing one. Used by `SharedNodeStore.setNode()` to
+   * recognise "the user has unsaved local changes for this node" and skip
+   * a daemon-broadcast apply that would otherwise clobber them.
+   */
+  hasPending(nodeId: string): boolean {
+    return (
+      this.pendingOperations.has(nodeId) ||
+      this.executingOperations.has(nodeId) ||
+      this.queuedOperations.has(nodeId)
+    );
+  }
+
+  /**
    * Flush ALL pending operations immediately and wait for completion.
    *
    * This is more aggressive than flushAndWaitForNodes - it ensures the entire
@@ -504,6 +520,14 @@ export class SharedNodeStore {
 
   // Version tracking for optimistic concurrency
   private versions = new Map<string, number>();
+
+  // Non-reactive cache of the latest server-confirmed `node.version` per id.
+  // Populated by the skip-while-editing guard in setNode() instead of
+  // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
+  // that remount the textarea and reset selectionStart — see
+  // nodespace-sync#77). Consumed by the UpdateNode persistence path so the
+  // next OCC carries the freshest version.
+  private serverConfirmedVersions = new Map<string, number>();
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
   private testErrors: Error[] = [];
@@ -1144,8 +1168,53 @@ export class SharedNodeStore {
     const existingNode = this.nodes.get(node.id);
     const isHierarchyChange = !existingNode;
 
+    // Skip-while-editing guard. A daemon-broadcast event (source.type ===
+    // 'database') arriving for a node the user is actively editing — or has
+    // unsaved local changes for — would otherwise overwrite the optimistic
+    // store with the *older* server-confirmed state. The optimistic state is
+    // authoritative until persistence settles, so we keep the local content
+    // and stash the server-confirmed version in a non-reactive cache.
+    //
+    // CRITICAL: do NOT call `this.nodes.set()` or mutate any property of a
+    // node inside the reactive Map. Either triggers Svelte re-renders that
+    // remount the textarea (the `{#if isEditing}` block in base-node.svelte)
+    // and reset selectionStart.
+    //
+    // Fixes nodespace-sync#76 (typing corruption: chars dropped/replaced
+    // under sustained input as the optimistic store is clobbered by the
+    // daemon's own confirmation looped back through the WatchNodes stream).
+    if (
+      source.type === 'database' &&
+      existingNode &&
+      (focusManager.editingNodeId === node.id ||
+        PersistenceCoordinator.getInstance().hasPending(node.id))
+    ) {
+      log.debug(
+        `setNode: skipping clobber of actively-edited node ${node.id} ` +
+        `(focused=${focusManager.editingNodeId === node.id}, ` +
+        `pending=${PersistenceCoordinator.getInstance().hasPending(node.id)})`
+      );
+      // Stash the server-confirmed version in the non-reactive cache so
+      // the next UpdateNode RPC carries the freshest version. The
+      // persistence path reads from this cache before falling back to the
+      // node's own .version field.
+      if (typeof node.version === 'number') {
+        this.serverConfirmedVersions.set(node.id, node.version);
+      }
+      this.persistedNodeIds.add(node.id);
+      // Do NOT touch this.nodes or notify subscribers — there is no
+      // observable change to the local view, and any reactive write here
+      // remounts the focused textarea.
+      return;
+    }
+
     this.nodes.set(node.id, node);
     this.versions.set(node.id, this.getNextVersion(node.id));
+    // A non-guarded setNode means the local store has caught up with the
+    // server (either the user blurred, persistence settled, or the node is
+    // arriving fresh). Drop any stale entry from the skip-while-editing
+    // cache so it doesn't shadow a now-current node.version.
+    this.serverConfirmedVersions.delete(node.id);
     this.notifySubscribers(node.id, node, source);
 
     if (isHierarchyChange) {
@@ -1230,8 +1299,14 @@ export class SharedNodeStore {
                 }
 
                 try {
-                  // Get current version for optimistic concurrency control
-                  const currentVersion = currentNode.version ?? 1;
+                  // Get current version for optimistic concurrency control.
+                  // Prefer the server-confirmed version stashed by the
+                  // skip-while-editing guard (see setNode) — that's the
+                  // freshest version we know about without having paid the
+                  // Svelte-reactivity cost of updating `currentNode.version`
+                  // in the reactive Map.
+                  const confirmedVersion = this.serverConfirmedVersions.get(nodeId);
+                  const currentVersion = confirmedVersion ?? currentNode.version ?? 1;
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the skip-while-editing guard in SharedNodeStore.setNode().
+ *
+ * Repro context: nodespace-sync#76 (typing corruption) and #77 (Enter
+ * relocates text). Root cause: daemon broadcasts of just-confirmed writes
+ * arrive via the WatchNodes gRPC stream while the user is still typing.
+ * The unguarded `setNode()` clobbers the optimistic store with the older
+ * server-confirmed state.
+ *
+ * The guard skips the clobber when source.type === 'database' AND the
+ * node is actively focused OR has unsaved local changes pending.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
+import { focusManager } from '../../lib/services/focus-manager.svelte';
+import type { Node } from '../../lib/types';
+import type { UpdateSource } from '../../lib/types/update-protocol';
+
+describe('SharedNodeStore — skip-while-editing guard', () => {
+  let store: SharedNodeStore;
+
+  const makeNode = (id: string, content: string, version = 1): Node => ({
+    id,
+    nodeType: 'text',
+    content,
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version,
+    properties: {},
+    mentions: []
+  });
+
+  const viewerSource: UpdateSource = {
+    type: 'viewer',
+    viewerId: 'viewer-1'
+  };
+
+  const databaseSource: UpdateSource = {
+    type: 'database',
+    reason: 'domain-event'
+  };
+
+  beforeEach(() => {
+    SharedNodeStore.resetInstance();
+    store = SharedNodeStore.getInstance();
+    focusManager.clearEditing();
+  });
+
+  afterEach(() => {
+    store.clearAll();
+    focusManager.clearEditing();
+    SharedNodeStore.resetInstance();
+  });
+
+  it('skips clobbering the content of a focused node on a database event', () => {
+    // User-typed optimistic state
+    const optimisticNode = makeNode('n1', 'hello world', 1);
+    store.setNode(optimisticNode, viewerSource);
+
+    // User focuses the node (actively editing)
+    focusManager.setEditingNode('n1', 'default');
+
+    // Daemon broadcast lands with the older confirmed content
+    const stalerNode = makeNode('n1', 'hell', 2);
+    store.setNode(stalerNode, databaseSource);
+
+    // Local content stays at the user's optimistic state. Crucially the
+    // local node's `.version` is also unchanged — mutating it inside the
+    // reactive Map would cause Svelte to re-render and remount the focused
+    // textarea (resetting selectionStart → triggers sync#77).
+    const after = store.getNode('n1');
+    expect(after?.content).toBe('hello world');
+    expect(after?.version).toBe(1);
+  });
+
+  it('skips clobbering when the node has pending persistence even if unfocused', () => {
+    // Plant a node and put it into the user-edit path so the persistence
+    // coordinator is engaged with a debounced write for it.
+    const initial = makeNode('n2', 'initial', 1);
+    store.setNode(initial, viewerSource);
+
+    // Trigger a viewer-side update that schedules a debounced persist.
+    // Persistence stays in the "pending" bucket because we don't flush.
+    store.updateNode('n2', { content: 'user-typing-this' }, viewerSource);
+
+    // Daemon broadcast lands with the older confirmed content.
+    const stalerNode = makeNode('n2', 'initial', 2);
+    store.setNode(stalerNode, databaseSource);
+
+    // Optimistic content survives the broadcast; local .version untouched.
+    const after = store.getNode('n2');
+    expect(after?.content).toBe('user-typing-this');
+    expect(after?.version).toBe(1);
+  });
+
+  it('does apply database events for non-focused, non-dirty nodes (regression check)', () => {
+    // Seed via the database path so no persistence is scheduled — mirrors
+    // the production case where the node arrived from the daemon and the
+    // user hasn't touched it yet.
+    const initial = makeNode('n3', 'before', 1);
+    store.setNode(initial, databaseSource);
+
+    // No focus, no pending writes → genuine remote update should land.
+    const remoteUpdate = makeNode('n3', 'after', 5);
+    store.setNode(remoteUpdate, databaseSource);
+
+    expect(store.getNode('n3')?.content).toBe('after');
+    expect(store.getNode('n3')?.version).toBe(5);
+  });
+
+  it('does apply viewer-source updates to a focused node (user actions are authoritative)', () => {
+    const initial = makeNode('n4', 'before', 1);
+    store.setNode(initial, viewerSource);
+    focusManager.setEditingNode('n4', 'default');
+
+    // The user themselves is the source — this is their own typed change.
+    const userEdit = makeNode('n4', 'after', 1);
+    store.setNode(userEdit, viewerSource);
+
+    expect(store.getNode('n4')?.content).toBe('after');
+  });
+
+  it('does apply database events when the node has never been seen locally', () => {
+    // First time the local store sees this node — the guard's "existingNode"
+    // check ensures we still accept the new state.
+    focusManager.setEditingNode('n5', 'default'); // even with focus on the id
+    const incoming = makeNode('n5', 'fresh from cloud', 1);
+    store.setNode(incoming, databaseSource);
+
+    expect(store.getNode('n5')?.content).toBe('fresh from cloud');
+  });
+
+  it('preserves the optimistic content AND leaves local version untouched (no reactive mutation)', () => {
+    const optimistic = makeNode('n6', 'local-newer', 3);
+    store.setNode(optimistic, viewerSource);
+    focusManager.setEditingNode('n6', 'default');
+
+    const broadcast = makeNode('n6', 'cloud-older', 7);
+    store.setNode(broadcast, databaseSource);
+
+    const after = store.getNode('n6');
+    expect(after?.content).toBe('local-newer'); // content preserved
+    expect(after?.version).toBe(3); // local version NOT touched
+    // The server-confirmed version (7) is stashed in a non-reactive cache
+    // and consumed by the persistence path; not observable via getNode.
+  });
+
+  it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {
+    // Seed via the database path so no persistence is scheduled — we want
+    // to exercise just the focus/clear-cache flow without a pending op
+    // tripping the guard.
+    store.setNode(makeNode('n7', 'seed', 3), databaseSource);
+
+    // Focus the node so the next database event hits the guard and stashes
+    // its version in the non-reactive cache.
+    focusManager.setEditingNode('n7', 'default');
+    store.setNode(makeNode('n7', 'older', 9), databaseSource);
+    // Verify the local view didn't change (guard fired).
+    expect(store.getNode('n7')?.content).toBe('seed');
+    expect(store.getNode('n7')?.version).toBe(3);
+
+    // User blurs. Subsequent database event no longer matches the guard;
+    // the normal setNode path runs, writes the new state, and MUST clear
+    // the cache so a stale stashed version can't shadow it on the next
+    // persistence.
+    focusManager.clearEditing();
+    store.setNode(makeNode('n7', 'cloud-current', 15), databaseSource);
+
+    const after = store.getNode('n7');
+    expect(after?.content).toBe('cloud-current');
+    expect(after?.version).toBe(15);
+  });
+});

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -156,14 +156,16 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // carry bob's version against alice's content and the backend would
     // silently overwrite bob's change.
     //
-    // The "is plausibly an own echo" heuristic resolves this: if our
-    // optimistic content equals or extends the incoming content, treat
-    // it as an own echo (own write looping back, possibly with newer
-    // local chars on top) and stash. Otherwise treat it as foreign and
-    // leave the cache empty so the next OCC conflict-detects.
+    // The "is plausibly an own echo" heuristic resolves this: stash only
+    // when `incoming.content` matches this client's recorded last-sent
+    // content for the node. For any other broadcast (including the
+    // alice="hello world" + bob="hello" prefix-compatible race the
+    // earlier startsWith heuristic mis-classified), treat as foreign.
     const optimistic = makeNode('foreign', 'alice typed this', 3);
     store.setNode(optimistic, viewerSource);
     focusManager.setEditingNode('foreign', 'default');
+    // Alice last persisted "alice typed this" to backend.
+    store.__test_setLastPersistedContent('foreign', 'alice typed this');
 
     // Foreign-looking broadcast (different writer altered the node).
     const foreignBroadcast = makeNode('foreign', 'bob wrote something else', 9);
@@ -171,12 +173,45 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
 
     // Local content is preserved (guard still fired — we keep optimistic).
     expect(store.getNode('foreign')?.content).toBe('alice typed this');
-    // Local version is preserved.
     expect(store.getNode('foreign')?.version).toBe(3);
-    // And crucially: the foreign version was NOT stashed, so the next
-    // UpdateNode RPC will use the local v3, the backend will see its
-    // current v9, and the OCC conflict surfaces.
+    // Foreign version was NOT stashed: next UpdateNode uses local v3,
+    // backend has v9, OCC conflict surfaces.
     expect(store.peekServerConfirmedVersion('foreign')).toBeUndefined();
+  });
+
+  it('does NOT mis-classify a prefix-compatible foreign write as an own-echo (regression for the startsWith hole)', () => {
+    // Previously the heuristic was `localContent.startsWith(incomingContent)`.
+    // That would mis-classify the following case as own-echo and stash
+    // bob's version, defeating OCC for bob's change:
+    //
+    //   alice's optimistic state: "hello world"
+    //   bob writes (in a parallel window): "hello"
+    //   bob's broadcast hits alice with content="hello", version=v_bob
+    //
+    // `"hello world".startsWith("hello")` is true, so the old code
+    // stashed v_bob. Next UpdateNode from alice would have carried
+    // v_bob against "hello world" and silently overwritten bob.
+    //
+    // The current heuristic compares against this client's recorded
+    // last-sent content. Alice never sent "hello" — her last persisted
+    // value (if any) is whatever she actually persisted. So bob's
+    // broadcast is correctly classified as foreign.
+    const aliceOptimistic = makeNode('shared', 'hello world', 5);
+    store.setNode(aliceOptimistic, viewerSource);
+    focusManager.setEditingNode('shared', 'default');
+    // Alice has never persisted "hello" — only "hello world" via her
+    // own typing. (For the regression check the exact prior value
+    // doesn't matter — what matters is that it ISN'T "hello".)
+    store.__test_setLastPersistedContent('shared', 'hello world');
+
+    const bobsBroadcast = makeNode('shared', 'hello', 7);
+    store.setNode(bobsBroadcast, databaseSource);
+
+    // Bob's version must NOT be stashed.
+    expect(store.peekServerConfirmedVersion('shared')).toBeUndefined();
+    // Alice's content and version are preserved (no clobber).
+    expect(store.getNode('shared')?.content).toBe('hello world');
+    expect(store.getNode('shared')?.version).toBe(5);
   });
 
   it('persistence path uses the stashed server-confirmed version for OCC (not the stale local node.version)', () => {
@@ -188,11 +223,15 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // OCC-defeat from nodespace-sync#76 — the unit tests above only
     // assert cache *population*, not *consumption*.
     store.setNode(makeNode('persist', 'abc', 1), databaseSource);
+    // Simulate that the local client just persisted 'abc' (own echo
+    // gate). Without this, the guard correctly treats the next
+    // broadcast as foreign and does NOT stash the version.
+    store.__test_setLastPersistedContent('persist', 'abc');
 
     // Before the guard fires, the OCC version is the local one.
     expect(store.computeOccVersionForUpdate('persist')).toBe(1);
 
-    // Guard fires for a plausible-own-echo broadcast (content matches).
+    // Guard fires for an own-echo broadcast (content matches what we sent).
     focusManager.setEditingNode('persist', 'default');
     store.setNode(makeNode('persist', 'abc', 5), databaseSource);
 

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -146,6 +146,61 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // and consumed by the persistence path; not observable via getNode.
   });
 
+  it('does NOT stash the server-confirmed version when the broadcast looks like a foreign write (preserves OCC)', () => {
+    // The guard's whole point is to avoid clobbering local optimistic
+    // content with the server-confirmed snapshot. But the broadcast
+    // mechanism doesn't distinguish "my-own-write echoing back" from
+    // "another client's write to the same node arriving via cloud
+    // round-trip". For the latter case, blindly stashing the foreign
+    // writer's version would defeat OCC: alice's next UpdateNode would
+    // carry bob's version against alice's content and the backend would
+    // silently overwrite bob's change.
+    //
+    // The "is plausibly an own echo" heuristic resolves this: if our
+    // optimistic content equals or extends the incoming content, treat
+    // it as an own echo (own write looping back, possibly with newer
+    // local chars on top) and stash. Otherwise treat it as foreign and
+    // leave the cache empty so the next OCC conflict-detects.
+    const optimistic = makeNode('foreign', 'alice typed this', 3);
+    store.setNode(optimistic, viewerSource);
+    focusManager.setEditingNode('foreign', 'default');
+
+    // Foreign-looking broadcast (different writer altered the node).
+    const foreignBroadcast = makeNode('foreign', 'bob wrote something else', 9);
+    store.setNode(foreignBroadcast, databaseSource);
+
+    // Local content is preserved (guard still fired — we keep optimistic).
+    expect(store.getNode('foreign')?.content).toBe('alice typed this');
+    // Local version is preserved.
+    expect(store.getNode('foreign')?.version).toBe(3);
+    // And crucially: the foreign version was NOT stashed, so the next
+    // UpdateNode RPC will use the local v3, the backend will see its
+    // current v9, and the OCC conflict surfaces.
+    expect(store.peekServerConfirmedVersion('foreign')).toBeUndefined();
+  });
+
+  it('persistence path uses the stashed server-confirmed version for OCC (not the stale local node.version)', () => {
+    // Contract test for the cache's read site. The actual persistence
+    // closure inside SharedNodeStore calls `computeOccVersionForUpdate`,
+    // which routes through the same `serverConfirmedVersions` cache the
+    // skip-while-editing guard populates. Without this test, a future
+    // refactor that drops that read would silently reintroduce the
+    // OCC-defeat from nodespace-sync#76 — the unit tests above only
+    // assert cache *population*, not *consumption*.
+    store.setNode(makeNode('persist', 'abc', 1), databaseSource);
+
+    // Before the guard fires, the OCC version is the local one.
+    expect(store.computeOccVersionForUpdate('persist')).toBe(1);
+
+    // Guard fires for a plausible-own-echo broadcast (content matches).
+    focusManager.setEditingNode('persist', 'default');
+    store.setNode(makeNode('persist', 'abc', 5), databaseSource);
+
+    // Local .version unchanged, but the persistence path now picks 5.
+    expect(store.getNode('persist')?.version).toBe(1);
+    expect(store.computeOccVersionForUpdate('persist')).toBe(5);
+  });
+
   it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {
     // Seed via the database path so no persistence is scheduled — we want
     // to exercise just the focus/clear-cache flow without a pending op


### PR DESCRIPTION
## Summary

Daemon-broadcast events arrive on the gRPC `WatchNodes` stream after every local `UpdateNode` RPC confirms. With the existing 500 ms persistence debounce in `PersistenceCoordinator`, the user types optimistically, the debounced write fires, the daemon broadcasts the confirm, and the front-end's `setNode()` races back in and overwrites the editor with the *older* confirmed state — destroying characters typed in the meantime.

Add a guard: when `source.type === 'database'` and the incoming node is either focused (`focusManager.editingNodeId === node.id`) or has an in-flight or pending persistence operation, keep the local optimistic copy untouched. Stash the server-confirmed version in a non-reactive `serverConfirmedVersions` Map so the next `UpdateNode` RPC carries the freshest version for OCC — without mutating any reactive state.

### Why non-reactive

Mutating the reactive `nodes` Map (or mutating a property of a node inside it) triggers Svelte re-renders that remount the focused textarea via the `{#if isEditing}` block in `base-node.svelte`. That has its own observable side effects on cursor state and we want zero observable change from the guard path.

### What this fixes

[`NodeSpaceAI/nodespace-sync#76`](https://github.com/NodeSpaceAI/nodespace-sync/issues/76) — typing corruption: characters dropped or replaced under sustained input.

## What changed

- `packages/desktop-app/src/lib/services/shared-node-store.svelte.ts`
  - New `setNode` guard before the unconditional Map mutation
  - New `serverConfirmedVersions: Map<string, number>` (non-reactive)
  - Persistence path now prefers `serverConfirmedVersions` over `currentNode.version` at OCC time
  - New `PersistenceCoordinator.hasPending(nodeId)` so the guard can ask the coordinator directly rather than reaching into its private state
- `packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts` — 7 new test cases

## Test plan

- [x] `cargo test -p nodespace-core --lib` — 1191 passed / 0 failed
- [x] Frontend shared-node-store family — 245 → 252 passed (+7 new)
- [x] Full frontend baseline delta: 93 pre-existing localStorage-env failures unchanged
- [x] `cargo clippy -p nodespace-core --lib -- -D warnings` — clean
- [x] Manually verified end-to-end against the two-window same-device demo: sustained typing in alice no longer corrupts characters; bob continues to receive alice's writes within ~1s.

## Related PRs

Two parallel PRs for the companion bug `nodespace-sync#77` (Enter relocates new node to top of list) will follow shortly:
- PR B — backend ordering: `create_parent_edge` idempotency + `None`-translation
- PR C — frontend resilience: `tauri-sync-listener` order preservation + persistence-time stale-sibling check