### PR TITLE
Add access_tags to nodes and relationships; stamp from in node (fixes #1217)

### DIFF
--- a/packages/agent/src/acp/context_assembly.rs
+++ b/packages/agent/src/acp/context_assembly.rs
@@ -587,6 +587,7 @@ mod tests {
             mentioned_in: vec![],
             title: title.map(|s| s.to_string()),
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/benches/performance.rs
+++ b/packages/core/benches/performance.rs
@@ -186,6 +186,7 @@ fn bench_occ_overhead(c: &mut Criterion) {
                             properties: None,
                             title: None,
                             lifecycle_status: None,
+                            access_tags: None,
                         },
                     )
                     .await
@@ -205,6 +206,7 @@ fn bench_occ_overhead(c: &mut Criterion) {
                                 properties: None,
                                 title: None,
                                 lifecycle_status: None,
+                                access_tags: None,
                             },
                         )
                         .await
@@ -374,6 +376,7 @@ fn bench_batch_update(c: &mut Criterion) {
                                     properties: None,
                                     title: None,
                                     lifecycle_status: None,
+                                    access_tags: None,
                                 },
                             )
                             .await

--- a/packages/core/src/db/schema.surql
+++ b/packages/core/src/db/schema.surql
@@ -49,6 +49,11 @@ DEFINE FIELD IF NOT EXISTS title ON TABLE node TYPE option<string>;
 --   - "deleted": Soft-deleted, in trash, excluded from all queries, purgeable
 DEFINE FIELD IF NOT EXISTS lifecycle_status ON TABLE node TYPE string DEFAULT "active";
 
+-- Stamped ACL tags for cloud-side LIVE SELECT filtering (Issue #1217)
+-- Identifies which collections this node belongs to (e.g., ["col:hr", "user:uuid"]).
+-- Empty means unrestricted (local-only nodes without cloud sync).
+DEFINE FIELD IF NOT EXISTS access_tags ON TABLE node TYPE array<string> DEFAULT [];
+
 -- Indexes for performance
 DEFINE INDEX IF NOT EXISTS idx_node_type ON TABLE node COLUMNS node_type;
 DEFINE INDEX IF NOT EXISTS idx_node_modified ON TABLE node COLUMNS modified_at;
@@ -95,6 +100,10 @@ DEFINE FIELD IF NOT EXISTS relationship_type ON TABLE relationship TYPE string A
 
 -- Type-specific data stored in properties
 DEFINE FIELD IF NOT EXISTS properties ON TABLE relationship TYPE object FLEXIBLE DEFAULT {};
+
+-- Stamped ACL: inherited from the `in` node's access_tags at creation time,
+-- re-stamped when the in node's access_tags change.
+DEFINE FIELD IF NOT EXISTS access_tags ON TABLE relationship TYPE array<string> DEFAULT [];
 
 -- System metadata
 DEFINE FIELD IF NOT EXISTS version ON TABLE relationship TYPE int DEFAULT 1;

--- a/packages/core/src/db/surreal_store.rs
+++ b/packages/core/src/db/surreal_store.rs
@@ -223,6 +223,9 @@ struct SurrealNode {
     /// Lifecycle status for knowledge governance (Issue #755)
     #[serde(default = "default_lifecycle_status")]
     lifecycle_status: String,
+    /// Stamped ACL tags (Issue #1217)
+    #[serde(default)]
+    access_tags: Vec<String>,
 }
 
 /// Default lifecycle status ("active") for serde
@@ -254,6 +257,7 @@ impl From<SurrealNode> for Node {
             mentioned_in: Vec::new(), // Populated at fetch time by get_children_tree
             title: sn.title,
             lifecycle_status: sn.lifecycle_status,
+            access_tags: sn.access_tags,
         }
     }
 }
@@ -705,7 +709,8 @@ impl SurrealStore {
                 created_at: time::now(),
                 modified_at: time::now(),
                 properties: $properties,
-                title: $title
+                title: $title,
+                access_tags: $access_tags
             }};
         "#,
             node.id
@@ -727,6 +732,7 @@ impl SurrealStore {
             .bind(("version", node.version))
             .bind(("properties", properties))
             .bind(("title", node.title.clone()))
+            .bind(("access_tags", node.access_tags.clone()))
             .await
             .context("Failed to create node in universal table")?;
 
@@ -1053,6 +1059,10 @@ impl SurrealStore {
         if title_update.is_some() {
             set_clauses.push("title = $title".to_string());
         }
+        let access_tags_update = update.access_tags;
+        if access_tags_update.is_some() {
+            set_clauses.push("access_tags = $access_tags".to_string());
+        }
 
         let query = format!(
             "UPDATE type::record('node', $id) SET {};",
@@ -1071,6 +1081,9 @@ impl SurrealStore {
         }
         if let Some(title) = title_update {
             query_builder = query_builder.bind(("title", title));
+        }
+        if let Some(tags) = access_tags_update {
+            query_builder = query_builder.bind(("access_tags", tags));
         }
 
         query_builder.await.context("Failed to update node")?;
@@ -1557,6 +1570,16 @@ impl SurrealStore {
                 .bind(("lifecycle_status", status))
                 .await
                 .context("Failed to update lifecycle_status")?;
+        }
+
+        // Issue #1217: Update access_tags if provided
+        if let Some(tags) = update.access_tags {
+            self.db
+                .query("UPDATE type::record('node', $id) SET access_tags = $access_tags;")
+                .bind(("id", id.to_string()))
+                .bind(("access_tags", tags))
+                .await
+                .context("Failed to update access_tags")?;
         }
 
         // Fetch fresh node
@@ -3587,6 +3610,7 @@ impl SurrealStore {
                 mentioned_in: vec![],
                 title: None, // Child nodes don't have titles
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
             self.notify(StoreChange {
                 operation: StoreOperation::Created,
@@ -3702,6 +3726,7 @@ impl SurrealStore {
                     mentioned_in: vec![],
                     title: None,
                     lifecycle_status: "active".to_string(),
+                    access_tags: vec![],
                 };
                 self.notify(StoreChange {
                     operation: StoreOperation::Created,
@@ -3801,6 +3826,7 @@ impl SurrealStore {
             mentioned_in: vec![],
             title: None, // Streaming nodes don't have titles (typically child nodes)
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         self.notify(StoreChange {
             operation: StoreOperation::Created,

--- a/packages/core/src/mcp/handlers/nodes.rs
+++ b/packages/core/src/mcp/handlers/nodes.rs
@@ -1103,6 +1103,7 @@ pub async fn handle_update_nodes_batch(
             properties: update.properties,
             title: None,            // Title is managed by NodeService
             lifecycle_status: None, // Batch update doesn't support lifecycle_status yet
+            access_tags: None,
         };
 
         // Apply update via NodeService (enforces all business rules)

--- a/packages/core/src/models/node.rs
+++ b/packages/core/src/models/node.rs
@@ -236,6 +236,13 @@ pub struct Node {
     #[serde(default = "default_lifecycle_status")]
     #[serde(skip_serializing_if = "is_active_lifecycle")]
     pub lifecycle_status: String,
+
+    /// Stamped ACL tags for cloud-side LIVE SELECT filtering.
+    /// Identifies which collections this node belongs to (e.g., ["col:hr", "user:uuid"]).
+    /// Empty means unrestricted (local-only nodes without cloud sync).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub access_tags: Vec<String>,
 }
 
 impl Node {
@@ -282,6 +289,7 @@ impl Node {
             mentioned_in: Vec::new(),
             title: None, // Title is set by NodeService based on root/task status
             lifecycle_status: "active".to_string(),
+            access_tags: Vec::new(),
         }
     }
 
@@ -326,6 +334,7 @@ impl Node {
             mentioned_in: Vec::new(),
             title: None, // Title is set by NodeService based on root/task status
             lifecycle_status: "active".to_string(),
+            access_tags: Vec::new(),
         }
     }
 
@@ -450,6 +459,11 @@ pub struct NodeUpdate {
     /// Valid values: "active" (default), "archived", "deleted"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle_status: Option<String>,
+
+    /// Update Stamped ACL tags (replaces the full set).
+    /// Propagates to all outgoing relationships via NodeService.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_tags: Option<Vec<String>>,
 }
 
 impl NodeUpdate {
@@ -489,6 +503,12 @@ impl NodeUpdate {
         self
     }
 
+    /// Set access_tags update (Stamped ACL, Issue #1217)
+    pub fn with_access_tags(mut self, access_tags: Vec<String>) -> Self {
+        self.access_tags = Some(access_tags);
+        self
+    }
+
     /// Check if update contains any changes
     pub fn is_empty(&self) -> bool {
         self.node_type.is_none()
@@ -496,6 +516,7 @@ impl NodeUpdate {
             && self.properties.is_none()
             && self.title.is_none()
             && self.lifecycle_status.is_none()
+            && self.access_tags.is_none()
     }
 }
 

--- a/packages/core/src/models/schema_node.rs
+++ b/packages/core/src/models/schema_node.rs
@@ -234,6 +234,7 @@ impl SchemaNode {
             mentioned_in: Vec::new(),
             title: None, // Schema nodes don't have indexed titles
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/src/models/task_node.rs
+++ b/packages/core/src/models/task_node.rs
@@ -580,6 +580,7 @@ impl TaskNode {
             mentioned_in: Vec::new(),
             title: Some(crate::utils::strip_markdown(&self.content)), // Task nodes have indexed titles
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/src/ops/node_ops.rs
+++ b/packages/core/src/ops/node_ops.rs
@@ -232,6 +232,7 @@ pub async fn update_node(
         properties: input.properties,
         title: None,
         lifecycle_status: input.lifecycle_status,
+        access_tags: None,
     };
 
     // Auto-fetch version if not provided

--- a/packages/core/src/playbook/actions.rs
+++ b/packages/core/src/playbook/actions.rs
@@ -770,6 +770,7 @@ mod tests {
             mentioned_in: vec![],
             title: Some("Test Node".to_string()),
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/src/playbook/cel.rs
+++ b/packages/core/src/playbook/cel.rs
@@ -494,6 +494,7 @@ mod tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/src/playbook/cron_runner.rs
+++ b/packages/core/src/playbook/cron_runner.rs
@@ -392,6 +392,7 @@ mod tests {
                 mentioned_in: vec![],
                 title: Some("Cron Playbook".to_string()),
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
             lm.activate_playbook(&playbook_node).unwrap();
 

--- a/packages/core/src/playbook/graph_resolver.rs
+++ b/packages/core/src/playbook/graph_resolver.rs
@@ -21,7 +21,7 @@ use tracing::warn;
 #[derive(Debug, Clone)]
 pub enum ResolvedValue {
     /// A single node
-    Node(Node),
+    Node(Box<Node>),
     /// A collection of nodes (from a "many" relationship)
     Collection(Vec<Node>),
     /// A scalar property value
@@ -60,7 +60,7 @@ impl GraphResolver {
     /// Uses the segment cache: if a prefix has already been resolved, starts from there.
     pub fn resolve_path(&mut self, root_node: &Node, segments: &[String]) -> ResolvedValue {
         if segments.is_empty() {
-            return ResolvedValue::Node(root_node.clone());
+            return ResolvedValue::Node(Box::new(root_node.clone()));
         }
 
         // Check cache for the full path first
@@ -77,7 +77,7 @@ impl GraphResolver {
             if let Some(cached) = self.cache.get(prefix) {
                 match cached {
                     ResolvedValue::Node(n) => {
-                        current_node = n.clone();
+                        current_node = *n.clone();
                         start_idx = i;
                         break;
                     }
@@ -126,10 +126,12 @@ impl GraphResolver {
                 }
                 Ok(nodes) if nodes.len() == 1 => {
                     let node = nodes.into_iter().next().unwrap();
-                    self.cache
-                        .insert(segments[..=i].to_vec(), ResolvedValue::Node(node.clone()));
+                    self.cache.insert(
+                        segments[..=i].to_vec(),
+                        ResolvedValue::Node(Box::new(node.clone())),
+                    );
                     if is_last {
-                        let result = ResolvedValue::Node(node);
+                        let result = ResolvedValue::Node(Box::new(node.clone()));
                         self.cache.insert(segments.to_vec(), result.clone());
                         return result;
                     }
@@ -160,7 +162,7 @@ impl GraphResolver {
             }
         }
 
-        ResolvedValue::Node(current_node)
+        ResolvedValue::Node(Box::new(current_node))
     }
 
     /// Resolve a collection path and return the collection nodes.
@@ -177,7 +179,7 @@ impl GraphResolver {
 
         match self.resolve_path(root_node, &segments[1..]) {
             ResolvedValue::Collection(nodes) => nodes,
-            ResolvedValue::Node(n) => vec![n],
+            ResolvedValue::Node(n) => vec![*n],
             _ => vec![],
         }
     }
@@ -536,6 +538,7 @@ mod tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         assert_eq!(get_node_property(&node, "status"), Some(json!("open")));
         assert_eq!(get_node_property(&node, "missing"), None);
@@ -555,6 +558,7 @@ mod tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         // "amount" should match "custom:amount"
         assert_eq!(get_node_property(&node, "amount"), Some(json!(1500)));
@@ -575,6 +579,7 @@ mod tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         assert_eq!(get_node_property(&node, "status"), Some(json!("open")));
         assert_eq!(get_node_property(&node, "priority"), Some(json!("high")));
@@ -657,6 +662,7 @@ mod tests {
                 mentioned_in: vec![],
                 title: Some(format!("{} title", id)),
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             }
         }
 

--- a/packages/core/src/playbook/lifecycle.rs
+++ b/packages/core/src/playbook/lifecycle.rs
@@ -412,6 +412,7 @@ mod tests {
             mentioned_in: vec![],
             title: Some(format!("Playbook {}", id)),
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 

--- a/packages/core/src/playbook/tests.rs
+++ b/packages/core/src/playbook/tests.rs
@@ -26,6 +26,7 @@ mod playbook_tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         }
     }
 
@@ -1045,6 +1046,7 @@ mod playbook_tests {
             mentioned_in: vec![],
             title: Some("My task".to_string()),
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
 
         let envelope = EventEnvelope {
@@ -1091,6 +1093,7 @@ mod playbook_tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
 
         let envelope = EventEnvelope {
@@ -1153,6 +1156,7 @@ mod playbook_tests {
             mentioned_in: vec![],
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
 
         let envelope = EventEnvelope {
@@ -1196,6 +1200,7 @@ mod playbook_tests {
                 mentioned_in: vec![],
                 title: None,
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
             let envelope = EventEnvelope {
                 event: DomainEvent::NodeCreated {

--- a/packages/core/src/services/node_service.rs
+++ b/packages/core/src/services/node_service.rs
@@ -1116,6 +1116,7 @@ impl NodeService {
             modified_at: chrono::Utc::now(),
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         behavior.get_embeddable_content(&probe).is_some()
     }
@@ -2206,6 +2207,7 @@ impl NodeService {
                 modified_at: chrono::Utc::now(),
                 title: None,
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
             // is_root = parent_id.is_none() — avoids a DB lookup at create time
             self.compute_title(&temp_node, Some(params.parent_id.is_none()))
@@ -2224,6 +2226,7 @@ impl NodeService {
             modified_at: chrono::Utc::now(),
             title,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
 
         tracing::debug!(
@@ -2531,6 +2534,7 @@ impl NodeService {
                     mentioned_in: vec![],
                     title: None, // Date nodes don't have indexed titles
                     lifecycle_status: "active".to_string(),
+                    access_tags: vec![],
                 };
                 return Ok(Some(virtual_date));
             }
@@ -2955,6 +2959,7 @@ impl NodeService {
         let mut content_changed = false;
         let mut node_type_changed = false;
         let mut properties_changed = false;
+        let new_access_tags = update.access_tags.clone();
 
         if let Some(node_type) = update.node_type {
             node_type_changed = updated.node_type != node_type;
@@ -3037,6 +3042,7 @@ impl NodeService {
             properties: Some(updated.properties.clone()),
             title: title_update,
             lifecycle_status: None, // Schema update doesn't change lifecycle_status
+            access_tags: new_access_tags.clone(),
         };
 
         // For schema nodes, use atomic update with DDL generation (Issue #690, #703)
@@ -3074,6 +3080,17 @@ impl NodeService {
         }
 
         // NOTE: NodeUpdated event is now automatically emitted by store notifier (Issue #718)
+
+        // Issue #1217: Re-stamp outgoing relationships if access_tags changed
+        if let Some(ref tags) = new_access_tags {
+            if let Err(e) = self.restamp_outgoing_relationships(id, tags).await {
+                tracing::warn!(
+                    "Failed to restamp relationship access_tags for node {}: {}",
+                    id,
+                    e
+                );
+            }
+        }
 
         // Sync mentions if content changed
         if content_changed {
@@ -3205,6 +3222,7 @@ impl NodeService {
             properties: Some(updated.properties.clone()),
             title: title_update,
             lifecycle_status: update.lifecycle_status,
+            access_tags: update.access_tags.clone(),
         };
 
         // Perform atomic update with version check
@@ -3245,6 +3263,17 @@ impl NodeService {
                 )
                 .await;
             });
+        }
+
+        // Issue #1217: Re-stamp outgoing relationships if access_tags changed
+        if let Some(ref tags) = update.access_tags {
+            if let Err(e) = self.restamp_outgoing_relationships(id, tags).await {
+                tracing::warn!(
+                    "Failed to restamp relationship access_tags for node {}: {}",
+                    id,
+                    e
+                );
+            }
         }
 
         // Sync mentions if content changed
@@ -4142,6 +4171,7 @@ impl NodeService {
             modified_at: chrono::Utc::now(),
             title: None,
             lifecycle_status: "active".to_string(),
+            access_tags: vec![],
         };
         if behavior.get_embeddable_content(&probe).is_none() {
             tracing::debug!(
@@ -4872,6 +4902,7 @@ impl NodeService {
             properties: Some(node.properties.clone()),
             title: None,            // Don't update title on version bump
             lifecycle_status: None, // Don't update lifecycle_status on version bump
+            access_tags: None,      // Don't update access_tags on version bump
         };
 
         // Perform atomic update with version check
@@ -5411,6 +5442,7 @@ impl NodeService {
                 modified_at: chrono::Utc::now(),
                 title: None, // Bulk nodes don't need titles (validated only)
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
 
             // Validate via behaviors
@@ -5522,6 +5554,7 @@ impl NodeService {
                 modified_at: chrono::Utc::now(),
                 title: None,
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
 
             self.behaviors.validate_node(&temp_node)?;
@@ -5625,6 +5658,7 @@ impl NodeService {
                 modified_at: chrono::Utc::now(),
                 title: None,
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
 
             // Only behavior validation - skip schema validation
@@ -5947,6 +5981,7 @@ impl NodeService {
                 modified_at: chrono::Utc::now(),
                 title: None, // Title managed by NodeService for root/task nodes
                 lifecycle_status: "active".to_string(),
+                access_tags: vec![],
             };
             self.store
                 .create_node(node, self.client_id.clone(), self.execution_context.clone())
@@ -6530,6 +6565,13 @@ impl NodeService {
             edge_data.clone()
         };
 
+        // Issue #1217: fetch access_tags from the source (in) node to stamp onto the relationship
+        let source_access_tags: Vec<String> = self
+            .get_node(source_id)
+            .await?
+            .map(|n| n.access_tags)
+            .unwrap_or_default();
+
         // Build and execute the RELATE query - all relationships use the same table
         let properties_json =
             serde_json::to_string(&final_edge_data).unwrap_or_else(|_| "{}".to_string());
@@ -6538,6 +6580,7 @@ impl NodeService {
             r#"RELATE $source->relationship->$target CONTENT {{
                 relationship_type: $rel_type,
                 properties: {},
+                access_tags: $access_tags,
                 created_at: time::now(),
                 modified_at: time::now(),
                 version: 1
@@ -6552,6 +6595,7 @@ impl NodeService {
             .bind(("source", source_thing))
             .bind(("target", target_thing))
             .bind(("rel_type", relationship_name.to_string()))
+            .bind(("access_tags", source_access_tags))
             .await
             .map_err(|e| {
                 NodeServiceError::query_failed(format!("Failed to create relationship: {}", e))
@@ -6576,6 +6620,31 @@ impl NodeService {
             });
         }
 
+        Ok(())
+    }
+
+    /// Re-stamp access_tags on all outgoing relationships for a node (Issue #1217).
+    ///
+    /// Called after a node's access_tags are updated. Updates every relationship where
+    /// `in = node_id` so that cloud LIVE SELECT filters stay consistent.
+    async fn restamp_outgoing_relationships(
+        &self,
+        node_id: &str,
+        access_tags: &[String],
+    ) -> Result<(), NodeServiceError> {
+        let node_thing = surrealdb::types::RecordId::new("node", node_id);
+        self.store
+            .db()
+            .query("UPDATE relationship SET access_tags = $access_tags WHERE in = $node_id;")
+            .bind(("node_id", node_thing))
+            .bind(("access_tags", access_tags.to_vec()))
+            .await
+            .map_err(|e| {
+                NodeServiceError::query_failed(format!(
+                    "Failed to restamp relationship access_tags for node {}: {}",
+                    node_id, e
+                ))
+            })?;
         Ok(())
     }
 
@@ -11922,6 +11991,174 @@ mod tests {
             assert!(contents.contains("Batch 1"));
             assert!(contents.contains("Batch 2"));
             assert!(contents.contains("Batch 3"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1217: Stamped ACL — access_tags on relationships
+    // -------------------------------------------------------------------------
+
+    mod access_tags_stamping {
+        use super::*;
+        use serde_json::json;
+
+        #[derive(Debug, serde::Deserialize, surrealdb::types::SurrealValue)]
+        struct RelAccessTags {
+            access_tags: Vec<String>,
+        }
+
+        async fn get_rel_access_tags(
+            service: &NodeService,
+            source_id: &str,
+            rel_type: &str,
+            target_id: &str,
+        ) -> Vec<String> {
+            let source_thing = surrealdb::types::RecordId::new("node", source_id);
+            let target_thing = surrealdb::types::RecordId::new("node", target_id);
+            let mut resp = service
+                .store
+                .db()
+                .query(
+                    "SELECT access_tags FROM relationship WHERE in = $src AND out = $tgt AND relationship_type = $rt LIMIT 1",
+                )
+                .bind(("src", source_thing))
+                .bind(("tgt", target_thing))
+                .bind(("rt", rel_type.to_string()))
+                .await
+                .unwrap();
+            let rows: Vec<RelAccessTags> = resp.take(0).unwrap_or_default();
+            rows.into_iter()
+                .next()
+                .map(|r| r.access_tags)
+                .unwrap_or_default()
+        }
+
+        #[tokio::test]
+        async fn test_create_relationship_stamps_access_tags_from_source() {
+            let (service, _temp) = create_test_service().await;
+
+            // Create source node with access_tags
+            let mut source = Node::new("text".to_string(), "source".to_string(), json!({}));
+            source.access_tags = vec!["col:work".to_string(), "user:alice".to_string()];
+            service.create_node(source.clone()).await.unwrap();
+
+            let target = Node::new("text".to_string(), "target".to_string(), json!({}));
+            service.create_node(target.clone()).await.unwrap();
+
+            service
+                .create_relationship(&source.id, "mentions", &target.id, json!({}))
+                .await
+                .unwrap();
+
+            let tags = get_rel_access_tags(&service, &source.id, "mentions", &target.id).await;
+            assert_eq!(tags, vec!["col:work".to_string(), "user:alice".to_string()]);
+        }
+
+        #[tokio::test]
+        async fn test_create_relationship_empty_tags_when_source_has_none() {
+            let (service, _temp) = create_test_service().await;
+
+            // Source with no access_tags (default empty)
+            let source = Node::new("text".to_string(), "source".to_string(), json!({}));
+            service.create_node(source.clone()).await.unwrap();
+
+            let target = Node::new("text".to_string(), "target".to_string(), json!({}));
+            service.create_node(target.clone()).await.unwrap();
+
+            service
+                .create_relationship(&source.id, "mentions", &target.id, json!({}))
+                .await
+                .unwrap();
+
+            let tags = get_rel_access_tags(&service, &source.id, "mentions", &target.id).await;
+            assert!(tags.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_restamp_propagates_to_outgoing_relationships() {
+            let (service, _temp) = create_test_service().await;
+
+            // Create source with no tags initially
+            let source = Node::new("text".to_string(), "source".to_string(), json!({}));
+            let source_id = service.create_node(source.clone()).await.unwrap();
+
+            let target1 = Node::new("text".to_string(), "t1".to_string(), json!({}));
+            service.create_node(target1.clone()).await.unwrap();
+            let target2 = Node::new("text".to_string(), "t2".to_string(), json!({}));
+            service.create_node(target2.clone()).await.unwrap();
+
+            service
+                .create_relationship(&source_id, "mentions", &target1.id, json!({}))
+                .await
+                .unwrap();
+            service
+                .create_relationship(&source_id, "mentions", &target2.id, json!({}))
+                .await
+                .unwrap();
+
+            // Initially both relationships have empty tags
+            assert!(
+                get_rel_access_tags(&service, &source_id, "mentions", &target1.id)
+                    .await
+                    .is_empty()
+            );
+            assert!(
+                get_rel_access_tags(&service, &source_id, "mentions", &target2.id)
+                    .await
+                    .is_empty()
+            );
+
+            // Update source node's access_tags
+            let new_tags = vec!["col:hr".to_string()];
+            let current = service.get_node(&source_id).await.unwrap().unwrap();
+            service
+                .update_node(
+                    &source_id,
+                    current.version,
+                    crate::models::NodeUpdate::new().with_access_tags(new_tags.clone()),
+                )
+                .await
+                .unwrap();
+
+            // Both outgoing relationships should now carry the new tags
+            assert_eq!(
+                get_rel_access_tags(&service, &source_id, "mentions", &target1.id).await,
+                new_tags
+            );
+            assert_eq!(
+                get_rel_access_tags(&service, &source_id, "mentions", &target2.id).await,
+                new_tags
+            );
+        }
+
+        #[tokio::test]
+        async fn test_delete_cascade_independent_of_access_tags() {
+            // Ensure cascade delete (already implemented) still works when access_tags present
+            let (service, _temp) = create_test_service().await;
+
+            let mut source = Node::new("text".to_string(), "source".to_string(), json!({}));
+            source.access_tags = vec!["col:x".to_string()];
+            let source_id = service.create_node(source.clone()).await.unwrap();
+
+            let target = Node::new("text".to_string(), "target".to_string(), json!({}));
+            service.create_node(target.clone()).await.unwrap();
+
+            service
+                .create_relationship(&source_id, "mentions", &target.id, json!({}))
+                .await
+                .unwrap();
+
+            // Tags stamped correctly
+            let tags = get_rel_access_tags(&service, &source_id, "mentions", &target.id).await;
+            assert_eq!(tags, vec!["col:x".to_string()]);
+
+            // Delete source — cascade should remove the relationship
+            let v = service.get_node(&source_id).await.unwrap().unwrap().version;
+            service.delete_node(&source_id, v).await.unwrap();
+
+            // Relationship gone
+            let remaining = get_rel_access_tags(&service, &source_id, "mentions", &target.id).await;
+            assert!(remaining.is_empty());
         }
     }
 }

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -170,6 +170,7 @@ impl GrpcNodeService for NodeServiceImpl {
             properties,
             title: None,
             lifecycle_status: empty_to_none(req.lifecycle_status),
+            access_tags: None,
         };
 
         // Auto-fetch version if not supplied (matches the prior ops-layer behaviour).


### PR DESCRIPTION
## Summary

- Adds `access_tags: array<string>` field to both `node` and `relationship` tables in `schema.surql`
- Adds `access_tags` to the `Node` model, `NodeUpdate`, and the `SurrealNode` deserializer
- `NodeService::create_relationship` stamps the source node's `access_tags` onto the new relationship at creation time
- New `restamp_outgoing_relationships` helper propagates updated `access_tags` to all outgoing relationships when a node's `access_tags` change (hooked into both `update_node_unchecked` and `update_with_version_check_returning_node`)
- Boxes `ResolvedValue::Node` in the playbook graph resolver to avoid the `large_enum_variant` clippy lint caused by `Node` growing slightly

## Test plan

- [x] `test_create_relationship_stamps_access_tags_from_source` — verifies tags from source node are written to the relationship
- [x] `test_create_relationship_empty_tags_when_source_has_none` — verifies empty source = empty relationship tags
- [x] `test_restamp_propagates_to_outgoing_relationships` — verifies updating a node's access_tags re-stamps all outgoing relationships
- [x] `test_delete_cascade_independent_of_access_tags` — verifies cascade delete still works with access_tags present
- [x] `cargo clippy -p nodespace-core -- -D warnings` clean
- [x] No frontend test regressions (same baseline: 4 files/93 tests pre-existing layout failures)

## Notes

- `nodespace-cli` has 4 pre-existing `&PathBuf`/`&Path` clippy errors unrelated to this PR
- No cloud/sync changes — this is strictly the local schema + NodeService implementation per issue scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)