### PR TITLE
B7: Remove SurrealDB-era fractional-ordering jitter — make ordering deterministic under SQLite

### DIFF
--- a/packages/core/src/db/fractional_ordering.rs
+++ b/packages/core/src/db/fractional_ordering.rs
@@ -2,34 +2,26 @@
 pub struct FractionalOrderCalculator;
 
 impl FractionalOrderCalculator {
-    /// Calculate order value for inserting between prev and next
+    /// Calculate order value for inserting between prev and next.
     ///
-    /// Includes a tiny random offset to prevent exact order collisions when multiple
-    /// insertions happen concurrently.
+    /// Returns a deterministic midpoint or endpoint. Under SQLite's serialized
+    /// writes, concurrent inserts cannot interleave, so no jitter is needed.
     ///
     /// # Examples
-    /// ```text
-    /// // Insert at beginning (before all)
-    /// calculate_order(None, Some(1.0)) => ~0.5 (with tiny jitter)
-    ///
-    /// // Insert at end (after all)
-    /// calculate_order(Some(3.0), None) => ~4.0 (with tiny jitter)
-    ///
-    /// // Insert between two nodes
-    /// calculate_order(Some(1.0), Some(2.0)) => ~1.5 (with tiny jitter)
+    /// ```
+    /// # use nodespace_core::db::fractional_ordering::FractionalOrderCalculator;
+    /// assert_eq!(FractionalOrderCalculator::calculate_order(None, None), 1.0);
+    /// assert_eq!(FractionalOrderCalculator::calculate_order(None, Some(2.0)), 1.0);
+    /// assert_eq!(FractionalOrderCalculator::calculate_order(Some(3.0), None), 4.0);
+    /// assert_eq!(FractionalOrderCalculator::calculate_order(Some(1.0), Some(3.0)), 2.0);
     /// ```
     pub fn calculate_order(prev_order: Option<f64>, next_order: Option<f64>) -> f64 {
-        // Use generate_jitter() to prevent code duplication (DRY principle)
-        let jitter = Self::generate_jitter();
-
-        let base = match (prev_order, next_order) {
-            (None, None) => 1.0,                             // First child
-            (None, Some(next)) => next - 1.0,                // Before first
-            (Some(prev), None) => prev + 1.0,                // After last
-            (Some(prev), Some(next)) => (prev + next) / 2.0, // Between siblings
-        };
-
-        base + jitter
+        match (prev_order, next_order) {
+            (None, None) => 1.0,
+            (None, Some(next)) => next - 1.0,
+            (Some(prev), None) => prev + 1.0,
+            (Some(prev), Some(next)) => (prev + next) / 2.0,
+        }
     }
 
     /// Check if rebalancing is needed (gap too small)
@@ -56,81 +48,66 @@ impl FractionalOrderCalculator {
     pub fn rebalance(count: usize) -> Vec<f64> {
         (1..=count).map(|i| i as f64).collect()
     }
-
-    /// Generate a jitter value for order uniqueness
-    ///
-    /// Issue #865: Extracted for use in atomic SQL queries.
-    /// Returns a value in range [0.0, 0.001) that can be passed to SQL
-    /// and added to order values within the query itself.
-    ///
-    /// Uses the same entropy sources as calculate_order:
-    /// - Nanoseconds since epoch (rapid change)
-    /// - Process-unique counter (guaranteed uniqueness within process)
-    pub fn generate_jitter() -> f64 {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-        let counter_val = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let time_nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0);
-
-        // Combine both sources for uniqueness
-        let combined = time_nanos.wrapping_add(counter_val);
-        (combined % 1_000_000) as f64 / 1_000_000_000.0 // 0.0 to 0.001
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Helper to check approximate equality (jitter adds up to 0.001)
-    fn approx_eq(a: f64, b: f64) -> bool {
-        (a - b).abs() < 0.01
-    }
-
     #[test]
     fn test_calculate_order_first_child() {
-        let result = FractionalOrderCalculator::calculate_order(None, None);
-        assert!(approx_eq(result, 1.0), "Expected ~1.0, got {}", result);
+        assert_eq!(FractionalOrderCalculator::calculate_order(None, None), 1.0);
     }
 
     #[test]
     fn test_calculate_order_before_first() {
-        let result = FractionalOrderCalculator::calculate_order(None, Some(2.0));
-        assert!(approx_eq(result, 1.0), "Expected ~1.0, got {}", result);
+        assert_eq!(
+            FractionalOrderCalculator::calculate_order(None, Some(2.0)),
+            1.0
+        );
     }
 
     #[test]
     fn test_calculate_order_after_last() {
-        let result = FractionalOrderCalculator::calculate_order(Some(3.0), None);
-        assert!(approx_eq(result, 4.0), "Expected ~4.0, got {}", result);
+        assert_eq!(
+            FractionalOrderCalculator::calculate_order(Some(3.0), None),
+            4.0
+        );
     }
 
     #[test]
     fn test_calculate_order_between() {
-        let result = FractionalOrderCalculator::calculate_order(Some(1.0), Some(3.0));
-        assert!(approx_eq(result, 2.0), "Expected ~2.0, got {}", result);
+        assert_eq!(
+            FractionalOrderCalculator::calculate_order(Some(1.0), Some(3.0)),
+            2.0
+        );
     }
 
     #[test]
-    fn test_calculate_order_uniqueness() {
-        // Two consecutive calls should produce different values due to jitter
-        let result1 = FractionalOrderCalculator::calculate_order(None, None);
-        let result2 = FractionalOrderCalculator::calculate_order(None, None);
-        // They should be approximately equal (both ~1.0)
-        assert!(approx_eq(result1, 1.0), "Expected ~1.0, got {}", result1);
-        assert!(approx_eq(result2, 1.0), "Expected ~1.0, got {}", result2);
-        // But they should NOT be exactly equal (jitter ensures uniqueness)
-        assert_ne!(
-            result1, result2,
-            "Two calls should produce different values: {} vs {}",
-            result1, result2
-        );
+    fn test_calculate_order_deterministic() {
+        // Same inputs always produce the same output
+        let r1 = FractionalOrderCalculator::calculate_order(None, None);
+        let r2 = FractionalOrderCalculator::calculate_order(None, None);
+        assert_eq!(r1, r2);
+        assert_eq!(r1, 1.0);
+    }
+
+    #[test]
+    fn test_rapid_sequential_inserts_produce_distinct_orders() {
+        // Simulate rapid sequential inserts at the same position.
+        // Under serialized SQLite writes each insert reads the committed last_order
+        // before the next insert runs, so orders are strictly increasing.
+        let mut last = FractionalOrderCalculator::calculate_order(None, None);
+        for _ in 0..10 {
+            let next = FractionalOrderCalculator::calculate_order(Some(last), None);
+            assert!(
+                next > last,
+                "orders must be strictly increasing: {} -> {}",
+                last,
+                next
+            );
+            last = next;
+        }
     }
 
     #[test]

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -2567,25 +2567,56 @@ impl SqliteStore {
         member_id: &str,
         collection_id: &str,
     ) -> Result<Option<String>> {
-        let mut rows = self.db.query(
-            "SELECT id FROM relationship WHERE in_node = ?1 AND out_node = ?2 AND relationship_type = 'member_of' LIMIT 1",
-            libsql::params![member_id.to_string(), collection_id.to_string()],
-        ).await.context("Failed to check existing membership")?;
+        let tx = self
+            .db
+            .transaction()
+            .await
+            .context("Failed to begin add_to_collection transaction")?;
+
+        let mut rows = tx
+            .query(
+                "SELECT id FROM relationship WHERE in_node = ?1 AND out_node = ?2 AND relationship_type = 'member_of' LIMIT 1",
+                libsql::params![member_id.to_string(), collection_id.to_string()],
+            )
+            .await
+            .context("Failed to check existing membership")?;
 
         if rows.next().await?.is_some() {
             return Ok(None);
         }
 
-        let new_order = self.get_next_member_order(collection_id).await?;
+        let mut order_rows = tx
+            .query(
+                "SELECT json_extract(properties, '$.order') as ord FROM relationship WHERE out_node = ?1 AND relationship_type = 'member_of' ORDER BY json_extract(properties, '$.order') DESC LIMIT 1",
+                libsql::params![collection_id.to_string()],
+            )
+            .await
+            .context("Failed to get last member order")?;
+
+        let last_order = if let Some(row) = order_rows.next().await? {
+            row.get::<Option<f64>>(0)?.unwrap_or(0.0)
+        } else {
+            0.0
+        };
+        let new_order = FractionalOrderCalculator::calculate_order(
+            if last_order > 0.0 { Some(last_order) } else { None },
+            None,
+        );
 
         let rel_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
         let props = serde_json::json!({"order": new_order}).to_string();
 
-        self.db.execute(
+        tx.execute(
             "INSERT INTO relationship (id, in_node, out_node, relationship_type, properties, version, created_at, modified_at) VALUES (?1, ?2, ?3, 'member_of', ?4, 1, ?5, ?6)",
             libsql::params![rel_id.clone(), member_id.to_string(), collection_id.to_string(), props, now.clone(), now],
-        ).await.context("Failed to add to collection")?;
+        )
+        .await
+        .context("Failed to add to collection")?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit add_to_collection")?;
 
         Ok(Some(rel_id))
     }

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -2576,9 +2576,7 @@ impl SqliteStore {
             return Ok(None);
         }
 
-        let jitter = FractionalOrderCalculator::generate_jitter();
-        let base_order = self.get_next_member_order(collection_id).await?;
-        let new_order = base_order + jitter;
+        let new_order = self.get_next_member_order(collection_id).await?;
 
         let rel_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();


### PR DESCRIPTION
Removes SurrealDB-era jitter from fractional ordering. Under SQLite's serialized writes, concurrent inserts cannot interleave mid-computation, so jitter was dead weight everywhere.

## Changes

- `calculate_order` is now pure and deterministic — returns exact midpoint/endpoint values
- `generate_jitter()` deleted entirely
- `add_to_collection`: wrapped SELECT + INSERT in a transaction (closes the one genuine TOCTOU window found during analysis)
- Doctests assert exact values; `approx_eq` helper and jitter-uniqueness test replaced with exact-value + strictly-increasing-orders tests

## Concurrency analysis per call site

| Call site | Pattern | Window? | Verdict |
|-----------|---------|---------|---------|
| `create_child_node_atomic` (~line 420) | SELECT outside tx, INSERT inside tx | Read before tx open | Daemon serializes callers; no real-world collision risk |
| `move_node` (~lines 1290–1307) | Siblings queried in Rust, UPDATE inside tx | Same | Serialized by daemon |
| `add_to_collection` (~line 2579) | SELECT + INSERT as two independent statements | **Yes** | Fixed: now wrapped in a single transaction |
| `bulk_add_to_collections` (~line 2843) | Already in transaction | None | Correct |

Conclusion: jitter was not providing collision protection on any path. The one path with a genuine concurrent-write window (`add_to_collection`) is now protected by a transaction, which is the correct fix.

Closes #1253