### PR TITLE
Add e2e test infrastructure: frontend→daemon→database round-trip

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:db:watch": "bun run --cwd packages/desktop-app test:db:watch",
     "test:coverage": "bun run --cwd packages/desktop-app test:coverage",
     "test:skill": "bun run --cwd packages/skill test",
+    "test:e2e": "bun run --cwd packages/desktop-app test:e2e",
     "test:all": "bun run test && bun run test:skill && bun run rust:test",
     "test:all:db": "bun run test:db && bun run test:skill && bun run rust:test",
     "check": "bun run --cwd packages/desktop-app check",

--- a/packages/desktop-app/eslint.config.js
+++ b/packages/desktop-app/eslint.config.js
@@ -264,6 +264,9 @@ export default [
         global: 'readonly', // Node.js global for tests
         globalThis: 'readonly',
         process: 'readonly',
+        __dirname: 'readonly', // Node.js CommonJS global (available via Bun/Vitest)
+        __filename: 'readonly',
+        Buffer: 'readonly', // Node.js Buffer global
         vi: 'readonly', // Vitest
         describe: 'readonly', // Vitest
         it: 'readonly', // Vitest

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -27,6 +27,8 @@
     "test:db": "TEST_USE_DATABASE=true bunx vitest run",
     "test:db:watch": "TEST_USE_DATABASE=true bunx vitest",
     "test:integration:full": "bun run test && bun run test:browser && bun run test:perf && bun run rust:test",
+    "test:e2e": "bunx vitest run --config vitest.e2e.config.ts",
+    "test:e2e:watch": "bunx vitest --config vitest.e2e.config.ts",
     "test:all": "bun run test && bun run rust:test",
     "rust:test": "cd src-tauri && cargo test --lib -p nodespace-core -- --test-threads=2",
     "quality:check": "bunx eslint 'src/**/*.{ts,svelte}' && BROWSERSLIST_IGNORE_OLD_DATA=1 bunx svelte-check",

--- a/packages/desktop-app/src/tests/e2e/daemon-harness.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-harness.ts
@@ -1,0 +1,326 @@
+/**
+ * DaemonTestHarness — spin up a real nodespaced + dev-proxy for e2e tests.
+ *
+ * Usage:
+ *   const h = await DaemonTestHarness.start();
+ *   const adapter = h.adapter;   // HttpAdapter pointing at the live stack
+ *   await h.stop();
+ *
+ * Environment:
+ *   NODESPACED_BINARY   — override binary path (defaults to prebuilt sidecar)
+ *   E2E_DAEMON_TIMEOUT  — ms to wait for daemon readiness (default 10000)
+ */
+
+import * as child_process from 'node:child_process';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Import HttpAdapter by constructing it directly — avoid the singleton
+// `backendAdapter` export, which detects the test environment and returns
+// a MockAdapter.
+class HttpAdapter {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      let message = `HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const body = await response.json() as { message?: string };
+        if (body.message) message = body.message;
+      } catch {
+        // non-JSON body — keep default message
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T;
+    }
+    return response.json() as Promise<T>;
+  }
+
+  async createNode(input: {
+    id: string;
+    nodeType: string;
+    content: string;
+    properties?: Record<string, unknown>;
+    mentions?: string[];
+    parentId?: string | null;
+  }): Promise<string> {
+    const now = new Date().toISOString();
+    const response = await fetch(`${this.baseUrl}/api/nodes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...input, properties: input.properties ?? {}, mentions: input.mentions ?? [], createdAt: now, modifiedAt: now, version: 1 })
+    });
+    return this.handleResponse<string>(response);
+  }
+
+  async getNode(id: string): Promise<Record<string, unknown> | null> {
+    const response = await fetch(`${this.baseUrl}/api/nodes/${encodeURIComponent(id)}`);
+    if (response.status === 404) return null;
+    return this.handleResponse<Record<string, unknown>>(response);
+  }
+
+  async updateNode(id: string, version: number, update: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const response = await fetch(`${this.baseUrl}/api/nodes/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...update, version })
+    });
+    return this.handleResponse<Record<string, unknown>>(response);
+  }
+
+  async deleteNode(id: string, version: number): Promise<{ existed: boolean; deletedCount: number }> {
+    const response = await fetch(`${this.baseUrl}/api/nodes/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ version })
+    });
+    return this.handleResponse<{ existed: boolean; deletedCount: number }>(response);
+  }
+
+  async getChildren(parentId: string): Promise<Record<string, unknown>[]> {
+    const response = await fetch(`${this.baseUrl}/api/nodes/${encodeURIComponent(parentId)}/children`);
+    return this.handleResponse<Record<string, unknown>[]>(response);
+  }
+
+  async getAllSchemas(): Promise<Record<string, unknown>[]> {
+    const response = await fetch(`${this.baseUrl}/api/schemas`);
+    return this.handleResponse<Record<string, unknown>[]>(response);
+  }
+
+  async getSchema(schemaId: string): Promise<Record<string, unknown>> {
+    const response = await fetch(`${this.baseUrl}/api/schemas/${encodeURIComponent(schemaId)}`);
+    return this.handleResponse<Record<string, unknown>>(response);
+  }
+
+  get baseURL(): string {
+    return this.baseUrl;
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolveDesktopAppDir(): string {
+  // Walk up from __dirname until we find the src-tauri directory,
+  // which marks the desktop-app package root.
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    if (fs.existsSync(path.join(dir, 'src-tauri'))) return dir;
+    dir = path.dirname(dir);
+  }
+  // Fallback: this file is at packages/desktop-app/src/tests/e2e/
+  return path.resolve(__dirname, '../../..');
+}
+
+function resolveDaemonBinary(): string {
+  if (process.env.NODESPACED_BINARY) {
+    return process.env.NODESPACED_BINARY;
+  }
+  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+  const platform = process.platform === 'darwin' ? 'apple-darwin' : 'unknown-linux-gnu';
+  const binaryName = `nodespaced-${arch}-${platform}`;
+  const desktopApp = resolveDesktopAppDir();
+  return path.join(desktopApp, 'src-tauri', 'binaries', binaryName);
+}
+
+function resolveDevProxyScript(): string {
+  const desktopApp = resolveDesktopAppDir();
+  // packages/desktop-app/../dev-tools/src/dev-proxy.ts
+  return path.join(desktopApp, '..', 'dev-tools', 'src', 'dev-proxy.ts');
+}
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Could not determine free port'));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const connected = await new Promise<boolean>((resolve) => {
+      const sock = net.createConnection(socketPath);
+      sock.once('connect', () => { sock.destroy(); resolve(true); });
+      sock.once('error', () => resolve(false));
+    });
+    if (connected) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`Daemon socket ${socketPath} not ready after ${timeoutMs}ms`);
+}
+
+async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`HTTP endpoint ${url} not ready after ${timeoutMs}ms`);
+}
+
+// ============================================================================
+// DaemonTestHarness
+// ============================================================================
+
+export class DaemonTestHarness {
+  readonly adapter: HttpAdapter;
+  private readonly tmpDir: string;
+  private readonly socketPath: string;
+  private readonly proxyPort: number;
+  private readonly daemonProc: child_process.ChildProcess;
+  private readonly proxyProc: child_process.ChildProcess;
+
+  private constructor(opts: {
+    adapter: HttpAdapter;
+    tmpDir: string;
+    socketPath: string;
+    proxyPort: number;
+    daemonProc: child_process.ChildProcess;
+    proxyProc: child_process.ChildProcess;
+  }) {
+    this.adapter = opts.adapter;
+    this.tmpDir = opts.tmpDir;
+    this.socketPath = opts.socketPath;
+    this.proxyPort = opts.proxyPort;
+    this.daemonProc = opts.daemonProc;
+    this.proxyProc = opts.proxyProc;
+  }
+
+  static async start(): Promise<DaemonTestHarness> {
+    const timeoutMs = parseInt(process.env.E2E_DAEMON_TIMEOUT ?? '10000', 10);
+    const binary = resolveDaemonBinary();
+    const devProxyScript = resolveDevProxyScript();
+
+    if (!fs.existsSync(binary)) {
+      throw new Error(
+        `nodespaced binary not found at ${binary}. ` +
+        `Build with 'cargo build -p nodespaced' or set NODESPACED_BINARY.`
+      );
+    }
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodespace-e2e-'));
+    const socketPath = path.join(tmpDir, 'daemon.sock');
+    const dbPath = path.join(tmpDir, 'test-db');
+    const proxyPort = await findFreePort();
+
+    // Spawn daemon
+    const daemonEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODESPACED_SOCKET: socketPath,
+      NODESPACED_DB_PATH: dbPath,
+      NODESPACED_HEADLESS: '1',
+      RUST_LOG: 'warn'
+    };
+
+    const daemonProc = child_process.spawn(binary, [], {
+      env: daemonEnv,
+      stdio: 'pipe',
+      detached: false
+    });
+
+    daemonProc.stderr?.on('data', (chunk: Buffer) => {
+      // Only log daemon output on test failure debugging
+      if (process.env.E2E_VERBOSE) {
+        process.stderr.write(`[daemon] ${chunk.toString()}`);
+      }
+    });
+
+    daemonProc.on('error', (err) => {
+      throw new Error(`Failed to start nodespaced: ${err.message}`);
+    });
+
+    // Wait for daemon socket
+    try {
+      await waitForSocket(socketPath, timeoutMs);
+    } catch (err) {
+      daemonProc.kill();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      throw err;
+    }
+
+    // Spawn dev-proxy via bun
+    const proxyEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODESPACED_SOCKET: socketPath,
+      DEV_PROXY_PORT: String(proxyPort)
+    };
+
+    const proxyProc = child_process.spawn('bun', ['run', devProxyScript], {
+      env: proxyEnv,
+      stdio: 'pipe',
+      detached: false
+    });
+
+    proxyProc.stderr?.on('data', (chunk: Buffer) => {
+      if (process.env.E2E_VERBOSE) {
+        process.stderr.write(`[proxy] ${chunk.toString()}`);
+      }
+    });
+
+    proxyProc.on('error', (err) => {
+      daemonProc.kill();
+      throw new Error(`Failed to start dev-proxy: ${err.message}`);
+    });
+
+    // Wait for proxy HTTP health
+    try {
+      await waitForHttp(`http://localhost:${proxyPort}/health`, timeoutMs);
+    } catch (err) {
+      proxyProc.kill();
+      daemonProc.kill();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      throw err;
+    }
+
+    const adapter = new HttpAdapter(`http://localhost:${proxyPort}`);
+    return new DaemonTestHarness({ adapter, tmpDir, socketPath, proxyPort, daemonProc, proxyProc });
+  }
+
+  /** SSE endpoint URL for WatchNodes event tests. */
+  get sseUrl(): string {
+    return `http://localhost:${this.proxyPort}/api/events`;
+  }
+
+  async stop(): Promise<void> {
+    this.proxyProc.kill('SIGTERM');
+    this.daemonProc.kill('SIGTERM');
+
+    // Give processes a moment to exit
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Force-kill if still running
+    try { this.proxyProc.kill('SIGKILL'); } catch { /* already dead */ }
+    try { this.daemonProc.kill('SIGKILL'); } catch { /* already dead */ }
+
+    // Remove temp directory
+    try {
+      fs.rmSync(this.tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}

--- a/packages/desktop-app/src/tests/e2e/daemon-harness.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-harness.ts
@@ -249,13 +249,19 @@ export class DaemonTestHarness {
       }
     });
 
-    daemonProc.on('error', (err) => {
-      throw new Error(`Failed to start nodespaced: ${err.message}`);
+    // Store spawn errors so waitForSocket can surface them as clear messages
+    // rather than silent timeouts.
+    let daemonSpawnError: Error | undefined;
+    daemonProc.on('error', (err: Error) => {
+      daemonSpawnError = err;
     });
 
     // Wait for daemon socket
     try {
       await waitForSocket(socketPath, timeoutMs);
+      if (daemonSpawnError !== undefined) {
+        throw new Error(`nodespaced spawn failed: ${daemonSpawnError.message}`);
+      }
     } catch (err) {
       daemonProc.kill();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -281,14 +287,17 @@ export class DaemonTestHarness {
       }
     });
 
-    proxyProc.on('error', (err) => {
-      daemonProc.kill();
-      throw new Error(`Failed to start dev-proxy: ${err.message}`);
+    let proxySpawnError: Error | undefined;
+    proxyProc.on('error', (err: Error) => {
+      proxySpawnError = err;
     });
 
     // Wait for proxy HTTP health
     try {
       await waitForHttp(`http://localhost:${proxyPort}/health`, timeoutMs);
+      if (proxySpawnError !== undefined) {
+        throw new Error(`dev-proxy spawn failed: ${proxySpawnError.message}`);
+      }
     } catch (err) {
       proxyProc.kill();
       daemonProc.kill();

--- a/packages/desktop-app/src/tests/e2e/node-roundtrip.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/node-roundtrip.e2e.ts
@@ -1,0 +1,109 @@
+/**
+ * E2E: Node CRUD round-trip via HttpAdapter → dev-proxy → nodespaced → SQLite
+ *
+ * These tests exercise the full write→read round-trip, verifying that data
+ * persists through the gRPC serialization layer and the SQLite store.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DaemonTestHarness } from './daemon-harness';
+
+let h: DaemonTestHarness;
+
+beforeAll(async () => {
+  h = await DaemonTestHarness.start();
+}, 15_000);
+
+afterAll(async () => {
+  await h?.stop();
+});
+
+describe('Node CRUD round-trip (HTTP → gRPC → SQLite)', () => {
+  it('creates a node and reads it back', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'hello e2e' });
+
+    const node = await h.adapter.getNode(id);
+
+    expect(node).not.toBeNull();
+    expect(node!.id).toBe(id);
+    expect(node!.nodeType).toBe('text');
+    expect(node!.content).toBe('hello e2e');
+    expect(node!.version).toBe(1);
+  });
+
+  it('updates a node and reads back the new content', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'original' });
+
+    const updated = await h.adapter.updateNode(id, 1, { content: 'updated' });
+
+    expect(updated.content).toBe('updated');
+    expect(updated.version).toBe(2);
+
+    const fetched = await h.adapter.getNode(id);
+    expect(fetched!.content).toBe('updated');
+    expect(fetched!.version).toBe(2);
+  });
+
+  it('version increments on each update', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'v1' });
+
+    const v2 = await h.adapter.updateNode(id, 1, { content: 'v2' });
+    expect(v2.version).toBe(2);
+
+    const v3 = await h.adapter.updateNode(id, 2, { content: 'v3' });
+    expect(v3.version).toBe(3);
+  });
+
+  it('deletes a node and confirms it is absent', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'to delete' });
+
+    await h.adapter.deleteNode(id, 1);
+
+    const node = await h.adapter.getNode(id);
+    expect(node).toBeNull();
+  });
+
+  it('returns null for a non-existent node', async () => {
+    const node = await h.adapter.getNode('00000000-0000-0000-0000-000000000000');
+    expect(node).toBeNull();
+  });
+
+  it('creates a parent-child hierarchy and reads children', async () => {
+    const parentId = crypto.randomUUID();
+    const childId = crypto.randomUUID();
+
+    await h.adapter.createNode({ id: parentId, nodeType: 'text', content: 'parent' });
+    await h.adapter.createNode({ id: childId, nodeType: 'text', content: 'child', parentId });
+
+    const children = await h.adapter.getChildren(parentId);
+    expect(children).toHaveLength(1);
+    expect(children[0].id).toBe(childId);
+    expect(children[0].content).toBe('child');
+  });
+
+  it('persists node properties through the round-trip', async () => {
+    const id = crypto.randomUUID();
+    // Daemon stores custom properties under the node-type namespace key (e.g. "text")
+    const properties = { text: { priority: 'high', tags: ['a', 'b'], count: 42 } };
+
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'with props', properties });
+
+    const node = await h.adapter.getNode(id);
+    expect(node).not.toBeNull();
+    const props = node!.properties as Record<string, Record<string, unknown>>;
+    expect(props.text.priority).toBe('high');
+    expect(props.text.tags).toEqual(['a', 'b']);
+    expect(props.text.count).toBe(42);
+  });
+
+  it('createNode returns the new node id string', async () => {
+    const id = crypto.randomUUID();
+    const result = await h.adapter.createNode({ id, nodeType: 'text', content: 'id check' });
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/desktop-app/src/tests/e2e/schema-seeding.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/schema-seeding.e2e.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E: Schema seeding verification
+ *
+ * Verifies that core schemas are populated after daemon startup, covering
+ * the startup timing requirement from issue #1308.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DaemonTestHarness } from './daemon-harness';
+
+let h: DaemonTestHarness;
+
+beforeAll(async () => {
+  h = await DaemonTestHarness.start();
+}, 15_000);
+
+afterAll(async () => {
+  await h?.stop();
+});
+
+describe('Schema seeding after daemon startup', () => {
+  it('getAllSchemas returns core schemas immediately after start', async () => {
+    const schemas = await h.adapter.getAllSchemas();
+    expect(schemas.length).toBeGreaterThan(0);
+  });
+
+  it('core schemas have the isCore flag set to true', async () => {
+    const schemas = await h.adapter.getAllSchemas();
+    const coreSchemas = schemas.filter((s) => s.isCore === true);
+    expect(coreSchemas.length).toBeGreaterThan(0);
+  });
+
+  it('each schema has an id and nodeType', async () => {
+    const schemas = await h.adapter.getAllSchemas();
+    for (const schema of schemas) {
+      expect(typeof schema.id).toBe('string');
+      expect((schema.id as string).length).toBeGreaterThan(0);
+      expect(typeof schema.nodeType).toBe('string');
+    }
+  });
+
+  it('getSchema returns a specific core schema by id', async () => {
+    const schemas = await h.adapter.getAllSchemas();
+    expect(schemas.length).toBeGreaterThan(0);
+
+    const first = schemas[0];
+    const fetched = await h.adapter.getSchema(first.id as string);
+
+    expect(fetched.id).toBe(first.id);
+    expect(fetched.isCore).toBe(first.isCore);
+  });
+
+  it('schemas have a fields array', async () => {
+    const schemas = await h.adapter.getAllSchemas();
+    for (const schema of schemas) {
+      expect(Array.isArray(schema.fields)).toBe(true);
+    }
+  });
+});

--- a/packages/desktop-app/src/tests/e2e/watch-nodes.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/watch-nodes.e2e.ts
@@ -1,0 +1,142 @@
+/**
+ * E2E: WatchNodes SSE stream delivers events for writes
+ *
+ * Opens an SSE connection via fetch (streaming) to the dev-proxy endpoint and
+ * asserts that node create/update/delete operations produce the expected events.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DaemonTestHarness } from './daemon-harness';
+
+let h: DaemonTestHarness;
+
+beforeAll(async () => {
+  h = await DaemonTestHarness.start();
+}, 15_000);
+
+afterAll(async () => {
+  await h?.stop();
+});
+
+/**
+ * Subscribe to the SSE stream and wait for the first event matching `predicate`.
+ * Uses fetch streaming — works in Node.js and Bun without extra packages.
+ * Rejects after `timeoutMs` if no matching event arrives.
+ */
+async function waitForEvent(
+  sseUrl: string,
+  predicate: (event: Record<string, unknown>) => boolean,
+  timeoutMs = 5000
+): Promise<Record<string, unknown>> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(sseUrl, { signal: controller.signal });
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+
+  if (!response.ok || !response.body) {
+    clearTimeout(timer);
+    throw new Error(`SSE connect failed: ${response.status}`);
+  }
+
+  const decoder = new TextDecoder();
+  let buf = '';
+  let found: Record<string, unknown> | null = null;
+  const reader = response.body.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue;
+        const raw = line.slice(5).trim();
+        if (!raw) continue;
+        try {
+          const ev = JSON.parse(raw) as Record<string, unknown>;
+          if (predicate(ev)) {
+            found = ev;
+            controller.abort();
+            break;
+          }
+        } catch {
+          // ignore non-JSON lines (heartbeat comments)
+        }
+      }
+      if (found) break;
+    }
+  } catch (err) {
+    // AbortError is expected when we call controller.abort() after finding our event
+    if (found) {
+      clearTimeout(timer);
+      reader.cancel().catch(() => undefined);
+      return found;
+    }
+    clearTimeout(timer);
+    reader.cancel().catch(() => undefined);
+    throw err;
+  }
+
+  clearTimeout(timer);
+  reader.cancel().catch(() => undefined);
+  if (found) return found;
+  throw new Error(`SSE stream ended without matching event`);
+}
+
+describe('WatchNodes SSE stream', () => {
+  it('delivers nodeCreated event when a node is written', async () => {
+    const id = crypto.randomUUID();
+
+    const eventPromise = waitForEvent(
+      h.sseUrl,
+      (ev) => ev.type === 'nodeCreated' && ev.nodeId === id
+    );
+
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'watched create' });
+
+    const event = await eventPromise;
+    expect(event.type).toBe('nodeCreated');
+    expect(event.nodeId).toBe(id);
+  });
+
+  it('delivers nodeUpdated event when a node is modified', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'before update' });
+
+    const eventPromise = waitForEvent(
+      h.sseUrl,
+      (ev) => ev.type === 'nodeUpdated' && ev.nodeId === id
+    );
+
+    await h.adapter.updateNode(id, 1, { content: 'after update' });
+
+    const event = await eventPromise;
+    expect(event.type).toBe('nodeUpdated');
+    expect(event.nodeId).toBe(id);
+  });
+
+  it('delivers nodeDeleted event when a node is removed', async () => {
+    const id = crypto.randomUUID();
+    await h.adapter.createNode({ id, nodeType: 'text', content: 'to be deleted' });
+
+    const eventPromise = waitForEvent(
+      h.sseUrl,
+      (ev) => ev.type === 'nodeDeleted' && ev.nodeId === id
+    );
+
+    await h.adapter.deleteNode(id, 1);
+
+    const event = await eventPromise;
+    expect(event.type).toBe('nodeDeleted');
+    expect(event.nodeId).toBe(id);
+  });
+});

--- a/packages/desktop-app/src/tests/e2e/watch-nodes.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/watch-nodes.e2e.ts
@@ -21,13 +21,18 @@ afterAll(async () => {
 /**
  * Subscribe to the SSE stream and wait for the first event matching `predicate`.
  * Uses fetch streaming — works in Node.js and Bun without extra packages.
+ *
+ * `onConnected` is called once the server sends the initial `: connected` comment,
+ * guaranteeing the subscription is registered before any writes fire.
+ *
  * Rejects after `timeoutMs` if no matching event arrives.
  */
 async function waitForEvent(
   sseUrl: string,
   predicate: (event: Record<string, unknown>) => boolean,
-  timeoutMs = 5000
+  opts: { timeoutMs?: number; onConnected?: () => Promise<void> } = {}
 ): Promise<Record<string, unknown>> {
+  const { timeoutMs = 5000, onConnected } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -47,6 +52,7 @@ async function waitForEvent(
   const decoder = new TextDecoder();
   let buf = '';
   let found: Record<string, unknown> | null = null;
+  let connectedFired = false;
   const reader = response.body.getReader();
 
   try {
@@ -58,6 +64,14 @@ async function waitForEvent(
       buf = lines.pop() ?? '';
 
       for (const line of lines) {
+        // Fire onConnected once the server acknowledges the SSE connection.
+        // This guarantees writes happen only after the subscription is registered.
+        if (!connectedFired && line.trim() === ': connected' && onConnected) {
+          connectedFired = true;
+          onConnected().catch(() => undefined);
+          continue;
+        }
+
         if (!line.startsWith('data:')) continue;
         const raw = line.slice(5).trim();
         if (!raw) continue;
@@ -96,12 +110,18 @@ describe('WatchNodes SSE stream', () => {
   it('delivers nodeCreated event when a node is written', async () => {
     const id = crypto.randomUUID();
 
+    // Pass onConnected so the write fires only after the SSE subscription is
+    // confirmed — prevents a race where createNode completes before the server
+    // has registered this client in sseClients.
     const eventPromise = waitForEvent(
       h.sseUrl,
-      (ev) => ev.type === 'nodeCreated' && ev.nodeId === id
+      (ev) => ev.type === 'nodeCreated' && ev.nodeId === id,
+      {
+        onConnected: () =>
+          h.adapter.createNode({ id, nodeType: 'text', content: 'watched create' })
+            .then(() => undefined)
+      }
     );
-
-    await h.adapter.createNode({ id, nodeType: 'text', content: 'watched create' });
 
     const event = await eventPromise;
     expect(event.type).toBe('nodeCreated');
@@ -114,10 +134,13 @@ describe('WatchNodes SSE stream', () => {
 
     const eventPromise = waitForEvent(
       h.sseUrl,
-      (ev) => ev.type === 'nodeUpdated' && ev.nodeId === id
+      (ev) => ev.type === 'nodeUpdated' && ev.nodeId === id,
+      {
+        onConnected: () =>
+          h.adapter.updateNode(id, 1, { content: 'after update' })
+            .then(() => undefined)
+      }
     );
-
-    await h.adapter.updateNode(id, 1, { content: 'after update' });
 
     const event = await eventPromise;
     expect(event.type).toBe('nodeUpdated');
@@ -130,10 +153,13 @@ describe('WatchNodes SSE stream', () => {
 
     const eventPromise = waitForEvent(
       h.sseUrl,
-      (ev) => ev.type === 'nodeDeleted' && ev.nodeId === id
+      (ev) => ev.type === 'nodeDeleted' && ev.nodeId === id,
+      {
+        onConnected: () =>
+          h.adapter.deleteNode(id, 1)
+            .then(() => undefined)
+      }
     );
-
-    await h.adapter.deleteNode(id, 1);
 
     const event = await eventPromise;
     expect(event.type).toBe('nodeDeleted');

--- a/packages/desktop-app/vitest.e2e.config.ts
+++ b/packages/desktop-app/vitest.e2e.config.ts
@@ -1,0 +1,51 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Vitest config for e2e tests that spawn a real nodespaced + dev-proxy.
+ *
+ * Run with: bun run test:e2e
+ *
+ * Prerequisites:
+ *   - nodespaced binary in packages/desktop-app/src-tauri/binaries/ (prebuilt sidecar)
+ *   - Or set NODESPACED_BINARY=/path/to/nodespaced
+ *
+ * Optional env vars:
+ *   E2E_DAEMON_TIMEOUT — ms to wait for daemon readiness (default 10000)
+ *   E2E_VERBOSE        — set to any value to print daemon/proxy stdout
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, 'src/lib')
+    }
+  },
+
+  test: {
+    include: ['src/tests/e2e/**/*.e2e.ts'],
+    environment: 'node',
+    globals: true,
+
+    // E2e tests start real processes — allow longer timeouts
+    testTimeout: 30_000,
+    hookTimeout: 20_000,
+
+    // Each test file gets its own daemon instance via beforeAll/afterAll,
+    // so run files sequentially to avoid port conflicts
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true
+      }
+    },
+
+    sequence: {
+      concurrent: false,
+      shuffle: false
+    }
+  }
+});

--- a/packages/dev-tools/src/dev-proxy.ts
+++ b/packages/dev-tools/src/dev-proxy.ts
@@ -282,16 +282,18 @@ async function handleRequest(req: Request): Promise<Response> {
   if (method === 'POST' && pathname === '/api/nodes') {
     try {
       const body = await req.json() as Record<string, unknown>;
-      const request = {
+      // Optional proto string fields (parentId, collection, lifecycleStatus) must be
+      // omitted entirely for the "unset" case — sending '' is treated as Some("") by
+      // the Rust side and triggers validation errors (empty parent lookup, empty path).
+      const request: Record<string, unknown> = {
         nodeType: body.nodeType ?? '',
         content: body.content ?? '',
-        parentId: body.parentId ?? '',
-        insertAfterNodeId: body.insertAfterNodeId ?? '',
         properties: body.properties ? JSON.stringify(body.properties) : '',
-        collection: '',
-        lifecycleStatus: '',
         id: body.id ?? ''
       };
+      if (body.parentId && body.parentId !== '') request.parentId = body.parentId;
+      if (body.collection && body.collection !== '') request.collection = body.collection;
+      if (body.lifecycleStatus && body.lifecycleStatus !== '') request.lifecycleStatus = body.lifecycleStatus;
       const res = await call<typeof request, { nodeId: string }>(
         (nodeClient as unknown as Record<string, Function>).createNode,
         request
@@ -325,16 +327,17 @@ async function handleRequest(req: Request): Promise<Response> {
     const nodeId = decodeURIComponent(getNodeMatch[1]);
     try {
       const body = await req.json() as Record<string, unknown>;
-      const request = {
+      // Optional proto fields must be omitted (not '') for the "no change" case.
+      const request: Record<string, unknown> = {
         nodeId,
-        version: body.version ?? null,
-        nodeType: body.nodeType ?? '',
-        content: body.content !== undefined ? String(body.content) : null,
-        properties: body.properties !== undefined ? JSON.stringify(body.properties) : null,
-        addToCollection: body.addToCollection ?? '',
-        removeFromCollection: body.removeFromCollection ?? '',
-        lifecycleStatus: body.lifecycleStatus ?? ''
+        version: body.version ?? null
       };
+      if (body.nodeType && body.nodeType !== '') request.nodeType = body.nodeType;
+      if (body.content !== undefined) request.content = String(body.content);
+      if (body.properties !== undefined) request.properties = JSON.stringify(body.properties);
+      if (body.addToCollection && body.addToCollection !== '') request.addToCollection = body.addToCollection;
+      if (body.removeFromCollection && body.removeFromCollection !== '') request.removeFromCollection = body.removeFromCollection;
+      if (body.lifecycleStatus && body.lifecycleStatus !== '') request.lifecycleStatus = body.lifecycleStatus;
       const res = await call<typeof request, { nodeData?: ProtoNodeData }>(
         (nodeClient as unknown as Record<string, Function>).updateNode,
         request


### PR DESCRIPTION
## Summary

- Adds `DaemonTestHarness` that spawns a real `nodespaced` + `dev-proxy` against a temp database — no mocks, full stack
- 16 e2e tests across three suites: CRUD round-trip, schema seeding, WatchNodes SSE
- New `bun run test:e2e` command using a dedicated `vitest.e2e.config.ts`
- Fixes two `dev-proxy` bugs: optional proto string fields were sent as `''` instead of being omitted, causing `Invalid parent node` and `path cannot be empty` errors

## Closes

Closes #1308

## Acceptance Criteria Status

- [x] At least one test exercises the full write→read round-trip via HttpAdapter against a live nodespaced
- [x] Test for daemon startup timing: schemas are populated after startup
- [x] Test for WatchNodes: write via backend, assert SSE stream receives the event
- [ ] AI chat persistence (out of scope per issue — blocked on #1305)
- [ ] Tests run in CI against a test daemon (requires CI pipeline update, not in this PR)
- [x] Clear documentation on how to run the full e2e suite locally (vitest.e2e.config.ts + nodespace-docs/development/e2e-testing.md)

## Test plan

- `bun run test:e2e` — all 16 tests pass
- `bun run test` — baseline maintained (7 failed | 125 passed, pre-existing failures unchanged)
- `bun run quality:fix` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)