### PR TITLE
B6: Exhaustive NodeServiceError→gRPC error mapping + parity tests

### DIFF
--- a/packages/core/src/ops/mod.rs
+++ b/packages/core/src/ops/mod.rs
@@ -70,7 +70,20 @@ impl From<NodeServiceError> for OpsError {
                 OpsError::InvalidParams(err.to_string())
             }
             NodeServiceError::CollectionNotFound(name) => OpsError::NotFound { id: name },
-            other => OpsError::Internal(other.to_string()),
+            NodeServiceError::InvalidUpdate(msg) => OpsError::ValidationFailed(msg),
+            NodeServiceError::InvalidCollectionPath(msg) => OpsError::ValidationFailed(msg),
+            NodeServiceError::CollectionCycle(msg) => OpsError::ValidationFailed(msg),
+            NodeServiceError::CollectionDepthExceeded { path, max_depth } => {
+                OpsError::ValidationFailed(format!(
+                    "Collection path exceeds maximum depth of {max_depth} levels: {path}"
+                ))
+            }
+            NodeServiceError::DatabaseError(e) => OpsError::Internal(e.to_string()),
+            NodeServiceError::TransactionFailed { context } => OpsError::Internal(context),
+            NodeServiceError::SerializationError(msg) => OpsError::Internal(msg),
+            NodeServiceError::QueryFailed(msg) => OpsError::Internal(msg),
+            NodeServiceError::BulkOperationFailed { context } => OpsError::Internal(context),
+            NodeServiceError::InitializationError(msg) => OpsError::Internal(msg),
         }
     }
 }

--- a/packages/core/src/ops/mod.rs
+++ b/packages/core/src/ops/mod.rs
@@ -66,8 +66,8 @@ impl From<NodeServiceError> for OpsError {
             NodeServiceError::HierarchyViolation(msg) => {
                 OpsError::ValidationFailed(format!("Hierarchy violation: {}", msg))
             }
-            NodeServiceError::PlaybookValidationFailed { .. } => {
-                OpsError::InvalidParams(err.to_string())
+            NodeServiceError::PlaybookValidationFailed { errors } => {
+                OpsError::InvalidParams(errors)
             }
             NodeServiceError::CollectionNotFound(name) => OpsError::NotFound { id: name },
             NodeServiceError::InvalidUpdate(msg) => OpsError::ValidationFailed(msg),

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -667,7 +667,10 @@ impl GrpcNodeService for NodeServiceImpl {
                     nodespace_core::markdown::MarkdownError::InvalidParams(m) => {
                         Status::invalid_argument(m)
                     }
-                    other => Status::internal(format!("ExportMarkdown failed: {other}")),
+                    nodespace_core::markdown::MarkdownError::CreationFailed(m) => {
+                        Status::failed_precondition(format!("Node creation failed: {m}"))
+                    }
+                    nodespace_core::markdown::MarkdownError::Internal(m) => Status::internal(m),
                 })?;
 
         let markdown = result["markdown"]
@@ -708,7 +711,7 @@ impl GrpcNodeService for NodeServiceImpl {
             .node_service
             .get_nodes(&id_refs)
             .await
-            .map_err(|e| Status::internal(format!("get_nodes_batch failed: {e}")))?;
+            .map_err(service_error_to_status)?;
 
         let fetched_ids: std::collections::HashSet<String> =
             fetched.iter().map(|n| n.id.clone()).collect();

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -1266,7 +1266,7 @@ async fn fetch_node(service: &Arc<CoreNodeService>, node_id: &str) -> Result<Nod
     service
         .get_node(node_id)
         .await
-        .map_err(|e| Status::internal(format!("get_node failed: {}", e)))?
+        .map_err(service_error_to_status)?
         .ok_or_else(|| Status::not_found(format!("Node not found: {}", node_id)))
 }
 
@@ -1395,7 +1395,7 @@ fn ops_error_to_status(err: OpsError) -> Status {
             node_id, expected, actual
         )),
         OpsError::ValidationFailed(msg) => {
-            Status::failed_precondition(format!("Validation failed: {}", msg))
+            Status::invalid_argument(format!("Validation failed: {}", msg))
         }
         OpsError::InvalidParams(msg) => Status::invalid_argument(msg),
         OpsError::Internal(msg) => Status::internal(msg),
@@ -1670,5 +1670,139 @@ mod tests {
         });
         let resp = svc.delete_node(req).await.unwrap().into_inner();
         assert!(!resp.existed);
+    }
+
+    // -- Error mapping parity tests ------------------------------------------
+    //
+    // For each NodeServiceError variant: assert the resulting tonic::Status code.
+    // These exercise the full NodeServiceError → OpsError → Status chain.
+
+    fn to_status(err: NodeServiceError) -> tonic::Status {
+        service_error_to_status(err)
+    }
+
+    #[test]
+    fn error_mapping_node_not_found_returns_not_found() {
+        let s = to_status(NodeServiceError::node_not_found("abc"));
+        assert_eq!(s.code(), tonic::Code::NotFound);
+    }
+
+    #[test]
+    fn error_mapping_version_conflict_returns_aborted() {
+        let s = to_status(NodeServiceError::version_conflict("n1", 3, 5));
+        assert_eq!(s.code(), tonic::Code::Aborted);
+    }
+
+    #[test]
+    fn error_mapping_validation_failed_returns_invalid_argument() {
+        use nodespace_core::models::ValidationError;
+        let s = to_status(NodeServiceError::ValidationFailed(
+            ValidationError::MissingField("x".into()),
+        ));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_invalid_parent_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::invalid_parent("p1"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_invalid_root_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::invalid_root("r1"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_circular_reference_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::circular_reference("A→B→A"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_hierarchy_violation_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::hierarchy_violation("root immutable"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_invalid_update_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::invalid_update("cannot change type"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_invalid_collection_path_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::invalid_collection_path("empty segment"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_collection_cycle_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::collection_cycle("A→B→A"));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_collection_depth_exceeded_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::collection_depth_exceeded(
+            "a:b:c:d:e:f",
+            5,
+        ));
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_playbook_validation_failed_returns_invalid_argument() {
+        let s = to_status(NodeServiceError::PlaybookValidationFailed {
+            errors: "bad rule".into(),
+        });
+        assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn error_mapping_collection_not_found_returns_not_found() {
+        let s = to_status(NodeServiceError::collection_not_found("inbox"));
+        assert_eq!(s.code(), tonic::Code::NotFound);
+    }
+
+    #[test]
+    fn error_mapping_database_error_returns_internal() {
+        use nodespace_core::db::DatabaseError;
+        let s = to_status(NodeServiceError::DatabaseError(
+            DatabaseError::initialization_failed("conn lost"),
+        ));
+        assert_eq!(s.code(), tonic::Code::Internal);
+    }
+
+    #[test]
+    fn error_mapping_transaction_failed_returns_internal() {
+        let s = to_status(NodeServiceError::transaction_failed("commit failed"));
+        assert_eq!(s.code(), tonic::Code::Internal);
+    }
+
+    #[test]
+    fn error_mapping_serialization_error_returns_internal() {
+        let s = to_status(NodeServiceError::serialization_error("bad json"));
+        assert_eq!(s.code(), tonic::Code::Internal);
+    }
+
+    #[test]
+    fn error_mapping_query_failed_returns_internal() {
+        let s = to_status(NodeServiceError::query_failed("syntax error"));
+        assert_eq!(s.code(), tonic::Code::Internal);
+    }
+
+    #[test]
+    fn error_mapping_bulk_operation_failed_returns_internal() {
+        let s = to_status(NodeServiceError::bulk_operation_failed("3 of 5 failed"));
+        assert_eq!(s.code(), tonic::Code::Internal);
+    }
+
+    #[test]
+    fn error_mapping_initialization_error_returns_internal() {
+        let s = to_status(NodeServiceError::initialization_error("db unavailable"));
+        assert_eq!(s.code(), tonic::Code::Internal);
     }
 }

--- a/packages/daemon/tests/grpc_round_trip.rs
+++ b/packages/daemon/tests/grpc_round_trip.rs
@@ -981,7 +981,10 @@ async fn move_node_to_root_when_new_parent_id_empty_string() {
         .expect("move_node with empty new_parent_id failed");
 
     let roots = client
-        .get_roots(GetRootsRequest { limit: 100, offset: 0 })
+        .get_roots(GetRootsRequest {
+            limit: 100,
+            offset: 0,
+        })
         .await
         .expect("get_roots failed")
         .into_inner();


### PR DESCRIPTION
Closes #1254.

## Summary
- `From<NodeServiceError> for OpsError` (`ops/mod.rs`) is now exhaustive — catch-all `other => Internal` replaced with explicit arms for every remaining variant
- `InvalidUpdate` → `ValidationFailed` → `InvalidArgument` (was `Internal`)
- Collection-validation variants (`InvalidCollectionPath`, `CollectionCycle`, `CollectionDepthExceeded`) → `ValidationFailed` → `InvalidArgument`
- Genuinely-internal variants (`DatabaseError`, `TransactionFailed`, `SerializationError`, `QueryFailed`, `BulkOperationFailed`, `InitializationError`) mapped explicitly to `Internal` — compile error on any future unmapped variant
- `ops_error_to_status`: `ValidationFailed` → `invalid_argument` (was `failed_precondition`)
- `fetch_node` routes through `service_error_to_status` instead of bare `Status::internal`
- 19 table-driven parity tests asserting `NodeServiceError` variant → `tonic::Code` for every variant

## Test plan
- [ ] `cargo test -p nodespace-daemon` — 19 new `error_mapping_*` tests pass
- [ ] `cargo test --workspace --exclude nodespace-agent` — all green (agent/Ollama tests require live Ollama, pre-existing skip)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)