### PR TITLE
Make create_parent_edge idempotent on already-existing edges (fixes nodespace-sync#77, alice-side)

### DIFF
--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -2788,7 +2788,14 @@ impl SurrealStore {
                     FractionalOrderCalculator::calculate_order(last_order, None)
                 }
             } else {
-                // No insert_after_sibling specified, insert at beginning
+                // No insert_after_sibling specified, insert at beginning. The
+                // MCP handlers (`handle_insert_child_at_index` with index=0
+                // and `handle_move_child_to_index` with target_index=0) rely
+                // on this: they pass `None` to mean "move to the first
+                // position". Hierarchical-create callers that want "append at
+                // end" semantics (the sync layer's pull-side `apply_remote`
+                // among them) translate `None` to `Some(last_child_id)` at
+                // their layer — see `NodeService::create_parent_edge`.
                 let first_order = relationships.first().map(|e| e.order);
                 FractionalOrderCalculator::calculate_order(None, first_order)
             }
@@ -7310,10 +7317,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_parent_reorder_preserves_created_at() -> Result<()> {
-        // Issue #795: Same-parent reorder should preserve created_at
+        // Issue #795: Same-parent reorder should preserve created_at.
+        //
+        // Use an explicit `insert_after_sibling` for the reorder. Calling
+        // `move_node(child, parent, None)` on an already-present edge is a
+        // no-op in nodespace-sync#77's fix (the pull-side echoes its own
+        // writes as `(child, parent, None)` and the previous behavior of
+        // re-running the order calculation dragged the row to the top).
         let (store, _temp_dir) = create_test_store().await?;
 
-        // Create parent and two children
         let parent = store
             .create_node(
                 Node::new("text".to_string(), "Parent".to_string(), json!({})),
@@ -7322,37 +7334,33 @@ mod tests {
             )
             .await?;
 
-        let _child1 = store
+        let child1 = store
             .create_child_node_atomic(&parent.id, "text", "Child 1", json!({}), None)
             .await?;
         let child2 = store
             .create_child_node_atomic(&parent.id, "text", "Child 2", json!({}), None)
             .await?;
 
-        // Get original relationship metadata for child2
-        let original_metadata = get_relationship_metadata(&store, &child2.id)
+        let original_metadata = get_relationship_metadata(&store, &child1.id)
             .await?
             .expect("Relationship should exist");
         let original_created_at = original_metadata.0.clone();
 
-        // Wait a tiny bit to ensure time difference
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
-        // Reorder child2 to be before child1 (same parent, just reordering)
-        store.move_node(&child2.id, Some(&parent.id), None).await?;
+        // Reorder: move child1 to be AFTER child2 (real position change).
+        store
+            .move_node(&child1.id, Some(&parent.id), Some(&child2.id))
+            .await?;
 
-        // Get new relationship metadata
-        let new_metadata = get_relationship_metadata(&store, &child2.id)
+        let new_metadata = get_relationship_metadata(&store, &child1.id)
             .await?
             .expect("Relationship should still exist");
 
-        // created_at should be PRESERVED (same value)
         assert_eq!(
             new_metadata.0, original_created_at,
             "Same-parent reorder should preserve created_at"
         );
-
-        // modified_at should be UPDATED (different value)
         assert_ne!(
             new_metadata.1, original_metadata.1,
             "Same-parent reorder should update modified_at"
@@ -7363,10 +7371,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_parent_reorder_increments_version() -> Result<()> {
-        // Issue #795: Same-parent reorder should increment version for OCC
+        // Issue #795: Same-parent reorder should increment version for OCC.
+        //
+        // Like `test_same_parent_reorder_preserves_created_at`, pass an
+        // explicit `insert_after_sibling` so this exercises an actual
+        // reorder rather than the now-no-op `(child, parent, None)` shape
+        // that nodespace-sync#77 relies on to short-circuit pull-side echoes.
         let (store, _temp_dir) = create_test_store().await?;
 
-        // Create parent and child
         let parent = store
             .create_node(
                 Node::new("text".to_string(), "Parent".to_string(), json!({})),
@@ -7375,25 +7387,26 @@ mod tests {
             )
             .await?;
 
-        let child = store
-            .create_child_node_atomic(&parent.id, "text", "Child", json!({}), None)
+        let child1 = store
+            .create_child_node_atomic(&parent.id, "text", "Child 1", json!({}), None)
+            .await?;
+        let child2 = store
+            .create_child_node_atomic(&parent.id, "text", "Child 2", json!({}), None)
             .await?;
 
-        // Get original version
-        let original_metadata = get_relationship_metadata(&store, &child.id)
+        let original_metadata = get_relationship_metadata(&store, &child1.id)
             .await?
             .expect("Relationship should exist");
         let original_version = original_metadata.2;
 
-        // Reorder (same parent)
-        store.move_node(&child.id, Some(&parent.id), None).await?;
+        store
+            .move_node(&child1.id, Some(&parent.id), Some(&child2.id))
+            .await?;
 
-        // Get new version
-        let new_metadata = get_relationship_metadata(&store, &child.id)
+        let new_metadata = get_relationship_metadata(&store, &child1.id)
             .await?
             .expect("Relationship should still exist");
 
-        // Version should be incremented
         assert_eq!(
             new_metadata.2,
             original_version + 1,
@@ -7404,6 +7417,7 @@ mod tests {
 
         Ok(())
     }
+
 
     #[tokio::test]
     async fn test_cross_parent_move_creates_new_relationship() -> Result<()> {
@@ -7464,10 +7478,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_same_parent_reorders_accumulate_version() -> Result<()> {
-        // Issue #795: Multiple reorders should accumulate version
+        // Issue #795: Multiple reorders should accumulate version.
+        //
+        // Each reorder uses an explicit `insert_after_sibling` (alternating
+        // between the two pivot children) so it's a genuine position change.
+        // The previous shape of this test used `move_node(child, parent,
+        // None)` which is now a no-op (preserves existing order) per the
+        // nodespace-sync#77 fix.
         let (store, _temp_dir) = create_test_store().await?;
 
-        // Create parent and child
         let parent = store
             .create_node(
                 Node::new("text".to_string(), "Parent".to_string(), json!({})),
@@ -7476,19 +7495,32 @@ mod tests {
             )
             .await?;
 
+        let pivot_a = store
+            .create_child_node_atomic(&parent.id, "text", "Pivot A", json!({}), None)
+            .await?;
+        let pivot_b = store
+            .create_child_node_atomic(&parent.id, "text", "Pivot B", json!({}), None)
+            .await?;
         let child = store
             .create_child_node_atomic(&parent.id, "text", "Child", json!({}), None)
             .await?;
 
-        // Initial version should be 1
         let initial_metadata = get_relationship_metadata(&store, &child.id)
             .await?
             .expect("Relationship should exist");
         assert_eq!(initial_metadata.2, 1, "Initial version should be 1");
 
-        // Reorder multiple times
+        // Alternate insert_after between the two pivots so every reorder is
+        // a real position change. Four iterations → version 2..=5.
         for expected_version in 2..=5 {
-            store.move_node(&child.id, Some(&parent.id), None).await?;
+            let pivot = if expected_version % 2 == 0 {
+                &pivot_a.id
+            } else {
+                &pivot_b.id
+            };
+            store
+                .move_node(&child.id, Some(&parent.id), Some(pivot))
+                .await?;
 
             let metadata = get_relationship_metadata(&store, &child.id)
                 .await?

--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -7419,7 +7419,6 @@ mod tests {
         Ok(())
     }
 
-
     #[tokio::test]
     async fn test_cross_parent_move_creates_new_relationship() -> Result<()> {
         // Issue #795: Cross-parent move should create new relationship with new created_at
@@ -7514,9 +7513,7 @@ mod tests {
         assert_eq!(before[1].id, child2.id);
 
         // Now move child2 to the beginning via the no-hint shape.
-        store
-            .move_node(&child2.id, Some(&parent.id), None)
-            .await?;
+        store.move_node(&child2.id, Some(&parent.id), None).await?;
 
         let after = store.get_children(&parent.id).await?;
         assert_eq!(after.len(), 2);

--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -7319,11 +7319,12 @@ mod tests {
     async fn test_same_parent_reorder_preserves_created_at() -> Result<()> {
         // Issue #795: Same-parent reorder should preserve created_at.
         //
-        // Use an explicit `insert_after_sibling` for the reorder. Calling
-        // `move_node(child, parent, None)` on an already-present edge is a
-        // no-op in nodespace-sync#77's fix (the pull-side echoes its own
-        // writes as `(child, parent, None)` and the previous behavior of
-        // re-running the order calculation dragged the row to the top).
+        // Use an explicit `insert_after_sibling` so the test exercises a
+        // real position change. The store-level `move_node(child, parent,
+        // None)` still moves the child to the beginning of the parent's
+        // children — see `test_move_node_same_parent_no_hint_moves_to_beginning`
+        // for that layered contract. The `NodeService::create_parent_edge`
+        // *caller* is where nodespace-sync#77's idempotency lives.
         let (store, _temp_dir) = create_test_store().await?;
 
         let parent = store
@@ -7374,9 +7375,9 @@ mod tests {
         // Issue #795: Same-parent reorder should increment version for OCC.
         //
         // Like `test_same_parent_reorder_preserves_created_at`, pass an
-        // explicit `insert_after_sibling` so this exercises an actual
-        // reorder rather than the now-no-op `(child, parent, None)` shape
-        // that nodespace-sync#77 relies on to short-circuit pull-side echoes.
+        // explicit `insert_after_sibling` for a real reorder. Store-level
+        // `move_node` with `None` still moves to the beginning; the layered
+        // idempotency for sync echoes lives at `NodeService::create_parent_edge`.
         let (store, _temp_dir) = create_test_store().await?;
 
         let parent = store
@@ -7472,6 +7473,58 @@ mod tests {
             new_metadata.2, 1,
             "Cross-parent move should reset version to 1"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_move_node_same_parent_no_hint_moves_to_beginning() -> Result<()> {
+        // Locks in the store-level contract used by `reorder_node(_, _, None)`
+        // and the MCP "move to first position" path: when the caller does
+        // not provide `insert_after_sibling_id`, `move_node` places the
+        // child at the *beginning* of its parent's children — even when
+        // the child is already a child of that parent.
+        //
+        // nodespace-sync#77's idempotency lives at the higher
+        // `NodeService::create_parent_edge` layer, NOT here. If a future
+        // change pushes the idempotency into `move_node` (or flips the
+        // None default to "append at end" at this layer), the MCP
+        // index=0 reorder path silently breaks; this test catches that.
+        let (store, _temp_dir) = create_test_store().await?;
+
+        let parent = store
+            .create_node(
+                Node::new("text".to_string(), "Parent".to_string(), json!({})),
+                None,
+                None,
+            )
+            .await?;
+
+        let child1 = store
+            .create_child_node_atomic(&parent.id, "text", "Child 1", json!({}), None)
+            .await?;
+        let child2 = store
+            .create_child_node_atomic(&parent.id, "text", "Child 2", json!({}), None)
+            .await?;
+
+        // Sanity: child1 was created first, so it's currently first.
+        let before = store.get_children(&parent.id).await?;
+        assert_eq!(before.len(), 2);
+        assert_eq!(before[0].id, child1.id);
+        assert_eq!(before[1].id, child2.id);
+
+        // Now move child2 to the beginning via the no-hint shape.
+        store
+            .move_node(&child2.id, Some(&parent.id), None)
+            .await?;
+
+        let after = store.get_children(&parent.id).await?;
+        assert_eq!(after.len(), 2);
+        assert_eq!(
+            after[0].id, child2.id,
+            "move_node with no insert_after must move child to the beginning"
+        );
+        assert_eq!(after[1].id, child1.id);
 
         Ok(())
     }

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -4552,22 +4552,37 @@ impl NodeService {
         );
 
         // Idempotency guard for nodespace-sync#77 (alice-side echo) — if
-        // `child_id` is already a child of `parent_id`, treat this call as a
-        // no-op. The sync pull-side `apply_remote` re-invokes
+        // `child_id` is already a child of `parent_id` AND no explicit
+        // `insert_after_node_id` was provided, treat this call as a no-op.
+        // The sync pull-side `apply_remote` re-invokes
         // `create_parent_edge(child, parent, None)` for every `has_child` edge
         // it replays from the cloud LIVE-SELECT, including edges JUST created
         // by the local push side. Before this guard, the redundant call ran
         // through `move_node` and re-positioned the child — dragging the row
-        // off its just-computed local order. Callers that want to actually
-        // reorder an existing child should use `reorder_child`.
-        if let Some(existing_parent) = self.get_parent(child_id).await? {
-            if existing_parent.id == parent_id {
-                tracing::debug!(
-                    child_id = %child_id,
-                    parent_id = %parent_id,
-                    "create_parent_edge: edge already exists, treating as no-op"
-                );
-                return Ok(());
+        // off its just-computed local order.
+        //
+        // The `insert_after_node_id.is_none()` clause narrows the guard so a
+        // caller that DOES pass an explicit hint still triggers a real
+        // reorder. Callers wanting to actually reposition an existing child
+        // should pass `Some(target_sibling)` here OR use `reorder_child`.
+        //
+        // `get_parent` is propagated via `?` — a transient DB error aborts
+        // the whole `create_parent_edge` call. The retry budget for the
+        // happy path (`move_node` loop below) is intentionally larger than
+        // for this one-off parent lookup; if `get_parent` flakes, fail fast
+        // and let the caller decide whether to retry. The 10×100ms retry
+        // budget on `move_node` is for the *sibling-not-found* case, which
+        // is a different consistency window.
+        if insert_after_node_id.is_none() {
+            if let Some(existing_parent) = self.get_parent(child_id).await? {
+                if existing_parent.id == parent_id {
+                    tracing::debug!(
+                        child_id = %child_id,
+                        parent_id = %parent_id,
+                        "create_parent_edge: edge already exists with no reorder hint, treating as no-op"
+                    );
+                    return Ok(());
+                }
             }
         }
 
@@ -4581,14 +4596,31 @@ impl NodeService {
         // layer can only call `create_parent_edge(child, parent, None)`.
         // Translating to `Some(last_child_id)` here keeps `move_node`'s
         // semantics intact and gives sync the append-at-end behavior it needs.
+        //
+        // Concurrency note: there is a read-then-write window between this
+        // `get_children` and the `move_node` call below. Two concurrent
+        // `create_parent_edge(_, parent, None)` calls can race: both see
+        // the same `last_child_id`, then `move_node`'s fractional-order
+        // calculation (which re-reads the children) places them at order
+        // values that don't strictly match cloud-canonical ordering. The
+        // rows DO get distinct fractional orders (no collision), but the
+        // *between-which-siblings* placement reflects whichever transaction
+        // landed last. Acceptable for sync echo replay (eventually
+        // consistent across windows); callers needing strict ordering
+        // should serialise their calls or use `reorder_child` afterwards.
+        //
+        // `get_children` is propagated via `?` rather than swallowed —
+        // silently degrading to `None` would re-trigger the very bug this
+        // path was added to fix (the new child would land at the
+        // beginning of the parent's list).
         let effective_after_owned: Option<String> = if insert_after_node_id.is_some() {
             None
         } else {
             // get_children returns siblings in current order; take the last.
-            match self.get_children(parent_id).await {
-                Ok(children) => children.last().map(|c| c.id.clone()),
-                Err(_) => None,
-            }
+            self.get_children(parent_id)
+                .await?
+                .last()
+                .map(|c| c.id.clone())
         };
         let resolved_insert_after: Option<&str> = insert_after_node_id
             .or(effective_after_owned.as_deref());
@@ -9591,6 +9623,61 @@ mod tests {
             assert_eq!(children.len(), 2);
             assert_eq!(children[0].content, "Child 1");
             assert_eq!(children[1].content, "Child 2");
+        }
+
+        #[tokio::test]
+        #[serial(sibling_ordering)]
+        async fn test_create_parent_edge_reorders_when_explicit_hint_against_existing_edge() {
+            // The sync-echo idempotency in `create_parent_edge` is narrowed
+            // to `insert_after_node_id.is_none()`: callers that pass an
+            // explicit `Some(target_sibling)` against an already-present
+            // edge must still see a real reorder. If a future refactor
+            // widens the guard back to "any same-parent edge is a no-op",
+            // this test fails.
+            let (service, _temp) = create_test_service().await;
+
+            let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
+            let parent_id = service.create_node(parent).await.unwrap();
+
+            let child1 = Node::new("text".to_string(), "Child 1".to_string(), json!({}));
+            let child1_id = service.create_node(child1).await.unwrap();
+            service
+                .create_parent_edge(&child1_id, &parent_id, None)
+                .await
+                .unwrap();
+
+            let child2 = Node::new("text".to_string(), "Child 2".to_string(), json!({}));
+            let child2_id = service.create_node(child2).await.unwrap();
+            service
+                .create_parent_edge(&child2_id, &parent_id, None)
+                .await
+                .unwrap();
+
+            sleep(Duration::from_millis(50)).await;
+
+            // Initial state: Child 1, Child 2.
+            let before = service.get_children(&parent_id).await.unwrap();
+            assert_eq!(before.len(), 2);
+            assert_eq!(before[0].content, "Child 1");
+            assert_eq!(before[1].content, "Child 2");
+
+            // Re-invoke create_parent_edge for child1 with an explicit hint
+            // pointing AFTER child2 — the edge already exists, but the
+            // explicit hint must take effect (real reorder).
+            service
+                .create_parent_edge(&child1_id, &parent_id, Some(&child2_id))
+                .await
+                .unwrap();
+
+            sleep(Duration::from_millis(50)).await;
+
+            let after = service.get_children(&parent_id).await.unwrap();
+            assert_eq!(after.len(), 2);
+            assert_eq!(
+                after[0].content, "Child 2",
+                "explicit reorder hint on existing edge must take effect"
+            );
+            assert_eq!(after[1].content, "Child 1");
         }
 
         #[tokio::test]

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -2125,18 +2125,18 @@ impl NodeService {
             }
 
             if !sibling_valid {
-                // Hint is stale (sibling moved or deleted). Clear it so the
-                // edge-creation step (`create_parent_edge`) takes the
-                // append-at-end path it implements for unspecified hints —
-                // that's the right "fall back to append" semantic the
-                // surrounding comment describes. (Before nodespace-sync#77,
-                // `None` here flowed straight to `move_node` and ended up at
-                // the "insert at beginning" branch, which silently dropped the
-                // new node at the top of the parent's children.)
+                // Hint is stale (sibling moved or deleted). Clear it; the
+                // downstream `create_parent_edge` will pass `None` to
+                // `move_node`, which inserts at the parent's beginning.
+                // (The comment in this block previously promised "fall back
+                // to append" — the underlying implementation never delivered
+                // that, and shifting the receive-side fix to the sync layer
+                // for nodespace-sync#77 leaves `move_node`'s None semantic
+                // intact.)
                 tracing::warn!(
                     sibling_id = %sibling_id,
                     parent_id = ?params.parent_id,
-                    "insert_after_node_id is stale after retries (sibling moved or deleted), falling back to append at end via create_parent_edge"
+                    "insert_after_node_id is stale after retries (sibling moved or deleted), falling back to insert at beginning"
                 );
                 params.insert_after_node_id = None;
             }
@@ -4586,51 +4586,20 @@ impl NodeService {
             }
         }
 
-        // Normalise `insert_after_node_id = None` to "append after the parent's
-        // current last child" (nodespace-sync#77 receive-side). The store's
-        // `move_node` interprets a bare `None` as "insert at beginning" — that
-        // matches what the MCP handlers want for an explicit "move to first
-        // position" reorder, but for a *hierarchical CREATE* it would drop
-        // the new child at the top of its parent's list every time, because
-        // the cloud LIVE-SELECT echo carries no order field and the sync
-        // layer can only call `create_parent_edge(child, parent, None)`.
-        // Translating to `Some(last_child_id)` here keeps `move_node`'s
-        // semantics intact and gives sync the append-at-end behavior it needs.
+        // `insert_after_node_id` is passed straight through to `move_node`,
+        // which interprets `None` as "insert at beginning of children". That
+        // semantic is what the frontend's Enter-at-position-0 path
+        // (`shouldCreateNodeAbove`) relies on — the new empty line is meant
+        // to land ABOVE the cursor's line.
         //
-        // Concurrency note: there is a read-then-write window between this
-        // `get_children` and the `move_node` call below. Two concurrent
-        // `create_parent_edge(_, parent, None)` calls can race: both see
-        // the same `last_child_id`, then `move_node`'s fractional-order
-        // calculation (which re-reads the children) places them at order
-        // values that don't strictly match cloud-canonical ordering. The
-        // rows DO get distinct fractional orders (no collision), but the
-        // *between-which-siblings* placement reflects whichever transaction
-        // landed last. Acceptable for sync echo replay (eventually
-        // consistent across windows); callers needing strict ordering
-        // should serialise their calls or use `reorder_child` afterwards.
-        //
-        // `get_children` is propagated via `?` rather than swallowed —
-        // silently degrading to `None` would re-trigger the very bug this
-        // path was added to fix (the new child would land at the
-        // beginning of the parent's list).
-        let effective_after_owned: Option<String> = if insert_after_node_id.is_some() {
-            None
-        } else {
-            // get_children returns siblings in current order; take the last.
-            self.get_children(parent_id)
-                .await?
-                .last()
-                .map(|c| c.id.clone())
-        };
-        let resolved_insert_after: Option<&str> = insert_after_node_id
-            .or(effective_after_owned.as_deref());
-
-        // Pass insert_after_node_id to store.move_node.
-        // store.move_node semantics:
-        //   Some(id) → "insert AFTER this sibling"
-        //   None     → "insert at beginning" (used by MCP `reorder_node` for
-        //              explicit move-to-first; create-side has translated
-        //              `None` to `Some(last_child_id)` above)
+        // The companion receive-side fix for nodespace-sync#77 lives in the
+        // sync repo (`apply_remote` in `nodespace-sync/src/pull/...`): when
+        // the cloud LIVE-SELECT echo carries no `properties.order` and the
+        // pull-side is creating a brand-new local edge, it computes the
+        // parent's current last-child id and passes that as the explicit
+        // hint here, rather than relying on a backend-side translation that
+        // would conflate "no hint" with "append at end" for all callers.
+        // See nodespace-sync PR D' (referenced from PR #1214's description).
 
         // Use store's move_node which creates the has_child relationship atomically
         // Retry if sibling not found (eventual consistency).
@@ -4646,7 +4615,7 @@ impl NodeService {
             attempt_count += 1;
             match self
                 .store
-                .move_node(child_id, Some(parent_id), resolved_insert_after)
+                .move_node(child_id, Some(parent_id), insert_after_node_id)
                 .await
             {
                 Ok(order) => {
@@ -9580,15 +9549,17 @@ mod tests {
             );
         }
 
-        /// Test that None for `insert_after_node_id` appends at the end of
-        /// the parent's children when the parent already has at least one
-        /// child. Changed in nodespace-sync#77 — the previous default was
-        /// "insert at beginning", which made the receive side of two-window
-        /// sync land replayed has_child edges at the top of the list (cloud
-        /// doesn't carry the order field, so sync passes `None`).
+        /// Test that None for `insert_after_node_id` inserts at the beginning
+        /// of the parent's children. This is the canonical "insert at start"
+        /// path used by the outliner's Enter-at-position-0 UX (frontend's
+        /// `shouldCreateNodeAbove` branch). The companion fix for
+        /// nodespace-sync#77's receive-side ordering lives in the sync
+        /// layer's `apply_remote`, which now passes an explicit
+        /// `last_child_id` hint when replaying a has_child relationship —
+        /// keeping this semantic intact for the legitimate-prepend callers.
         #[tokio::test]
         #[serial(sibling_ordering)]
-        async fn test_insert_at_end_by_default() {
+        async fn test_insert_at_beginning_by_default() {
             let (service, _temp) = create_test_service().await;
 
             let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
@@ -9606,7 +9577,7 @@ mod tests {
 
             sleep(Duration::from_millis(50)).await;
 
-            // No hint provided — should append after Child 1.
+            // No hint provided — should prepend, so Child 2 ends up first.
             let params2 = CreateNodeParams {
                 id: Some("test-child-2".to_string()),
                 node_type: "text".to_string(),
@@ -9621,8 +9592,8 @@ mod tests {
 
             let children = service.get_children(&parent_id).await.unwrap();
             assert_eq!(children.len(), 2);
-            assert_eq!(children[0].content, "Child 1");
-            assert_eq!(children[1].content, "Child 2");
+            assert_eq!(children[0].content, "Child 2");
+            assert_eq!(children[1].content, "Child 1");
         }
 
         #[tokio::test]
@@ -9639,6 +9610,9 @@ mod tests {
             let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
             let parent_id = service.create_node(parent).await.unwrap();
 
+            // Use explicit hints so the test setup is independent of the
+            // `None = insert at beginning` default. After this setup the
+            // order is deterministic: Child 1, Child 2.
             let child1 = Node::new("text".to_string(), "Child 1".to_string(), json!({}));
             let child1_id = service.create_node(child1).await.unwrap();
             service
@@ -9649,13 +9623,12 @@ mod tests {
             let child2 = Node::new("text".to_string(), "Child 2".to_string(), json!({}));
             let child2_id = service.create_node(child2).await.unwrap();
             service
-                .create_parent_edge(&child2_id, &parent_id, None)
+                .create_parent_edge(&child2_id, &parent_id, Some(&child1_id))
                 .await
                 .unwrap();
 
             sleep(Duration::from_millis(50)).await;
 
-            // Initial state: Child 1, Child 2.
             let before = service.get_children(&parent_id).await.unwrap();
             assert_eq!(before.len(), 2);
             assert_eq!(before[0].content, "Child 1");

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -2125,10 +2125,18 @@ impl NodeService {
             }
 
             if !sibling_valid {
+                // Hint is stale (sibling moved or deleted). Clear it so the
+                // edge-creation step (`create_parent_edge`) takes the
+                // append-at-end path it implements for unspecified hints —
+                // that's the right "fall back to append" semantic the
+                // surrounding comment describes. (Before nodespace-sync#77,
+                // `None` here flowed straight to `move_node` and ended up at
+                // the "insert at beginning" branch, which silently dropped the
+                // new node at the top of the parent's children.)
                 tracing::warn!(
                     sibling_id = %sibling_id,
                     parent_id = ?params.parent_id,
-                    "insert_after_node_id is stale after retries (sibling moved or deleted), falling back to insert at beginning (None)"
+                    "insert_after_node_id is stale after retries (sibling moved or deleted), falling back to append at end via create_parent_edge"
                 );
                 params.insert_after_node_id = None;
             }
@@ -4543,10 +4551,54 @@ impl NodeService {
             "create_parent_edge: START"
         );
 
-        // Pass insert_after_node_id directly to store.move_node without translation
+        // Idempotency guard for nodespace-sync#77 (alice-side echo) — if
+        // `child_id` is already a child of `parent_id`, treat this call as a
+        // no-op. The sync pull-side `apply_remote` re-invokes
+        // `create_parent_edge(child, parent, None)` for every `has_child` edge
+        // it replays from the cloud LIVE-SELECT, including edges JUST created
+        // by the local push side. Before this guard, the redundant call ran
+        // through `move_node` and re-positioned the child — dragging the row
+        // off its just-computed local order. Callers that want to actually
+        // reorder an existing child should use `reorder_child`.
+        if let Some(existing_parent) = self.get_parent(child_id).await? {
+            if existing_parent.id == parent_id {
+                tracing::debug!(
+                    child_id = %child_id,
+                    parent_id = %parent_id,
+                    "create_parent_edge: edge already exists, treating as no-op"
+                );
+                return Ok(());
+            }
+        }
+
+        // Normalise `insert_after_node_id = None` to "append after the parent's
+        // current last child" (nodespace-sync#77 receive-side). The store's
+        // `move_node` interprets a bare `None` as "insert at beginning" — that
+        // matches what the MCP handlers want for an explicit "move to first
+        // position" reorder, but for a *hierarchical CREATE* it would drop
+        // the new child at the top of its parent's list every time, because
+        // the cloud LIVE-SELECT echo carries no order field and the sync
+        // layer can only call `create_parent_edge(child, parent, None)`.
+        // Translating to `Some(last_child_id)` here keeps `move_node`'s
+        // semantics intact and gives sync the append-at-end behavior it needs.
+        let effective_after_owned: Option<String> = if insert_after_node_id.is_some() {
+            None
+        } else {
+            // get_children returns siblings in current order; take the last.
+            match self.get_children(parent_id).await {
+                Ok(children) => children.last().map(|c| c.id.clone()),
+                Err(_) => None,
+            }
+        };
+        let resolved_insert_after: Option<&str> = insert_after_node_id
+            .or(effective_after_owned.as_deref());
+
+        // Pass insert_after_node_id to store.move_node.
         // store.move_node semantics:
-        //   insert_after_node_id = Some(id) → "insert AFTER this sibling"
-        //   insert_after_node_id = None → "insert at beginning"
+        //   Some(id) → "insert AFTER this sibling"
+        //   None     → "insert at beginning" (used by MCP `reorder_node` for
+        //              explicit move-to-first; create-side has translated
+        //              `None` to `Some(last_child_id)` above)
 
         // Use store's move_node which creates the has_child relationship atomically
         // Retry if sibling not found (eventual consistency).
@@ -4562,7 +4614,7 @@ impl NodeService {
             attempt_count += 1;
             match self
                 .store
-                .move_node(child_id, Some(parent_id), insert_after_node_id)
+                .move_node(child_id, Some(parent_id), resolved_insert_after)
                 .await
             {
                 Ok(order) => {
@@ -7569,14 +7621,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_reorder_siblings() {
+        // `move_node_unchecked(child, parent, None)` preserves the original
+        // "insert at beginning" semantic, so the children land in reverse
+        // creation order (child2 added second → first). Then `reorder_child`
+        // with `None` moves child1 to the beginning, producing the order
+        // expected here. (`create_parent_edge` now translates `None` to
+        // append-at-end internally, but the lower-level `move_node` path
+        // still means "to beginning" — see nodespace-sync#77 commit for the
+        // rationale.)
         let (service, _temp) = create_test_service().await;
 
-        // Create parent node
         let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
         let parent_id = service.create_node(parent).await.unwrap();
 
-        // Create two children under the parent
-        // Note: move_node without sibling inserts at BEGINNING, so child2 will be first
         let child1 = Node::new("text".to_string(), "Child 1".to_string(), json!({}));
         let child1_id = service.create_node(child1).await.unwrap();
         service
@@ -7591,20 +7648,16 @@ mod tests {
             .await
             .unwrap();
 
-        // Get initial order - child2 should be FIRST (inserted at beginning)
         let children_before = service.get_children(&parent_id).await.unwrap();
         assert_eq!(children_before.len(), 2);
         assert_eq!(
             children_before[0].id, child2_id,
-            "Child2 should be first (inserted at beginning)"
+            "Child2 should be first (move_node None = insert at beginning)"
         );
         assert_eq!(children_before[1].id, child1_id, "Child1 should be second");
 
-        // Reorder child1 to be before child2 (making child1 first)
-        // Using insert_after=None means insert at beginning
         service.reorder_child(&child1_id, None).await.unwrap();
 
-        // Verify new order - child1 should now be first
         let children_after = service.get_children(&parent_id).await.unwrap();
         assert_eq!(children_after.len(), 2);
         assert_eq!(
@@ -9495,18 +9548,20 @@ mod tests {
             );
         }
 
-        /// Test that None inserts at beginning (new behavior)
+        /// Test that None for `insert_after_node_id` appends at the end of
+        /// the parent's children when the parent already has at least one
+        /// child. Changed in nodespace-sync#77 — the previous default was
+        /// "insert at beginning", which made the receive side of two-window
+        /// sync land replayed has_child edges at the top of the list (cloud
+        /// doesn't carry the order field, so sync passes `None`).
         #[tokio::test]
         #[serial(sibling_ordering)]
-        async fn test_insert_at_beginning_by_default() {
+        async fn test_insert_at_end_by_default() {
             let (service, _temp) = create_test_service().await;
 
-            // Create parent
             let parent = Node::new("text".to_string(), "Parent".to_string(), json!({}));
             let parent_id = service.create_node(parent).await.unwrap();
 
-            // Create first child (None = insert at beginning)
-            // NOTE: Small delays between insertions ensure SurrealDB write visibility
             let params1 = CreateNodeParams {
                 id: Some("test-child-1".to_string()),
                 node_type: "text".to_string(),
@@ -9519,7 +9574,7 @@ mod tests {
 
             sleep(Duration::from_millis(50)).await;
 
-            // Create second child (None = insert at beginning, so comes BEFORE first)
+            // No hint provided — should append after Child 1.
             let params2 = CreateNodeParams {
                 id: Some("test-child-2".to_string()),
                 node_type: "text".to_string(),
@@ -9532,11 +9587,10 @@ mod tests {
 
             sleep(Duration::from_millis(50)).await;
 
-            // Verify order: Child 2, Child 1 (reversed - None inserts at beginning)
             let children = service.get_children(&parent_id).await.unwrap();
             assert_eq!(children.len(), 2);
-            assert_eq!(children[0].content, "Child 2");
-            assert_eq!(children[1].content, "Child 1");
+            assert_eq!(children[0].content, "Child 1");
+            assert_eq!(children[1].content, "Child 2");
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary

Backend half of [`nodespace-sync#77`](https://github.com/NodeSpaceAI/nodespace-sync/issues/77). Makes `NodeService::create_parent_edge` idempotent on already-existing edges so the sync pull-side's echo replay doesn't re-position the just-created child off its local order.

## What changed

`packages/core/src/services/node_service.rs` — `create_parent_edge` now short-circuits when:

1. `insert_after_node_id` is `None` (no explicit reorder intent), AND
2. `get_parent(child_id)` reports the child is already under `parent_id`

The guard is narrowed via `insert_after_node_id.is_none()` so a caller that passes an explicit hint still triggers a real reorder (covered by `test_create_parent_edge_reorders_when_explicit_hint_against_existing_edge`).

`packages/core/src/db/surreal_store.rs` — added `test_move_node_same_parent_no_hint_moves_to_beginning` to lock the store-level contract used by `reorder_node(_, _, None)` (MCP "move to first position" path).

The three existing `test_same_parent_*` tests were already updated to use explicit `insert_after_sibling` for their reorder calls.

## Scope note: what this PR does NOT do

An earlier revision of this PR ALSO translated `None → last_child_id` inside `create_parent_edge` to fix the sync receive-side bug (bob's view of alice's new child landed at the top of the parent's list). That translation has been **stripped** in `e25fa571` because it conflated two callers with opposite intents:

| Caller | Intended meaning of `None` |
|---|---|
| Sync pull-side `apply_remote` | "no order info from cloud, append at end" |
| Outliner Enter-at-position-0 | "insert at beginning of the parent's list" |

Core can't disambiguate at the API layer. The fix lives at the call sites instead — sync's pull-side computes `last_child_id` explicitly in [`NodeSpaceAI/nodespace-sync#79`](https://github.com/NodeSpaceAI/nodespace-sync/pull/79). The outliner's "insert at beginning" UX is preserved by core's unchanged `move_node(_, _, None) = "insert at beginning"` semantic.

## Test plan

- [x] `cargo test -p nodespace-core --lib` — 1191 → 1193 passing (+2 new, no removals)
- [x] `cargo clippy -p nodespace-core --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual verification: two-window same-device demo, alice types + Enter at end of text → new sibling appears directly below in both windows (requires `nodespace-sync#79` for the receive-side correction)

## Related

- [#1213](https://github.com/NodeSpaceAI/nodespace-core/pull/1213) — setNode skip-while-editing guard (`nodespace-sync#76`). Independent of this PR.
- [#1215](https://github.com/NodeSpaceAI/nodespace-core/pull/1215) — frontend resilience for `#77` (tauri-sync-listener fallback + structureTree-based stale check). Independent of this PR.
- [`nodespace-sync#79`](https://github.com/NodeSpaceAI/nodespace-sync/pull/79) — receive-side companion that passes the explicit `last_child_id` hint. Required for the full `#77` fix.
- [#1216](https://github.com/NodeSpaceAI/nodespace-core/issues/1216) — follow-up suggestion: introduce an `InsertPosition` enum so future callers can express intent without overloading `Option`.