### PR TITLE
Wire the agent's embedding service by construction instead of re-injecting it per engine swap

### DIFF
--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -15,6 +15,18 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Shared handle to the embedding service.
+///
+/// The embedding model loads in a background task after daemon startup, so the
+/// service may be absent when the executor is built and appear later. Holding it
+/// behind a shared `RwLock` (rather than a captured snapshot) lets the executor
+/// read the *current* value on every call — it never gets wired with a stale or
+/// `None` service once one becomes available, and there is no engine-swap step
+/// to remember. The inner `Option` is `None` until the embedding model finishes
+/// loading.
+pub type SharedEmbeddingService = Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>;
 
 // ---------------------------------------------------------------------------
 // Agent-specific parameter structs
@@ -672,36 +684,14 @@ pub(crate) fn all_tool_definitions() -> Vec<ToolDefinition> {
 pub struct GraphToolExecutor {
     /// Node service for graph operations. `None` if services aren't initialized yet.
     pub node_service: Option<Arc<NodeService>>,
-    /// Embedding service for semantic search. `None` if unavailable.
-    pub embedding_service: Option<Arc<NodeEmbeddingService>>,
+    /// Shared handle to the embedding service for semantic search and skill
+    /// routing. Read per-call so the executor always sees the current value,
+    /// even when the embedding model finishes loading after this executor is
+    /// built. See [`SharedEmbeddingService`].
+    pub embedding_service: SharedEmbeddingService,
 }
 
 impl GraphToolExecutor {
-    /// Create a new executor with the given services.
-    pub fn new(
-        node_service: Arc<NodeService>,
-        embedding_service: Option<Arc<NodeEmbeddingService>>,
-    ) -> Self {
-        Self {
-            node_service: Some(node_service),
-            embedding_service,
-        }
-    }
-
-    /// Create an executor with optional services.
-    ///
-    /// Use when services may not be initialized yet (e.g., at startup).
-    /// Operations that need missing services will return a clear error.
-    pub fn new_with_optional_services(
-        node_service: Option<Arc<NodeService>>,
-        embedding_service: Option<Arc<NodeEmbeddingService>>,
-    ) -> Self {
-        Self {
-            node_service,
-            embedding_service,
-        }
-    }
-
     // -- Individual tool implementations --
 
     async fn exec_search_nodes(
@@ -809,7 +799,7 @@ impl GraphToolExecutor {
         let threshold = params.threshold.unwrap_or(SEMANTIC_THRESHOLD);
 
         let ns = self.node_service()?;
-        let emb = self.embedding_service()?;
+        let emb = self.embedding_service().await?;
 
         let input = search_ops::SearchSemanticInput {
             query: query.clone(),
@@ -1171,7 +1161,7 @@ impl GraphToolExecutor {
             })?;
         let limit = params.limit.unwrap_or(3);
 
-        let emb = match &self.embedding_service {
+        let emb = match self.embedding_service.read().await.clone() {
             Some(svc) => svc,
             None => {
                 return Ok(error_result(
@@ -1186,7 +1176,7 @@ impl GraphToolExecutor {
 
         use nodespace_core::ops::skill_ops;
         let output = skill_ops::find_skills(
-            emb,
+            &emb,
             &ns,
             skill_ops::FindSkillsInput {
                 query: params.query.clone(),
@@ -1384,8 +1374,14 @@ impl GraphToolExecutor {
             .ok_or_else(|| ToolError::ExecutionFailed("Node service unavailable".to_string()))
     }
 
-    fn embedding_service(&self) -> Result<Arc<NodeEmbeddingService>, ToolError> {
+    /// Read the current embedding service from the shared handle.
+    ///
+    /// Returns the value live each call, so a service that loaded after this
+    /// executor was built is picked up without any re-wiring.
+    async fn embedding_service(&self) -> Result<Arc<NodeEmbeddingService>, ToolError> {
         self.embedding_service
+            .read()
+            .await
             .clone()
             .ok_or_else(|| ToolError::ExecutionFailed("Embedding service unavailable".to_string()))
     }
@@ -1423,7 +1419,7 @@ impl AgentToolExecutor for GraphToolExecutor {
         query: &str,
         all_tools: Vec<ToolDefinition>,
     ) -> Vec<ToolDefinition> {
-        let emb = match &self.embedding_service {
+        let emb = match self.embedding_service.read().await.clone() {
             Some(svc) => svc,
             None => {
                 tracing::debug!("select_tools: no embedding service, using full tool list");
@@ -1441,7 +1437,7 @@ impl AgentToolExecutor for GraphToolExecutor {
 
         use nodespace_core::ops::skill_ops;
         let skill_result = skill_ops::find_skills(
-            emb,
+            &emb,
             ns,
             skill_ops::FindSkillsInput {
                 query: query.to_string(),
@@ -1545,7 +1541,7 @@ mod tests {
     fn test_executor() -> GraphToolExecutor {
         GraphToolExecutor {
             node_service: None,
-            embedding_service: None,
+            embedding_service: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -2026,6 +2022,49 @@ mod tests {
                 baseline
             );
         }
+    }
+
+    // -- Embedding handle is read live (race fix, #1328) --
+
+    /// The executor must read the embedding service through the shared handle on
+    /// every call, not capture a snapshot at construction. This is what closes
+    /// the startup race: an executor built before the embedding model loads must
+    /// see the service the moment the background loader writes it — with no
+    /// engine swap or re-wiring.
+    ///
+    /// We can't construct a real `NodeEmbeddingService` here (it needs an NLP
+    /// engine), so we assert the structural guarantee: the executor holds the
+    /// *same* `Arc<RwLock<..>>` it was given. A `None → Some` write through that
+    /// handle is therefore observed by the executor by construction.
+    #[tokio::test]
+    async fn embedding_handle_is_shared_not_snapshotted() {
+        let handle: SharedEmbeddingService = Arc::new(RwLock::new(None));
+        let executor = GraphToolExecutor {
+            node_service: None,
+            embedding_service: handle.clone(),
+        };
+
+        // Same lock — a write through `handle` is visible to `executor`.
+        assert!(
+            Arc::ptr_eq(&handle, &executor.embedding_service),
+            "executor must hold the shared handle, not a captured snapshot"
+        );
+
+        // With the handle empty, the accessor and the skill path both report the
+        // service as unavailable — read live from the shared lock.
+        assert!(
+            executor.embedding_service().await.is_err(),
+            "empty handle must surface as unavailable"
+        );
+        let result = executor
+            .execute("search_skills", json!({ "query": "manage tasks" }))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.result["error"]
+            .as_str()
+            .unwrap()
+            .contains("embedding service"));
     }
 
     // -- Helper: node_uri / strip_node_uri round-trip --

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -22,7 +22,7 @@ use nodespace_agent::local_agent::agent_loop::LocalAgentService;
 use nodespace_agent::local_agent::composite_model_manager::CompositeModelManager;
 use nodespace_agent::local_agent::model_manager::GgufModelManager;
 use nodespace_agent::local_agent::ollama_model_manager::OllamaModelManager;
-use nodespace_agent::local_agent::tools::GraphToolExecutor;
+use nodespace_agent::local_agent::tools::{GraphToolExecutor, SharedEmbeddingService};
 use nodespace_core::models::{NodeFilter, NodeUpdate};
 use nodespace_core::services::{NodeEmbeddingService, NodeService};
 use tokio::sync::{broadcast, Mutex, RwLock};
@@ -82,7 +82,7 @@ struct LocalAgentServiceInner {
     model_manager: Arc<CompositeModelManager>,
     node_service: Arc<NodeService>,
     active_model_id: Mutex<Option<String>>,
-    embedding_service: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>,
+    embedding_service: SharedEmbeddingService,
     /// Broadcast channel for streaming tokens → all SubscribeTokenStream clients.
     token_tx: broadcast::Sender<AgentChunk>,
     /// Cancellation tokens keyed by node_id.
@@ -97,10 +97,7 @@ pub struct LocalAgentServiceImpl {
 }
 
 impl LocalAgentServiceImpl {
-    pub fn new(
-        node_service: Arc<NodeService>,
-        embedding_service: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>,
-    ) -> Self {
+    pub fn new(node_service: Arc<NodeService>, embedding_service: SharedEmbeddingService) -> Self {
         let gguf =
             Arc::new(GgufModelManager::new().expect("GgufModelManager initialization failed"));
         let ollama = Arc::new(OllamaModelManager::new());
@@ -111,7 +108,10 @@ impl LocalAgentServiceImpl {
 
         Self {
             inner: Arc::new(LocalAgentServiceInner {
-                service: RwLock::new(Arc::new(Self::build_noop_service(node_service.clone()))),
+                service: RwLock::new(Arc::new(Self::build_noop_service(
+                    node_service.clone(),
+                    embedding_service.clone(),
+                ))),
                 model_manager,
                 node_service,
                 active_model_id: Mutex::new(None),
@@ -124,11 +124,12 @@ impl LocalAgentServiceImpl {
 
     fn build_noop_service(
         node_service: Arc<NodeService>,
+        embedding_service: SharedEmbeddingService,
     ) -> LocalAgentService<dyn ChatInferenceEngine, dyn AgentToolExecutor> {
         let engine: Arc<dyn ChatInferenceEngine> = Arc::new(NoOpInferenceEngine);
         let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
             node_service: Some(node_service),
-            embedding_service: None,
+            embedding_service,
         });
         LocalAgentService::new(engine, executor)
     }
@@ -138,15 +139,14 @@ impl LocalAgentServiceImpl {
     }
 
     async fn replace_engine(&self, engine: Arc<dyn ChatInferenceEngine>) {
-        // Wire the embedding service into the tool executor so the agent can run
-        // search_semantic and so select_tools can skill-route (both need
-        // embeddings). It's populated in the background after model load; if it
-        // isn't ready yet the executor degrades to None and skill routing falls
-        // back to the full tool list until the next engine swap.
-        let embedding_service = self.inner.embedding_service.read().await.clone();
+        // Hand the executor the *shared* embedding handle, not a snapshot. The
+        // executor reads the current value per call, so search_semantic and
+        // skill-based select_tools work as soon as the embedding model finishes
+        // loading in the background — no engine swap required, and no
+        // construction site can wire a stale or `None` service.
         let executor: Arc<dyn AgentToolExecutor> = Arc::new(GraphToolExecutor {
             node_service: Some(self.inner.node_service.clone()),
-            embedding_service,
+            embedding_service: self.inner.embedding_service.clone(),
         });
 
         let prompt_assembler = Some(Arc::new(
@@ -183,7 +183,10 @@ impl LocalAgentServiceImpl {
 
     pub async fn reset_to_noop_engine(&self) {
         let mut guard = self.inner.service.write().await;
-        *guard = Arc::new(Self::build_noop_service(self.inner.node_service.clone()));
+        *guard = Arc::new(Self::build_noop_service(
+            self.inner.node_service.clone(),
+            self.inner.embedding_service.clone(),
+        ));
         drop(guard);
         *self.inner.active_model_id.lock().await = None;
         tracing::debug!("LocalAgentServiceImpl: inference engine reset to NoOp");
@@ -1220,7 +1223,7 @@ mod tests {
                 .expect("SqliteStore"),
         );
         let node_service = Arc::new(CoreNodeService::new(&mut store).await.expect("NodeService"));
-        let embedding: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>> = Arc::new(RwLock::new(None));
+        let embedding: SharedEmbeddingService = Arc::new(RwLock::new(None));
         let svc = LocalAgentServiceImpl::new(node_service.clone(), embedding);
         (svc, node_service, tempdir)
     }


### PR DESCRIPTION
Closes #1328