### PR TITLE
Fix Gemma 4 12B tool-call routing: chat template mismatch causes Python-prose output instead of structured tool calls

### DIFF
--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -136,8 +136,36 @@ const GEMMA_4_31B: CatalogEntry = CatalogEntry {
     min_memory_gb: 24,
 };
 
+/// Gemma 4 12B -- Google's mid-tier dense model; stronger reasoning than E4B,
+/// viable on 16GB Apple Silicon with Q8_0 KV cache quantization.
+/// Q4_K_M quantization; Q8_0 KV cache cuts 32K KV from ~5GB (F16) to ~2.5GB,
+/// making it fit alongside ~7.4GB weights on a 16GB device.
+const GEMMA_4_12B: CatalogEntry = CatalogEntry {
+    id: "gemma-4-12b-q4km",
+    family: ModelFamily::Gemma4,
+    name: "Gemma 4 12B Instruct Q4_K_M",
+    filename: "gemma-4-12B-it-Q4_K_M.gguf",
+    size_bytes: 7_381_382_048, // ~7.4 GB
+    quantization: "Q4_K_M",
+    url: "https://huggingface.co/ggml-org/gemma-4-12B-it-GGUF/resolve/main/gemma-4-12B-it-Q4_K_M.gguf",
+    sha256: "", // Skip verification — official ggml-org repo (llama.cpp team), Xet storage
+    context_window: 32_768,
+    default_temperature: 0.3,
+    // Q8_0 cuts the 32K KV cache from ~5GB (F16) to ~2.5GB, leaving enough
+    // headroom alongside the ~7.4GB weights on a 16GB device.
+    type_k: Some(nodespace_nlp_engine::KvCacheQuantType::Q8_0),
+    type_v: Some(nodespace_nlp_engine::KvCacheQuantType::Q8_0),
+    min_memory_gb: 16,
+};
+
 /// All catalog entries, in preference order.
-const CATALOG: &[&CatalogEntry] = &[&MINISTRAL_3B, &MINISTRAL_8B, &GEMMA_4_E4B, &GEMMA_4_31B];
+const CATALOG: &[&CatalogEntry] = &[
+    &MINISTRAL_3B,
+    &MINISTRAL_8B,
+    &GEMMA_4_E4B,
+    &GEMMA_4_12B,
+    &GEMMA_4_31B,
+];
 
 /// RAM threshold (in bytes) at or above which the large recommended model
 /// (Gemma 4 31B) is selected instead of the small one (Gemma 4 E4B).
@@ -920,10 +948,11 @@ mod tests {
     async fn list_returns_all_catalog_models() {
         let (mgr, _tmp) = test_manager();
         let models = mgr.list().await.unwrap();
-        assert_eq!(models.len(), 4);
+        assert_eq!(models.len(), 5);
         assert!(models.iter().any(|m| m.id == "ministral-3b-q4km"));
         assert!(models.iter().any(|m| m.id == "ministral-8b-q4km"));
         assert!(models.iter().any(|m| m.id == "gemma-4-e4b-q4km"));
+        assert!(models.iter().any(|m| m.id == "gemma-4-12b-q4km"));
         assert!(models.iter().any(|m| m.id == "gemma-4-31b-q4km"));
     }
 
@@ -1040,6 +1069,19 @@ mod tests {
         assert_eq!(spec.family, ModelFamily::Ministral);
         assert_eq!(spec.context_window, 32_768);
         assert!(spec.type_k.is_none());
+
+        // 12B uses Q8_0 KV compression to fit alongside the ~7.4GB weights on 16GB RAM.
+        let spec = mgr.model_spec_for("gemma-4-12b-q4km").unwrap();
+        assert_eq!(spec.model_id, "gemma-4-12b-q4km");
+        assert_eq!(spec.family, ModelFamily::Gemma4);
+        assert_eq!(
+            spec.type_k,
+            Some(nodespace_nlp_engine::KvCacheQuantType::Q8_0)
+        );
+        assert_eq!(
+            spec.type_v,
+            Some(nodespace_nlp_engine::KvCacheQuantType::Q8_0)
+        );
 
         // 31B uses Q8_0 KV compression to fit alongside the ~19GB weights on 24GB RAM.
         let spec = mgr.model_spec_for("gemma-4-31b-q4km").unwrap();

--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -167,8 +167,12 @@ const CATALOG: &[&CatalogEntry] = &[
     &GEMMA_4_31B,
 ];
 
+/// RAM threshold (in bytes) at or above which the mid-tier model (Gemma 4 12B)
+/// is selected instead of the small one (Gemma 4 E4B).
+const RAM_THRESHOLD_MEDIUM: u64 = 16 * 1024 * 1024 * 1024; // 16 GB
+
 /// RAM threshold (in bytes) at or above which the large recommended model
-/// (Gemma 4 31B) is selected instead of the small one (Gemma 4 E4B).
+/// (Gemma 4 31B) is selected instead of the mid-tier one (Gemma 4 12B).
 const RAM_THRESHOLD_LARGE: u64 = 32 * 1024 * 1024 * 1024; // 32 GB
 
 // ---------------------------------------------------------------------------
@@ -268,12 +272,14 @@ impl GgufModelManager {
     /// current system's RAM.
     ///
     /// - `Ministral`: 8B at or above [`RAM_THRESHOLD_LARGE`], otherwise 3B.
-    /// - `Gemma4`:    31B at or above [`RAM_THRESHOLD_LARGE`], otherwise E4B.
+    /// - `Gemma4`:    three-tier — 31B at or above [`RAM_THRESHOLD_LARGE`],
+    ///   12B at or above [`RAM_THRESHOLD_MEDIUM`], otherwise E4B.
     /// - `Ollama`:    has no GGUF catalog entries; falls back to the default
     ///   Gemma 4 recommendation.
     pub fn recommended_model_id_for(family: ModelFamily) -> &'static str {
         let total_ram = detect_system_ram();
         let large = total_ram >= RAM_THRESHOLD_LARGE;
+        let medium = total_ram >= RAM_THRESHOLD_MEDIUM;
         match family {
             ModelFamily::Ministral => {
                 if large {
@@ -285,6 +291,8 @@ impl GgufModelManager {
             ModelFamily::Gemma4 => {
                 if large {
                     GEMMA_4_31B.id
+                } else if medium {
+                    GEMMA_4_12B.id
                 } else {
                     GEMMA_4_E4B.id
                 }
@@ -292,6 +300,8 @@ impl GgufModelManager {
             ModelFamily::Ollama => {
                 if large {
                     GEMMA_4_31B.id
+                } else if medium {
+                    GEMMA_4_12B.id
                 } else {
                     GEMMA_4_E4B.id
                 }
@@ -1037,7 +1047,7 @@ mod tests {
         let (mgr, _tmp) = test_manager();
         let rec = mgr.recommended_model().await.unwrap();
         assert!(
-            rec == "gemma-4-e4b-q4km" || rec == "gemma-4-31b-q4km",
+            rec == "gemma-4-e4b-q4km" || rec == "gemma-4-12b-q4km" || rec == "gemma-4-31b-q4km",
             "unexpected recommendation: {}",
             rec
         );
@@ -1046,7 +1056,11 @@ mod tests {
     #[test]
     fn recommended_spec_has_valid_fields() {
         let spec = GgufModelManager::recommended_model_spec();
-        assert!(spec.model_id == "gemma-4-e4b-q4km" || spec.model_id == "gemma-4-31b-q4km");
+        assert!(
+            spec.model_id == "gemma-4-e4b-q4km"
+                || spec.model_id == "gemma-4-12b-q4km"
+                || spec.model_id == "gemma-4-31b-q4km"
+        );
         assert_eq!(spec.family, ModelFamily::Gemma4);
         assert!(spec.context_window > 0);
         assert!(spec.default_temperature > 0.0);

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -316,12 +316,14 @@ impl ChatEngine {
         // specialized format (e.g. COMMON_CHAT_FORMAT_PEG_GEMMA4=3). When tools are
         // provided this is a routing failure — tool calls will be emitted as plain text
         // and never parsed. Warn so the failure is visible without a debug build.
-        if tmpl_result.chat_format == 0 && tools.as_ref().is_some_and(|t| !t.is_empty()) {
-            tracing::warn!(
-                "chat_format=0 (CONTENT_ONLY) with {} tools — specialized template detection \
-                 may have failed; tool calls will not be parsed",
-                tools.as_ref().map_or(0, |t| t.len()),
-            );
+        if let Some(active_tools) = tools.as_ref().filter(|t| !t.is_empty()) {
+            if tmpl_result.chat_format == 0 {
+                tracing::warn!(
+                    "chat_format=0 (CONTENT_ONLY) with {} tools — specialized template \
+                     detection may have failed; tool calls will not be parsed",
+                    active_tools.len(),
+                );
+            }
         }
         let prompt = &tmpl_result.prompt;
         tracing::debug!(

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -306,12 +306,23 @@ impl ChatEngine {
 
         // --- Apply chat template ---
         let tmpl_result = Self::apply_chat_template(&llama.model, &messages, &tools)?;
-        tracing::info!(
+        tracing::debug!(
             "Chat template applied: chat_format={} parse_tool_calls={} additional_stops={:?}",
             tmpl_result.chat_format,
             tmpl_result.parse_tool_calls,
             tmpl_result.additional_stops,
         );
+        // chat_format=0 (CONTENT_ONLY) means llama.cpp failed to detect the model's
+        // specialized format (e.g. COMMON_CHAT_FORMAT_PEG_GEMMA4=3). When tools are
+        // provided this is a routing failure — tool calls will be emitted as plain text
+        // and never parsed. Warn so the failure is visible without a debug build.
+        if tmpl_result.chat_format == 0 && tools.as_ref().is_some_and(|t| !t.is_empty()) {
+            tracing::warn!(
+                "chat_format=0 (CONTENT_ONLY) with {} tools — specialized template detection \
+                 may have failed; tool calls will not be parsed",
+                tools.as_ref().map_or(0, |t| t.len()),
+            );
+        }
         let prompt = &tmpl_result.prompt;
         tracing::debug!(
             "Chat prompt ({} chars): {:?}",

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -306,6 +306,12 @@ impl ChatEngine {
 
         // --- Apply chat template ---
         let tmpl_result = Self::apply_chat_template(&llama.model, &messages, &tools)?;
+        tracing::info!(
+            "Chat template applied: chat_format={} parse_tool_calls={} additional_stops={:?}",
+            tmpl_result.chat_format,
+            tmpl_result.parse_tool_calls,
+            tmpl_result.additional_stops,
+        );
         let prompt = &tmpl_result.prompt;
         tracing::debug!(
             "Chat prompt ({} chars): {:?}",


### PR DESCRIPTION
Closes #1346