### PR TITLE
Store schema descriptions as a node subtree (markdown) instead of properties.description, and embed them for semantic schema discovery

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -1271,7 +1271,7 @@ impl NodeBehavior for SchemaNodeBehavior {
     }
 
     fn can_have_children(&self) -> bool {
-        false // Schemas are metadata nodes, not containers
+        true // Description is stored as a child node subtree
     }
 
     fn supports_markdown(&self) -> bool {
@@ -1282,8 +1282,23 @@ impl NodeBehavior for SchemaNodeBehavior {
         serde_json::json!({
             "is_core": false,
             "version": 1,
-            "description": "",
             "fields": []
+        })
+    }
+
+    /// Schema nodes aggregate their description child subtree for embedding.
+    ///
+    /// The description is stored as a markdown node subtree under the schema node.
+    /// Aggregating it gives semantic search the full descriptive text, enabling
+    /// synonym discovery (e.g. "billing" → existing "Invoice" schema).
+    fn get_aggregated_content<'a>(
+        &'a self,
+        node: &'a Node,
+        accessor: &'a dyn NodeAccessor,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
+        Box::pin(async move {
+            let registry = NodeBehaviorRegistry::new();
+            aggregate_children_content(node, accessor, &registry).await
         })
     }
 }

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -906,6 +906,29 @@ impl SqliteStore {
         Ok((true, nodes_to_delete))
     }
 
+    /// Delete all descendants of `parent_id` (the full child subtree) without touching the parent.
+    ///
+    /// Uses a recursive CTE to collect all descendant IDs, then deletes them in one statement.
+    /// FK CASCADE cleans relationship and embedding rows automatically.
+    /// No OCC check — intended for internal system operations where version checks are unnecessary.
+    pub async fn delete_children_subtree_unchecked(&self, parent_id: &str) -> Result<()> {
+        self.db
+            .execute(
+                r#"WITH RECURSIVE subtree(node_id) AS (
+                    SELECT out_node FROM relationship WHERE in_node = ?1 AND relationship_type = 'has_child'
+                    UNION ALL
+                    SELECT r.out_node FROM relationship r
+                    JOIN subtree s ON r.in_node = s.node_id
+                    WHERE r.relationship_type = 'has_child'
+                )
+                DELETE FROM node WHERE id IN (SELECT node_id FROM subtree)"#,
+                libsql::params![parent_id.to_string()],
+            )
+            .await
+            .context("Failed to delete children subtree")?;
+        Ok(())
+    }
+
     pub async fn delete_with_version_check(
         &self,
         id: &str,

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -921,11 +921,27 @@ impl SqliteStore {
                     JOIN subtree s ON r.in_node = s.node_id
                     WHERE r.relationship_type = 'has_child'
                 )
-                DELETE FROM node WHERE id IN (SELECT node_id FROM subtree)"#,
+                DELETE FROM node WHERE id IN (SELECT DISTINCT node_id FROM subtree)"#,
                 libsql::params![parent_id.to_string()],
             )
             .await
             .context("Failed to delete children subtree")?;
+        Ok(())
+    }
+
+    /// Remove a single top-level key from a node's properties JSON in-place using `json_remove`.
+    ///
+    /// Used by migrations to clear legacy fields (e.g. `description`) after they have been
+    /// moved to the child-subtree representation, making the migration idempotent.
+    pub async fn remove_property_key(&self, node_id: &str, key: &str) -> Result<()> {
+        let json_path = format!("$.{}", key);
+        self.db
+            .execute(
+                "UPDATE node SET properties = json_remove(properties, ?1), modified_at = ?2 WHERE id = ?3",
+                libsql::params![json_path, chrono::Utc::now().to_rfc3339(), node_id.to_string()],
+            )
+            .await
+            .context("Failed to remove property key")?;
         Ok(())
     }
 

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -43,7 +43,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Task tracking schema".to_string(),
             fields: vec![
                 SchemaField {
                     name: "status".to_string(),
@@ -179,7 +178,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Plain text content".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -194,7 +192,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Date node schema".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -209,7 +206,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Markdown header (h1-h6)".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -224,7 +220,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Code block with syntax highlighting".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -239,7 +234,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Blockquote for citations".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -254,7 +248,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Numbered list item".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -269,7 +262,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Horizontal rule / thematic break".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -284,7 +276,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "GFM markdown table with alignment support".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -299,7 +290,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Hierarchical label for organizing nodes into groups".to_string(),
             fields: vec![],        // Uses content for name
             relationships: vec![], // member_of is a native edge, not schema-defined
             title_template: None,
@@ -314,7 +304,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Checkbox item — markdown annotation, not a managed task".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -329,8 +318,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "AI conversation node with messages stored as nested properties"
-                .to_string(),
             fields: vec![
                 SchemaField {
                     name: "provider".to_string(),
@@ -671,7 +658,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Query definition for filtering and searching nodes".to_string(),
             fields: vec![
                 SchemaField {
                     name: "target_type".to_string(),
@@ -816,7 +802,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "AI agent prompt template".to_string(),
             fields: vec![],
             relationships: vec![],
             title_template: None,
@@ -831,7 +816,6 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            description: "Agent skill with tool whitelisting and guidance".to_string(),
             fields: vec![
                 SchemaField {
                     name: "description".to_string(),

--- a/packages/core/src/models/schema_node.rs
+++ b/packages/core/src/models/schema_node.rs
@@ -14,7 +14,6 @@
 //!     record::id(id) AS id,
 //!     properties.isCore AS isCore,
 //!     properties.version AS schemaVersion,
-//!     properties.description AS description,
 //!     properties.fields AS fields,
 //!     properties.relationships AS relationships,
 //!     content,
@@ -23,6 +22,17 @@
 //!     modified_at AS modifiedAt
 //! FROM node:`task` WHERE node_type = 'schema';
 //! ```
+//!
+//! ## Description Storage (Issue #1351)
+//!
+//! Schema descriptions are stored as a **child node subtree** (markdown parsed into text/header
+//! nodes), not as `properties.description`. This enables:
+//! - Semantic search: the subtree is aggregated into the schema's embedding via `get_aggregated_content`
+//! - Rich content: descriptions can contain headers, lists, code blocks, etc.
+//!
+//! The `description` field on `SchemaNode` is a **transient/computed field** — it is NOT stored
+//! in `properties` and NOT populated by `from_node()`. Callers that need the description text
+//! must fetch it from the child subtree separately.
 //!
 //! # Examples
 //!
@@ -81,10 +91,6 @@ pub struct SchemaNode {
     /// Schema version number (increments on schema changes)
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
-
-    /// Human-readable description of this schema
-    #[serde(default)]
-    pub description: String,
 
     /// List of fields in this schema
     #[serde(default)]
@@ -155,13 +161,6 @@ impl SchemaNode {
             .map(|v| v as u32)
             .unwrap_or(1);
 
-        let description = node
-            .properties
-            .get("description")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
         let fields: Vec<SchemaField> = node
             .properties
             .get("fields")
@@ -194,7 +193,6 @@ impl SchemaNode {
             modified_at: node.modified_at,
             is_core,
             schema_version,
-            description,
             fields,
             relationships,
             title_template,
@@ -209,7 +207,6 @@ impl SchemaNode {
         let mut properties = serde_json::json!({
             "isCore": self.is_core,
             "schemaVersion": self.schema_version,
-            "description": self.description,
             "fields": self.fields,
             "relationships": self.relationships,
         });
@@ -361,7 +358,6 @@ mod tests {
             json!({
                 "isCore": true,
                 "schemaVersion": 2,
-                "description": "Task tracking schema",
                 "fields": [
                     {
                         "name": "status",
@@ -399,7 +395,6 @@ mod tests {
 
         assert!(schema.is_core);
         assert_eq!(schema.schema_version, 2);
-        assert_eq!(schema.description, "Task tracking schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "status");
     }
@@ -436,10 +431,8 @@ mod tests {
         let mut schema = SchemaNode::from_node(node).unwrap();
 
         // Direct field mutation
-        schema.description = "Updated description".to_string();
         schema.schema_version += 1;
 
-        assert_eq!(schema.description, "Updated description");
         assert_eq!(schema.schema_version, 3);
     }
 
@@ -512,7 +505,6 @@ mod tests {
         let json = serde_json::to_value(&schema).unwrap();
         assert_eq!(json["isCore"], true);
         assert_eq!(json["schemaVersion"], 2);
-        assert_eq!(json["description"], "Task tracking schema");
     }
 
     #[test]
@@ -526,7 +518,6 @@ mod tests {
             "modifiedAt": "2025-01-01T00:00:00Z",
             "isCore": false,
             "schemaVersion": 1,
-            "description": "A test schema",
             "fields": []
         });
 
@@ -535,7 +526,6 @@ mod tests {
         assert_eq!(schema.content, "Test Schema");
         assert!(!schema.is_core);
         assert_eq!(schema.schema_version, 1);
-        assert_eq!(schema.description, "A test schema");
         assert!(schema.fields.is_empty());
     }
 }

--- a/packages/core/src/ops/context_ops.rs
+++ b/packages/core/src/ops/context_ops.rs
@@ -231,7 +231,6 @@ mod tests {
             modified_at: chrono::Utc::now(),
             is_core: false,
             schema_version: 1,
-            description: String::new(),
             fields: fields
                 .iter()
                 .map(|name| SchemaField {

--- a/packages/core/src/schema/mod.rs
+++ b/packages/core/src/schema/mod.rs
@@ -786,32 +786,25 @@ async fn create_description_subtree(
 
 /// Replace the description child subtree of a schema node with new content.
 ///
-/// Deletes all existing direct children of the schema node, then creates
-/// a fresh subtree from the new markdown description.
+/// Atomically deletes the entire existing subtree (all descendants, not just direct children),
+/// then creates a fresh subtree from the new markdown description.
 async fn replace_description_subtree(
     node_service: &Arc<NodeService>,
     schema_id: &str,
     new_description: &str,
 ) -> Result<(), MarkdownError> {
-    // Delete existing description children (cascade — each deletes its own subtree)
-    let children = node_service.get_children(schema_id).await.map_err(|e| {
-        MarkdownError::internal_error(format!(
-            "Failed to fetch description children for schema '{}': {}",
-            schema_id, e
-        ))
-    })?;
-
-    for child in children {
-        node_service
-            .delete_node_unchecked(&child.id)
-            .await
-            .map_err(|e| {
-                MarkdownError::internal_error(format!(
-                    "Failed to delete description child '{}': {}",
-                    child.id, e
-                ))
-            })?;
-    }
+    // Delete the entire descendant subtree in one statement (recursive CTE).
+    // This correctly handles nested markdown structures (e.g. header → text children).
+    node_service
+        .store()
+        .delete_children_subtree_unchecked(schema_id)
+        .await
+        .map_err(|e| {
+            MarkdownError::internal_error(format!(
+                "Failed to delete description subtree for schema '{}': {}",
+                schema_id, e
+            ))
+        })?;
 
     // Create new description subtree
     create_description_subtree(node_service, schema_id, new_description).await

--- a/packages/core/src/schema/mod.rs
+++ b/packages/core/src/schema/mod.rs
@@ -179,7 +179,7 @@ pub async fn handle_create_schema(
         )));
     }
 
-    // Schema properties (flat structure matching SchemaNode)
+    // Schema properties (description is stored as child node subtree, not in properties)
     let description_text = params
         .description
         .clone()
@@ -187,7 +187,6 @@ pub async fn handle_create_schema(
     let mut properties = serde_json::json!({
         "isCore": false,
         "schemaVersion": 1,
-        "description": &description_text,
         "fields": &namespaced_fields,
         "relationships": &relationships
     });
@@ -209,7 +208,7 @@ pub async fn handle_create_schema(
     };
 
     // Store the schema node
-    node_service
+    let created_schema_id = node_service
         .create_node_with_parent(schema_node_params)
         .await
         .map_err(|e| {
@@ -218,6 +217,10 @@ pub async fn handle_create_schema(
                 schema_id, e
             ))
         })?;
+
+    // Store the description as a child node subtree so it is included in the
+    // schema's embedding and enables synonym-based semantic discovery.
+    create_description_subtree(node_service, &created_schema_id, &description_text).await?;
 
     let output = CreateSchemaOutput {
         schema_id: schema_id.clone(),
@@ -375,7 +378,6 @@ pub async fn handle_add_schema_relationship(
     let properties = serde_json::json!({
         "isCore": schema.is_core,
         "version": schema.schema_version,
-        "description": schema.description,
         "fields": schema.fields,
         "relationships": relationships
     });
@@ -447,7 +449,6 @@ pub async fn handle_remove_schema_relationship(
     let properties = serde_json::json!({
         "isCore": schema.is_core,
         "version": schema.schema_version,
-        "description": schema.description,
         "fields": schema.fields,
         "relationships": relationships
     });
@@ -637,9 +638,6 @@ pub async fn handle_update_schema(
         relationships.extend(add_rels.clone());
     }
 
-    // Update description if provided
-    let description = params.description.unwrap_or(schema.description);
-
     // Resolve title_template: use new value if provided, otherwise keep existing
     let title_template = params.title_template.or(schema.title_template);
 
@@ -648,11 +646,10 @@ pub async fn handle_update_schema(
         .properties_header_summary_template
         .or(schema.properties_header_summary_template);
 
-    // Build updated properties
+    // Build updated properties (description is stored as child subtree, not in properties)
     let mut properties = serde_json::json!({
         "isCore": schema.is_core,
         "schemaVersion": schema.schema_version,
-        "description": description,
         "fields": fields,
         "relationships": relationships
     });
@@ -667,7 +664,7 @@ pub async fn handle_update_schema(
     // pipeline, so we run SchemaNodeBehavior validation explicitly here)
     let temp_node = Node::new(
         "schema".to_string(),
-        description.clone(),
+        schema.content.clone(),
         properties.clone(),
     );
     let updated_schema = SchemaNode::from_node(temp_node).map_err(|e| {
@@ -686,6 +683,11 @@ pub async fn handle_update_schema(
         .update_node_unchecked(&params.schema_id, update)
         .await
         .map_err(|e| MarkdownError::internal_error(format!("Failed to update schema: {}", e)))?;
+
+    // If a new description was provided, replace the description child subtree
+    if let Some(ref new_description) = params.description {
+        replace_description_subtree(node_service, &params.schema_id, new_description).await?;
+    }
 
     let output = SchemaUpdateOutput {
         schema_id: params.schema_id,
@@ -720,6 +722,99 @@ pub async fn handle_update_schema(
 
     serde_json::to_value(&output)
         .map_err(|e| MarkdownError::internal_error(format!("Failed to serialize output: {}", e)))
+}
+
+// ============================================================================
+// Description Subtree Helpers
+// ============================================================================
+
+/// Create a description child subtree under a schema node.
+///
+/// Parses the markdown description into node types (text, header, etc.) and
+/// inserts them as children of the schema node via bulk insert. The subtree
+/// is then included in the schema's embedding via `get_aggregated_content`,
+/// enabling synonym-based semantic discovery of schemas.
+async fn create_description_subtree(
+    node_service: &Arc<NodeService>,
+    schema_id: &str,
+    description: &str,
+) -> Result<(), MarkdownError> {
+    use crate::markdown::prepare_nodes_from_markdown;
+
+    if description.trim().is_empty() {
+        return Ok(());
+    }
+
+    let prepared = prepare_nodes_from_markdown(description, Some(schema_id.to_string()))?;
+    if prepared.is_empty() {
+        return Ok(());
+    }
+
+    let bulk_nodes: Vec<(
+        String,
+        String,
+        String,
+        Option<String>,
+        f64,
+        serde_json::Value,
+    )> = prepared
+        .into_iter()
+        .map(|n| {
+            (
+                n.id,
+                n.node_type,
+                n.content,
+                n.parent_id,
+                n.order,
+                n.properties,
+            )
+        })
+        .collect();
+
+    node_service
+        .bulk_create_hierarchy(bulk_nodes)
+        .await
+        .map_err(|e| {
+            MarkdownError::internal_error(format!(
+                "Failed to create description subtree for schema '{}': {}",
+                schema_id, e
+            ))
+        })?;
+
+    Ok(())
+}
+
+/// Replace the description child subtree of a schema node with new content.
+///
+/// Deletes all existing direct children of the schema node, then creates
+/// a fresh subtree from the new markdown description.
+async fn replace_description_subtree(
+    node_service: &Arc<NodeService>,
+    schema_id: &str,
+    new_description: &str,
+) -> Result<(), MarkdownError> {
+    // Delete existing description children (cascade — each deletes its own subtree)
+    let children = node_service.get_children(schema_id).await.map_err(|e| {
+        MarkdownError::internal_error(format!(
+            "Failed to fetch description children for schema '{}': {}",
+            schema_id, e
+        ))
+    })?;
+
+    for child in children {
+        node_service
+            .delete_node_unchecked(&child.id)
+            .await
+            .map_err(|e| {
+                MarkdownError::internal_error(format!(
+                    "Failed to delete description child '{}': {}",
+                    child.id, e
+                ))
+            })?;
+    }
+
+    // Create new description subtree
+    create_description_subtree(node_service, schema_id, new_description).await
 }
 
 /// Parse natural language description and extract fields

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -655,3 +655,41 @@ async fn test_schema_behavior_can_have_children_is_true() {
         "SchemaNodeBehavior should allow children (description subtree)"
     );
 }
+
+#[tokio::test]
+async fn test_schema_get_aggregated_content_returns_description_text() {
+    use crate::behaviors::{NodeBehavior, SchemaNodeBehavior};
+
+    let (svc, _tmp) = create_test_service().await;
+
+    handle_create_schema(
+        &svc,
+        json!({
+            "name": "Billing",
+            "description": "Tracks invoices and payment records for clients.",
+            "fields": []
+        }),
+    )
+    .await
+    .expect("create_schema should succeed");
+
+    let schema_node = svc
+        .get_node("billing")
+        .await
+        .expect("get_node failed")
+        .expect("schema node not found");
+
+    let behavior = SchemaNodeBehavior;
+    let aggregated = behavior.get_aggregated_content(&schema_node, &*svc).await;
+
+    assert!(
+        aggregated.is_some(),
+        "get_aggregated_content should return Some when description subtree exists"
+    );
+    let text = aggregated.unwrap();
+    assert!(
+        text.contains("invoices") || text.contains("payment"),
+        "Aggregated content should include description text for semantic search: {:?}",
+        text
+    );
+}

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -503,3 +503,155 @@ async fn test_rename_field_migrates_node_data() {
         "old_field should be removed after rename"
     );
 }
+
+// ============================================================================
+// Issue #1351: Description subtree tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_schema_stores_description_as_child_subtree() {
+    let (svc, _tmp) = create_test_service().await;
+
+    let result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "Invoice",
+            "description": "Tracks money owed by clients for goods or services rendered.",
+            "fields": []
+        }),
+    )
+    .await
+    .expect("create_schema should succeed");
+
+    let schema_id = result["schemaId"].as_str().expect("schemaId missing");
+    assert_eq!(schema_id, "invoice");
+
+    // Description must NOT be stored in properties
+    let node = svc
+        .get_node(schema_id)
+        .await
+        .expect("get_node failed")
+        .expect("schema node not found");
+    assert!(
+        node.properties.get("description").is_none(),
+        "description should not be in properties after #1351"
+    );
+
+    // Description must be stored as child text node(s)
+    let children = svc
+        .get_children(schema_id)
+        .await
+        .expect("get_children failed");
+    assert!(
+        !children.is_empty(),
+        "Schema should have child description nodes"
+    );
+
+    // The child content should contain the description text
+    let combined: String = children
+        .iter()
+        .map(|c| c.content.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        combined.contains("money owed") || combined.contains("clients"),
+        "Description text should appear in children: {:?}",
+        combined
+    );
+}
+
+#[tokio::test]
+async fn test_create_schema_description_not_in_properties() {
+    let (svc, _tmp) = create_test_service().await;
+
+    handle_create_schema(
+        &svc,
+        json!({
+            "name": "Project",
+            "description": "Organizes work into milestones and tasks.",
+            "fields": []
+        }),
+    )
+    .await
+    .expect("create_schema should succeed");
+
+    let node = svc
+        .get_node("project")
+        .await
+        .expect("get_node failed")
+        .expect("schema node not found");
+
+    // properties.description must be absent
+    assert!(
+        node.properties.get("description").is_none(),
+        "description must not be written to properties (Issue #1351)"
+    );
+}
+
+#[tokio::test]
+async fn test_update_schema_replaces_description_subtree() {
+    let (svc, _tmp) = create_test_service().await;
+
+    handle_create_schema(
+        &svc,
+        json!({
+            "name": "Contact",
+            "description": "Original description.",
+            "fields": []
+        }),
+    )
+    .await
+    .expect("create_schema should succeed");
+
+    let initial_children = svc
+        .get_children("contact")
+        .await
+        .expect("get_children failed");
+    assert!(
+        !initial_children.is_empty(),
+        "Schema should have initial description children"
+    );
+
+    // Update description
+    handle_update_schema(
+        &svc,
+        json!({
+            "schema_id": "contact",
+            "description": "Updated description with new content."
+        }),
+    )
+    .await
+    .expect("update_schema should succeed");
+
+    let updated_children = svc
+        .get_children("contact")
+        .await
+        .expect("get_children failed");
+    assert!(
+        !updated_children.is_empty(),
+        "Schema should still have description children after update"
+    );
+
+    // The combined text should reflect the new description
+    let combined: String = updated_children
+        .iter()
+        .map(|c| c.content.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        combined.contains("Updated description") || combined.contains("new content"),
+        "Updated description should appear in children: {:?}",
+        combined
+    );
+}
+
+#[tokio::test]
+async fn test_schema_behavior_can_have_children_is_true() {
+    use crate::behaviors::{NodeBehavior, SchemaNodeBehavior};
+
+    let behavior = SchemaNodeBehavior;
+    assert!(
+        behavior.can_have_children(),
+        "SchemaNodeBehavior should allow children (description subtree)"
+    );
+}

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -611,6 +611,8 @@ async fn test_update_schema_replaces_description_subtree() {
         !initial_children.is_empty(),
         "Schema should have initial description children"
     );
+    let initial_ids: std::collections::HashSet<String> =
+        initial_children.iter().map(|c| c.id.clone()).collect();
 
     // Update description
     handle_update_schema(
@@ -631,6 +633,16 @@ async fn test_update_schema_replaces_description_subtree() {
         !updated_children.is_empty(),
         "Schema should still have description children after update"
     );
+
+    // None of the original child IDs should survive — replace_description_subtree must
+    // delete the full old subtree before creating a new one.
+    for child in &updated_children {
+        assert!(
+            !initial_ids.contains(&child.id),
+            "Stale child node {:?} should have been deleted by replace_description_subtree",
+            child.id
+        );
+    }
 
     // The combined text should reflect the new description
     let combined: String = updated_children

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -912,6 +912,10 @@ impl NodeService {
             embedding_waker: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
 
+        // Issue #1351: backfill description subtrees for schemas that still have
+        // properties.description but no child nodes (databases created before this change).
+        service.backfill_schema_description_subtrees().await?;
+
         Ok(service)
     }
 
@@ -1104,6 +1108,106 @@ impl NodeService {
                 created_children,
                 skipped,
                 "Agent nodes seeded from templates"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Backfill description child subtrees for schemas that still have `properties.description`
+    /// but no child nodes (Issue #1351).
+    ///
+    /// This runs once at startup to migrate databases created before descriptions were moved
+    /// to the child subtree. Idempotent: schemas that already have children are skipped.
+    async fn backfill_schema_description_subtrees(&self) -> Result<(), NodeServiceError> {
+        use crate::markdown::prepare_nodes_from_markdown;
+
+        let schemas = self.get_all_schemas().await.map_err(|e| {
+            NodeServiceError::QueryFailed(format!("Failed to fetch schemas for migration: {}", e))
+        })?;
+
+        let mut backfilled = 0usize;
+
+        for schema in schemas {
+            // Skip schemas that already have child description nodes
+            let children = self.get_children(&schema.id).await.unwrap_or_default();
+            if !children.is_empty() {
+                continue;
+            }
+
+            // Read the legacy description from properties (may be absent in new schemas)
+            let description = self
+                .store
+                .get_node(&schema.id)
+                .await
+                .unwrap_or(None)
+                .and_then(|n| {
+                    n.properties
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                });
+
+            let description = match description {
+                Some(d) => d,
+                None => continue, // No legacy description to migrate
+            };
+
+            let prepared = match prepare_nodes_from_markdown(&description, Some(schema.id.clone()))
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        schema_id = %schema.id,
+                        error = %e,
+                        "Failed to prepare description subtree during migration, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            if prepared.is_empty() {
+                continue;
+            }
+
+            let bulk_nodes: Vec<(
+                String,
+                String,
+                String,
+                Option<String>,
+                f64,
+                serde_json::Value,
+            )> = prepared
+                .into_iter()
+                .map(|n| {
+                    (
+                        n.id,
+                        n.node_type,
+                        n.content,
+                        n.parent_id,
+                        n.order,
+                        n.properties,
+                    )
+                })
+                .collect();
+
+            if let Err(e) = self.bulk_create_hierarchy(bulk_nodes).await {
+                tracing::warn!(
+                    schema_id = %schema.id,
+                    error = %e,
+                    "Failed to backfill description subtree, skipping"
+                );
+                continue;
+            }
+
+            backfilled += 1;
+        }
+
+        if backfilled > 0 {
+            tracing::info!(
+                count = backfilled,
+                "✅ Backfilled schema description subtrees (Issue #1351)"
             );
         }
 

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1115,10 +1115,10 @@ impl NodeService {
     }
 
     /// Backfill description child subtrees for schemas that still have `properties.description`
-    /// but no child nodes (Issue #1351).
+    /// (Issue #1351).
     ///
-    /// This runs once at startup to migrate databases created before descriptions were moved
-    /// to the child subtree. Idempotent: schemas that already have children are skipped.
+    /// Runs at every startup; idempotent because `properties.description` is removed from the
+    /// schema node after a successful backfill. Schemas without that key are skipped in O(1).
     async fn backfill_schema_description_subtrees(&self) -> Result<(), NodeServiceError> {
         use crate::markdown::prepare_nodes_from_markdown;
 
@@ -1196,6 +1196,20 @@ impl NodeService {
                     "Failed to backfill description subtree, skipping"
                 );
                 continue;
+            }
+
+            // Clear the legacy properties.description so this schema is not re-migrated
+            // on the next startup (the subtree's existence is now the canonical description).
+            if let Err(e) = self
+                .store
+                .remove_property_key(&schema.id, "description")
+                .await
+            {
+                tracing::warn!(
+                    schema_id = %schema.id,
+                    error = %e,
+                    "Failed to clear legacy description property after backfill"
+                );
             }
 
             backfilled += 1;

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1129,13 +1129,10 @@ impl NodeService {
         let mut backfilled = 0usize;
 
         for schema in schemas {
-            // Skip schemas that already have child description nodes
-            let children = self.get_children(&schema.id).await.unwrap_or_default();
-            if !children.is_empty() {
-                continue;
-            }
-
-            // Read the legacy description from properties (may be absent in new schemas)
+            // Read the legacy description from properties — its presence is the migration trigger.
+            // Using child count as the check would be incorrect: schemas can now legitimately
+            // have non-description children, and would permanently skip backfill if any child
+            // exists before the description is migrated.
             let description = self
                 .store
                 .get_node(&schema.id)
@@ -1151,7 +1148,7 @@ impl NodeService {
 
             let description = match description {
                 Some(d) => d,
-                None => continue, // No legacy description to migrate
+                None => continue, // No legacy description to migrate (already migrated or never had one)
             };
 
             let prepared = match prepare_nodes_from_markdown(&description, Some(schema.id.clone()))
@@ -1207,7 +1204,7 @@ impl NodeService {
         if backfilled > 0 {
             tracing::info!(
                 count = backfilled,
-                "✅ Backfilled schema description subtrees (Issue #1351)"
+                "Backfilled schema description subtrees (Issue #1351)"
             );
         }
 

--- a/packages/core/src/services/node_service/schema.rs
+++ b/packages/core/src/services/node_service/schema.rs
@@ -290,7 +290,6 @@ impl NodeService {
         let mut properties = serde_json::json!({
             "isCore": schema.is_core,
             "schemaVersion": schema.schema_version,
-            "description": schema.description,
             "fields": updated_fields,
             "relationships": schema.relationships,
         });

--- a/packages/desktop-app/src/lib/plugins/schema-plugin-loader.ts
+++ b/packages/desktop-app/src/lib/plugins/schema-plugin-loader.ts
@@ -116,7 +116,7 @@ export function createPluginFromSchema(schema: SchemaNode): PluginDefinition {
   // Display name comes from schema content (the schema's name, e.g. "Customer").
   // description is for human-readable purpose/context, not the display name.
   const displayName = schema.content || humanizeSchemaId(schemaId);
-  const description = schema.description;
+  const description = schema.description ?? '';
 
   return {
     id: schemaId,

--- a/packages/desktop-app/src/lib/types/schema-node.ts
+++ b/packages/desktop-app/src/lib/types/schema-node.ts
@@ -132,8 +132,8 @@ export interface SchemaNode {
   /** Schema version (increments on schema changes) */
   schemaVersion: number;
 
-  /** Human-readable schema description */
-  description: string;
+  /** Human-readable schema description (sourced from child node subtree, may be absent) */
+  description?: string;
 
   /** Array of field definitions */
   fields: SchemaField[];

--- a/packages/desktop-app/src/lib/types/schema-node.ts
+++ b/packages/desktop-app/src/lib/types/schema-node.ts
@@ -17,10 +17,11 @@
  *   "version": 1,
  *   "isCore": true,
  *   "schemaVersion": 1,
- *   "description": "Task schema",
  *   "fields": [...]
  * }
  * ```
+ *
+ * Note: `description` is optional — it is sourced from child node text and may be absent.
  *
  * Note: nodeType is NOT included in the response - it's implicit (always "schema").
  *

--- a/packages/desktop-app/src/tests/components/custom-entity-node.test.ts
+++ b/packages/desktop-app/src/tests/components/custom-entity-node.test.ts
@@ -278,8 +278,8 @@ describe('CustomEntityNode Logic', () => {
       });
 
       expect(getEntityName(schemaNode, 'invoice')).toBe('💰 Invoice Management');
-      // Access typed field directly
-      expect(extractIconFromDescription(schemaNode.description)).toBe('💰');
+      // Access typed field directly (description is optional, provide fallback)
+      expect(extractIconFromDescription(schemaNode.description ?? '')).toBe('💰');
     });
 
     it('should handle schema with fields array', () => {


### PR DESCRIPTION
Closes #1351