### PR TITLE
Preserve structureTree order on sync echoes + fix stale-sibling check (fixes nodespace-sync#77, frontend)

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -525,9 +525,68 @@ export class SharedNodeStore {
   // Populated by the skip-while-editing guard in setNode() instead of
   // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
   // that remount the textarea and reset selectionStart — see
-  // nodespace-sync#77). Consumed by the UpdateNode persistence path so the
+  // nodespace-sync#76). Consumed by the UpdateNode persistence path so the
   // next OCC carries the freshest version.
   private serverConfirmedVersions = new Map<string, number>();
+
+  /**
+   * Test-only accessor for the non-reactive server-confirmed-version cache.
+   * Production code consumes this cache via the persistence path
+   * (UpdateNode OCC version selection). Tests use this to assert the cache
+   * was populated/cleared as expected — see
+   * `shared-node-store-skip-while-editing.test.ts`.
+   */
+  peekServerConfirmedVersion(nodeId: string): number | undefined {
+    return this.serverConfirmedVersions.get(nodeId);
+  }
+
+  /**
+   * Returns the version the next UpdateNode RPC would send for this node,
+   * applying the same lookup the persistence closure uses:
+   *
+   *   serverConfirmedVersions[nodeId] ?? localNode.version ?? 1
+   *
+   * Exposed so the skip-while-editing test suite can lock the contract in
+   * place — a future refactor that drops the cache read at the
+   * persistence call site would fail the corresponding test instead of
+   * silently re-introducing the OCC-defeat bug from nodespace-sync#76.
+   */
+  computeOccVersionForUpdate(nodeId: string): number {
+    const confirmed = this.serverConfirmedVersions.get(nodeId);
+    if (typeof confirmed === 'number') return confirmed;
+    const local = this.nodes.get(nodeId);
+    return local?.version ?? 1;
+  }
+
+  /**
+   * Heuristic for "is this database broadcast plausibly an echo of *this
+   * client's own* write?" Used by the skip-while-editing guard to decide
+   * whether to stash the broadcast's `node.version` for the next OCC.
+   *
+   * Returns `true` when the local optimistic content equals or extends the
+   * incoming content — i.e., the incoming is an older snapshot of what we
+   * already have. That covers both shapes the daemon's own confirmation
+   * loops back through:
+   *
+   *   - exact match: the broadcast is the just-confirmed write, no further
+   *     keystrokes since;
+   *   - local extension: the user typed more characters in the optimistic
+   *     state while the daemon was confirming the previous version.
+   *
+   * Returns `false` when the local content diverges from the incoming —
+   * which signals a *foreign* write (e.g., another client editing the
+   * same node concurrently). In that case the cache is intentionally left
+   * untouched so the next UpdateNode RPC uses the local `node.version`,
+   * conflicts with the server's newer version, and surfaces the
+   * divergence via the normal OCC path.
+   */
+  private isPlausibleOwnEcho(local: Node, incoming: Node): boolean {
+    const localContent = local.content ?? '';
+    const incomingContent = incoming.content ?? '';
+    if (localContent === incomingContent) return true;
+    // Local is an extension of incoming → user kept typing past the confirm.
+    return localContent.startsWith(incomingContent);
+  }
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
   private testErrors: Error[] = [];
@@ -1180,27 +1239,54 @@ export class SharedNodeStore {
     // remount the textarea (the `{#if isEditing}` block in base-node.svelte)
     // and reset selectionStart.
     //
+    // `source.type === 'database'` is the contract for "this update came from
+    // the daemon's domain-event broadcast" — see UpdateSource in
+    // `$lib/types/update-protocol`. Local user actions use `'viewer'`. The
+    // guard relies on no other producer of `'database'` events bypassing the
+    // intended skip behavior; the only consumers today are
+    // `tauri-sync-listener` and `browser-sync-service`.
+    //
     // Fixes nodespace-sync#76 (typing corruption: chars dropped/replaced
     // under sustained input as the optimistic store is clobbered by the
     // daemon's own confirmation looped back through the WatchNodes stream).
+    //
+    // Compute the predicates once into locals: (a) `hasPending` does three
+    // Map lookups, and (b) the coordinator transitions a node between its
+    // pending/executing/queued maps, so reading it twice can return
+    // different answers — the log message would otherwise contradict the
+    // branch taken.
+    const isFocused = focusManager.editingNodeId === node.id;
+    const hasPending = PersistenceCoordinator.getInstance().hasPending(node.id);
     if (
       source.type === 'database' &&
       existingNode &&
-      (focusManager.editingNodeId === node.id ||
-        PersistenceCoordinator.getInstance().hasPending(node.id))
+      (isFocused || hasPending)
     ) {
       log.debug(
         `setNode: skipping clobber of actively-edited node ${node.id} ` +
-        `(focused=${focusManager.editingNodeId === node.id}, ` +
-        `pending=${PersistenceCoordinator.getInstance().hasPending(node.id)})`
+          `(focused=${isFocused}, pending=${hasPending})`
       );
-      // Stash the server-confirmed version in the non-reactive cache so
-      // the next UpdateNode RPC carries the freshest version. The
-      // persistence path reads from this cache before falling back to the
-      // node's own .version field.
-      if (typeof node.version === 'number') {
+      // Only stash the server-confirmed version when the broadcast is
+      // plausibly an echo of *this client's own write* — otherwise the
+      // next UpdateNode RPC would carry the foreign writer's version
+      // against our content, defeating OCC and silently overwriting the
+      // foreign change.
+      //
+      // Heuristic: if the existing optimistic content equals or starts
+      // with the incoming content, the incoming is an older snapshot of
+      // OUR work (either an exact echo of our most-recent confirm, or a
+      // prefix from before the user typed more characters). Otherwise it
+      // is a foreign change — preserve OCC by leaving the cache empty so
+      // the next RPC uses our local `node.version`, which will conflict
+      // and surface the divergence.
+      if (typeof node.version === 'number' && this.isPlausibleOwnEcho(existingNode, node)) {
         this.serverConfirmedVersions.set(node.id, node.version);
       }
+      // `persistedNodeIds.add` is safe here precisely because the guard
+      // only runs when `existingNode` is truthy — a database event for a
+      // node we've already seen implies the node IS persisted server-side.
+      // Do not remove the `existingNode` check thinking the add is
+      // unconditional bookkeeping; it is not.
       this.persistedNodeIds.add(node.id);
       // Do NOT touch this.nodes or notify subscribers — there is no
       // observable change to the local view, and any reactive write here
@@ -1300,13 +1386,12 @@ export class SharedNodeStore {
 
                 try {
                   // Get current version for optimistic concurrency control.
-                  // Prefer the server-confirmed version stashed by the
-                  // skip-while-editing guard (see setNode) — that's the
-                  // freshest version we know about without having paid the
-                  // Svelte-reactivity cost of updating `currentNode.version`
-                  // in the reactive Map.
-                  const confirmedVersion = this.serverConfirmedVersions.get(nodeId);
-                  const currentVersion = confirmedVersion ?? currentNode.version ?? 1;
+                  // Routes through `computeOccVersionForUpdate` so the
+                  // skip-while-editing guard (see `setNode`) can stash a
+                  // server-confirmed version without mutating reactive
+                  // state. Test coverage:
+                  // `shared-node-store-skip-while-editing.test.ts`.
+                  const currentVersion = this.computeOccVersionForUpdate(nodeId);
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -529,6 +529,27 @@ export class SharedNodeStore {
   // next OCC carries the freshest version.
   private serverConfirmedVersions = new Map<string, number>();
 
+  // The content this client most-recently sent to the backend per node.
+  // Set by the UpdateNode/CreateNode persistence paths right before the RPC
+  // fires. Used by `isPlausibleOwnEcho` to recognise true own-write echoes
+  // (broadcast.content matches what WE just sent) rather than guessing
+  // from prefix relationships — the previous `local.startsWith(incoming)`
+  // heuristic mis-classified bob's `"hello"` write as alice's echo when
+  // alice's optimistic state was `"hello world"`.
+  private lastPersistedContent = new Map<string, string>();
+
+  /**
+   * Test-only helper to seed the "content this client last sent" cache
+   * without running the persistence path. Production code populates this
+   * cache from the UpdateNode/CreateNode RPC sites; tests don't have a
+   * tauriCommands mock running and need a way to assert the
+   * `isPlausibleOwnEcho` heuristic's gate on real own-write history.
+   * Marked `__test_` to keep it out of the production call surface.
+   */
+  __test_setLastPersistedContent(nodeId: string, content: string): void {
+    this.lastPersistedContent.set(nodeId, content);
+  }
+
   /**
    * Test-only accessor for the non-reactive server-confirmed-version cache.
    * Production code consumes this cache via the persistence path
@@ -559,33 +580,40 @@ export class SharedNodeStore {
   }
 
   /**
-   * Heuristic for "is this database broadcast plausibly an echo of *this
-   * client's own* write?" Used by the skip-while-editing guard to decide
-   * whether to stash the broadcast's `node.version` for the next OCC.
+   * Decide whether an incoming database broadcast is plausibly an echo of
+   * *this client's own* most-recent write. Used by the skip-while-editing
+   * guard to decide whether to stash the broadcast's `node.version` for
+   * the next OCC.
    *
-   * Returns `true` when the local optimistic content equals or extends the
-   * incoming content — i.e., the incoming is an older snapshot of what we
-   * already have. That covers both shapes the daemon's own confirmation
-   * loops back through:
+   * Returns `true` only when `incoming.content` matches the content this
+   * client last sent to the backend for this node (tracked in
+   * `lastPersistedContent`, populated by the persistence path right
+   * before the RPC fires). That covers the canonical case the guard
+   * exists for: our own write looping back through the daemon broadcast.
    *
-   *   - exact match: the broadcast is the just-confirmed write, no further
-   *     keystrokes since;
-   *   - local extension: the user typed more characters in the optimistic
-   *     state while the daemon was confirming the previous version.
+   * Returns `false` for everything else, including any incoming content
+   * we have no last-sent record for. This is deliberately conservative
+   * — false negatives just defer to OCC (the next UpdateNode RPC carries
+   * the local `node.version` and the backend's OCC surfaces any
+   * conflict), while false positives would silently overwrite a foreign
+   * writer's change. The earlier `local.startsWith(incoming)` heuristic
+   * had exactly that false-positive shape: alice with optimistic
+   * `"hello world"` + bob writes `"hello"` → bob's broadcast falsely
+   * classified as own-echo → bob's version stashed → alice's next RPC
+   * overwrites bob.
    *
-   * Returns `false` when the local content diverges from the incoming —
-   * which signals a *foreign* write (e.g., another client editing the
-   * same node concurrently). In that case the cache is intentionally left
-   * untouched so the next UpdateNode RPC uses the local `node.version`,
-   * conflicts with the server's newer version, and surfaces the
-   * divergence via the normal OCC path.
+   * Trade-off: a client that has never persisted this node before
+   * (initial-load path, no edits) reports false for all broadcasts —
+   * including legitimate own-echoes from the daemon's first confirmation
+   * after load. That's fine: with no last-sent record, the local
+   * `node.version` is the load-time version, OCC won't conflict against
+   * the daemon's confirm-of-the-same-state, and the next genuine edit
+   * populates the cache for subsequent echoes.
    */
-  private isPlausibleOwnEcho(local: Node, incoming: Node): boolean {
-    const localContent = local.content ?? '';
-    const incomingContent = incoming.content ?? '';
-    if (localContent === incomingContent) return true;
-    // Local is an extension of incoming → user kept typing past the confirm.
-    return localContent.startsWith(incomingContent);
+  private isPlausibleOwnEcho(_local: Node, incoming: Node): boolean {
+    const lastSent = this.lastPersistedContent.get(incoming.id);
+    if (lastSent === undefined) return false;
+    return lastSent === (incoming.content ?? '');
   }
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
@@ -1392,6 +1420,10 @@ export class SharedNodeStore {
                   // state. Test coverage:
                   // `shared-node-store-skip-while-editing.test.ts`.
                   const currentVersion = this.computeOccVersionForUpdate(nodeId);
+                  // Record the content we are about to send so the next
+                  // database broadcast for this node can be classified as
+                  // an own-echo (see `isPlausibleOwnEcho`).
+                  this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead
@@ -1408,6 +1440,7 @@ export class SharedNodeStore {
                     log.warn(
                       `Node ${nodeId} not found in database, creating instead of updating (error: ${errorMessage})`
                     );
+                    this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                     await tauriCommands.createNode(currentNode);
                     this.persistedNodeIds.add(nodeId);
                   } else {
@@ -1435,6 +1468,7 @@ export class SharedNodeStore {
                   }
                 }
 
+                this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                 await tauriCommands.createNode(currentNode);
                 this.persistedNodeIds.add(nodeId); // Track as persisted
 

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -31,6 +31,7 @@ import { isVersionConflict } from '$lib/types/errors';
 import { isValidDateId } from '$lib/types/date-node';
 import { createLogger } from '$lib/utils/logger';
 import { getPendingMoveOperation } from './pending-operations';
+import { focusManager } from './focus-manager.svelte';
 import { contentProcessor } from './content-processor';
 import { stripMarkdown } from './markdown-utils';
 import type { Node } from '$lib/types';
@@ -357,6 +358,21 @@ class SimplePersistenceCoordinator {
   }
 
   /**
+   * Returns true when a persistence operation for this node is either
+   * pending (debounced and not yet fired), executing (in-flight RPC), or
+   * queued behind an executing one. Used by `SharedNodeStore.setNode()` to
+   * recognise "the user has unsaved local changes for this node" and skip
+   * a daemon-broadcast apply that would otherwise clobber them.
+   */
+  hasPending(nodeId: string): boolean {
+    return (
+      this.pendingOperations.has(nodeId) ||
+      this.executingOperations.has(nodeId) ||
+      this.queuedOperations.has(nodeId)
+    );
+  }
+
+  /**
    * Flush ALL pending operations immediately and wait for completion.
    *
    * This is more aggressive than flushAndWaitForNodes - it ensures the entire
@@ -504,6 +520,14 @@ export class SharedNodeStore {
 
   // Version tracking for optimistic concurrency
   private versions = new Map<string, number>();
+
+  // Non-reactive cache of the latest server-confirmed `node.version` per id.
+  // Populated by the skip-while-editing guard in setNode() instead of
+  // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
+  // that remount the textarea and reset selectionStart — see
+  // nodespace-sync#77). Consumed by the UpdateNode persistence path so the
+  // next OCC carries the freshest version.
+  private serverConfirmedVersions = new Map<string, number>();
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
   private testErrors: Error[] = [];
@@ -1144,8 +1168,53 @@ export class SharedNodeStore {
     const existingNode = this.nodes.get(node.id);
     const isHierarchyChange = !existingNode;
 
+    // Skip-while-editing guard. A daemon-broadcast event (source.type ===
+    // 'database') arriving for a node the user is actively editing — or has
+    // unsaved local changes for — would otherwise overwrite the optimistic
+    // store with the *older* server-confirmed state. The optimistic state is
+    // authoritative until persistence settles, so we keep the local content
+    // and stash the server-confirmed version in a non-reactive cache.
+    //
+    // CRITICAL: do NOT call `this.nodes.set()` or mutate any property of a
+    // node inside the reactive Map. Either triggers Svelte re-renders that
+    // remount the textarea (the `{#if isEditing}` block in base-node.svelte)
+    // and reset selectionStart.
+    //
+    // Fixes nodespace-sync#76 (typing corruption: chars dropped/replaced
+    // under sustained input as the optimistic store is clobbered by the
+    // daemon's own confirmation looped back through the WatchNodes stream).
+    if (
+      source.type === 'database' &&
+      existingNode &&
+      (focusManager.editingNodeId === node.id ||
+        PersistenceCoordinator.getInstance().hasPending(node.id))
+    ) {
+      log.debug(
+        `setNode: skipping clobber of actively-edited node ${node.id} ` +
+        `(focused=${focusManager.editingNodeId === node.id}, ` +
+        `pending=${PersistenceCoordinator.getInstance().hasPending(node.id)})`
+      );
+      // Stash the server-confirmed version in the non-reactive cache so
+      // the next UpdateNode RPC carries the freshest version. The
+      // persistence path reads from this cache before falling back to the
+      // node's own .version field.
+      if (typeof node.version === 'number') {
+        this.serverConfirmedVersions.set(node.id, node.version);
+      }
+      this.persistedNodeIds.add(node.id);
+      // Do NOT touch this.nodes or notify subscribers — there is no
+      // observable change to the local view, and any reactive write here
+      // remounts the focused textarea.
+      return;
+    }
+
     this.nodes.set(node.id, node);
     this.versions.set(node.id, this.getNextVersion(node.id));
+    // A non-guarded setNode means the local store has caught up with the
+    // server (either the user blurred, persistence settled, or the node is
+    // arriving fresh). Drop any stale entry from the skip-while-editing
+    // cache so it doesn't shadow a now-current node.version.
+    this.serverConfirmedVersions.delete(node.id);
     this.notifySubscribers(node.id, node, source);
 
     if (isHierarchyChange) {
@@ -1230,8 +1299,14 @@ export class SharedNodeStore {
                 }
 
                 try {
-                  // Get current version for optimistic concurrency control
-                  const currentVersion = currentNode.version ?? 1;
+                  // Get current version for optimistic concurrency control.
+                  // Prefer the server-confirmed version stashed by the
+                  // skip-while-editing guard (see setNode) — that's the
+                  // freshest version we know about without having paid the
+                  // Svelte-reactivity cost of updating `currentNode.version`
+                  // in the reactive Map.
+                  const confirmedVersion = this.serverConfirmedVersions.get(nodeId);
+                  const currentVersion = confirmedVersion ?? currentNode.version ?? 1;
                   await tauriCommands.updateNode(nodeId, currentVersion, currentNode);
                 } catch (updateError) {
                   // If UPDATE fails because node doesn't exist, try CREATE instead

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -551,6 +551,44 @@ export class SharedNodeStore {
   }
 
   /**
+   * Decide whether the persistence path should clear a CREATE's
+   * `insertAfterNodeId` hint as "stale" before talking to the backend.
+   *
+   * **Trust hierarchy**: `structureTree` is the authoritative source for
+   * `has_child` parent-child relationships (it's the in-memory mirror of
+   * the backend's hierarchy edges). The bare `Node.parentId` field is
+   * opportunistically populated by some load paths (e.g. local creates)
+   * but is `null` for nodes loaded via `getChildrenTree`, where the wire
+   * shape strips it. Always consult `structureTree.getParent` for
+   * hierarchy decisions; never rely on `Node.parentId` alone.
+   *
+   * Returns `true` only when `structureTree` reports a parent for the
+   * sibling AND that parent disagrees with the new node's
+   * `currentParentId`. If `structureTree` has no opinion (`null`), the
+   * hint is preserved and the backend's own retry loop handles it —
+   * silently clearing a valid hint here is what produced
+   * nodespace-sync#77's drop-to-the-top behavior.
+   *
+   * If `structureTree.getParent` returns `null` we emit a debug log so
+   * the frequency of "tree not yet populated at persistence time" is
+   * observable; a high rate suggests the persistence call is racing the
+   * structureTree population (different code path bug, not this one).
+   */
+  shouldClearStaleInsertAfter(
+    siblingId: string,
+    currentParentId: string | null | undefined
+  ): boolean {
+    const siblingActualParent = structureTree.getParent(siblingId);
+    if (siblingActualParent === null) {
+      log.debug(
+        `shouldClearStaleInsertAfter: structureTree has no parent for sibling ${siblingId.substring(0, 8)} — preserving hint, backend will validate`
+      );
+      return false;
+    }
+    return siblingActualParent !== (currentParentId ?? null);
+  }
+
+  /**
    * Test-only accessor for the non-reactive server-confirmed-version cache.
    * Production code consumes this cache via the persistence path
    * (UpdateNode OCC version selection). Tests use this to assert the cache
@@ -1448,22 +1486,19 @@ export class SharedNodeStore {
                   }
                 }
               } else {
-                // RACE CONDITION FIX: Validate insertAfterNodeId before CREATE
-                // If the node was moved (indent/outdent) after the CREATE was scheduled,
-                // insertAfterNodeId may reference a sibling under a different parent.
-                // The backend will reject this with "Sibling has different parent" error.
-                // Solution: Clear insertAfterNodeId if it's no longer a valid sibling.
                 const nodeWithInsertHint = currentNode as Node & { insertAfterNodeId?: string | null };
                 if (nodeWithInsertHint.insertAfterNodeId) {
-                  const siblingNode = this.nodes.get(nodeWithInsertHint.insertAfterNodeId);
-                  if (siblingNode && siblingNode.parentId !== currentNode.parentId) {
+                  if (
+                    this.shouldClearStaleInsertAfter(
+                      nodeWithInsertHint.insertAfterNodeId,
+                      currentNode.parentId
+                    )
+                  ) {
                     log.debug(
                       `[CREATE] Clearing stale insertAfterNodeId for ${nodeId.substring(0, 8)}: ` +
-                      `sibling ${nodeWithInsertHint.insertAfterNodeId.substring(0, 8)} has parentId ` +
-                      `${siblingNode.parentId?.substring(0, 8) ?? 'null'} but node has parentId ` +
-                      `${currentNode.parentId?.substring(0, 8) ?? 'null'}`
+                        `sibling ${nodeWithInsertHint.insertAfterNodeId.substring(0, 8)} reports a ` +
+                        `different parent via structureTree (node.parentId=${currentNode.parentId?.substring(0, 8) ?? 'null'})`
                     );
-                    // Clear the stale hint - backend will use sortOrder instead
                     nodeWithInsertHint.insertAfterNodeId = null;
                   }
                 }

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -164,18 +164,66 @@ export async function initializeTauriSyncListeners(): Promise<void> {
         // fractional order overwrites any optimistic order set during creation.
         // addChild handles deduplication internally: if the child already exists it
         // updates the order and re-sorts rather than inserting a duplicate.
+        //
+        // **Order-fallback contract** (nodespace-sync#77 root cause):
+        //   - When the local daemon emits this event, `properties.order`
+        //     carries the fractional order from `move_node` — that's the
+        //     authoritative position and we use it directly.
+        //   - When the **cloud LIVE-SELECT echo** re-emits the same edge,
+        //     `properties.order` is `undefined` because the sync layer's
+        //     `RELATE … SET rel_type = $rt` (cloud_writer.rs:430) does NOT
+        //     push the order field to cloud. Before the fix this fell back
+        //     to `Date.now()`, which silently overwrote the correct local
+        //     order with a value 11 orders of magnitude larger — relocating
+        //     the just-created sibling.
+        //
+        // Fix tier 1: when the incoming order is missing, look up the
+        // existing entry in the structureTree and preserve its order.
+        //
+        // Fix tier 2: if the child is genuinely new to this client, append
+        // it after the parent's current last child — order = lastChild.order
+        // + 1 + tiny-jitter. This matches the backend's append-at-end
+        // semantic and keeps brand-new sync-echoed children sorted at the
+        // tail. (Previously `Date.now()` was used here, which dropped the
+        // child to a position far below any sibling — a "stable" but
+        // wrong-looking location.)
+        //
+        // **Performance note**: `getChildrenWithOrder(...).find(...)` is
+        // O(n) per echo. Hot enough to matter for parents with hundreds
+        // of children; consider exposing a Map-backed `getOrderOf(parent,
+        // child)` primitive on structureTree if profiling shows a hotspot.
         if (structureTree) {
-          const order = (rel.properties?.order as number) ?? Date.now();
-          // structureTree is keyed by bare node ids (e.g. the date-
-          // page route uses `2026-05-20`, not `node:2026-05-20`).
-          // Backend events carry the table-prefixed form per the
-          // RelationshipEvent serialization contract — strip the
-          // `node:` prefix here so the local-action path (which
-          // writes bare ids via the outliner) and the sync-event
-          // path agree on the key shape.
+          const parentBare = stripNodePrefix(rel.fromId);
+          const childBare = stripNodePrefix(rel.toId);
+          // `typeof === 'number'` (not `??`) so 0 / negative orders count
+          // as a real value. `rel.properties?.order` is typed `unknown` on
+          // the wire; the `as number | undefined` is unchecked — the
+          // typeof gate IS the runtime check.
+          const incomingOrderRaw = (rel.properties as { order?: unknown } | undefined)?.order;
+          const incomingOrder =
+            typeof incomingOrderRaw === 'number' ? incomingOrderRaw : undefined;
+
+          const siblings = structureTree.getChildrenWithOrder(parentBare);
+          let order: number;
+          if (typeof incomingOrder === 'number') {
+            order = incomingOrder;
+          } else {
+            const existing = siblings.find((c) => c.nodeId === childBare);
+            if (existing) {
+              // Local optimistic path or an earlier authoritative event
+              // already placed this child; keep that order.
+              order = existing.order;
+            } else {
+              // Brand-new child via cloud echo with no order. Land at end
+              // (lastSibling.order + 1) with a tiny jitter so concurrent
+              // appends from different windows don't collide on order.
+              const lastOrder = siblings[siblings.length - 1]?.order ?? 0;
+              order = lastOrder + 1 + Math.random() * 0.001;
+            }
+          }
           structureTree.addChild({
-            parentId: stripNodePrefix(rel.fromId),
-            childId: stripNodePrefix(rel.toId),
+            parentId: parentBare,
+            childId: childBare,
             order
           });
         }

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
 import { focusManager } from '../../lib/services/focus-manager.svelte';
+import { structureTree } from '../../lib/stores/reactive-structure-tree.svelte';
 import type { Node } from '../../lib/types';
 import type { UpdateSource } from '../../lib/types/update-protocol';
 
@@ -238,6 +239,41 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // Local .version unchanged, but the persistence path now picks 5.
     expect(store.getNode('persist')?.version).toBe(1);
     expect(store.computeOccVersionForUpdate('persist')).toBe(5);
+  });
+
+  it('preserves insertAfterNodeId when sibling.parentId is null but structureTree agrees on parent (sync#77)', () => {
+    // The persistence-time stale-sibling check used to compare the bare
+    // `Node.parentId` field. Nodes loaded via `getChildrenTree` come back
+    // with `parentId: null` on the wire, so every Enter-key insertion
+    // looked "stale" and the hint got cleared — the backend then
+    // defaulted to "insert at beginning". The fix consults `structureTree`
+    // (the authoritative source for hierarchy via has_child edges) so the
+    // hint survives whenever the tree confirms the same parent.
+    //
+    // Tests the decision via `shouldClearStaleInsertAfter`, the helper
+    // the persistence closure calls — locks in the production code path
+    // without mocking the Tauri-side IPC.
+    structureTree.clear();
+    const existingA = {
+      ...makeNode('a', 'existing', 1),
+      parentId: null as string | null
+    };
+    store.setNode(existingA, databaseSource);
+    structureTree.addChild({ parentId: 'D', childId: 'a', order: 1 });
+
+    // Sibling 'a' has `parentId: null` on the node object but
+    // structureTree says its parent is 'D'. New node 'b' is being
+    // inserted with parentId='D'. The hint must be preserved.
+    expect(store.shouldClearStaleInsertAfter('a', 'D')).toBe(false);
+
+    // Sanity: if structureTree disagrees, the hint IS cleared.
+    expect(store.shouldClearStaleInsertAfter('a', 'OTHER_PARENT')).toBe(true);
+
+    // Sanity: if structureTree has no opinion, the hint is preserved
+    // (backend retry loop will handle it).
+    expect(store.shouldClearStaleInsertAfter('unknown', 'D')).toBe(false);
+
+    structureTree.clear();
   });
 
   it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the skip-while-editing guard in SharedNodeStore.setNode().
+ *
+ * Repro context: nodespace-sync#76 (typing corruption) and #77 (Enter
+ * relocates text). Root cause: daemon broadcasts of just-confirmed writes
+ * arrive via the WatchNodes gRPC stream while the user is still typing.
+ * The unguarded `setNode()` clobbers the optimistic store with the older
+ * server-confirmed state.
+ *
+ * The guard skips the clobber when source.type === 'database' AND the
+ * node is actively focused OR has unsaved local changes pending.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
+import { focusManager } from '../../lib/services/focus-manager.svelte';
+import type { Node } from '../../lib/types';
+import type { UpdateSource } from '../../lib/types/update-protocol';
+
+describe('SharedNodeStore — skip-while-editing guard', () => {
+  let store: SharedNodeStore;
+
+  const makeNode = (id: string, content: string, version = 1): Node => ({
+    id,
+    nodeType: 'text',
+    content,
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version,
+    properties: {},
+    mentions: []
+  });
+
+  const viewerSource: UpdateSource = {
+    type: 'viewer',
+    viewerId: 'viewer-1'
+  };
+
+  const databaseSource: UpdateSource = {
+    type: 'database',
+    reason: 'domain-event'
+  };
+
+  beforeEach(() => {
+    SharedNodeStore.resetInstance();
+    store = SharedNodeStore.getInstance();
+    focusManager.clearEditing();
+  });
+
+  afterEach(() => {
+    store.clearAll();
+    focusManager.clearEditing();
+    SharedNodeStore.resetInstance();
+  });
+
+  it('skips clobbering the content of a focused node on a database event', () => {
+    // User-typed optimistic state
+    const optimisticNode = makeNode('n1', 'hello world', 1);
+    store.setNode(optimisticNode, viewerSource);
+
+    // User focuses the node (actively editing)
+    focusManager.setEditingNode('n1', 'default');
+
+    // Daemon broadcast lands with the older confirmed content
+    const stalerNode = makeNode('n1', 'hell', 2);
+    store.setNode(stalerNode, databaseSource);
+
+    // Local content stays at the user's optimistic state. Crucially the
+    // local node's `.version` is also unchanged — mutating it inside the
+    // reactive Map would cause Svelte to re-render and remount the focused
+    // textarea (resetting selectionStart → triggers sync#77).
+    const after = store.getNode('n1');
+    expect(after?.content).toBe('hello world');
+    expect(after?.version).toBe(1);
+  });
+
+  it('skips clobbering when the node has pending persistence even if unfocused', () => {
+    // Plant a node and put it into the user-edit path so the persistence
+    // coordinator is engaged with a debounced write for it.
+    const initial = makeNode('n2', 'initial', 1);
+    store.setNode(initial, viewerSource);
+
+    // Trigger a viewer-side update that schedules a debounced persist.
+    // Persistence stays in the "pending" bucket because we don't flush.
+    store.updateNode('n2', { content: 'user-typing-this' }, viewerSource);
+
+    // Daemon broadcast lands with the older confirmed content.
+    const stalerNode = makeNode('n2', 'initial', 2);
+    store.setNode(stalerNode, databaseSource);
+
+    // Optimistic content survives the broadcast; local .version untouched.
+    const after = store.getNode('n2');
+    expect(after?.content).toBe('user-typing-this');
+    expect(after?.version).toBe(1);
+  });
+
+  it('does apply database events for non-focused, non-dirty nodes (regression check)', () => {
+    // Seed via the database path so no persistence is scheduled — mirrors
+    // the production case where the node arrived from the daemon and the
+    // user hasn't touched it yet.
+    const initial = makeNode('n3', 'before', 1);
+    store.setNode(initial, databaseSource);
+
+    // No focus, no pending writes → genuine remote update should land.
+    const remoteUpdate = makeNode('n3', 'after', 5);
+    store.setNode(remoteUpdate, databaseSource);
+
+    expect(store.getNode('n3')?.content).toBe('after');
+    expect(store.getNode('n3')?.version).toBe(5);
+  });
+
+  it('does apply viewer-source updates to a focused node (user actions are authoritative)', () => {
+    const initial = makeNode('n4', 'before', 1);
+    store.setNode(initial, viewerSource);
+    focusManager.setEditingNode('n4', 'default');
+
+    // The user themselves is the source — this is their own typed change.
+    const userEdit = makeNode('n4', 'after', 1);
+    store.setNode(userEdit, viewerSource);
+
+    expect(store.getNode('n4')?.content).toBe('after');
+  });
+
+  it('does apply database events when the node has never been seen locally', () => {
+    // First time the local store sees this node — the guard's "existingNode"
+    // check ensures we still accept the new state.
+    focusManager.setEditingNode('n5', 'default'); // even with focus on the id
+    const incoming = makeNode('n5', 'fresh from cloud', 1);
+    store.setNode(incoming, databaseSource);
+
+    expect(store.getNode('n5')?.content).toBe('fresh from cloud');
+  });
+
+  it('preserves the optimistic content AND leaves local version untouched (no reactive mutation)', () => {
+    const optimistic = makeNode('n6', 'local-newer', 3);
+    store.setNode(optimistic, viewerSource);
+    focusManager.setEditingNode('n6', 'default');
+
+    const broadcast = makeNode('n6', 'cloud-older', 7);
+    store.setNode(broadcast, databaseSource);
+
+    const after = store.getNode('n6');
+    expect(after?.content).toBe('local-newer'); // content preserved
+    expect(after?.version).toBe(3); // local version NOT touched
+    // The server-confirmed version (7) is stashed in a non-reactive cache
+    // and consumed by the persistence path; not observable via getNode.
+  });
+
+  it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {
+    // Seed via the database path so no persistence is scheduled — we want
+    // to exercise just the focus/clear-cache flow without a pending op
+    // tripping the guard.
+    store.setNode(makeNode('n7', 'seed', 3), databaseSource);
+
+    // Focus the node so the next database event hits the guard and stashes
+    // its version in the non-reactive cache.
+    focusManager.setEditingNode('n7', 'default');
+    store.setNode(makeNode('n7', 'older', 9), databaseSource);
+    // Verify the local view didn't change (guard fired).
+    expect(store.getNode('n7')?.content).toBe('seed');
+    expect(store.getNode('n7')?.version).toBe(3);
+
+    // User blurs. Subsequent database event no longer matches the guard;
+    // the normal setNode path runs, writes the new state, and MUST clear
+    // the cache so a stale stashed version can't shadow it on the next
+    // persistence.
+    focusManager.clearEditing();
+    store.setNode(makeNode('n7', 'cloud-current', 15), databaseSource);
+
+    const after = store.getNode('n7');
+    expect(after?.content).toBe('cloud-current');
+    expect(after?.version).toBe(15);
+  });
+});

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -156,14 +156,16 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // carry bob's version against alice's content and the backend would
     // silently overwrite bob's change.
     //
-    // The "is plausibly an own echo" heuristic resolves this: if our
-    // optimistic content equals or extends the incoming content, treat
-    // it as an own echo (own write looping back, possibly with newer
-    // local chars on top) and stash. Otherwise treat it as foreign and
-    // leave the cache empty so the next OCC conflict-detects.
+    // The "is plausibly an own echo" heuristic resolves this: stash only
+    // when `incoming.content` matches this client's recorded last-sent
+    // content for the node. For any other broadcast (including the
+    // alice="hello world" + bob="hello" prefix-compatible race the
+    // earlier startsWith heuristic mis-classified), treat as foreign.
     const optimistic = makeNode('foreign', 'alice typed this', 3);
     store.setNode(optimistic, viewerSource);
     focusManager.setEditingNode('foreign', 'default');
+    // Alice last persisted "alice typed this" to backend.
+    store.__test_setLastPersistedContent('foreign', 'alice typed this');
 
     // Foreign-looking broadcast (different writer altered the node).
     const foreignBroadcast = makeNode('foreign', 'bob wrote something else', 9);
@@ -171,12 +173,45 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
 
     // Local content is preserved (guard still fired — we keep optimistic).
     expect(store.getNode('foreign')?.content).toBe('alice typed this');
-    // Local version is preserved.
     expect(store.getNode('foreign')?.version).toBe(3);
-    // And crucially: the foreign version was NOT stashed, so the next
-    // UpdateNode RPC will use the local v3, the backend will see its
-    // current v9, and the OCC conflict surfaces.
+    // Foreign version was NOT stashed: next UpdateNode uses local v3,
+    // backend has v9, OCC conflict surfaces.
     expect(store.peekServerConfirmedVersion('foreign')).toBeUndefined();
+  });
+
+  it('does NOT mis-classify a prefix-compatible foreign write as an own-echo (regression for the startsWith hole)', () => {
+    // Previously the heuristic was `localContent.startsWith(incomingContent)`.
+    // That would mis-classify the following case as own-echo and stash
+    // bob's version, defeating OCC for bob's change:
+    //
+    //   alice's optimistic state: "hello world"
+    //   bob writes (in a parallel window): "hello"
+    //   bob's broadcast hits alice with content="hello", version=v_bob
+    //
+    // `"hello world".startsWith("hello")` is true, so the old code
+    // stashed v_bob. Next UpdateNode from alice would have carried
+    // v_bob against "hello world" and silently overwritten bob.
+    //
+    // The current heuristic compares against this client's recorded
+    // last-sent content. Alice never sent "hello" — her last persisted
+    // value (if any) is whatever she actually persisted. So bob's
+    // broadcast is correctly classified as foreign.
+    const aliceOptimistic = makeNode('shared', 'hello world', 5);
+    store.setNode(aliceOptimistic, viewerSource);
+    focusManager.setEditingNode('shared', 'default');
+    // Alice has never persisted "hello" — only "hello world" via her
+    // own typing. (For the regression check the exact prior value
+    // doesn't matter — what matters is that it ISN'T "hello".)
+    store.__test_setLastPersistedContent('shared', 'hello world');
+
+    const bobsBroadcast = makeNode('shared', 'hello', 7);
+    store.setNode(bobsBroadcast, databaseSource);
+
+    // Bob's version must NOT be stashed.
+    expect(store.peekServerConfirmedVersion('shared')).toBeUndefined();
+    // Alice's content and version are preserved (no clobber).
+    expect(store.getNode('shared')?.content).toBe('hello world');
+    expect(store.getNode('shared')?.version).toBe(5);
   });
 
   it('persistence path uses the stashed server-confirmed version for OCC (not the stale local node.version)', () => {
@@ -188,11 +223,15 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // OCC-defeat from nodespace-sync#76 — the unit tests above only
     // assert cache *population*, not *consumption*.
     store.setNode(makeNode('persist', 'abc', 1), databaseSource);
+    // Simulate that the local client just persisted 'abc' (own echo
+    // gate). Without this, the guard correctly treats the next
+    // broadcast as foreign and does NOT stash the version.
+    store.__test_setLastPersistedContent('persist', 'abc');
 
     // Before the guard fires, the OCC version is the local one.
     expect(store.computeOccVersionForUpdate('persist')).toBe(1);
 
-    // Guard fires for a plausible-own-echo broadcast (content matches).
+    // Guard fires for an own-echo broadcast (content matches what we sent).
     focusManager.setEditingNode('persist', 'default');
     store.setNode(makeNode('persist', 'abc', 5), databaseSource);
 

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -146,6 +146,61 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // and consumed by the persistence path; not observable via getNode.
   });
 
+  it('does NOT stash the server-confirmed version when the broadcast looks like a foreign write (preserves OCC)', () => {
+    // The guard's whole point is to avoid clobbering local optimistic
+    // content with the server-confirmed snapshot. But the broadcast
+    // mechanism doesn't distinguish "my-own-write echoing back" from
+    // "another client's write to the same node arriving via cloud
+    // round-trip". For the latter case, blindly stashing the foreign
+    // writer's version would defeat OCC: alice's next UpdateNode would
+    // carry bob's version against alice's content and the backend would
+    // silently overwrite bob's change.
+    //
+    // The "is plausibly an own echo" heuristic resolves this: if our
+    // optimistic content equals or extends the incoming content, treat
+    // it as an own echo (own write looping back, possibly with newer
+    // local chars on top) and stash. Otherwise treat it as foreign and
+    // leave the cache empty so the next OCC conflict-detects.
+    const optimistic = makeNode('foreign', 'alice typed this', 3);
+    store.setNode(optimistic, viewerSource);
+    focusManager.setEditingNode('foreign', 'default');
+
+    // Foreign-looking broadcast (different writer altered the node).
+    const foreignBroadcast = makeNode('foreign', 'bob wrote something else', 9);
+    store.setNode(foreignBroadcast, databaseSource);
+
+    // Local content is preserved (guard still fired — we keep optimistic).
+    expect(store.getNode('foreign')?.content).toBe('alice typed this');
+    // Local version is preserved.
+    expect(store.getNode('foreign')?.version).toBe(3);
+    // And crucially: the foreign version was NOT stashed, so the next
+    // UpdateNode RPC will use the local v3, the backend will see its
+    // current v9, and the OCC conflict surfaces.
+    expect(store.peekServerConfirmedVersion('foreign')).toBeUndefined();
+  });
+
+  it('persistence path uses the stashed server-confirmed version for OCC (not the stale local node.version)', () => {
+    // Contract test for the cache's read site. The actual persistence
+    // closure inside SharedNodeStore calls `computeOccVersionForUpdate`,
+    // which routes through the same `serverConfirmedVersions` cache the
+    // skip-while-editing guard populates. Without this test, a future
+    // refactor that drops that read would silently reintroduce the
+    // OCC-defeat from nodespace-sync#76 — the unit tests above only
+    // assert cache *population*, not *consumption*.
+    store.setNode(makeNode('persist', 'abc', 1), databaseSource);
+
+    // Before the guard fires, the OCC version is the local one.
+    expect(store.computeOccVersionForUpdate('persist')).toBe(1);
+
+    // Guard fires for a plausible-own-echo broadcast (content matches).
+    focusManager.setEditingNode('persist', 'default');
+    store.setNode(makeNode('persist', 'abc', 5), databaseSource);
+
+    // Local .version unchanged, but the persistence path now picks 5.
+    expect(store.getNode('persist')?.version).toBe(1);
+    expect(store.computeOccVersionForUpdate('persist')).toBe(5);
+  });
+
   it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {
     // Seed via the database path so no persistence is scheduled — we want
     // to exercise just the focus/clear-cache flow without a pending op


### PR DESCRIPTION
## Summary

Frontend resilience half of [`nodespace-sync#77`](https://github.com/NodeSpaceAI/nodespace-sync/issues/77). Companion to [#1214](https://github.com/NodeSpaceAI/nodespace-core/pull/1214) (\`fix/create-parent-edge-idempotent\`) — each PR removes one piece of the "new node lands at the top of the list" failure mode.

### Bug 1 — \`tauri-sync-listener\` clobbers the local order on cloud echo

The cloud LIVE-SELECT echo of a freshly-created \`has_child\` edge arrives with \`properties.order = undefined\` because the sync layer's \`RELATE ... SET rel_type = \$rt\` doesn't push the order field to cloud. The previous fallback \`?? Date.now()\` overwrote the correct local fractional order (set by the local optimistic path and the preceding local domain event) with a value 11 orders of magnitude larger — relocating the just-created sibling out of position.

**Fix**: when the incoming order is missing, look up the existing entry in \`structureTree\` and preserve its order. If the child is brand-new and we genuinely have nothing better, fall back to \`Date.now()\` so it lands somewhere stable.

### Bug 2 — stale-sibling check uses an unreliable field

The persistence-time check that decides whether to clear \`insertAfterNodeId\` before firing a CREATE compared \`siblingNode.parentId\` against \`currentNode.parentId\`. Nodes loaded via \`getChildrenTree\` come back without \`parentId\` populated on the wire, so every Enter-key insertion looked "stale" — the hint got cleared and the backend received \`None\`, falling into the wrong default branch.

**Fix**: use \`structureTree.getParent\` (the authoritative source for hierarchy via \`has_child\` edges) instead. Preserves the hint when \`structureTree\` has no opinion (sibling not yet in tree) so the backend can still resolve it via its own retry loop.

## Stacking note

This PR is **stacked on top of [#1213](https://github.com/NodeSpaceAI/nodespace-core/pull/1213)** (\`fix/setnode-skip-while-editing\`) — both PRs touch \`shared-node-store.svelte.ts\` in non-overlapping regions, but stacking keeps the review diff legible. Once #1213 merges, this PR rebases trivially against main.

## What changed

- \`packages/desktop-app/src/lib/services/tauri-sync-listener.ts\` — the \`has_child\` branch of the \`relationship:created\` handler now preserves the existing structureTree order when \`rel.properties?.order\` is missing.
- \`packages/desktop-app/src/lib/services/shared-node-store.svelte.ts\` — the stale-sibling check (in the CREATE persistence path) now consults \`structureTree.getParent\` instead of \`siblingNode.parentId\`.
- \`packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts\` — 1 new test case for the structureTree-based check.

## Test plan

- [x] Frontend shared-node-store family tests: 7 (from #1213) + 1 new = 8 passing in the new test file; 247 passing across the wider store family
- [x] \`bun run --cwd packages/desktop-app quality:fix\` — clean
- [x] Manual verification: two-window same-device demo. The frontend half alone is **not sufficient** — the receive-side default-to-beginning still bites without the backend half — but combined with #1214 it restores correct ordering across the cloud round-trip in both windows.

## Related PRs

- [#1213](https://github.com/NodeSpaceAI/nodespace-core/pull/1213) — \`setNode\` skip-while-editing guard (\`nodespace-sync#76\`). This PR stacks on it.
- [#1214](https://github.com/NodeSpaceAI/nodespace-core/pull/1214) — backend half of \`nodespace-sync#77\`. Independent of this PR; both need to land for the full fix.