### PR TITLE
Graceful stale-count when EmbeddingsService is absent (fixes nodespace-sync#82)

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -10,8 +10,9 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use nodespace_proto::nodespace::{
-    BatchQueueEmbeddingsRequest, GetStaleCountRequest, QueueEmbeddingRequest,
-    RegenerateEmbeddingRequest, SearchSemanticRequest, TriggerBatchEmbedRequest,
+    BatchQueueEmbeddingsRequest, GetStaleCountRequest, GetStaleCountResponse,
+    QueueEmbeddingRequest, RegenerateEmbeddingRequest, SearchSemanticRequest,
+    TriggerBatchEmbedRequest,
 };
 
 fn grpc_err(msg: impl std::fmt::Display) -> CommandError {
@@ -205,25 +206,44 @@ pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandE
     Ok(())
 }
 
-/// Get count of stale topics/roots.
+/// Map a `get_stale_count` gRPC result to the command's `Result<usize>`.
 ///
-/// Degrades gracefully when the daemon does not serve the `EmbeddingsService`.
-/// `nodespaced-pro` omits the NLP/embedding stack (no llama-cpp, per
-/// nodespace-sync#10), so its gRPC server never registers `EmbeddingsService`
-/// and this call returns `Unimplemented`. With no embedding processor there is
-/// no embedding queue, so the honest stale count is zero. The status bar polls
-/// this every 5s — returning `Ok(0)` keeps it quiet instead of flooding the
-/// console with a recurring `GRPC_ERROR` (nodespace-sync#82). Any other gRPC
-/// failure still surfaces as an error.
-#[tauri::command]
-pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
-    let mut client = grpc.embeddings_client().await;
-
-    match client.get_stale_count(GetStaleCountRequest {}).await {
+/// `Unimplemented` collapses to `Ok(0)`: the daemon serves no
+/// `EmbeddingsService` — `nodespaced-pro` omits the NLP/embedding stack
+/// (no llama-cpp, per nodespace-sync#10) and never registers it — so there
+/// is no embedding queue and zero is the honest count.
+///
+/// Note this arm intentionally collapses *any* `Unimplemented` for this
+/// RPC, including the (today non-existent) case where a **registered**
+/// `EmbeddingsService` leaves `get_stale_count` itself unimplemented at the
+/// method level. That's acceptable because the community daemon implements
+/// it; were that to change, the queue indicator would read zero rather than
+/// surface the gap. Every other status surfaces as an error so real
+/// failures still reach the UI.
+///
+/// Extracted as a pure fn (no `State`/network) so the
+/// `Unimplemented → Ok(0)` contract is unit-testable without a mock gRPC
+/// server.
+fn stale_count_from_result(
+    result: Result<tonic::Response<GetStaleCountResponse>, tonic::Status>,
+) -> Result<usize, CommandError> {
+    match result {
         Ok(response) => Ok(response.into_inner().count as usize),
         Err(status) if status.code() == tonic::Code::Unimplemented => Ok(0),
         Err(status) => Err(grpc_err(status.message())),
     }
+}
+
+/// Get count of stale topics/roots.
+///
+/// Degrades gracefully when the daemon serves no `EmbeddingsService` (e.g.
+/// `nodespaced-pro`): the status bar polls this every 5s, so an
+/// `Unimplemented` must not flood the console (nodespace-sync#82). See
+/// [`stale_count_from_result`] for the mapping rationale.
+#[tauri::command]
+pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
+    let mut client = grpc.embeddings_client().await;
+    stale_count_from_result(client.get_stale_count(GetStaleCountRequest {}).await)
 }
 
 /// Error details for a failed batch embedding operation
@@ -301,5 +321,36 @@ mod tests {
         assert_eq!(params.threshold.unwrap(), 0.8);
         assert_eq!(params.limit.unwrap(), 50);
         assert!(params.exact.unwrap());
+    }
+
+    /// Regression guard for nodespace-sync#82: a daemon with no
+    /// `EmbeddingsService` returns `Unimplemented`, which must collapse to
+    /// a quiet `Ok(0)` rather than an error the 5s poll would flood.
+    #[test]
+    fn stale_count_unimplemented_maps_to_zero() {
+        let out =
+            stale_count_from_result(Err(tonic::Status::unimplemented("no EmbeddingsService")));
+        assert_eq!(out.expect("Unimplemented should map to Ok(0)"), 0);
+    }
+
+    /// A real count passes through unchanged.
+    #[test]
+    fn stale_count_ok_passes_through() {
+        let resp = tonic::Response::new(GetStaleCountResponse { count: 7 });
+        assert_eq!(
+            stale_count_from_result(Ok(resp)).expect("Ok response passes through"),
+            7
+        );
+    }
+
+    /// Any non-`Unimplemented` status still surfaces as an error so genuine
+    /// failures aren't silently swallowed as "zero queued".
+    #[test]
+    fn stale_count_other_status_is_error() {
+        let out = stale_count_from_result(Err(tonic::Status::unavailable("daemon down")));
+        assert!(
+            out.is_err(),
+            "non-Unimplemented status must surface as an error"
+        );
     }
 }

--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -205,17 +205,25 @@ pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandE
     Ok(())
 }
 
-/// Get count of stale topics/roots
+/// Get count of stale topics/roots.
+///
+/// Degrades gracefully when the daemon does not serve the `EmbeddingsService`.
+/// `nodespaced-pro` omits the NLP/embedding stack (no llama-cpp, per
+/// nodespace-sync#10), so its gRPC server never registers `EmbeddingsService`
+/// and this call returns `Unimplemented`. With no embedding processor there is
+/// no embedding queue, so the honest stale count is zero. The status bar polls
+/// this every 5s — returning `Ok(0)` keeps it quiet instead of flooding the
+/// console with a recurring `GRPC_ERROR` (nodespace-sync#82). Any other gRPC
+/// failure still surfaces as an error.
 #[tauri::command]
 pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
     let mut client = grpc.embeddings_client().await;
 
-    let response = client
-        .get_stale_count(GetStaleCountRequest {})
-        .await
-        .map_err(|e| grpc_err(e.message()))?;
-
-    Ok(response.into_inner().count as usize)
+    match client.get_stale_count(GetStaleCountRequest {}).await {
+        Ok(response) => Ok(response.into_inner().count as usize),
+        Err(status) if status.code() == tonic::Code::Unimplemented => Ok(0),
+        Err(status) => Err(grpc_err(status.message())),
+    }
 }
 
 /// Error details for a failed batch embedding operation


### PR DESCRIPTION
## Problem

In the two-window Pro demo, the frontend logs `Failed to get stale nodes count: {code: \"GRPC_ERROR\", message: \"\"}` **every 5 seconds** for the entire session in both windows.

`nodespaced-pro` omits the NLP/embedding stack (no llama-cpp, per nodespace-sync#10), so its gRPC server never registers `EmbeddingsService`. The status bar's 5s `get_stale_root_count` poll therefore hits an unregistered service → tonic returns `Unimplemented` → the Tauri command propagated it as an error → recurring console flood that masks real errors during debugging.

## Fix

`get_stale_root_count` now treats `Unimplemented` as "no embedding processor ⇒ no embedding queue ⇒ zero stale roots" and returns `Ok(0)`. Every other gRPC error still surfaces unchanged.

```rust
match client.get_stale_count(GetStaleCountRequest {}).await {
    Ok(response) => Ok(response.into_inner().count as usize),
    Err(status) if status.code() == tonic::Code::Unimplemented => Ok(0),
    Err(status) => Err(grpc_err(status.message())),
}
```

The status bar already treats a count of 0 as "nothing queued" (clears the message), so the UI is correct and quiet in Pro mode, while the full daemon (`nodespaced`) is unaffected — it registers `EmbeddingsService` and returns real counts.

## Why this approach

The flood is specifically the embeddings RPC. `EmbeddingsServiceImpl` cannot be constructed without the loaded embedding model, so the Pro daemon cannot cheaply serve it — and per nodespace-sync#10 the NLP stack is deliberately excluded from Pro. Graceful degradation at the command boundary is the honest fix: it respects #10 and removes the silent-failure noise without pretending an embedding queue exists.

Note: `nodespaced-pro` also doesn't register Import/Settings/LocalAgent/AgentSession services, but those are user-triggered (not polled) so they don't flood. Making Pro a strict superset for those non-NLP services is tracked separately and is not required to resolve the flood this issue is about.

## Validation

- `cargo check -p nodespace-app` — clean
- `cargo clippy -p nodespace-app` — no warnings
- `cargo fmt --check` — clean
- Happy path unchanged (same `Result<usize>` signature); frontend behavior identical when the service is present.

Fixes NodeSpaceAI/nodespace-sync#82