### PR TITLE
ai-chat agent quality: fix runaway/hang + tool-call template leaks, tune prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tauri:dev": "bun run dev:tauri",
     "tauri:build": "cd packages/desktop-app && bun run tauri:build",
     "install:all": "bun install",
+    "chat": "bun run scripts/aichat.ts",
     "build:sidecars": "bun run scripts/build-sidecars.ts",
     "download:models": "bun run scripts/download-models.ts",
     "download:models:bundle": "bun run scripts/download-models.ts --bundle",

--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -17,7 +17,8 @@
 /// `skill_pipeline.rs` (used only by the skill-based schema-creation path) and
 /// should be consolidated here when that path is unified — tracked separately
 /// from #1089.
-pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in ENTITY TYPES.";
+pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in ENTITY TYPES.\n\
+    \"DATABASE\" = SCHEMA: When the user asks to set up a tracker, database, system, or \"a way to track X\" (e.g. \"create an invoice tracking database\", \"set up a CRM\"), they want a new entity TYPE — call create_schema to define it, not search or create_node. The singular entity name is the schema (an \"invoice tracking database\" → an Invoice schema).";
 
 /// Tool strategy guidance.
 ///
@@ -26,7 +27,8 @@ pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built
 /// search_semantic, and canonical create/update/connect patterns. Parameter-level
 /// detail is intentionally deferred to tool schemas to avoid duplication.
 pub const TOOL_STRATEGY_RULES: &str = "TOOL STRATEGY:\n\
-    - Before any non-conversational action: call search_skills(query) to find a matching skill. Empty result = no skill, proceed with general tools. Skip for greetings/small talk.\n\
+    - CONVERSATIONAL TURNS USE NO TOOLS. Greetings (\"hi\", \"hello\"), thanks, small talk, capability questions (\"what can you do?\"), and meta questions about yourself — answer directly in text. Do NOT call any tool, not even search_skills. Only reach for tools when the user asks you to find, create, update, delete, or connect something in their graph.\n\
+    - For a real graph action: call search_skills(query) first to find a matching skill. Empty result = no skill, proceed with general tools.\n\
     - ALWAYS search first before updating or getting a node. NEVER use placeholder IDs like \"abc-123\".\n\
     - By keyword/type/property: search_nodes(query, node_type, filters). By meaning: search_semantic(query, node_types, scope, threshold, graph_boost).\n\
     - search_semantic result: if 'markdown' is non-empty, summarize from it directly — skip get_node.\n\

--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -273,10 +273,60 @@ pub struct ChatMessage {
     pub role: Role,
     /// Text content of the message.
     pub content: String,
+    /// Tool calls this (assistant) message made, in order. Empty for non-tool
+    /// turns. Carried through re-prompts so the chat template can emit a
+    /// well-formed assistant turn: an assistant message with `tool_calls`
+    /// followed by the matching `tool` result messages. Without this, the
+    /// template sees orphan tool results (no preceding `tool_calls`), which
+    /// makes some models (e.g. Gemma 4) run away to the token limit.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCallRaw>,
     /// If this message is a tool result, the ID of the originating tool call.
     pub tool_call_id: Option<String>,
     /// Optional name for tool-role messages (the tool name).
     pub name: Option<String>,
+}
+
+impl ChatMessage {
+    /// A plain text message (no tool calls). Covers system/user/assistant-text.
+    pub fn text(role: Role, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// An assistant message that issued one or more tool calls.
+    pub fn assistant_with_tool_calls(
+        content: impl Into<String>,
+        tool_calls: Vec<ToolCallRaw>,
+    ) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+            tool_calls,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// A tool-result message paired to the tool call `tool_call_id`.
+    pub fn tool_result(
+        content: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: Role::Tool,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_call_id: Some(tool_call_id.into()),
+            name: Some(name.into()),
+        }
+    }
 }
 
 /// Parameters for an inference request.

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -29,6 +29,16 @@ use crate::prompt_assembler::{PromptAssembler, TemplateContext};
 /// Maximum number of tool-call iterations per turn.
 const MAX_TOOL_ITERATIONS: usize = 5;
 
+/// Maximum tokens any single inference round may generate.
+///
+/// Small local models (e.g. Gemma-4-E4B) occasionally open an empty
+/// assistant turn with nothing to say and then run away to the model's
+/// hard ceiling, producing a multi-minute hang that surfaces to the user
+/// as "no reply". A tight cap bounds any such runaway to a couple of
+/// seconds while still leaving ample room for a normal chat reply or a
+/// tool-call argument blob.
+const MAX_RESPONSE_TOKENS: u32 = 2_048;
+
 /// Total token budget for the context window.
 const TOTAL_TOKEN_BUDGET: u32 = 32_000;
 
@@ -222,7 +232,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 messages,
                 tools: Some(tools.clone()),
                 temperature: Some(0.1),
-                max_tokens: Some(16384),
+                max_tokens: Some(MAX_RESPONSE_TOKENS),
             };
 
             // Run inference
@@ -311,10 +321,20 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             // Append the assistant message that issued these tool calls, carrying
             // the structured tool_calls so the next re-prompt produces a
             // well-formed turn (assistant tool_calls → matching tool results).
+            //
+            // Drop any prose the model emitted alongside the tool call. Small
+            // models (Gemma 4) tend to narrate ("Let me search…") in the same
+            // turn as a tool call; when re-prompted, the chat template collapses
+            // that prose + the tool_call + the following tool result into a
+            // single malformed assistant turn, then opens an empty turn the
+            // model fills by running away to the token cap. Persisting only the
+            // tool_calls keeps the turn structurally clean: the assistant turn
+            // is purely the call, and the answer is produced in a later turn
+            // once the tool results are in hand.
             session
                 .messages
                 .push(ChatMessage::assistant_with_tool_calls(
-                    response_text.clone(),
+                    String::new(),
                     tool_calls.clone(),
                 ));
 
@@ -409,7 +429,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                     messages,
                     tools: None, // No tools — force text response
                     temperature: Some(0.1),
-                    max_tokens: Some(16384),
+                    max_tokens: Some(MAX_RESPONSE_TOKENS),
                 };
 
                 if let Ok(usage) = self.engine.generate(final_request, final_callback).await {

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -607,6 +607,14 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             split_point -= 1;
         }
 
+        // If the back-off consumed the whole prefix there is nothing older to
+        // summarize — skip the summarization inference entirely rather than
+        // spending a model call on empty input. (Rare: only when the entire
+        // over-budget history is one unbroken tool-call chain.)
+        if split_point == 0 {
+            return Ok(());
+        }
+
         let older_messages: Vec<ChatMessage> = session.messages.drain(..split_point).collect();
 
         // Build summarization text from older messages. A tool-call assistant
@@ -623,10 +631,16 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 Role::Tool => "Tool",
             };
             let rendered = if msg.content.is_empty() && !msg.tool_calls.is_empty() {
+                // Cap each argument blob: a single tool call can emit up to the
+                // generation token cap of JSON, and the summary only needs the
+                // gist of what was called, not the full payload.
                 let calls = msg
                     .tool_calls
                     .iter()
-                    .map(|tc| format!("{}({})", tc.function_name, tc.arguments_json))
+                    .map(|tc| {
+                        let args: String = tc.arguments_json.chars().take(120).collect();
+                        format!("{}({})", tc.function_name, args)
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("called tools: {calls}")
@@ -1730,10 +1744,13 @@ mod tests {
                 .messages
                 .push(ChatMessage::text(role, "x".repeat(8000)));
         }
-        // Tail arranged so the last 3 are: [assistant tool-call, tool result, user].
-        // The naive cut keeps exactly these 3 and would orphan the tool result if
-        // it instead landed at the window boundary; here we also assert the
-        // assistant tool-call turn is retained with its result.
+        // CRITICAL fixture detail: the tail is
+        //   [assistant tool-call, tool result, user, user]
+        // so the naive "keep last 3" window is [tool result, user, user] — it
+        // STARTS on the orphan tool result, with its assistant tool-call turn
+        // sitting just before the cut. This is what actually exercises the
+        // back-off; without it (e.g. a 3-element tail) the split lands on the
+        // assistant turn and the loop never runs, making the test a tautology.
         session
             .messages
             .push(ChatMessage::assistant_with_tool_calls(
@@ -1751,15 +1768,17 @@ mod tests {
         ));
         session
             .messages
-            .push(ChatMessage::text(Role::User, "follow-up question"));
+            .push(ChatMessage::text(Role::User, "first follow-up"));
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "second follow-up"));
 
         agent_loop
             .maybe_summarize_history(&mut session, "system")
             .await
             .unwrap();
 
-        // Find the first non-summary, non-system message and assert it is NOT an
-        // orphan tool result. Every Tool message must be immediately preceded by
+        // (1) No orphan: every retained Tool message is immediately preceded by
         // an assistant turn carrying tool_calls.
         for (i, m) in session.messages.iter().enumerate() {
             if matches!(m.role, Role::Tool) {
@@ -1774,6 +1793,20 @@ mod tests {
                 );
             }
         }
+
+        // (2) Back-off actually fired: the assistant tool-call turn (which a naive
+        // cut would have drained into the summary) must be RETAINED in the kept
+        // window, paired with its tool result. Without the back-off this assertion
+        // fails — that is what makes this test exercise the fix rather than pass
+        // vacuously.
+        let retained_tool_call = session
+            .messages
+            .iter()
+            .any(|m| matches!(m.role, Role::Assistant) && !m.tool_calls.is_empty());
+        assert!(
+            retained_tool_call,
+            "assistant tool-call turn was drained, orphaning its tool result — back-off did not fire"
+        );
     }
 
     // -- Additional coverage tests ------------------------------------------

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -126,12 +126,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         let on_chunk = Arc::new(on_chunk);
 
         // Append user message
-        session.messages.push(ChatMessage {
-            role: Role::User,
-            content: user_message.to_string(),
-            tool_call_id: None,
-            name: None,
-        });
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, user_message.to_string()));
 
         // Get available tools, then scope to query-relevant tools.
         // select_tools runs a pre-inference semantic skill search to narrow
@@ -195,12 +192,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 .await?;
 
             // Build message list: system + history
-            let mut messages = vec![ChatMessage {
-                role: Role::System,
-                content: system_content.clone(),
-                tool_call_id: None,
-                name: None,
-            }];
+            let mut messages = vec![ChatMessage::text(Role::System, system_content.clone())];
             messages.extend(session.messages.clone());
 
             // Status: Thinking
@@ -302,12 +294,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 };
 
                 // Append assistant response to history
-                session.messages.push(ChatMessage {
-                    role: Role::Assistant,
-                    content: final_response.clone(),
-                    tool_call_id: None,
-                    name: None,
-                });
+                session
+                    .messages
+                    .push(ChatMessage::text(Role::Assistant, final_response.clone()));
 
                 on_status(LocalAgentStatus::Idle);
                 session.status = LocalAgentStatus::Idle;
@@ -319,13 +308,15 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 });
             }
 
-            // Append assistant message with tool call indication
-            session.messages.push(ChatMessage {
-                role: Role::Assistant,
-                content: response_text.clone(),
-                tool_call_id: None,
-                name: None,
-            });
+            // Append the assistant message that issued these tool calls, carrying
+            // the structured tool_calls so the next re-prompt produces a
+            // well-formed turn (assistant tool_calls → matching tool results).
+            session
+                .messages
+                .push(ChatMessage::assistant_with_tool_calls(
+                    response_text.clone(),
+                    tool_calls.clone(),
+                ));
 
             // Execute each tool call
             for tc in &tool_calls {
@@ -383,12 +374,11 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                     &result_value,
                     is_error,
                 );
-                session.messages.push(ChatMessage {
-                    role: Role::Tool,
-                    content: tool_msg,
-                    tool_call_id: Some(tc.id.clone()),
-                    name: Some(tc.function_name.clone()),
-                });
+                session.messages.push(ChatMessage::tool_result(
+                    tool_msg,
+                    tc.id.clone(),
+                    tc.function_name.clone(),
+                ));
             }
 
             // If this was the last allowed iteration, do one final inference
@@ -399,12 +389,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 );
                 on_status(LocalAgentStatus::Thinking);
 
-                let mut messages = vec![ChatMessage {
-                    role: Role::System,
-                    content: system_content.clone(),
-                    tool_call_id: None,
-                    name: None,
-                }];
+                let mut messages = vec![ChatMessage::text(Role::System, system_content.clone())];
                 messages.extend(session.messages.clone());
 
                 let final_chunks: Arc<std::sync::Mutex<Vec<StreamingChunk>>> =
@@ -439,12 +424,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                     let (final_text, _) = Self::parse_chunks(&chunks);
                     if !final_text.is_empty() {
                         let normalized = normalize_response(&final_text);
-                        session.messages.push(ChatMessage {
-                            role: Role::Assistant,
-                            content: normalized.clone(),
-                            tool_call_id: None,
-                            name: None,
-                        });
+                        session
+                            .messages
+                            .push(ChatMessage::text(Role::Assistant, normalized.clone()));
 
                         on_status(LocalAgentStatus::Idle);
                         session.status = LocalAgentStatus::Idle;
@@ -604,12 +586,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
 
         // Run a single-shot summarization inference (no tools)
         let summary_request = InferenceRequest {
-            messages: vec![ChatMessage {
-                role: Role::User,
-                content: summary_prompt,
-                tool_call_id: None,
-                name: None,
-            }],
+            messages: vec![ChatMessage::text(Role::User, summary_prompt)],
             tools: None,
             temperature: Some(0.1),
             max_tokens: Some(4096),
@@ -640,15 +617,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         };
 
         // Prepend summary as a system-like message at the start of remaining history
-        session.messages.insert(
-            0,
-            ChatMessage {
-                role: Role::System,
-                content: summary_content,
-                tool_call_id: None,
-                name: None,
-            },
-        );
+        session
+            .messages
+            .insert(0, ChatMessage::text(Role::System, summary_content));
 
         Ok(())
     }
@@ -1625,12 +1596,10 @@ mod tests {
             } else {
                 Role::Assistant
             };
-            session.messages.push(ChatMessage {
+            session.messages.push(ChatMessage::text(
                 role,
-                content: format!("Message {} with extensive content: {}", i, "x".repeat(7000)),
-                tool_call_id: None,
-                name: None,
-            });
+                format!("Message {} with extensive content: {}", i, "x".repeat(7000)),
+            ));
         }
 
         let messages_before = session.messages.len();
@@ -1947,12 +1916,10 @@ mod tests {
             } else {
                 Role::Assistant
             };
-            session.messages.push(ChatMessage {
+            session.messages.push(ChatMessage::text(
                 role,
-                content: format!("Msg {}: {}", i, "a".repeat(2000)),
-                tool_call_id: None,
-                name: None,
-            });
+                format!("Msg {}: {}", i, "a".repeat(2000)),
+            ));
         }
 
         let _result = agent_loop

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -37,6 +37,14 @@ const MAX_TOOL_ITERATIONS: usize = 5;
 /// as "no reply". A tight cap bounds any such runaway to a couple of
 /// seconds while still leaving ample room for a normal chat reply or a
 /// tool-call argument blob.
+///
+/// This is also the ceiling on a single tool call's generated arguments:
+/// 2048 tokens comfortably covers the largest realistic blob (a full
+/// `create_schema` with many fields/enums is a few hundred tokens). If a
+/// future tool needs to emit a larger single argument payload, raise this
+/// rather than letting the call truncate into unparseable JSON. The
+/// summarization path uses its own larger cap by design (see
+/// `maybe_summarize_history`).
 const MAX_RESPONSE_TOKENS: u32 = 2_048;
 
 /// Total token budget for the context window.
@@ -586,11 +594,26 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
 
         // Need to summarize. Keep the last 3 messages verbatim, summarize the rest.
         let keep_count = 3.min(session.messages.len());
-        let split_point = session.messages.len() - keep_count;
+        let mut split_point = session.messages.len() - keep_count;
+
+        // Never split an assistant tool-call turn from its tool results. A naive
+        // cut can leave the kept window starting with an orphan `Tool` message
+        // (its preceding assistant `tool_calls` turn drained into the summary),
+        // which is exactly the malformed sequence that makes Gemma's template
+        // collapse turns and run away. Walk the cut back until the kept window
+        // begins on a non-tool message, so every tool result stays paired with
+        // the assistant turn that issued it.
+        while split_point > 0 && matches!(session.messages[split_point].role, Role::Tool) {
+            split_point -= 1;
+        }
 
         let older_messages: Vec<ChatMessage> = session.messages.drain(..split_point).collect();
 
-        // Build summarization text from older messages
+        // Build summarization text from older messages. A tool-call assistant
+        // turn carries its signal in `tool_calls`, not `content` (content is
+        // empty by construction), so render a synthetic line for it — otherwise
+        // it collapses to a bare "Assistant:" and the summary loses what the
+        // agent actually did.
         let mut summary_input = String::new();
         for msg in &older_messages {
             let role_str = match msg.role {
@@ -599,12 +622,29 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 Role::Assistant => "Assistant",
                 Role::Tool => "Tool",
             };
-            summary_input.push_str(&format!("{}: {}\n", role_str, msg.content));
+            let rendered = if msg.content.is_empty() && !msg.tool_calls.is_empty() {
+                let calls = msg
+                    .tool_calls
+                    .iter()
+                    .map(|tc| format!("{}({})", tc.function_name, tc.arguments_json))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("called tools: {calls}")
+            } else {
+                msg.content.clone()
+            };
+            summary_input.push_str(&format!("{role_str}: {rendered}\n"));
         }
 
         let summary_prompt = prompt_templates::summarization_prompt(&summary_input);
 
-        // Run a single-shot summarization inference (no tools)
+        // Run a single-shot summarization inference (no tools).
+        //
+        // This cap is intentionally larger than `MAX_RESPONSE_TOKENS` (the chat
+        // turn cap): a summary condenses many drained turns and is not part of
+        // the runaway-prone ReAct loop (no tools, single shot, then discarded
+        // into one message), so it can afford more room without risking a
+        // multi-minute hang. Do NOT unify the two constants.
         let summary_request = InferenceRequest {
             messages: vec![ChatMessage::text(Role::User, summary_prompt)],
             tools: None,
@@ -1655,6 +1695,85 @@ mod tests {
         );
 
         assert_eq!(result.response, "Here is your answer.");
+    }
+
+    #[tokio::test]
+    async fn summarization_never_orphans_a_tool_result() {
+        // Build a history that exceeds the token budget and is arranged so the
+        // naive "keep last 3" window would START on a Tool message — i.e. its
+        // preceding assistant tool-call turn would be drained into the summary,
+        // leaving an orphan tool result. The split must back off so the kept
+        // window begins on the assistant tool-call turn instead.
+        let engine = Arc::new(MockEngine::new(vec![vec![
+            StreamingChunk::Token {
+                text: "Summary of earlier turns.".to_string(),
+            },
+            StreamingChunk::Done {
+                usage: InferenceUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                },
+            },
+        ]]));
+        let executor = Arc::new(MockToolExecutor::new());
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = new_session();
+        // Bulk filler to blow the budget (≈4 chars/token in the mock).
+        for i in 0..18 {
+            let role = if i % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            session
+                .messages
+                .push(ChatMessage::text(role, "x".repeat(8000)));
+        }
+        // Tail arranged so the last 3 are: [assistant tool-call, tool result, user].
+        // The naive cut keeps exactly these 3 and would orphan the tool result if
+        // it instead landed at the window boundary; here we also assert the
+        // assistant tool-call turn is retained with its result.
+        session
+            .messages
+            .push(ChatMessage::assistant_with_tool_calls(
+                String::new(),
+                vec![ToolCallRaw {
+                    id: "tc_1".into(),
+                    function_name: "search_nodes".into(),
+                    arguments_json: r#"{"query":"q"}"#.into(),
+                }],
+            ));
+        session.messages.push(ChatMessage::tool_result(
+            "result".to_string(),
+            "tc_1".to_string(),
+            "search_nodes".to_string(),
+        ));
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "follow-up question"));
+
+        agent_loop
+            .maybe_summarize_history(&mut session, "system")
+            .await
+            .unwrap();
+
+        // Find the first non-summary, non-system message and assert it is NOT an
+        // orphan tool result. Every Tool message must be immediately preceded by
+        // an assistant turn carrying tool_calls.
+        for (i, m) in session.messages.iter().enumerate() {
+            if matches!(m.role, Role::Tool) {
+                assert!(
+                    i > 0,
+                    "tool result at index 0 has no preceding assistant turn"
+                );
+                let prev = &session.messages[i - 1];
+                assert!(
+                    matches!(prev.role, Role::Assistant) && !prev.tool_calls.is_empty(),
+                    "tool result at index {i} is orphaned (preceding message is not an assistant tool-call turn)"
+                );
+            }
+        }
     }
 
     // -- Additional coverage tests ------------------------------------------

--- a/packages/agent/src/local_agent/inference.rs
+++ b/packages/agent/src/local_agent/inference.rs
@@ -8,7 +8,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nodespace_nlp_engine::chat::{ChatChunk, ChatConfig, ChatEngine, ChatMessageInput, ToolSpec};
+use nodespace_nlp_engine::chat::{
+    ChatChunk, ChatConfig, ChatEngine, ChatMessageInput, ToolCallInput, ToolSpec,
+};
 
 use crate::agent_types::{
     ChatInferenceEngine, ChatModelSpec, InferenceError, InferenceRequest, InferenceUsage,
@@ -75,6 +77,15 @@ impl ChatInferenceEngine for LlamaChatInferenceEngine {
                 },
                 content: m.content.clone(),
                 call_id: m.tool_call_id.clone(),
+                tool_calls: m
+                    .tool_calls
+                    .iter()
+                    .map(|tc| ToolCallInput {
+                        id: tc.id.clone(),
+                        name: tc.function_name.clone(),
+                        arguments: tc.arguments_json.clone(),
+                    })
+                    .collect(),
             })
             .collect();
 

--- a/packages/agent/src/local_agent/response_processing.rs
+++ b/packages/agent/src/local_agent/response_processing.rs
@@ -11,6 +11,51 @@ fn backtick_uri_re() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"`(nodespace://[^`]+)`").unwrap())
 }
 
+/// Matches Gemma's textual tool-call / tool-response syntax leaking into prose.
+///
+/// When the tool-less final inference still tries to "speak" tool activity, the
+/// model writes it as literal text like
+/// `call:update_schema{...}response:update_schema{...}` instead of emitting a
+/// real tool-call token. These segments are internal plumbing, never something
+/// the user should see, so we delete each `call:`/`response:` keyword plus its
+/// trailing `{...}` argument/result blob.
+fn tool_call_prose_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // `(?s)` so the brace blob may span newlines. The blob is a JSON object that
+    // may nest one or more levels (e.g. `{value:{success:true}}` or
+    // `{rels:[{name:x}]}`); the `rust regex` crate has no recursion, so match a
+    // balanced-ish blob greedily up to the final closing brace of the segment:
+    // run from `{` across any non-brace text and fully-paired `{…}` groups.
+    // `(?:[^{}]|\{[^{}]*\})*` covers text plus one nesting level, applied
+    // repeatedly, which spans the two-level shapes these leaks actually take.
+    RE.get_or_init(|| {
+        Regex::new(r"(?s)(?:call|response):[a-z_]+\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}")
+            .unwrap()
+    })
+}
+
+/// Matches Gemma's "channel" reasoning blocks leaking into prose.
+///
+/// Gemma 4 sometimes emits an internal chain-of-thought wrapped in channel
+/// markers, e.g. `<|channel>thought\n…reasoning…<channel|>actual answer`. The
+/// thought between the markers is internal and must never reach the user. We
+/// strip the opening marker plus everything up to and including the closing
+/// `<channel|>` marker, leaving the real answer that follows it.
+fn channel_block_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?s)<\|channel>.*?<channel\|>").unwrap())
+}
+
+/// Matches any stray Gemma channel marker not consumed as a full block.
+///
+/// Covers a dangling `<|channel>` with no closing marker (truncated by the
+/// token cap) or a `<channel|>` with no opener — either way the marker itself
+/// is plumbing and is removed.
+fn stray_channel_marker_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"<\|channel>|<channel\|>").unwrap())
+}
+
 /// Normalize LLM response text for consistent formatting.
 ///
 /// Applies post-processing rules to fix common formatting issues
@@ -20,7 +65,9 @@ pub fn normalize_response(text: &str) -> String {
         return String::new();
     }
 
-    let result = fix_markdown_link_uris(text);
+    let result = strip_channel_blocks(text);
+    let result = strip_tool_call_prose(&result);
+    let result = fix_markdown_link_uris(&result);
     let result = fix_backtick_wrapped_uris(&result);
     let result = normalize_snake_case_statuses(&result);
     let result = strip_raw_tool_output_json(&result);
@@ -157,6 +204,40 @@ fn replace_status_outside_special(line: &str, pattern: &str, replacement: &str) 
     }
 
     result
+}
+
+/// Strip leaked Gemma channel/thought reasoning blocks.
+///
+/// First removes complete `<|channel>…<channel|>` spans. If a dangling opener
+/// remains (closing marker lost to the token cap), everything from that opener
+/// onward is internal thought and is dropped. Any stray markers left over are
+/// then removed. See [`channel_block_re`] / [`stray_channel_marker_re`].
+fn strip_channel_blocks(text: &str) -> String {
+    if !text.contains("<|channel>") && !text.contains("<channel|>") {
+        return text.to_string();
+    }
+    let result = channel_block_re().replace_all(text, "").into_owned();
+    // Drop a dangling, never-closed thought block (truncated mid-reasoning).
+    let result = match result.find("<|channel>") {
+        Some(idx) => result[..idx].to_string(),
+        None => result,
+    };
+    stray_channel_marker_re()
+        .replace_all(&result, "")
+        .into_owned()
+}
+
+/// Strip leaked Gemma tool-call/response prose (`call:foo{...}response:foo{...}`).
+///
+/// See [`tool_call_prose_re`]. If stripping these segments leaves nothing but
+/// whitespace, the whole response was tool-call plumbing — return empty so the
+/// caller's "empty response" handling (a synthesized confirmation) kicks in
+/// rather than surfacing a blank bubble.
+fn strip_tool_call_prose(text: &str) -> String {
+    if !text.contains("call:") && !text.contains("response:") {
+        return text.to_string();
+    }
+    tool_call_prose_re().replace_all(text, "").into_owned()
 }
 
 /// Strip raw JSON blocks that look like pasted tool output.
@@ -435,5 +516,51 @@ mod tests {
         let input = "Results:\n{\n  \"count\": 5,\n  \"nodes\": [\n    \"a\"\n  ]\n}\nDone.";
         let result = normalize_response(input);
         assert_eq!(result, "Results:\n\nDone.");
+    }
+
+    #[test]
+    fn strips_leaked_tool_call_prose() {
+        // Gemma's textual tool-call/response syntax must never reach the user.
+        let input = "call:update_schema{add_relationships:[{name:invoices_for}],schema_id:product}response:update_schema{value:{success:true}}";
+        let result = normalize_response(input);
+        assert_eq!(result, "", "leaked tool-call prose should strip to empty");
+    }
+
+    #[test]
+    fn strips_tool_call_prose_keeping_surrounding_text() {
+        let input = "Created the schema. call:create_schema{name:Invoice} All set.";
+        let result = normalize_response(input);
+        assert_eq!(result, "Created the schema.  All set.");
+    }
+
+    #[test]
+    fn leaves_prose_mentioning_call_unchanged() {
+        // "call:" without a following brace blob is ordinary prose, not a leak.
+        let input = "Give me a call: I'll explain the response: it's ready.";
+        let result = normalize_response(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn strips_channel_thought_block_keeping_answer() {
+        let input =
+            "Done.<|channel>thought\nThe user wants X, I should Y.<channel|>I've added the node!";
+        let result = normalize_response(input);
+        assert_eq!(result, "Done.I've added the node!");
+    }
+
+    #[test]
+    fn strips_dangling_channel_block_truncated_by_token_cap() {
+        // No closing marker (generation hit the cap mid-thought): drop the rest.
+        let input = "Here is your answer.<|channel>thought\nNow I will reason endlessly";
+        let result = normalize_response(input);
+        assert_eq!(result, "Here is your answer.");
+    }
+
+    #[test]
+    fn strips_stray_channel_marker() {
+        let input = "All set.<channel|>";
+        let result = normalize_response(input);
+        assert_eq!(result, "All set.");
     }
 }

--- a/packages/agent/src/local_agent/response_processing.rs
+++ b/packages/agent/src/local_agent/response_processing.rs
@@ -22,12 +22,15 @@ fn backtick_uri_re() -> &'static Regex {
 fn tool_call_prose_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     // `(?s)` so the brace blob may span newlines. The blob is a JSON object that
-    // may nest one or more levels (e.g. `{value:{success:true}}` or
-    // `{rels:[{name:x}]}`); the `rust regex` crate has no recursion, so match a
-    // balanced-ish blob greedily up to the final closing brace of the segment:
-    // run from `{` across any non-brace text and fully-paired `{…}` groups.
-    // `(?:[^{}]|\{[^{}]*\})*` covers text plus one nesting level, applied
-    // repeatedly, which spans the two-level shapes these leaks actually take.
+    // may nest (e.g. `{value:{success:true}}` or `{rels:[{name:x}]}`); the
+    // `rust regex` crate has no recursion, so we hand-unroll the nesting: an
+    // outer `{…}` whose body is any mix of non-brace text and fully-paired inner
+    // groups that themselves allow one more level — i.e. up to TWO nested levels
+    // (three braces deep total), which spans the shapes these leaks actually
+    // take. A blob deeper than that, or one truncated by the token cap
+    // (unbalanced braces), simply fails to match and is left intact — safer than
+    // greedily eating real trailing prose. Being a DFA, the engine has no
+    // catastrophic-backtracking (ReDoS) risk on pathological input.
     RE.get_or_init(|| {
         Regex::new(r"(?s)(?:call|response):[a-z_]+\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}")
             .unwrap()

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -127,24 +127,28 @@ impl PromptAssembler {
             filters: None,
         };
 
-        let all_nodes: Vec<Node> =
-            match nodespace_core::ops::node_ops::query_nodes(&self.node_service, filter).await {
-                Ok(result) => result
-                    .nodes
-                    .into_iter()
-                    .filter_map(|v| match serde_json::from_value(v) {
-                        Ok(node) => Some(node),
-                        Err(e) => {
-                            tracing::warn!(error = %e, "Failed to deserialize prompt node, skipping");
-                            None
-                        }
-                    })
-                    .collect(),
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to fetch prompt overrides, using base only");
-                    return Vec::new();
-                }
-            };
+        let all_nodes: Vec<Node> = match nodespace_core::ops::node_ops::query_nodes(
+            &self.node_service,
+            filter,
+        )
+        .await
+        {
+            Ok(result) => result
+                .nodes
+                .into_iter()
+                .filter_map(|v| match serde_json::from_value(v) {
+                    Ok(node) => Some(node),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to deserialize prompt node, skipping");
+                        None
+                    }
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to fetch prompt overrides, using base only");
+                return Vec::new();
+            }
+        };
 
         // Keep only true root nodes (no parent edge pointing to them).
         // query_nodes ignores parent_id filter, so all prompt nodes are returned;
@@ -315,8 +319,8 @@ impl PromptAssembler {
                     - {}\n\
                     - Tool call enums: exact schema values (\"done\", \"in_progress\"). User-facing: friendly labels (\"Done\").\n\
                     - Listing: **Title** (nodespace://id) — description. Search results: \"Found N nodes...\" then top results.\n\
-                    - Empty results: say so. Do NOT retry the same query.\n\
-                    - Keep responses under 3 sentences unless asked for detail.",
+                    - Empty/error tool result: state it in one sentence and stop. Do NOT retry the same tool, and do NOT call another tool to compensate — just answer.\n\
+                    - Keep responses to 1-2 sentences unless the user asks for detail. No preamble, no sign-off.",
                     NODE_REFERENCE_FORMAT
                 ),
             },
@@ -368,9 +372,11 @@ mod tests {
             .map(|s| (s.title.as_str(), s.markdown_content.as_str()))
             .collect();
 
-        let expected_tool_strategy = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in ENTITY TYPES.\n\n\
+        let expected_tool_strategy = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in ENTITY TYPES.\n\
+            \"DATABASE\" = SCHEMA: When the user asks to set up a tracker, database, system, or \"a way to track X\" (e.g. \"create an invoice tracking database\", \"set up a CRM\"), they want a new entity TYPE — call create_schema to define it, not search or create_node. The singular entity name is the schema (an \"invoice tracking database\" → an Invoice schema).\n\n\
             TOOL STRATEGY:\n\
-            - Before any non-conversational action: call search_skills(query) to find a matching skill. Empty result = no skill, proceed with general tools. Skip for greetings/small talk.\n\
+            - CONVERSATIONAL TURNS USE NO TOOLS. Greetings (\"hi\", \"hello\"), thanks, small talk, capability questions (\"what can you do?\"), and meta questions about yourself — answer directly in text. Do NOT call any tool, not even search_skills. Only reach for tools when the user asks you to find, create, update, delete, or connect something in their graph.\n\
+            - For a real graph action: call search_skills(query) first to find a matching skill. Empty result = no skill, proceed with general tools.\n\
             - ALWAYS search first before updating or getting a node. NEVER use placeholder IDs like \"abc-123\".\n\
             - By keyword/type/property: search_nodes(query, node_type, filters). By meaning: search_semantic(query, node_types, scope, threshold, graph_boost).\n\
             - search_semantic result: if 'markdown' is non-empty, summarize from it directly — skip get_node.\n\
@@ -387,8 +393,8 @@ mod tests {
             - Reference nodes with bare URI: nodespace://abc-123 (no markdown links, no backticks)\n\
             - Tool call enums: exact schema values (\"done\", \"in_progress\"). User-facing: friendly labels (\"Done\").\n\
             - Listing: **Title** (nodespace://id) — description. Search results: \"Found N nodes...\" then top results.\n\
-            - Empty results: say so. Do NOT retry the same query.\n\
-            - Keep responses under 3 sentences unless asked for detail.";
+            - Empty/error tool result: state it in one sentence and stop. Do NOT retry the same tool, and do NOT call another tool to compensate — just answer.\n\
+            - Keep responses to 1-2 sentences unless the user asks for detail. No preamble, no sign-off.";
 
         assert_eq!(
             by_title.get("Tool Strategy Guide").copied(),

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -99,6 +99,8 @@ LISTING BY TYPE OR PROPERTY: To list all nodes of a type or filtered by a proper
 
 When creating a schema:
 
+ONE SCHEMA PER REQUEST: Create exactly the type the user named, in a single create_schema call, then stop and report it. Do NOT proactively invent or create related types (e.g. asked for "Invoice", do not also create "Customer" or "Product"), and do NOT follow up with update_schema to wire relationships unless the user explicitly asked for them. A relationship's targetType must already exist in ENTITY TYPES; if it doesn't, omit the relationship rather than creating the other type.
+
 FIELDS: Only define type-specific fields. Do NOT add a 'name' or 'title' field — every node already has a built-in content/title field. EXCEPTION: if you use a 'name' placeholder in title_template (e.g. "{name} ({status})"), you MUST define 'name' as a text field so title generation works. A 'description' field is acceptable when it adds value beyond the title. Good fields: status (enum), due_date (date), priority (enum), budget (number), owner (text).
 
 ENUMS: Use lowercase values with readable labels, e.g. {"value": "in_progress", "label": "In Progress"}.

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -40,7 +40,7 @@ pub fn seed_skill_nodes() -> Vec<NodeTemplate> {
 
 When answering questions about stored knowledge:
 
-SEARCH FIRST: Always call search_semantic with a natural language query. Results are ordered by relevance — the first result is the best match.
+SEARCH FIRST: When the user is looking for information or wants to act on a specific node, call search_semantic with a natural language query. Results are ordered by relevance — the first result is the best match. Skip search for conversational messages or capability questions.
 
 RESULT STRUCTURE: Each result contains:
 - id: node ID (use this for follow-up get_node calls)

--- a/packages/agent/tests/ollama_integration.rs
+++ b/packages/agent/tests/ollama_integration.rs
@@ -146,12 +146,10 @@ async fn test_ollama_inference_generate() {
 
     let engine = OllamaInferenceEngine::new(model_name.clone());
     let request = InferenceRequest {
-        messages: vec![ChatMessage {
-            role: Role::User,
-            content: "Reply with exactly the word 'pong'. No other text.".to_string(),
-            tool_call_id: None,
-            name: None,
-        }],
+        messages: vec![ChatMessage::text(
+            Role::User,
+            "Reply with exactly the word 'pong'. No other text.",
+        )],
         tools: None,
         temperature: Some(0.0),
         max_tokens: Some(10),
@@ -211,12 +209,10 @@ async fn test_ollama_inference_with_tools() {
     };
 
     let request = InferenceRequest {
-        messages: vec![ChatMessage {
-            role: Role::User,
-            content: "What's the weather in London?".to_string(),
-            tool_call_id: None,
-            name: None,
-        }],
+        messages: vec![ChatMessage::text(
+            Role::User,
+            "What's the weather in London?",
+        )],
         tools: Some(vec![tool]),
         temperature: Some(0.0),
         max_tokens: Some(100),
@@ -489,18 +485,8 @@ async fn run_skill_inference(
 
     let request = InferenceRequest {
         messages: vec![
-            ChatMessage {
-                role: Role::System,
-                content: system,
-                tool_call_id: None,
-                name: None,
-            },
-            ChatMessage {
-                role: Role::User,
-                content: user_message.to_string(),
-                tool_call_id: None,
-                name: None,
-            },
+            ChatMessage::text(Role::System, system),
+            ChatMessage::text(Role::User, user_message.to_string()),
         ],
         tools: Some(tools),
         temperature: Some(0.0),

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod diagnostics;
 pub mod import;
 pub mod mention;
+pub mod model;
 pub mod node;
 pub mod schema;
 pub mod search;

--- a/packages/cli/src/commands/model.rs
+++ b/packages/cli/src/commands/model.rs
@@ -1,0 +1,187 @@
+//! `nodespace model ...` — manage the local inference model.
+//!
+//! The daemon starts with a no-op inference engine; a model must be loaded
+//! before ai-chat turns can run. The desktop app normally does this on startup
+//! via `EnsureModelReady`. These subcommands expose the same flow to the shell
+//! so the agent can be driven (and its prompting tuned) without the UI.
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use nodespace_daemon::nodespace::{
+    EnsureModelReadyRequest, ListModelsRequest, RecommendedModelRequest,
+};
+use nodespace_daemon::LocalAgentServiceClient;
+use serde_json::json;
+use tonic::transport::Channel;
+
+#[derive(Subcommand, Debug)]
+pub enum ModelAction {
+    /// List models in the catalog and their download/load status.
+    List,
+    /// Load a model (downloading first if needed); streams progress to stdout.
+    Load(LoadArgs),
+    /// Print the recommended model id for this machine's RAM.
+    Recommended,
+}
+
+#[derive(Args, Debug)]
+pub struct LoadArgs {
+    /// Model id to load, e.g. `gemma-4-e4b-q4km`. Omit to use the recommended model.
+    pub model_id: Option<String>,
+}
+
+pub async fn run(
+    client: &mut LocalAgentServiceClient<Channel>,
+    action: ModelAction,
+    json: bool,
+) -> Result<()> {
+    match action {
+        ModelAction::List => list(client, json).await,
+        ModelAction::Load(args) => load(client, args, json).await,
+        ModelAction::Recommended => recommended(client, json).await,
+    }
+}
+
+async fn list(client: &mut LocalAgentServiceClient<Channel>, json: bool) -> Result<()> {
+    let response = client
+        .list_models(ListModelsRequest {})
+        .await
+        .context("ListModels RPC failed")?
+        .into_inner();
+
+    if json {
+        let models: Vec<_> = response
+            .models
+            .iter()
+            .map(|m| {
+                json!({
+                    "id": m.id,
+                    "name": m.name,
+                    "backend": m.backend,
+                    "status": serde_json::from_str::<serde_json::Value>(&m.status_json)
+                        .unwrap_or(serde_json::Value::String(m.status_json.clone())),
+                    "size_bytes": m.size_bytes,
+                    "quantization": m.quantization,
+                    "min_memory_gb": m.min_memory_gb,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "models": models }))?
+        );
+    } else {
+        for m in &response.models {
+            // status_json is a serialized enum, shaped `{"status": "loaded"}`
+            // (internally tagged) or sometimes a bare string. Render the tag.
+            let status = serde_json::from_str::<serde_json::Value>(&m.status_json)
+                .ok()
+                .and_then(|v| match v {
+                    serde_json::Value::String(s) => Some(s),
+                    serde_json::Value::Object(o) => o
+                        .get("status")
+                        .and_then(|s| s.as_str().map(str::to_string))
+                        .or_else(|| o.keys().next().cloned()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| m.status_json.clone());
+            println!(
+                "{:<22} {:<8} {:>6} GB  {}",
+                m.id, m.backend, m.min_memory_gb, status
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn load(
+    client: &mut LocalAgentServiceClient<Channel>,
+    args: LoadArgs,
+    json: bool,
+) -> Result<()> {
+    let model_id = match args.model_id {
+        Some(id) => id,
+        None => {
+            client
+                .recommended_model(RecommendedModelRequest {})
+                .await
+                .context("RecommendedModel RPC failed")?
+                .into_inner()
+                .model_id
+        }
+    };
+
+    let mut stream = client
+        .ensure_model_ready(EnsureModelReadyRequest {
+            model_id: model_id.clone(),
+        })
+        .await
+        .context("EnsureModelReady RPC failed")?
+        .into_inner();
+
+    let mut last_event = String::new();
+    while let Some(event) = stream.message().await.context("model load stream error")? {
+        last_event = event.event_type.clone();
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "event_type": event.event_type,
+                    "model_id": event.model_id,
+                    "message": event.message,
+                    "bytes_downloaded": event.bytes_downloaded,
+                    "bytes_total": event.bytes_total,
+                    "error_message": event.error_message,
+                    "engine_swapped": event.engine_swapped,
+                }))?
+            );
+        } else {
+            match event.event_type.as_str() {
+                "downloading" => {
+                    if let (Some(d), Some(t)) = (event.bytes_downloaded, event.bytes_total) {
+                        let pct = if t > 0 {
+                            d as f64 / t as f64 * 100.0
+                        } else {
+                            0.0
+                        };
+                        println!("downloading {model_id}: {pct:.0}%");
+                    } else {
+                        println!("downloading {model_id}...");
+                    }
+                }
+                "error" => {
+                    let msg = event.error_message.unwrap_or_default();
+                    anyhow::bail!("model load failed: {msg}");
+                }
+                other => {
+                    let detail = event.message.unwrap_or_default();
+                    println!("{other}: {detail}");
+                }
+            }
+        }
+    }
+
+    if last_event != "ready" && last_event != "error" {
+        // Stream ended without an explicit terminal event — surface it.
+        eprintln!("warning: model load stream ended on '{last_event}'");
+    }
+    Ok(())
+}
+
+async fn recommended(client: &mut LocalAgentServiceClient<Channel>, json: bool) -> Result<()> {
+    let model_id = client
+        .recommended_model(RecommendedModelRequest {})
+        .await
+        .context("RecommendedModel RPC failed")?
+        .into_inner()
+        .model_id;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "model_id": model_id }))?
+        );
+    } else {
+        println!("{model_id}");
+    }
+    Ok(())
+}

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -9,7 +9,9 @@ pub mod terminal;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use nodespace_daemon::{AgentSessionServiceClient, ImportServiceClient, NodeServiceClient};
+use nodespace_daemon::{
+    AgentSessionServiceClient, ImportServiceClient, LocalAgentServiceClient, NodeServiceClient,
+};
 use tonic::transport::Channel;
 
 #[derive(Parser, Debug)]
@@ -41,6 +43,11 @@ pub enum Command {
     Node {
         #[command(subcommand)]
         action: commands::node::NodeAction,
+    },
+    /// Manage the local inference model (list, load, recommended).
+    Model {
+        #[command(subcommand)]
+        action: commands::model::ModelAction,
     },
     /// Semantic search across the knowledge graph.
     Search(commands::search::SearchArgs),
@@ -149,6 +156,23 @@ pub async fn connect_session(sock: &std::path::Path) -> Result<AgentSessionServi
         })
 }
 
+/// Connect a LocalAgentServiceClient to the daemon.
+#[cfg(unix)]
+pub async fn connect_local_agent(
+    sock: &std::path::Path,
+) -> Result<LocalAgentServiceClient<Channel>> {
+    uds_channel(sock)
+        .await
+        .map(LocalAgentServiceClient::new)
+        .with_context(|| {
+            format!(
+                "Could not connect to nodespaced at {}.\n\
+                 Is the daemon running? Start it with `nodespaced` in another terminal.",
+                sock.display()
+            )
+        })
+}
+
 /// Top-level dispatch — wired by `main.rs` and reused by integration tests.
 #[cfg(unix)]
 pub async fn run(cli: Cli) -> Result<()> {
@@ -159,6 +183,10 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Node { action } => {
             let mut client = connect(&sock).await?;
             commands::node::run(&mut client, action, json).await
+        }
+        Command::Model { action } => {
+            let mut client = connect_local_agent(&sock).await?;
+            commands::model::run(&mut client, action, json).await
         }
         Command::Search(args) => {
             let mut client = connect(&sock).await?;

--- a/packages/core/src/db/events.rs
+++ b/packages/core/src/db/events.rs
@@ -164,10 +164,7 @@ pub struct EventEnvelope {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DomainEvent {
     /// A new node was created
-    NodeCreated {
-        node_id: String,
-        node_type: String,
-    },
+    NodeCreated { node_id: String, node_type: String },
 
     /// An existing node was updated — carries the full committed node so
     /// subscribers (WatchNodes, LocalAgentService) don't need a re-fetch.

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -138,9 +138,15 @@ impl LocalAgentServiceImpl {
     }
 
     async fn replace_engine(&self, engine: Arc<dyn ChatInferenceEngine>) {
+        // Wire the embedding service into the tool executor so the agent can run
+        // search_semantic and so select_tools can skill-route (both need
+        // embeddings). It's populated in the background after model load; if it
+        // isn't ready yet the executor degrades to None and skill routing falls
+        // back to the full tool list until the next engine swap.
+        let embedding_service = self.inner.embedding_service.read().await.clone();
         let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
             node_service: Some(self.inner.node_service.clone()),
-            embedding_service: None,
+            embedding_service,
         });
 
         let prompt_assembler = Some(Arc::new(
@@ -1147,12 +1153,7 @@ async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Ve
                 _ => return None,
             };
             let content = m.get("content")?.as_str()?.to_string();
-            Some(ChatMessage {
-                role,
-                content,
-                tool_call_id: None,
-                name: None,
-            })
+            Some(ChatMessage::text(role, content))
         })
         .collect()
 }

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -1296,7 +1296,7 @@ async fn convert_domain_event(
             }
         },
         DomainEvent::NodeUpdated { node, .. } => Some(NodeEvent {
-            event: Some(NodeEventKind::Updated(node_to_proto(node.clone(), None, None))),
+            event: Some(NodeEventKind::Updated(node_to_proto(node.clone()))),
         }),
         DomainEvent::NodeDeleted { id, node_type } => Some(NodeEvent {
             event: Some(NodeEventKind::Deleted(NodeDeleted {

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -23,7 +23,9 @@ pub mod types;
 
 pub use error::{ChatError, Result};
 pub use parser::{parse_tool_calls, ParseResult, ParsedToolCall, StreamingToolCallParser};
-pub use types::{ChatChunk, ChatConfig, ChatMessageInput, ChatUsage, LoadedModelInfo, ToolSpec};
+pub use types::{
+    ChatChunk, ChatConfig, ChatMessageInput, ChatUsage, LoadedModelInfo, ToolCallInput, ToolSpec,
+};
 
 #[cfg(feature = "chat-service")]
 use crate::embedding::{get_or_init_backend, register_atexit_handler};
@@ -650,6 +652,30 @@ impl ChatEngine {
                         "role": "tool",
                         "tool_call_id": msg.call_id.as_deref().unwrap_or("unknown"),
                         "content": msg.content,
+                    })
+                } else if msg.role == "assistant" && !msg.tool_calls.is_empty() {
+                    // Assistant turn that issued tool calls: emit OpenAI-format
+                    // `tool_calls` so the template pairs them with the following
+                    // `tool` result messages. Arguments are passed through as the
+                    // raw JSON string the model produced.
+                    let tool_calls: Vec<serde_json::Value> = msg
+                        .tool_calls
+                        .iter()
+                        .map(|tc| {
+                            serde_json::json!({
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": tc.arguments,
+                                }
+                            })
+                        })
+                        .collect();
+                    serde_json::json!({
+                        "role": "assistant",
+                        "content": msg.content,
+                        "tool_calls": tool_calls,
                     })
                 } else {
                     serde_json::json!({

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -559,6 +559,58 @@ fn strip_gemma_special_tokens(s: &str) -> String {
     out
 }
 
+/// Convert one `ChatMessageInput` into an OpenAI-format message value for the
+/// Jinja chat template.
+///
+/// Pure and model-independent so it can be unit-tested without a loaded model.
+/// Two shapings here are load-bearing for the Gemma 4 template — emitting the
+/// wrong shape makes `apply_chat_template` fail with llama.cpp `ffi error -3`,
+/// aborting the whole turn:
+/// - A tool-call assistant turn carries `content: null` (OpenAI convention)
+///   when it has no text, never `""`.
+/// - Each tool call's `arguments` must be a valid JSON *object* string; any
+///   non-object (empty, malformed) is normalized to `"{}"`.
+fn chat_message_to_oai_value(msg: &ChatMessageInput) -> serde_json::Value {
+    if msg.role == "tool" {
+        serde_json::json!({
+            "role": "tool",
+            "tool_call_id": msg.call_id.as_deref().unwrap_or("unknown"),
+            "content": msg.content,
+        })
+    } else if msg.role == "assistant" && !msg.tool_calls.is_empty() {
+        let tool_calls: Vec<serde_json::Value> = msg
+            .tool_calls
+            .iter()
+            .map(|tc| {
+                let arguments = match serde_json::from_str::<serde_json::Value>(&tc.arguments) {
+                    Ok(v) if v.is_object() => tc.arguments.clone(),
+                    _ => "{}".to_string(),
+                };
+                serde_json::json!({
+                    "id": tc.id,
+                    "type": "function",
+                    "function": { "name": tc.name, "arguments": arguments }
+                })
+            })
+            .collect();
+        let content: serde_json::Value = if msg.content.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::Value::String(msg.content.clone())
+        };
+        serde_json::json!({
+            "role": "assistant",
+            "content": content,
+            "tool_calls": tool_calls,
+        })
+    } else {
+        serde_json::json!({
+            "role": msg.role,
+            "content": msg.content,
+        })
+    }
+}
+
 /// Parse an OpenAI-compat streaming delta JSON string and emit the appropriate
 /// `ChatChunk` events. Called once per delta returned by `ChatParseStateOaicompat::update`.
 ///
@@ -655,69 +707,8 @@ impl ChatEngine {
         // Build OpenAI-format messages JSON. Tool-result messages carry
         // `tool_call_id`; the Jinja template handles family-specific wrapping
         // (Mistral [TOOL_RESULTS], Gemma 4 turn format, etc.).
-        let messages_value: Vec<serde_json::Value> = messages
-            .iter()
-            .map(|msg| {
-                if msg.role == "tool" {
-                    serde_json::json!({
-                        "role": "tool",
-                        "tool_call_id": msg.call_id.as_deref().unwrap_or("unknown"),
-                        "content": msg.content,
-                    })
-                } else if msg.role == "assistant" && !msg.tool_calls.is_empty() {
-                    // Assistant turn that issued tool calls: emit OpenAI-format
-                    // `tool_calls` so the template pairs them with the following
-                    // `tool` result messages. Arguments are passed through as the
-                    // raw JSON string the model produced.
-                    //
-                    // Arguments must be a valid JSON object string. A model that
-                    // emits a malformed/empty tool call (e.g. `create_schema` with
-                    // no args) would otherwise feed `""` straight into the Jinja
-                    // template, which then fails to apply (llama.cpp `ffi error
-                    // -3`) and aborts the whole turn. Normalize any non-object
-                    // arguments to `"{}"` so the template always renders.
-                    let tool_calls: Vec<serde_json::Value> = msg
-                        .tool_calls
-                        .iter()
-                        .map(|tc| {
-                            let arguments =
-                                match serde_json::from_str::<serde_json::Value>(&tc.arguments) {
-                                    Ok(v) if v.is_object() => tc.arguments.clone(),
-                                    _ => "{}".to_string(),
-                                };
-                            serde_json::json!({
-                                "id": tc.id,
-                                "type": "function",
-                                "function": {
-                                    "name": tc.name,
-                                    "arguments": arguments,
-                                }
-                            })
-                        })
-                        .collect();
-                    // OpenAI convention: a tool-call assistant turn carries
-                    // `content: null` when it has no accompanying text. Emitting
-                    // an empty string here instead can make the Jinja template
-                    // fail to apply (llama.cpp `ffi error -3`); `null` is the
-                    // shape the OAI-compat path expects.
-                    let content: serde_json::Value = if msg.content.is_empty() {
-                        serde_json::Value::Null
-                    } else {
-                        serde_json::Value::String(msg.content.clone())
-                    };
-                    serde_json::json!({
-                        "role": "assistant",
-                        "content": content,
-                        "tool_calls": tool_calls,
-                    })
-                } else {
-                    serde_json::json!({
-                        "role": msg.role,
-                        "content": msg.content,
-                    })
-                }
-            })
-            .collect();
+        let messages_value: Vec<serde_json::Value> =
+            messages.iter().map(chat_message_to_oai_value).collect();
 
         let messages_json = serde_json::to_string(&messages_value)
             .map_err(|e| ChatError::TemplateError(format!("Message JSON error: {}", e)))?;
@@ -929,5 +920,85 @@ mod tests {
             strip_gemma_special_tokens("text<|unknown|>end"),
             "text<|unknown|>end"
         );
+    }
+
+    fn msg(role: &str, content: &str) -> ChatMessageInput {
+        ChatMessageInput {
+            role: role.to_string(),
+            content: content.to_string(),
+            call_id: None,
+            tool_calls: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn oai_value_plain_message_passes_through() {
+        let v = chat_message_to_oai_value(&msg("user", "hi"));
+        assert_eq!(v["role"], "user");
+        assert_eq!(v["content"], "hi");
+        assert!(v.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn oai_value_tool_call_turn_empty_content_is_null() {
+        // The load-bearing shape: empty content on a tool-call turn must emit
+        // `null`, not `""` — else Gemma's template fails (ffi error -3).
+        let mut m = msg("assistant", "");
+        m.tool_calls = vec![ToolCallInput {
+            id: "tc_1".into(),
+            name: "search_nodes".into(),
+            arguments: r#"{"query":"x"}"#.into(),
+        }];
+        let v = chat_message_to_oai_value(&m);
+        assert!(
+            v["content"].is_null(),
+            "empty content must serialize to null"
+        );
+        assert_eq!(v["tool_calls"][0]["function"]["name"], "search_nodes");
+        assert_eq!(
+            v["tool_calls"][0]["function"]["arguments"],
+            r#"{"query":"x"}"#
+        );
+    }
+
+    #[test]
+    fn oai_value_tool_call_turn_keeps_real_content() {
+        let mut m = msg("assistant", "Let me check.");
+        m.tool_calls = vec![ToolCallInput {
+            id: "tc_1".into(),
+            name: "get_node".into(),
+            arguments: r#"{"id":"abc"}"#.into(),
+        }];
+        let v = chat_message_to_oai_value(&m);
+        assert_eq!(v["content"], "Let me check.");
+    }
+
+    #[test]
+    fn oai_value_normalizes_non_object_arguments_to_empty_object() {
+        // Empty / malformed / non-object arguments are normalized to "{}" so the
+        // template never receives invalid JSON.
+        for bad in ["", "not json", "[1,2]", "\"str\"", "42"] {
+            let mut m = msg("assistant", "");
+            m.tool_calls = vec![ToolCallInput {
+                id: "tc_1".into(),
+                name: "create_schema".into(),
+                arguments: bad.into(),
+            }];
+            let v = chat_message_to_oai_value(&m);
+            assert_eq!(
+                v["tool_calls"][0]["function"]["arguments"], "{}",
+                "non-object arguments {bad:?} should normalize to {{}}"
+            );
+        }
+    }
+
+    #[test]
+    fn oai_value_tool_result_carries_call_id() {
+        let mut m = msg("tool", "result text");
+        m.call_id = Some("tc_1".into());
+        let v = chat_message_to_oai_value(&m);
+        assert_eq!(v["role"], "tool");
+        assert_eq!(v["tool_call_id"], "tc_1");
+        assert_eq!(v["content"], "result text");
     }
 }

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -381,7 +381,16 @@ impl ChatEngine {
             .map_err(|e| ChatError::InferenceError(format!("Prompt decode failed: {}", e)))?;
 
         // --- Sampling setup ---
+        // A repetition penalty runs first so it reshapes the logits before the
+        // temperature softens them. Without it, small models at near-greedy
+        // temperature (0.1) fall into degenerate loops — repeating a closing
+        // phrase like "I'm ready to help you. What would you like to do next?"
+        // until they exhaust max_tokens (a ~100s hang that never emits the
+        // <end_of_turn> stop token). penalty_last_n=256 covers the recent
+        // window; repeat=1.3 is firm enough to escape a loop without distorting
+        // normal prose. Frequency/presence penalties stay disabled (0.0).
         let mut sampler = LlamaSampler::chain_simple([
+            LlamaSampler::penalties(256, 1.3, 0.0, 0.0),
             LlamaSampler::temp(temperature),
             LlamaSampler::dist(0), // seed=0 for deterministic given temperature
         ]);
@@ -540,6 +549,8 @@ fn strip_gemma_special_tokens(s: &str) -> String {
         "<|turn>",
         "<end_of_turn>",
         "<start_of_turn>",
+        "<|channel>",
+        "<channel|>",
     ];
     let mut out = s.to_string();
     for token in SPECIAL {
@@ -658,23 +669,45 @@ impl ChatEngine {
                     // `tool_calls` so the template pairs them with the following
                     // `tool` result messages. Arguments are passed through as the
                     // raw JSON string the model produced.
+                    //
+                    // Arguments must be a valid JSON object string. A model that
+                    // emits a malformed/empty tool call (e.g. `create_schema` with
+                    // no args) would otherwise feed `""` straight into the Jinja
+                    // template, which then fails to apply (llama.cpp `ffi error
+                    // -3`) and aborts the whole turn. Normalize any non-object
+                    // arguments to `"{}"` so the template always renders.
                     let tool_calls: Vec<serde_json::Value> = msg
                         .tool_calls
                         .iter()
                         .map(|tc| {
+                            let arguments =
+                                match serde_json::from_str::<serde_json::Value>(&tc.arguments) {
+                                    Ok(v) if v.is_object() => tc.arguments.clone(),
+                                    _ => "{}".to_string(),
+                                };
                             serde_json::json!({
                                 "id": tc.id,
                                 "type": "function",
                                 "function": {
                                     "name": tc.name,
-                                    "arguments": tc.arguments,
+                                    "arguments": arguments,
                                 }
                             })
                         })
                         .collect();
+                    // OpenAI convention: a tool-call assistant turn carries
+                    // `content: null` when it has no accompanying text. Emitting
+                    // an empty string here instead can make the Jinja template
+                    // fail to apply (llama.cpp `ffi error -3`); `null` is the
+                    // shape the OAI-compat path expects.
+                    let content: serde_json::Value = if msg.content.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::String(msg.content.clone())
+                    };
                     serde_json::json!({
                         "role": "assistant",
-                        "content": msg.content,
+                        "content": content,
                         "tool_calls": tool_calls,
                     })
                 } else {

--- a/packages/nlp-engine/src/chat/types.rs
+++ b/packages/nlp-engine/src/chat/types.rs
@@ -46,6 +46,22 @@ impl ChatConfig {
     }
 }
 
+/// A tool call issued by an assistant message, carried back through a re-prompt.
+///
+/// The chat template renders these into the assistant turn (e.g. OpenAI-format
+/// `tool_calls`) so the subsequent `tool` result messages have a matching call
+/// to pair with. Omitting them leaves orphan tool results in the history, which
+/// destabilizes generation on some models.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallInput {
+    /// Unique id of this tool call (must match the paired tool result's call_id).
+    pub id: String,
+    /// Name of the invoked tool.
+    pub name: String,
+    /// Raw JSON arguments string as the model emitted them.
+    pub arguments: String,
+}
+
 /// A chat message input for inference.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessageInput {
@@ -56,6 +72,10 @@ pub struct ChatMessageInput {
     /// For tool-result messages: the call ID that produced this result.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
+    /// For assistant messages that issued tool calls: the calls, in order.
+    /// Empty for ordinary messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCallInput>,
 }
 
 /// Specification of a tool the model may invoke.

--- a/packages/nlp-engine/src/lib.rs
+++ b/packages/nlp-engine/src/lib.rs
@@ -53,6 +53,6 @@ pub use error::{EmbeddingError, Result};
 pub use chat::error::ChatError;
 pub use chat::parser::{parse_tool_calls, ParseResult, ParsedToolCall, StreamingToolCallParser};
 pub use chat::types::{
-    ChatChunk, ChatConfig, ChatMessageInput, ChatUsage, LoadedModelInfo, ToolSpec,
+    ChatChunk, ChatConfig, ChatMessageInput, ChatUsage, LoadedModelInfo, ToolCallInput, ToolSpec,
 };
 pub use chat::ChatEngine;

--- a/scripts/aichat.ts
+++ b/scripts/aichat.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+/**
+ * aichat.ts — drive an ai-chat node end-to-end through the CLI, no UI.
+ *
+ * Used to iterate on agent prompting. Talks to a freshly-built nodespaced over a
+ * dedicated test socket/DB so it never touches the user's real ~/.nodespace data.
+ *
+ * Mechanism: there is no "send message" RPC. The daemon's event watcher runs an
+ * inference turn when an ai-chat node's properties['ai-chat'] has
+ * status:"processing" AND a trailing role:"user" message. On completion it
+ * appends the assistant reply and sets status:"idle". So a turn is:
+ * batch-update (append user msg + status:processing) → poll get until idle.
+ *
+ * Commands:
+ *   bun run scripts/aichat.ts new                  Create an ai-chat node; prints its ID.
+ *   bun run scripts/aichat.ts send <id> "message"  Run one turn; prints reply + tool calls.
+ *   bun run scripts/aichat.ts ask "message"        Shorthand: new + send.
+ *   bun run scripts/aichat.ts show <id>            Dump the full message history.
+ *
+ * Env:
+ *   NS_BIN             Path to the `nodespace` CLI (default: worktree release build).
+ *   NODESPACED_SOCKET  Socket the CLI/daemon share (default: test socket).
+ *   NS_LOG             Daemon log scraped for tool calls (default: test log).
+ *   NS_MODEL           Model id recorded on the node (default: gemma-4-e4b-q4km).
+ *   NS_TIMEOUT_MS      Turn timeout in ms (default: 180000).
+ */
+
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WORKTREE = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const NS_BIN = process.env.NS_BIN ?? join(WORKTREE, "target/release/nodespace");
+const SOCKET = process.env.NODESPACED_SOCKET ?? "/tmp/nodespaced-test/daemon.sock";
+const NS_LOG = process.env.NS_LOG ?? "/tmp/nodespaced-test/daemon.log";
+const NS_MODEL = process.env.NS_MODEL ?? "gemma-4-e4b-q4km";
+const TIMEOUT_MS = Number(process.env.NS_TIMEOUT_MS ?? 180_000);
+
+interface AiChat {
+  provider: string;
+  model: string;
+  status: string;
+  messages: Array<{ role: string; content: string; timestamp?: string }>;
+}
+
+/** Run the nodespace CLI with --json and parse stdout. Throws on non-zero exit. */
+function ns(args: string[]): unknown {
+  const result = Bun.spawnSync([NS_BIN, "--socket", SOCKET, "--json", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = result.stdout.toString();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `nodespace ${args.join(" ")} failed (exit ${result.exitCode}):\n${result.stderr.toString()}`,
+    );
+  }
+  return stdout.trim() ? JSON.parse(stdout) : null;
+}
+
+/** Run the CLI without expecting JSON (for batch-update which prints a summary). */
+function nsRaw(args: string[]): void {
+  const result = Bun.spawnSync([NS_BIN, "--socket", SOCKET, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `nodespace ${args.join(" ")} failed (exit ${result.exitCode}):\n${result.stderr.toString()}`,
+    );
+  }
+}
+
+interface NodeJson {
+  id: string;
+  version: number;
+  properties: { "ai-chat"?: AiChat };
+}
+
+function getNode(id: string): NodeJson {
+  return ns(["node", "get", id]) as NodeJson;
+}
+
+function defaultAiChat(): AiChat {
+  return { provider: "native", model: NS_MODEL, status: "idle", messages: [] };
+}
+
+function batchUpdateProps(id: string, version: number | null, props: Record<string, unknown>): void {
+  const item: Record<string, unknown> = { node_id: id, properties: props };
+  if (version !== null) item.version = version;
+  nsRaw(["node", "batch-update", "--updates", JSON.stringify([item])]);
+}
+
+function cmdNew(): string {
+  const created = ns(["node", "create", "--type", "ai-chat", "--content", "CLI test chat"]) as {
+    id: string;
+  };
+  if (!created?.id) throw new Error("create returned no id");
+  batchUpdateProps(created.id, null, { "ai-chat": defaultAiChat() });
+  return created.id;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Strip ANSI colour codes that tracing writes to the log. */
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Pull this turn's internal decisions out of the daemon log slice. */
+function reportTurnLog(sinceByte: number): void {
+  let slice = "";
+  try {
+    const buf = Bun.file(NS_LOG);
+    // Read only the bytes appended during this turn.
+    slice = stripAnsi(Bun.spawnSync(["tail", "-c", `+${sinceByte + 1}`, NS_LOG]).stdout.toString());
+    if (!slice && buf) slice = "";
+  } catch {
+    return;
+  }
+  const lines = slice.split("\n");
+  const offered = lines.filter((l) => l.includes("scoped tool list")).pop();
+  if (offered) {
+    const m = offered.match(/selected_tools="?([^"]*)"?/);
+    if (m) console.log(`[tools offered] ${m[1]}`);
+  }
+  const prepared = lines.filter((l) => l.includes("system prompt and tools prepared")).pop();
+  if (prepared) {
+    const m = prepared.match(/tool_names="?([^"]*?)"? system_prompt_len/);
+    if (m) console.log(`[tools available] ${m[1]}`);
+  }
+  for (const l of lines.filter((l) => l.includes("Tool executed"))) {
+    const tool = l.match(/tool="?([a-z_]+)"?/)?.[1] ?? "?";
+    const args = l.match(/args_preview="?([^"]*?)"? result_preview/)?.[1] ?? "";
+    const err = /is_error=true/.test(l) ? " [ERROR]" : "";
+    console.log(`[tool] ${tool}${err} ${args}`);
+  }
+}
+
+async function cmdSend(id: string, message: string): Promise<void> {
+  const node = getNode(id);
+  const aichat: AiChat = node.properties["ai-chat"] ?? defaultAiChat();
+  const beforeAssistant = aichat.messages.filter((m) => m.role === "assistant").length;
+
+  const logSize = (() => {
+    try {
+      return Bun.file(NS_LOG).size;
+    } catch {
+      return 0;
+    }
+  })();
+
+  aichat.messages.push({ role: "user", content: message, timestamp: new Date().toISOString() });
+  aichat.status = "processing";
+  batchUpdateProps(id, node.version, { "ai-chat": aichat });
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  let latest = aichat;
+  while (Date.now() < deadline) {
+    await sleep(1000);
+    const cur = getNode(id);
+    latest = cur.properties["ai-chat"] ?? latest;
+    const afterAssistant = latest.messages.filter((m) => m.role === "assistant").length;
+    if (latest.status === "idle" && afterAssistant > beforeAssistant) break;
+  }
+  if (latest.status !== "idle") {
+    console.error(`(timeout after ${TIMEOUT_MS}ms; status=${latest.status})`);
+  }
+
+  if (logSize > 0) reportTurnLog(logSize);
+
+  const reply = [...latest.messages].reverse().find((m) => m.role === "assistant");
+  console.log(`assistant> ${reply?.content ?? "(no assistant reply)"}`);
+}
+
+function cmdShow(id: string): void {
+  const node = getNode(id);
+  const aichat = node.properties["ai-chat"];
+  for (const m of aichat?.messages ?? []) {
+    console.log(`${m.role}> ${m.content}`);
+  }
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  switch (cmd) {
+    case "new":
+      console.log(cmdNew());
+      break;
+    case "send": {
+      const [id, ...msg] = rest;
+      if (!id || msg.length === 0) throw new Error("usage: send <id> <message>");
+      await cmdSend(id, msg.join(" "));
+      break;
+    }
+    case "ask": {
+      if (rest.length === 0) throw new Error("usage: ask <message>");
+      const id = cmdNew();
+      console.error(`chat: ${id}`);
+      await cmdSend(id, rest.join(" "));
+      break;
+    }
+    case "show": {
+      const [id] = rest;
+      if (!id) throw new Error("usage: show <id>");
+      cmdShow(id);
+      break;
+    }
+    default:
+      console.error("usage: aichat.ts {new | send <id> <msg> | ask <msg> | show <id>}");
+      process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Improves local ai-chat agent **response quality** on Gemma 4 E4B, driven via a headless CLI harness (no UI). Removes the infrastructure-level failure modes that were independent of model size — multi-minute hangs, runaway/repetition loops, and chat-template token leaks — and tunes the seeded prompts/skills.

This builds on the prior WIP commit (`dff3b855`: embedding-service fix, `tool_calls` plumbing, `model`/`chat` CLI harness).

## What changed

**Loop & sampling** (`agent_loop.rs`, `chat/mod.rs`)
- Cap any single inference round at `MAX_RESPONSE_TOKENS=2048` (was 16384) — a runaway is now bounded to seconds, not minutes.
- Add a repetition penalty to the sampler chain (`penalties(256, 1.3, 0, 0)` before temp) — kills degenerate loops small models fall into at near-greedy temperature.
- Persist assistant tool-call turns with empty content (drop chatty prose) so the Gemma template stops collapsing prose+call+result into one malformed turn.

**Chat template** (`chat/mod.rs`) — fixes an `ffi error -3` turn abort the empty-content change surfaced
- Emit `content: null` (not `""`) for assistant tool-call turns.
- Normalize non-object tool-call `arguments` to `"{}"` so a malformed/empty tool call never feeds invalid JSON into the Jinja template.

**Response normalization** (`response_processing.rs`, tested)
- Strip leaked tool-call/response prose (`call:foo{...}response:foo{...}`, nested braces handled).
- Strip Gemma channel/thought reasoning blocks (`<|channel>…<channel|>` + dangling/stray variants).
- Add `<|channel>`/`<channel|>` to `strip_gemma_special_tokens`.

**Prompt/skill tuning** (`agent_guidance.rs`, `prompt_assembler.rs`, `skill_pipeline.rs`)
- "DATABASE = SCHEMA" routing rule ("create an invoice tracking database" → `create_schema`).
- Loud "conversational turns use NO tools" rule.
- Response rules: 1–2 sentences; empty/error tool result → state and stop, no retry.
- Schema Creation: "ONE SCHEMA PER REQUEST" — no proactive related-type creation.

## Verification

Live matrix on `gemma-4-e4b-q4km` via the CLI harness: greeting (multi-min hang → ~12s), capability question (no longer loops to the token cap), schema creation (routes to `create_schema`, recovers cleanly, no leaks), instance creation, listing, and empty-result query all functionally correct and clean.

Tests: agent **232**, nlp-engine **61**, core **890**, frontend **3841**, skill **17** — all pass. `quality:fix` clean.

## Follow-ups (filed)

- **#1329** — A/B test Gemma 4 12B vs E4B on the corrected loop. The remaining rough edges (E4B calling tools on conversational turns, iterating past a complete answer, emitting unmarked bare-`thought` narration) are capability-bound, not infrastructural, and are documented there with the full scenario matrix and a special-token coverage check.
- **#1330** — Capture and surface the agent's reasoning as a structured, collapsible UI section (instead of stripping it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)