### PR TITLE
Capture and surface local agent reasoning as a collapsible section (#1330)

### DIFF
--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -128,9 +128,18 @@ pub enum Role {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StreamingChunk {
-    /// A token of generated text.
+    /// A token of generated text (answer content shown to the user).
     Token {
         /// The text content of this token.
+        text: String,
+    },
+    /// A span of the model's internal reasoning (chain-of-thought).
+    ///
+    /// Captured separately from the answer so it can be surfaced in a dedicated
+    /// collapsible UI section rather than inline. Not forwarded to the live UI
+    /// overlay; it is accumulated into the final assistant message.
+    Reasoning {
+        /// The reasoning text content of this span.
         text: String,
     },
     /// The model is starting a tool call.
@@ -285,6 +294,12 @@ pub struct ChatMessage {
     pub tool_call_id: Option<String>,
     /// Optional name for tool-role messages (the tool name).
     pub name: Option<String>,
+    /// The model's internal reasoning (chain-of-thought) toward this assistant
+    /// message, captured from channel markers and surfaced in a dedicated
+    /// collapsible UI section. `None` for non-assistant turns or when the model
+    /// produced no reasoning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
 }
 
 impl ChatMessage {
@@ -296,6 +311,7 @@ impl ChatMessage {
             tool_calls: Vec::new(),
             tool_call_id: None,
             name: None,
+            reasoning: None,
         }
     }
 
@@ -310,6 +326,7 @@ impl ChatMessage {
             tool_calls,
             tool_call_id: None,
             name: None,
+            reasoning: None,
         }
     }
 
@@ -325,6 +342,7 @@ impl ChatMessage {
             tool_calls: Vec::new(),
             tool_call_id: Some(tool_call_id.into()),
             name: Some(name.into()),
+            reasoning: None,
         }
     }
 }
@@ -507,6 +525,9 @@ pub struct AgentSession {
 pub struct AgentTurnResult {
     /// The final text response produced by the agent (after all tool calls).
     pub response: String,
+    /// The model's internal reasoning (chain-of-thought) accumulated across all
+    /// ReAct iterations of this turn. `None` when the model produced none.
+    pub reasoning: Option<String>,
     /// Tool calls that were made and executed during this turn.
     pub tool_calls_made: Vec<ToolExecutionRecord>,
     /// Token usage statistics for this turn.

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -194,6 +194,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         );
 
         let mut all_tool_executions: Vec<ToolExecutionRecord> = Vec::new();
+        // Reasoning (chain-of-thought) accumulated across every ReAct iteration of
+        // this turn, joined into a single section on the final assistant message.
+        let mut accumulated_reasoning = String::new();
         let mut total_usage = InferenceUsage {
             prompt_tokens: 0,
             completion_tokens: 0,
@@ -256,7 +259,16 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 let guard = collected_chunks.lock().unwrap_or_else(|p| p.into_inner());
                 guard.clone()
             };
-            let (response_text, tool_calls) = Self::parse_chunks(&chunks);
+            let (response_text, iteration_reasoning, tool_calls) = Self::parse_chunks(&chunks);
+
+            // Accumulate this iteration's reasoning into the turn-wide section,
+            // separating iterations with a blank line.
+            if !iteration_reasoning.trim().is_empty() {
+                if !accumulated_reasoning.is_empty() {
+                    accumulated_reasoning.push_str("\n\n");
+                }
+                accumulated_reasoning.push_str(iteration_reasoning.trim());
+            }
 
             tracing::info!(
                 iteration,
@@ -311,16 +323,22 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                     normalized
                 };
 
-                // Append assistant response to history
-                session
-                    .messages
-                    .push(ChatMessage::text(Role::Assistant, final_response.clone()));
+                // Collapse the accumulated reasoning into the final option.
+                let reasoning = (!accumulated_reasoning.trim().is_empty())
+                    .then(|| accumulated_reasoning.trim().to_string());
+
+                // Append assistant response to history, carrying the reasoning so
+                // it persists and round-trips on reload.
+                let mut assistant_msg = ChatMessage::text(Role::Assistant, final_response.clone());
+                assistant_msg.reasoning = reasoning.clone();
+                session.messages.push(assistant_msg);
 
                 on_status(LocalAgentStatus::Idle);
                 session.status = LocalAgentStatus::Idle;
 
                 return Ok(AgentTurnResult {
                     response: final_response,
+                    reasoning,
                     tool_calls_made: all_tool_executions,
                     usage: total_usage,
                 });
@@ -449,18 +467,28 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                         let guard = final_chunks.lock().unwrap_or_else(|p| p.into_inner());
                         guard.clone()
                     };
-                    let (final_text, _) = Self::parse_chunks(&chunks);
+                    let (final_text, final_reasoning, _) = Self::parse_chunks(&chunks);
+                    if !final_reasoning.trim().is_empty() {
+                        if !accumulated_reasoning.is_empty() {
+                            accumulated_reasoning.push_str("\n\n");
+                        }
+                        accumulated_reasoning.push_str(final_reasoning.trim());
+                    }
                     if !final_text.is_empty() {
                         let normalized = normalize_response(&final_text);
-                        session
-                            .messages
-                            .push(ChatMessage::text(Role::Assistant, normalized.clone()));
+                        let reasoning = (!accumulated_reasoning.trim().is_empty())
+                            .then(|| accumulated_reasoning.trim().to_string());
+                        let mut assistant_msg =
+                            ChatMessage::text(Role::Assistant, normalized.clone());
+                        assistant_msg.reasoning = reasoning.clone();
+                        session.messages.push(assistant_msg);
 
                         on_status(LocalAgentStatus::Idle);
                         session.status = LocalAgentStatus::Idle;
 
                         return Ok(AgentTurnResult {
                             response: normalized,
+                            reasoning,
                             tool_calls_made: all_tool_executions,
                             usage: total_usage,
                         });
@@ -502,6 +530,8 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
 
                 return Ok(AgentTurnResult {
                     response: fallback,
+                    reasoning: (!accumulated_reasoning.trim().is_empty())
+                        .then(|| accumulated_reasoning.trim().to_string()),
                     tool_calls_made: all_tool_executions,
                     usage: total_usage,
                 });
@@ -516,14 +546,22 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
 
         Ok(AgentTurnResult {
             response: String::new(),
+            reasoning: (!accumulated_reasoning.trim().is_empty())
+                .then(|| accumulated_reasoning.trim().to_string()),
             tool_calls_made: all_tool_executions,
             usage: total_usage,
         })
     }
 
     /// Parse collected streaming chunks into response text and tool calls.
-    fn parse_chunks(chunks: &[StreamingChunk]) -> (String, Vec<ToolCallRaw>) {
+    /// Parse a streamed chunk sequence into `(answer_text, reasoning_text, tool_calls)`.
+    ///
+    /// Reasoning chunks (the model's chain-of-thought, already separated from the
+    /// answer at the nlp-engine parse layer) are accumulated independently of the
+    /// answer text so the answer bubble stays clean.
+    fn parse_chunks(chunks: &[StreamingChunk]) -> (String, String, Vec<ToolCallRaw>) {
         let mut text = String::new();
+        let mut reasoning = String::new();
         let mut tool_calls: Vec<ToolCallRaw> = Vec::new();
         // Accumulate tool call args by id
         // Use Vec to preserve tool call ordering (important for causal dependencies)
@@ -533,6 +571,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             match chunk {
                 StreamingChunk::Token { text: t } => {
                     text.push_str(t);
+                }
+                StreamingChunk::Reasoning { text: r } => {
+                    reasoning.push_str(r);
                 }
                 StreamingChunk::ToolCallStart { id, name } => {
                     pending_calls.push((id.clone(), name.clone(), String::new()));
@@ -556,7 +597,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             });
         }
 
-        (text, tool_calls)
+        (text, reasoning, tool_calls)
     }
 
     /// Summarize older history turns if the conversation exceeds the token budget.
@@ -681,7 +722,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             let guard = summary_chunks.lock().unwrap_or_else(|p| p.into_inner());
             guard.clone()
         };
-        let (summary_text, _) = Self::parse_chunks(&chunks);
+        let (summary_text, _, _) = Self::parse_chunks(&chunks);
 
         let summary_content = if summary_text.is_empty() {
             // Fallback: just note that history was truncated
@@ -1419,9 +1460,36 @@ mod tests {
                 },
             },
         ];
-        let (text, tool_calls) =
+        let (text, reasoning, tool_calls) =
             LocalAgentLoop::<MockEngine, MockToolExecutor>::parse_chunks(&chunks);
         assert_eq!(text, "Hello world");
+        assert!(reasoning.is_empty());
+        assert!(tool_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parse_chunks_separates_reasoning_from_answer() {
+        let chunks = vec![
+            StreamingChunk::Reasoning {
+                text: "The user said hi; ".to_string(),
+            },
+            StreamingChunk::Token {
+                text: "Hello!".to_string(),
+            },
+            StreamingChunk::Reasoning {
+                text: "I should greet back.".to_string(),
+            },
+            StreamingChunk::Done {
+                usage: InferenceUsage {
+                    prompt_tokens: 3,
+                    completion_tokens: 2,
+                },
+            },
+        ];
+        let (text, reasoning, tool_calls) =
+            LocalAgentLoop::<MockEngine, MockToolExecutor>::parse_chunks(&chunks);
+        assert_eq!(text, "Hello!");
+        assert_eq!(reasoning, "The user said hi; I should greet back.");
         assert!(tool_calls.is_empty());
     }
 
@@ -1450,7 +1518,7 @@ mod tests {
                 },
             },
         ];
-        let (text, tool_calls) =
+        let (text, _reasoning, tool_calls) =
             LocalAgentLoop::<MockEngine, MockToolExecutor>::parse_chunks(&chunks);
         assert_eq!(text, "Let me search");
         assert_eq!(tool_calls.len(), 1);

--- a/packages/agent/src/local_agent/inference.rs
+++ b/packages/agent/src/local_agent/inference.rs
@@ -111,6 +111,9 @@ impl ChatInferenceEngine for LlamaChatInferenceEngine {
                     ChatChunk::Token(text) => {
                         on_chunk(StreamingChunk::Token { text });
                     }
+                    ChatChunk::Reasoning(text) => {
+                        on_chunk(StreamingChunk::Reasoning { text });
+                    }
                     ChatChunk::ToolCallStart { id, name } => {
                         on_chunk(StreamingChunk::ToolCallStart { id, name });
                     }

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -514,6 +514,23 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
                             item_fields: None,
                         },
                         SchemaField {
+                            name: "reasoning".to_string(),
+                            field_type: "text".to_string(),
+                            protection: SchemaProtectionLevel::Core,
+                            core_values: None,
+                            user_values: None,
+                            indexed: false,
+                            required: Some(false),
+                            extensible: None,
+                            default: None,
+                            description: Some(
+                                "Model chain-of-thought reasoning toward the answer".to_string(),
+                            ),
+                            item_type: None,
+                            fields: None,
+                            item_fields: None,
+                        },
+                        SchemaField {
                             name: "timestamp".to_string(),
                             field_type: "date".to_string(),
                             protection: SchemaProtectionLevel::System,

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -406,25 +406,17 @@ impl LocalAgentServiceImpl {
                 });
 
                 // Append assistant message; also atomically sets status: idle.
-                // Pull both the content and the captured reasoning from the
-                // session's last assistant message, falling back to the turn result.
-                let (assistant_content, assistant_reasoning) = service
-                    .get_session(&session_id)
-                    .await
-                    .and_then(|s| {
-                        s.messages
-                            .into_iter()
-                            .rev()
-                            .find(|m| m.role == Role::Assistant)
-                            .map(|m| (m.content, m.reasoning))
-                    })
-                    .unwrap_or_else(|| (result.response.clone(), result.reasoning.clone()));
-
+                // `AgentTurnResult` is the authoritative current-turn output: every
+                // return path (normal, no-tools-final, synthesized fallback, empty)
+                // sets `response`/`reasoning` for *this* turn. Using it directly avoids
+                // a session-history scan that, on the fallback branches (which do not
+                // push an assistant message), could surface a *previous* turn's
+                // content/reasoning instead.
                 match self
                     .append_assistant_message(
                         &node_id,
-                        &assistant_content,
-                        assistant_reasoning.as_deref(),
+                        &result.response,
+                        result.reasoning.as_deref(),
                     )
                     .await
                 {
@@ -1227,13 +1219,8 @@ mod tests {
                 .await
                 .expect("SqliteStore"),
         );
-        let node_service = Arc::new(
-            CoreNodeService::new(&mut store)
-                .await
-                .expect("NodeService"),
-        );
-        let embedding: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>> =
-            Arc::new(RwLock::new(None));
+        let node_service = Arc::new(CoreNodeService::new(&mut store).await.expect("NodeService"));
+        let embedding: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>> = Arc::new(RwLock::new(None));
         let svc = LocalAgentServiceImpl::new(node_service.clone(), embedding);
         (svc, node_service, tempdir)
     }
@@ -1244,7 +1231,10 @@ mod tests {
             "Test chat".to_string(),
             serde_json::json!({ "ai-chat": { "messages": [] } }),
         );
-        node_service.create_node(node).await.expect("create ai-chat")
+        node_service
+            .create_node(node)
+            .await
+            .expect("create ai-chat")
     }
 
     #[tokio::test]

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -1211,3 +1211,79 @@ async fn build_workspace_context(
     .map_err(|_| ())?;
     Ok(context.format_for_prompt(4000))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nodespace_core::models::Node;
+    use nodespace_core::{NodeService as CoreNodeService, SqliteStore};
+
+    /// Build a `LocalAgentServiceImpl` backed by a temp-dir SqliteStore.
+    /// Returns the `TempDir` so it outlives the test body.
+    async fn test_service() -> (LocalAgentServiceImpl, Arc<NodeService>, tempfile::TempDir) {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let mut store = Arc::new(
+            SqliteStore::new(tempdir.path().join("daemon-db"))
+                .await
+                .expect("SqliteStore"),
+        );
+        let node_service = Arc::new(
+            CoreNodeService::new(&mut store)
+                .await
+                .expect("NodeService"),
+        );
+        let embedding: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>> =
+            Arc::new(RwLock::new(None));
+        let svc = LocalAgentServiceImpl::new(node_service.clone(), embedding);
+        (svc, node_service, tempdir)
+    }
+
+    async fn create_ai_chat_node(node_service: &Arc<NodeService>) -> String {
+        let node = Node::new(
+            "ai-chat".to_string(),
+            "Test chat".to_string(),
+            serde_json::json!({ "ai-chat": { "messages": [] } }),
+        );
+        node_service.create_node(node).await.expect("create ai-chat")
+    }
+
+    #[tokio::test]
+    async fn reasoning_round_trips_through_persist_and_reload() {
+        let (svc, node_service, _tempdir) = test_service().await;
+        let node_id = create_ai_chat_node(&node_service).await;
+
+        svc.append_assistant_message(&node_id, "The answer.", Some("I reasoned about it."))
+            .await
+            .expect("append");
+
+        let history = load_node_history(&node_service, &node_id).await;
+        let assistant = history
+            .iter()
+            .find(|m| matches!(m.role, Role::Assistant))
+            .expect("assistant message present");
+        assert_eq!(assistant.content, "The answer.");
+        assert_eq!(assistant.reasoning.as_deref(), Some("I reasoned about it."));
+    }
+
+    #[tokio::test]
+    async fn empty_or_whitespace_reasoning_is_omitted() {
+        let (svc, node_service, _tempdir) = test_service().await;
+        let node_id = create_ai_chat_node(&node_service).await;
+
+        // None and whitespace-only both persist no reasoning field.
+        svc.append_assistant_message(&node_id, "Plain answer.", None)
+            .await
+            .expect("append none");
+        svc.append_assistant_message(&node_id, "Another answer.", Some("   "))
+            .await
+            .expect("append whitespace");
+
+        let history = load_node_history(&node_service, &node_id).await;
+        let assistants: Vec<_> = history
+            .iter()
+            .filter(|m| matches!(m.role, Role::Assistant))
+            .collect();
+        assert_eq!(assistants.len(), 2);
+        assert!(assistants.iter().all(|m| m.reasoning.is_none()));
+    }
+}

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -343,7 +343,14 @@ impl LocalAgentServiceImpl {
             &user_message,
             move |_status: LocalAgentStatus| {},
             move |chunk: StreamingChunk| {
-                if !matches!(chunk, StreamingChunk::Done { .. }) {
+                // `Done` is conveyed via the turn result, not a wire chunk.
+                // `Reasoning` is intentionally not streamed live (it is captured
+                // and surfaced via the persisted message; see issue design):
+                // skip it here so the live answer stream stays clean.
+                if !matches!(
+                    chunk,
+                    StreamingChunk::Done { .. } | StreamingChunk::Reasoning { .. }
+                ) {
                     let mut proto = streaming_chunk_to_proto(chunk);
                     proto.node_id = Some(node_id2.clone());
                     // Ignore send errors — no subscribers connected is fine.
@@ -399,7 +406,9 @@ impl LocalAgentServiceImpl {
                 });
 
                 // Append assistant message; also atomically sets status: idle.
-                let assistant_content = service
+                // Pull both the content and the captured reasoning from the
+                // session's last assistant message, falling back to the turn result.
+                let (assistant_content, assistant_reasoning) = service
                     .get_session(&session_id)
                     .await
                     .and_then(|s| {
@@ -407,12 +416,16 @@ impl LocalAgentServiceImpl {
                             .into_iter()
                             .rev()
                             .find(|m| m.role == Role::Assistant)
-                            .map(|m| m.content)
+                            .map(|m| (m.content, m.reasoning))
                     })
-                    .unwrap_or_else(|| result.response.clone());
+                    .unwrap_or_else(|| (result.response.clone(), result.reasoning.clone()));
 
                 match self
-                    .append_assistant_message(&node_id, &assistant_content)
+                    .append_assistant_message(
+                        &node_id,
+                        &assistant_content,
+                        assistant_reasoning.as_deref(),
+                    )
                     .await
                 {
                     Ok(()) => needs_idle_reset = false,
@@ -548,8 +561,14 @@ impl LocalAgentServiceImpl {
     }
 
     /// Append an assistant message to `properties['ai-chat']['messages']`.
-    /// Retries once on version conflict.
-    async fn append_assistant_message(&self, node_id: &str, content: &str) -> Result<(), String> {
+    /// Retries once on version conflict. `reasoning` is the model's captured
+    /// chain-of-thought, persisted alongside the answer when present.
+    async fn append_assistant_message(
+        &self,
+        node_id: &str,
+        content: &str,
+        reasoning: Option<&str>,
+    ) -> Result<(), String> {
         for attempt in 0..2 {
             let node = self
                 .inner
@@ -568,11 +587,16 @@ impl LocalAgentServiceImpl {
             let messages = ai_chat.get_mut("messages").and_then(|v| v.as_array_mut());
 
             let timestamp = chrono::Utc::now().to_rfc3339();
-            let new_msg = serde_json::json!({
+            let mut new_msg = serde_json::json!({
                 "role": "assistant",
                 "content": content,
                 "timestamp": timestamp
             });
+            // Persist reasoning only when the model produced some, keeping the
+            // message shape minimal for plain answers.
+            if let Some(r) = reasoning.filter(|r| !r.trim().is_empty()) {
+                new_msg["reasoning"] = serde_json::Value::String(r.to_string());
+            }
 
             if let Some(msgs) = messages {
                 msgs.push(new_msg);
@@ -1094,6 +1118,15 @@ fn streaming_chunk_to_proto(chunk: StreamingChunk) -> AgentChunk {
             token_text: Some(text),
             ..Default::default()
         },
+        // Reasoning is not streamed live (filtered out before this function in the
+        // send callback); it reaches the UI via the persisted message. This arm
+        // exists only for exhaustiveness and tags the chunk so any future live
+        // consumer can distinguish/ignore it rather than render it as the answer.
+        StreamingChunk::Reasoning { text } => AgentChunk {
+            chunk_type: "reasoning".to_string(),
+            token_text: Some(text),
+            ..Default::default()
+        },
         StreamingChunk::ToolCallStart { id, name } => AgentChunk {
             chunk_type: "tool_call_start".to_string(),
             tool_call_id: Some(id),
@@ -1153,7 +1186,13 @@ async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Ve
                 _ => return None,
             };
             let content = m.get("content")?.as_str()?.to_string();
-            Some(ChatMessage::text(role, content))
+            let mut msg = ChatMessage::text(role, content);
+            // Round-trip any persisted reasoning so reloaded history retains it.
+            msg.reasoning = m
+                .get("reasoning")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            Some(msg)
         })
         .collect()
 }

--- a/packages/desktop-app/src/lib/components/chat/chat-message.svelte
+++ b/packages/desktop-app/src/lib/components/chat/chat-message.svelte
@@ -41,6 +41,15 @@
       </div>
     {/if}
 
+    {#if isAssistant && message.reasoning}
+      <details class="reasoning-block">
+        <summary class="reasoning-summary">Reasoning</summary>
+        <div class="reasoning-content">
+          <ChatMarkdown content={message.reasoning} />
+        </div>
+      </details>
+    {/if}
+
     {#if isAssistant && showCopyButton}
       <button
         class="copy-button"
@@ -103,6 +112,42 @@
 
   .user-message .message-content {
     white-space: pre-wrap;
+  }
+
+  .reasoning-block {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid hsl(var(--border));
+    font-size: 0.8125rem;
+  }
+
+  .reasoning-summary {
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+    font-weight: 500;
+    user-select: none;
+    list-style: none;
+  }
+
+  .reasoning-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .reasoning-summary::before {
+    content: '▸';
+    display: inline-block;
+    margin-right: 0.375rem;
+    transition: transform 0.15s;
+  }
+
+  .reasoning-block[open] .reasoning-summary::before {
+    transform: rotate(90deg);
+  }
+
+  .reasoning-content {
+    margin-top: 0.375rem;
+    color: hsl(var(--muted-foreground));
+    word-break: break-word;
   }
 
   .copy-button {

--- a/packages/desktop-app/src/lib/components/chat/types.ts
+++ b/packages/desktop-app/src/lib/components/chat/types.ts
@@ -18,4 +18,6 @@ export interface DisplayMessage {
   content: string;
   readonly toolExecutions: ToolExecutionRecord[];
   readonly timestamp: number;
+  /** Model chain-of-thought, rendered as a collapsible section under the answer. */
+  readonly reasoning?: string;
 }

--- a/packages/desktop-app/src/lib/components/viewers/ai-chat-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/ai-chat-node-viewer.svelte
@@ -102,6 +102,7 @@
         content: m.content ?? '',
         toolExecutions: [],
         timestamp: m.timestamp ? new Date(m.timestamp).getTime() : Date.now(),
+        reasoning: m.reasoning,
       }));
   });
 

--- a/packages/desktop-app/src/lib/types/ai-chat-node.ts
+++ b/packages/desktop-app/src/lib/types/ai-chat-node.ts
@@ -7,6 +7,8 @@ export interface AiChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   timestamp?: string;
+  /** Model chain-of-thought reasoning toward the answer, when captured. */
+  reasoning?: string;
 }
 
 /**

--- a/packages/desktop-app/src/tests/components/chat-message-reasoning.test.ts
+++ b/packages/desktop-app/src/tests/components/chat-message-reasoning.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ChatMessage Component Tests — reasoning section rendering
+ *
+ * Verifies that the model's captured chain-of-thought renders as a collapsible
+ * section (collapsed by default) under an assistant answer, and is absent for
+ * clean answers or user messages.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ChatMessage from '$lib/components/chat/chat-message.svelte';
+import type { DisplayMessage } from '$lib/components/chat/types';
+
+// ChatMarkdown (rendered inside the bubble) uses the logger.
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function makeMessage(overrides: Partial<DisplayMessage>): DisplayMessage {
+  return {
+    id: 'm1',
+    role: 'assistant',
+    content: 'Here is your answer.',
+    toolExecutions: [],
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+describe('ChatMessage reasoning section', () => {
+  it('renders a collapsed reasoning section for an assistant message with reasoning', () => {
+    const { container } = render(ChatMessage, {
+      message: makeMessage({ reasoning: 'I chose create_schema because the user wants a type.' }),
+    });
+
+    const details = container.querySelector('details.reasoning-block');
+    expect(details).not.toBeNull();
+    // Collapsed by default: a <details> without the `open` attribute.
+    expect(details?.hasAttribute('open')).toBe(false);
+    expect(container.querySelector('.reasoning-summary')?.textContent).toContain('Reasoning');
+    expect(container.querySelector('.reasoning-content')?.textContent).toContain('create_schema');
+  });
+
+  it('renders no reasoning section when the assistant message has none', () => {
+    const { container } = render(ChatMessage, {
+      message: makeMessage({ reasoning: undefined }),
+    });
+    expect(container.querySelector('details.reasoning-block')).toBeNull();
+  });
+
+  it('renders no reasoning section for a user message even if reasoning is set', () => {
+    const { container } = render(ChatMessage, {
+      message: makeMessage({ role: 'user', content: 'Hi', reasoning: 'should not show' }),
+    });
+    expect(container.querySelector('details.reasoning-block')).toBeNull();
+  });
+});

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -406,6 +406,11 @@ impl ChatEngine {
         let mut tool_call_ids: std::collections::HashMap<u32, String> =
             std::collections::HashMap::new();
 
+        // Route the model's `<|channel> … <channel|>` reasoning out of the answer
+        // stream. Held across the whole loop so a span (or marker) that straddles
+        // a delta boundary is resolved correctly.
+        let mut channel_splitter = ChannelSplitter::default();
+
         // --- Token generation loop ---
         // Reborrow model and context separately to satisfy the borrow checker.
         // get_or_create_context() ensured the context exists, so we can safely
@@ -471,7 +476,12 @@ impl ChatEngine {
             match oai_parser.update(&piece, true) {
                 Ok(deltas) => {
                     for delta_json in deltas {
-                        emit_oai_delta(&delta_json, &mut tool_call_ids, on_chunk);
+                        emit_oai_delta(
+                            &delta_json,
+                            &mut tool_call_ids,
+                            &mut channel_splitter,
+                            on_chunk,
+                        );
                     }
                 }
                 Err(e) => {
@@ -504,10 +514,26 @@ impl ChatEngine {
         match oai_parser.update("", false) {
             Ok(deltas) => {
                 for delta_json in deltas {
-                    emit_oai_delta(&delta_json, &mut tool_call_ids, on_chunk);
+                    emit_oai_delta(
+                        &delta_json,
+                        &mut tool_call_ids,
+                        &mut channel_splitter,
+                        on_chunk,
+                    );
                 }
             }
             Err(e) => tracing::warn!("OAI parser finalize error: {}", e),
+        }
+
+        // Drain any text the splitter held back (a trailing partial marker that
+        // never completed, or an unclosed channel truncated by the token cap).
+        let (final_answer, final_reasoning) = channel_splitter.finalize();
+        if !final_reasoning.is_empty() {
+            on_chunk(ChatChunk::Reasoning(final_reasoning));
+        }
+        let final_cleaned = strip_gemma_special_tokens(&final_answer);
+        if !final_cleaned.is_empty() {
+            on_chunk(ChatChunk::Token(final_cleaned));
         }
 
         on_chunk(ChatChunk::Done);
@@ -525,6 +551,117 @@ impl ChatEngine {
 
         Ok(usage)
     }
+}
+
+/// Channel markers Gemma 4 uses to wrap its internal chain-of-thought.
+const CHANNEL_OPEN: &str = "<|channel>";
+const CHANNEL_CLOSE: &str = "<channel|>";
+
+/// Splits a streamed content sequence into answer text and reasoning text.
+///
+/// Gemma 4 wraps its internal chain-of-thought in `<|channel> … <channel|>`
+/// markers. llama.cpp's OAI-compat parser does not separate these — it passes
+/// the whole span through as plain content — so we route it ourselves: text
+/// between the markers is *reasoning* (surfaced in a dedicated collapsible UI
+/// section), text outside is the *answer* (the clean message bubble).
+///
+/// The splitter is stateful because a single logical span — and even a single
+/// marker — may be split across multiple streaming deltas. It tracks whether
+/// it is currently inside a channel and carries a tail that could be the
+/// beginning of a marker straddling a delta boundary.
+#[derive(Debug, Default)]
+struct ChannelSplitter {
+    /// True while between an opener and its (not-yet-seen) closer.
+    in_channel: bool,
+    /// Tail of the last delta that may be the prefix of a marker spanning the
+    /// boundary into the next delta. Always marker-free text otherwise.
+    carry: String,
+}
+
+impl ChannelSplitter {
+    /// Feed a content delta, returning `(answer, reasoning)` text resolved so far.
+    ///
+    /// Any trailing bytes that could still grow into a marker are held back in
+    /// `carry` and resolved on a later `push` or on `finalize`.
+    fn push(&mut self, content: &str) -> (String, String) {
+        let mut answer = String::new();
+        let mut reasoning = String::new();
+
+        let mut buf = std::mem::take(&mut self.carry);
+        buf.push_str(content);
+
+        let mut rest = buf.as_str();
+        loop {
+            let marker = if self.in_channel {
+                CHANNEL_CLOSE
+            } else {
+                CHANNEL_OPEN
+            };
+            match rest.find(marker) {
+                Some(idx) => {
+                    // Emit the text before the marker to the active sink, then
+                    // toggle state and continue scanning past the marker.
+                    let before = &rest[..idx];
+                    if self.in_channel {
+                        reasoning.push_str(before);
+                    } else {
+                        answer.push_str(before);
+                    }
+                    self.in_channel = !self.in_channel;
+                    rest = &rest[idx + marker.len()..];
+                }
+                None => {
+                    // No complete marker remains. Hold back any suffix that
+                    // could be the prefix of the marker we're looking for; emit
+                    // the rest to the active sink.
+                    let keep = partial_marker_suffix_len(rest, marker);
+                    let split = rest.len() - keep;
+                    let emit = &rest[..split];
+                    if self.in_channel {
+                        reasoning.push_str(emit);
+                    } else {
+                        answer.push_str(emit);
+                    }
+                    self.carry = rest[split..].to_string();
+                    break;
+                }
+            }
+        }
+
+        (answer, reasoning)
+    }
+
+    /// Flush any carried text once generation is complete.
+    ///
+    /// No further deltas can complete a marker, so the carry is plain text and
+    /// is emitted to whichever sink is currently active.
+    fn finalize(&mut self) -> (String, String) {
+        let carried = std::mem::take(&mut self.carry);
+        if self.in_channel {
+            (String::new(), carried)
+        } else {
+            (carried, String::new())
+        }
+    }
+}
+
+/// Length of the longest suffix of `text` that is a (strict) prefix of `marker`.
+///
+/// Used to decide how much trailing text to hold back across a delta boundary:
+/// e.g. if `text` ends in `"<chan"` and `marker` is `"<channel|>"`, the last 5
+/// bytes must be carried in case the rest of the marker arrives next. Marker
+/// bytes are ASCII, so a match position is always a UTF-8 char boundary.
+fn partial_marker_suffix_len(text: &str, marker: &str) -> usize {
+    let max = marker.len().min(text.len());
+    // Longest first so we hold back the most that could still match.
+    (1..=max)
+        .rev()
+        .find(|&k| {
+            marker
+                .as_bytes()
+                .starts_with(&text.as_bytes()[text.len() - k..])
+        })
+        .unwrap_or(0)
 }
 
 /// Remove Gemma 4 special-token strings from a content string.
@@ -622,6 +759,7 @@ fn chat_message_to_oai_value(msg: &ChatMessageInput) -> serde_json::Value {
 fn emit_oai_delta(
     delta_json: &str,
     tool_call_ids: &mut std::collections::HashMap<u32, String>,
+    splitter: &mut ChannelSplitter,
     on_chunk: &(impl Fn(ChatChunk) + Send),
 ) {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(delta_json) else {
@@ -629,11 +767,18 @@ fn emit_oai_delta(
         return;
     };
 
-    // Plain text content — strip any residual Gemma 4 special-token strings
-    // (e.g. "<|tool_call>", "<|"|>", "<tool_call|>") that the PEG parser may
-    // pass through as content before it recognises the full tool-call boundary.
+    // Plain text content. Route `<|channel> … <channel|>` spans to a separate
+    // reasoning stream (the splitter is stateful across deltas; a span or even a
+    // single marker may straddle a delta boundary). The answer part still passes
+    // through `strip_gemma_special_tokens` so other residual special tokens (e.g.
+    // "<|tool_call>", "<|"|>") the PEG parser leaks before recognising a tool-call
+    // boundary are scrubbed.
     if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
-        let cleaned = strip_gemma_special_tokens(content);
+        let (answer, reasoning) = splitter.push(content);
+        if !reasoning.is_empty() {
+            on_chunk(ChatChunk::Reasoning(reasoning));
+        }
+        let cleaned = strip_gemma_special_tokens(&answer);
         if !cleaned.is_empty() {
             on_chunk(ChatChunk::Token(cleaned));
         }
@@ -857,6 +1002,82 @@ fn uuid_v4_simple() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- ChannelSplitter: route <|channel> … <channel|> reasoning out of answer ---
+
+    /// Drive a splitter over a sequence of deltas, returning the fully
+    /// accumulated `(answer, reasoning)` including the finalize flush.
+    fn split_all(deltas: &[&str]) -> (String, String) {
+        let mut s = ChannelSplitter::default();
+        let mut answer = String::new();
+        let mut reasoning = String::new();
+        for d in deltas {
+            let (a, r) = s.push(d);
+            answer.push_str(&a);
+            reasoning.push_str(&r);
+        }
+        let (a, r) = s.finalize();
+        answer.push_str(&a);
+        reasoning.push_str(&r);
+        (answer, reasoning)
+    }
+
+    #[test]
+    fn channel_splitter_marker_within_one_delta() {
+        let (answer, reasoning) =
+            split_all(&["Done.<|channel>I should add the node.<channel|>Added it!"]);
+        assert_eq!(answer, "Done.Added it!");
+        assert_eq!(reasoning, "I should add the node.");
+    }
+
+    #[test]
+    fn channel_splitter_marker_split_across_deltas() {
+        // Both the opener and closer are fragmented across delta boundaries.
+        let (answer, reasoning) =
+            split_all(&["Hi<|cha", "nnel>think", "ing more<chan", "nel|>the answer"]);
+        assert_eq!(answer, "Hithe answer");
+        assert_eq!(reasoning, "thinking more");
+    }
+
+    #[test]
+    fn channel_splitter_opener_without_closer_is_all_reasoning() {
+        // Truncated by the token cap mid-thought: everything after the opener
+        // is reasoning, and no answer text leaks.
+        let (answer, reasoning) = split_all(&["Here.<|channel>reasoning that never closes"]);
+        assert_eq!(answer, "Here.");
+        assert_eq!(reasoning, "reasoning that never closes");
+    }
+
+    #[test]
+    fn channel_splitter_clean_content_has_no_reasoning() {
+        let (answer, reasoning) = split_all(&["Just a normal ", "answer."]);
+        assert_eq!(answer, "Just a normal answer.");
+        assert_eq!(reasoning, "");
+    }
+
+    #[test]
+    fn channel_splitter_trailing_partial_marker_flushed_as_answer() {
+        // A suffix that looks like the start of a marker but never completes
+        // must be flushed to the answer on finalize, not swallowed.
+        let (answer, reasoning) = split_all(&["answer<|chan"]);
+        assert_eq!(answer, "answer<|chan");
+        assert_eq!(reasoning, "");
+    }
+
+    #[test]
+    fn channel_splitter_multiple_channels_concatenate() {
+        let (answer, reasoning) = split_all(&["a<|channel>r1<channel|>b<|channel>r2<channel|>c"]);
+        assert_eq!(answer, "abc");
+        assert_eq!(reasoning, "r1r2");
+    }
+
+    #[test]
+    fn channel_splitter_handles_multibyte_answer_text() {
+        // Non-ASCII answer text must not panic the byte-based carry logic.
+        let (answer, reasoning) = split_all(&["café ☕<|channel>think<channel|> déjà vu"]);
+        assert_eq!(answer, "café ☕ déjà vu");
+        assert_eq!(reasoning, "think");
+    }
 
     #[test]
     fn test_chat_engine_creation() {

--- a/packages/nlp-engine/src/chat/types.rs
+++ b/packages/nlp-engine/src/chat/types.rs
@@ -92,8 +92,15 @@ pub struct ToolSpec {
 /// A chunk emitted during streaming inference.
 #[derive(Debug, Clone)]
 pub enum ChatChunk {
-    /// A generated text token.
+    /// A generated text token (answer content shown to the user).
     Token(String),
+    /// A span of the model's internal reasoning (chain-of-thought).
+    ///
+    /// Emitted for text the model wrapped in channel markers
+    /// (`<|channel> … <channel|>`). Routed to a separate reasoning stream rather
+    /// than the answer, so the answer bubble stays clean while the reasoning can
+    /// be surfaced in a dedicated collapsible UI section.
+    Reasoning(String),
     /// The model is starting a tool call.
     ToolCallStart {
         /// Unique identifier for this tool call.


### PR DESCRIPTION
Implements #1330 — captures the local agent's marked chain-of-thought into a dedicated `reasoning` field and surfaces it in the chat UI as a collapsible section, while keeping the answer bubble clean.

## What changed (by layer)

- **nlp-engine**: New `ChatChunk::Reasoning`. A stateful `ChannelSplitter` routes text between `<|channel> … <channel|>` markers to reasoning and the rest to the answer, at the streaming parse layer. Handles markers split across token deltas; finalize drains any held-back tail. `strip_gemma_special_tokens` retained as a defensive fallback.
- **agent**: `StreamingChunk::Reasoning` bridged in `inference.rs`; `parse_chunks` now returns `(answer, reasoning, tool_calls)`; `run_turn` accumulates reasoning across all ReAct iterations and attaches it to `AgentTurnResult` and the persisted assistant `ChatMessage` (`ChatMessage.reasoning`).
- **daemon**: Reasoning persisted on the ai-chat message (`append_assistant_message`) and round-tripped on history reload. Not streamed live — surfaced via the persisted/hydrated message (no proto `AgentChunk` change). `core_schemas.rs` gains a `reasoning` field on message items.
- **frontend**: `AiChatMessage` / `DisplayMessage` gain `reasoning`; the viewer maps it; `chat-message.svelte` renders a collapsible "Reasoning" section (collapsed by default), styled distinct from the answer.
- **docs**: `nodespace-docs/architecture/ai-chat-node.md` documents marked-reasoning capture and that unmarked bare-`thought` narration is intentionally not surfaced.

## Design decisions
- Capture at the nlp-engine parse layer (most reliable; markers visible there).
- Concatenate reasoning across iterations into one section.
- Final/persisted only — reasoning is captured but not streamed live; it appears once the message is persisted and re-hydrated.

## Acceptance criteria
- [x] Reasoning captured into a dedicated `reasoning` field, separate from `content`
- [x] Answer `content` stays free of reasoning/thought/channel leaks
- [x] `reasoning` plumbed through daemon persistence + persisted ai-chat shape + core schema
- [x] Chat UI renders a collapsible section, collapsed by default, distinct from the answer
- [x] Unmarked bare-`thought` behavior documented (not surfaced)
- [x] Tests: marked reasoning routed to `reasoning` & removed from `content`; clean answers render normally
- [x] Tests pass (`test:all`); `quality:fix` clean

## Verification
- nlp-engine 73 (incl. 7 ChannelSplitter), agent 234 (incl. reasoning separation), core 890, daemon 40 — all pass.
- Frontend: 3844 passed (+3 new reasoning rendering tests).
- `quality:fix`: eslint 0, svelte-check 0, tsc clean, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)