### PR TITLE
Collapse Tauri/TS node-typing redundancy: trust the flat wire contract (#1340)

### DIFF
--- a/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
@@ -196,11 +196,17 @@
   // User-Defined Field Helpers
   // ============================================================================
 
-  // Get value for a user-defined field from node properties
+  // Get value for a user-defined field from node properties.
+  //
+  // Two shapes can appear in the store: the flat API shape from the backend
+  // (node_to_typed_value flattens the `properties.task` namespace away, so fields
+  // arrive under `properties.<fieldName>`), and the nested STORAGE shape left
+  // transiently by an optimistic local write below (`properties.task.<fieldName>`).
+  // Prefer the nested form so a just-edited value renders immediately, then fall
+  // back to the flat form once the backend round-trip re-flattens it.
   function getUserFieldValue(fieldName: string): unknown {
     if (!node) return undefined;
 
-    // User fields are stored in properties.task namespace
     const rawNode = sharedNodeStore.getNode(nodeId);
     if (!rawNode) return undefined;
 
@@ -208,11 +214,15 @@
     return taskProps?.[fieldName] ?? rawNode.properties?.[fieldName];
   }
 
-  // Update a user-defined field
+  // Update a user-defined field.
+  //
+  // WRITE uses the STORAGE shape: the backend stores type properties namespaced
+  // under `properties.task` (issue #838), so updates must re-nest the field there.
+  // This leaves the local node in the nested shape until the backend echo
+  // re-flattens it — getUserFieldValue above reads both forms to bridge the gap.
   function updateUserField(fieldName: string, value: unknown) {
     if (!node) return;
 
-    // User fields go through generic properties update
     const rawNode = sharedNodeStore.getNode(nodeId);
     if (!rawNode) return;
 

--- a/packages/desktop-app/src/lib/types/ai-chat-node.ts
+++ b/packages/desktop-app/src/lib/types/ai-chat-node.ts
@@ -41,38 +41,25 @@ export function isAiChatNode(node: Node | AiChatNode): node is AiChatNode {
 /**
  * Convert a generic Node to AiChatNode.
  *
- * Handles both:
- * - Flat wire format: properties.messages, properties.status, etc. (from daemon)
- * - Already promoted: node.messages, node.status (already an AiChatNode)
+ * The backend (`node_to_typed_value` in `nodespace-types`) is the single typing
+ * authority: for every transport (Tauri IPC and HTTP/SSE) it promotes ai-chat
+ * fields to the TOP LEVEL of the node and flattens the `properties.ai-chat`
+ * namespace away. See the `wire_contract` tests in `nodespace-types/src/convert.rs`.
+ * This converter therefore trusts the flat contract and only fills defaults.
  */
 export function nodeToAiChatNode(node: Node): AiChatNode {
-  // Already promoted (messages already at top level)
-  const nodeAsAny = node as unknown as AiChatNode;
-  if ('messages' in node && Array.isArray(nodeAsAny.messages)) {
-    return nodeAsAny;
-  }
-
-  const props = node.properties as Record<string, unknown> | undefined;
-
-  // Flat wire format (after flatten_properties_for_api)
-  const status = (props?.['status'] as AiChatStatus) ?? 'active';
-  const provider = props?.['provider'] as AiChatProvider | undefined;
-  const model = props?.['model'] as string | undefined;
-  const messages = Array.isArray(props?.['messages'])
-    ? (props['messages'] as AiChatMessage[])
-    : [];
-
+  const chat = node as unknown as Partial<AiChatNode> & { lifecycleStatus?: string };
   return {
     id: node.id,
     nodeType: 'ai-chat',
     content: node.content,
     version: node.version,
-    lifecycleStatus: (node as unknown as { lifecycleStatus?: string }).lifecycleStatus,
+    lifecycleStatus: chat.lifecycleStatus,
     createdAt: node.createdAt,
     modifiedAt: node.modifiedAt,
-    status,
-    provider,
-    model,
-    messages,
+    status: chat.status ?? 'active',
+    provider: chat.provider,
+    model: chat.model,
+    messages: Array.isArray(chat.messages) ? chat.messages : [],
   };
 }

--- a/packages/desktop-app/src/lib/types/task-node.ts
+++ b/packages/desktop-app/src/lib/types/task-node.ts
@@ -54,9 +54,8 @@ export type TaskPriority = CoreTaskPriority | string;
  * Use this interface instead of the generic `Node` type when you need type-safe
  * access to task-specific fields (status, priority, dueDate, assignee).
  *
- * The generic `Node` interface does NOT include these fields - they must be
- * accessed through `TaskNode` for type safety or via `properties.task.*` for
- * dynamic access.
+ * The generic `Node` interface does NOT include these fields - they are promoted
+ * to the top level of the node by the backend and accessed through `TaskNode`.
  *
  * Flat structure matching Rust backend serialization:
  * ```json
@@ -253,36 +252,17 @@ export interface TaskNodeUpdate {
 /**
  * Convert a generic Node to a TaskNode by extracting type-specific fields from properties
  *
- * SSE events send generic Node objects where task-specific fields are stored in
- * `properties.status`, `properties.priority`, etc. This function normalizes them
- * to the flat TaskNode structure expected by the frontend.
+ * The backend (`node_to_typed_value` in `nodespace-types`) is the single typing
+ * authority: for every transport (Tauri IPC and HTTP/SSE) it promotes task fields
+ * to the TOP LEVEL of the node and flattens the `properties.task` namespace away.
+ * See the `wire_contract` tests in `nodespace-types/src/convert.rs`. This converter
+ * therefore trusts the flat contract and only fills defaults for missing fields.
  *
- * Handles both formats:
- * - Nested: `properties.task.status` (legacy)
- * - Flat: `properties.status` (current)
- * - Already flat: `node.status` (already a TaskNode)
- *
- * @param node - Generic Node with task data in properties
+ * @param node - Generic Node carrying a task (fields promoted to top level)
  * @returns TaskNode with flat type-specific fields
  */
 export function nodeToTaskNode(node: Node): TaskNode {
-  // If already has flat status, it's already a TaskNode
-  if ('status' in node && typeof (node as TaskNode).status === 'string') {
-    return node as TaskNode;
-  }
-
-  // Extract from properties (Issue #794: namespaced under properties.task)
-  // Per naming conventions: API returns camelCase (dueDate, startedAt, completedAt)
-  const props = node.properties as Record<string, unknown> | undefined;
-  const taskProps = (props?.task as Record<string, unknown>) ?? {};
-
-  const status = (taskProps.status as TaskStatus) ?? 'open';
-  const priority = taskProps.priority as TaskPriority | undefined;
-  const dueDate = taskProps.dueDate as string | null | undefined;
-  const assignee = taskProps.assignee as string | null | undefined;
-  const startedAt = taskProps.startedAt as string | null | undefined;
-  const completedAt = taskProps.completedAt as string | null | undefined;
-
+  const task = node as unknown as Partial<TaskNode>;
   return {
     id: node.id,
     nodeType: 'task',
@@ -290,12 +270,12 @@ export function nodeToTaskNode(node: Node): TaskNode {
     version: node.version,
     createdAt: node.createdAt,
     modifiedAt: node.modifiedAt,
-    status,
-    priority,
-    dueDate: dueDate ?? null,
-    assignee: assignee ?? null,
-    startedAt: startedAt ?? null,
-    completedAt: completedAt ?? null
+    status: task.status ?? 'open',
+    priority: task.priority,
+    dueDate: task.dueDate ?? null,
+    assignee: task.assignee ?? null,
+    startedAt: task.startedAt ?? null,
+    completedAt: task.completedAt ?? null
   };
 }
 

--- a/packages/desktop-app/src/lib/utils/logger.ts
+++ b/packages/desktop-app/src/lib/utils/logger.ts
@@ -46,17 +46,23 @@ const isProd =
   (typeof import.meta !== 'undefined' && import.meta.env?.PROD === true) ||
   (typeof process !== 'undefined' && process.env?.NODE_ENV === 'production');
 
+// Read a localStorage key defensively. Some runtimes (e.g. Node 25's built-in
+// localStorage) expose a partial Storage object where `getItem` is not a function,
+// so a bare `typeof localStorage !== 'undefined'` guard is insufficient.
+function readStorage(key: string): string | null {
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+    return null;
+  }
+  return localStorage.getItem(key);
+}
+
 // Default log level based on environment
 // Production: only warn/error
 // Development: warn/error by default; set localStorage.debug='*' to enable debug
-const _storedLevel =
-  typeof localStorage !== 'undefined' ? localStorage.getItem('nodespace:logLevel') : null;
+const _storedLevel = readStorage('nodespace:logLevel');
 const DEFAULT_LEVEL: LogLevel = isProd
   ? 'warn'
-  : (_storedLevel as LogLevel | null) ??
-    (typeof localStorage !== 'undefined' && localStorage.getItem('nodespace:debug')
-      ? 'debug'
-      : 'warn');
+  : (_storedLevel as LogLevel | null) ?? (readStorage('nodespace:debug') ? 'debug' : 'warn');
 
 /**
  * Logger class with environment-aware configuration.

--- a/packages/desktop-app/src/tests/services/node-normalize.test.ts
+++ b/packages/desktop-app/src/tests/services/node-normalize.test.ts
@@ -20,11 +20,17 @@ describe('normalizeNodeData', () => {
     expect(normalizeNodeData(node)).toBe(node);
   });
 
-  it('converts a task node with nested properties to flat TaskNode', () => {
+  // The backend (`node_to_typed_value`) promotes type-specific fields to the TOP
+  // LEVEL of the node for every transport — see the `wire_contract` tests in
+  // `nodespace-types/src/convert.rs`. These tests pin that flat contract on the TS
+  // side; the converters intentionally no longer accept the nested `properties.task`
+  // shape, which no live producer emits.
+  it('passes through a flat task node, preserving promoted fields', () => {
     const node = makeNode({
       nodeType: 'task',
-      properties: { task: { status: 'done', priority: 'high' } } as Record<string, unknown>
-    });
+      status: 'done',
+      priority: 'high'
+    } as Partial<Node>);
     const result = normalizeNodeData(node);
     expect(result.nodeType).toBe('task');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +39,7 @@ describe('normalizeNodeData', () => {
     expect((result as any).priority).toBe('high');
   });
 
-  it('task node with no properties gets default status "open"', () => {
+  it('task node with no status gets default "open"', () => {
     const node = makeNode({ nodeType: 'task' });
     const result = normalizeNodeData(node);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,13 +49,13 @@ describe('normalizeNodeData', () => {
   // Drift guard: both sync paths (Tauri + browser) call this single function, so the
   // transformation contract below applies identically to both runtime modes. Adding a
   // future type branch here is the one-place change that covers both paths.
-  it('normalizes full task node with status, priority, and dueDate', () => {
+  it('normalizes a full flat task node with status, priority, and dueDate', () => {
     const node = makeNode({
       nodeType: 'task',
-      properties: {
-        task: { status: 'in_progress', priority: 'low', dueDate: '2024-12-31' }
-      } as Record<string, unknown>
-    });
+      status: 'in_progress',
+      priority: 'low',
+      dueDate: '2024-12-31'
+    } as Partial<Node>);
     const result = normalizeNodeData(node);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const r = result as any;

--- a/packages/desktop-app/src/tests/setup.ts
+++ b/packages/desktop-app/src/tests/setup.ts
@@ -44,12 +44,16 @@ function createStoragePolyfill(): any {
   return storage;
 }
 
-// Apply storage polyfill when localStorage is missing or lacks the Web Storage API
-// (Node 25 exposed a partial Storage object without clear(); Node 26 exposes nothing)
+// Apply storage polyfill when localStorage is missing or lacks the Web Storage API.
+// Node's built-in localStorage has shipped several incomplete shapes across minor
+// versions — Node 25.9 exposes clear() but not getItem(), earlier 25.x exposed a
+// partial object without clear(), and Node 26 exposes nothing. Check every method
+// the app actually uses rather than probing a single one.
+const STORAGE_METHODS = ['getItem', 'setItem', 'removeItem', 'clear', 'key'] as const;
 for (const storageKey of ['localStorage', 'sessionStorage'] as const) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const current = (globalThis as Record<string, unknown>)[storageKey] as any;
-  if (!current || typeof current.clear !== 'function') {
+  if (!current || STORAGE_METHODS.some((m) => typeof current[m] !== 'function')) {
     const polyfill = createStoragePolyfill();
     Object.defineProperty(globalThis, storageKey, { value: polyfill, writable: true, configurable: true });
     if (typeof window !== 'undefined') {

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -239,4 +239,25 @@ mod wire_contract {
         assert!(out["properties"].get("ai-chat").is_none());
         assert!(out["uri"].as_str().unwrap().starts_with("nodespace://"));
     }
+
+    #[test]
+    fn schema_promotes_fields_top_level_and_injects_uri() {
+        let node = Node::new(
+            "schema".to_string(),
+            "Task schema".to_string(),
+            serde_json::json!({
+                "isCore": true,
+                "schemaVersion": 2,
+                "description": "Task type",
+                "fields": []
+            }),
+        );
+        let out = node_to_typed_value(node).unwrap();
+
+        // Schema fields are promoted to the top level by SchemaNode.
+        assert_eq!(out["isCore"], true);
+        assert_eq!(out["schemaVersion"], 2);
+        assert_eq!(out["description"], "Task type");
+        assert!(out["uri"].as_str().unwrap().starts_with("nodespace://"));
+    }
 }

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -13,7 +13,11 @@ use crate::task::{TaskNode, TaskPriority, TaskStatus};
 /// node shape. Adds a `nodespace://` URI field for rich client rendering.
 ///
 /// This is the single canonical implementation used by all entry points
-/// (Tauri commands, MCP, HTTP).
+/// (Tauri commands, MCP, HTTP) and the SOLE authority for property flattening
+/// and `nodespace://` URI production. Do NOT re-implement either in another layer
+/// (e.g. a TypeScript-side flatten in the frontend converters) — the frontend
+/// `nodeTo*` converters trust the flat, top-level shape this function guarantees.
+/// The `wire_contract` tests below pin that shape.
 pub fn node_to_typed_value(node: Node) -> Result<serde_json::Value, String> {
     let mut node = node;
     flatten_properties_for_api(&mut node);
@@ -180,4 +184,59 @@ fn ai_chat_node_to_value(node: Node) -> Result<serde_json::Value, String> {
     };
 
     serde_json::to_value(&chat).map_err(|e| format!("Failed to serialize ai-chat node: {}", e))
+}
+
+#[cfg(test)]
+mod wire_contract {
+    use super::*;
+    use crate::node::Node;
+
+    // These tests pin the wire contract that the frontend TS converters trust:
+    // for typed nodes, type-specific fields are promoted to TOP-LEVEL and the
+    // namespaced `properties.<type>` form is flattened away. If this contract
+    // ever changes, the frontend nodeTo* converters must change in lockstep.
+
+    #[test]
+    fn task_promotes_fields_top_level_and_flattens_properties() {
+        let node = Node::new(
+            "task".to_string(),
+            "Buy milk".to_string(),
+            serde_json::json!({
+                "task": { "status": "in_progress", "priority": "high", "custom:store": "Costco" }
+            }),
+        );
+        let out = node_to_typed_value(node).unwrap();
+
+        // Core fields promoted to top level.
+        assert_eq!(out["status"], "in_progress");
+        assert_eq!(out["priority"], "high");
+        // `properties` is flattened: no `task` namespace survives.
+        assert!(out["properties"].get("task").is_none());
+        // User/custom fields remain in flat `properties`.
+        assert_eq!(out["properties"]["custom:store"], "Costco");
+        // URI is injected by the backend.
+        assert!(out["uri"].as_str().unwrap().starts_with("nodespace://"));
+    }
+
+    #[test]
+    fn ai_chat_promotes_fields_top_level_and_flattens_properties() {
+        let node = Node::new(
+            "ai-chat".to_string(),
+            "Chat".to_string(),
+            serde_json::json!({
+                "ai-chat": {
+                    "status": "active",
+                    "provider": "ollama",
+                    "messages": [{ "role": "user", "content": "hi" }]
+                }
+            }),
+        );
+        let out = node_to_typed_value(node).unwrap();
+
+        assert_eq!(out["status"], "active");
+        assert_eq!(out["provider"], "ollama");
+        assert_eq!(out["messages"][0]["content"], "hi");
+        assert!(out["properties"].get("ai-chat").is_none());
+        assert!(out["uri"].as_str().unwrap().starts_with("nodespace://"));
+    }
 }


### PR DESCRIPTION
Closes #1340.

## Context

#1340 asked for a decision on collapsing the duplicated Node→typed conversion across Rust (core), Rust (Tauri), and TypeScript. Investigation found the issue's premise was **stale**: the Rust↔Rust mirror duplication was already resolved by #1344 (shared `nodespace-types` crate; `src-tauri/src/types.rs` is now 35 LOC). What remained was the Rust→TS **double-conversion** — defensive nested-shape branches in the TS `nodeTo*` converters that no live producer emits.

Full decision + acceptance-criteria sign-off: see the [decision comment on #1340](https://github.com/NodeSpaceAI/nodespace-core/issues/1340#issuecomment-4638415454).

## What this PR does

**Collapse to the flat contract** (chosen over option (a) — keeping Rust as the single flatten/uri authority for all transports, rather than pushing typing into TS for the Tauri leg only):

- `nodeToTaskNode` / `nodeToAiChatNode` now trust the flat, top-level wire shape and only fill defaults. Dead `properties.task.*` / `properties.*` extraction branches deleted.
- New `wire_contract` tests in `nodespace-types/src/convert.rs` pin the contract: typed fields promoted top-level, `properties.<type>` namespace flattened away, `nodespace://` uri injected. `convert.rs` documented as the **sole** flatten + uri authority.
- `node-normalize.test.ts` updated to assert the flat contract.
- `task-schema-form.svelte`: documented the deliberate **read-flat / write-nested-storage-shape** asymmetry for user fields (behavior unchanged — verified the nested read still bridges the optimistic-write transient).
- Docs (`nodespace-docs`): added a "Frontend typed-node layer (TypeScript)" section (interface + converters, *not* classes, with rationale) and fixed the stale persistence diagram (Tauri → external `nodespaced` daemon over gRPC/UDS, not embedded `NodeService`). Committed in the nodespace-docs repo.

## Verification

Empirically confirmed the wire shape by running `node_to_typed_value` on a storage-shaped task node: `status`/`priority` promoted top-level, `properties` flattened (no `task` namespace), `custom:store` retained flat, `uri` present — proving the deleted TS branches were dead.

## Out-of-scope fix (called out)

The frontend test suite was **fully broken on `main`** before this work: Node v25.9.0 ships a partial built-in `localStorage` (has `clear()` but not `getItem()`), so `logger.ts` threw at module load and all 134 suites failed at collection. Hardened `logger.ts` to read `localStorage` defensively and widened the test-setup polyfill guard. This is a pre-existing environment bug, fixed here to obtain a baseline.

## Testing

- `bun run test`: 134 files, **3844 passed** (baseline and after — no regression)
- `bun run test:all` (frontend + skill + Rust): **exit 0**, Rust 899 passed
- `bun run quality:fix`: ESLint 0/0, svelte-check 0 problems, tsc clean, cargo fmt + clippy (`-D warnings`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)