### PR TITLE
Add prompt-dump dev tool: capture exact agent prompt + raw response per turn

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "install:all": "bun install",
     "chat": "bun run scripts/aichat.ts",
     "eval:routing": "bun run scripts/routing-eval.ts",
+    "prompt:dump": "bun run scripts/prompt-dump.ts",
     "build:sidecars": "bun run scripts/build-sidecars.ts",
     "download:models": "bun run scripts/download-models.ts",
     "download:models:bundle": "bun run scripts/download-models.ts --bundle",

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -296,6 +296,46 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 serde_json::to_string(&messages_json).unwrap_or_default(),
             ));
 
+            // Dev-only file dump (NODESPACE_PROMPT_DUMP): record the EXACT prompt
+            // sent to the model on THIS iteration — full system prompt + the
+            // complete (untruncated) message list, which on later iterations
+            // includes the accumulated tool results fed back in. Tools are dumped
+            // once (iteration 0). Reliable local-disk view of exactly what
+            // reaches the model at every step of the loop.
+            if crate::local_agent::prompt_dump::enabled() {
+                let full_messages: Vec<serde_json::Value> = messages
+                    .iter()
+                    .map(|m| {
+                        serde_json::json!({
+                            "role": format!("{:?}", m.role).to_lowercase(),
+                            "content": m.content,
+                        })
+                    })
+                    .collect();
+                let tools_full: Vec<serde_json::Value> = if iteration == 0 {
+                    tools
+                        .iter()
+                        .map(|t| {
+                            serde_json::json!({
+                                "name": t.name,
+                                "description": t.description,
+                                "parameters": t.parameters_schema,
+                            })
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                crate::local_agent::prompt_dump::dump_turn_iteration(
+                    &session.id,
+                    iteration,
+                    user_message,
+                    &system_content,
+                    &full_messages,
+                    &tools_full,
+                );
+            }
+
             // Status: Thinking
             on_status(LocalAgentStatus::Thinking);
             session.status = LocalAgentStatus::Thinking;
@@ -356,6 +396,18 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 "tool_calls_parsed",
                 serde_json::to_string(&tool_calls_json).unwrap_or_default(),
             ));
+
+            // Dev-only file dump (NODESPACE_PROMPT_DUMP): the RAW model response
+            // (pre-normalization) and parsed tool calls for THIS iteration. One
+            // record per ReAct iteration, so multi-iteration tool loops are fully
+            // captured in order.
+            crate::local_agent::prompt_dump::dump_response(
+                &session.id,
+                iteration,
+                &response_text,
+                &tool_calls_json,
+            );
+
             iter_span.set_attribute(KeyValue::new("prompt_tokens", usage.prompt_tokens as i64));
             iter_span.set_attribute(KeyValue::new(
                 "completion_tokens",

--- a/packages/agent/src/local_agent/mod.rs
+++ b/packages/agent/src/local_agent/mod.rs
@@ -5,6 +5,7 @@ pub mod model_manager;
 pub mod ollama_inference;
 pub mod ollama_model_manager;
 pub mod otlp_tracer;
+pub mod prompt_dump;
 pub mod prompt_templates;
 pub mod response_processing;
 pub mod tools;

--- a/packages/agent/src/local_agent/prompt_dump.rs
+++ b/packages/agent/src/local_agent/prompt_dump.rs
@@ -1,0 +1,111 @@
+//! Dev-only prompt/response dump.
+//!
+//! When `NODESPACE_PROMPT_DUMP` is set to a file path, every agent turn appends
+//! the *exact* assembled system prompt, the full message list sent to the model,
+//! the tools offered, and the raw (pre-normalization) model response to that
+//! file as line-delimited JSON. When the env var is unset this is a zero-cost
+//! no-op.
+//!
+//! This gives a 100%-reliable view of what actually reached the model — the
+//! daemon log only records the system-prompt *length* and a short preview, which
+//! is insufficient for diagnosing prompt/tool-call issues. Reach for this when
+//! you need to see the verbatim prompt and the raw model output.
+//!
+//! Usage:
+//! ```sh
+//! NODESPACE_PROMPT_DUMP=/tmp/dump.jsonl <run the daemon>
+//! # then inspect /tmp/dump.jsonl — one JSON object per line:
+//! #   {"kind":"turn","iteration":0,"system_prompt":"<full>","messages":[...],"tools":[...]}
+//! #   {"kind":"response","iteration":0,"raw_response":"<full>","tool_calls":[...]}
+//! ```
+
+use std::io::Write;
+
+/// Env var holding the dump file path. Unset → no-op.
+const ENV_DUMP_PATH: &str = "NODESPACE_PROMPT_DUMP";
+
+/// Returns the configured dump path, or `None` when dumping is disabled.
+fn dump_path() -> Option<String> {
+    match std::env::var(ENV_DUMP_PATH) {
+        Ok(p) if !p.trim().is_empty() => Some(p),
+        _ => None,
+    }
+}
+
+/// Append one JSON value as a line to the dump file. Best-effort: any IO error
+/// is logged at debug and otherwise ignored — dumping must never affect a turn.
+fn append(value: &serde_json::Value) {
+    let Some(path) = dump_path() else { return };
+    let line = match serde_json::to_string(value) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(error = %e, "prompt_dump: serialize failed");
+            return;
+        }
+    };
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(mut f) => {
+            if let Err(e) = writeln!(f, "{line}") {
+                tracing::debug!(error = %e, path = %path, "prompt_dump: write failed");
+            }
+        }
+        Err(e) => tracing::debug!(error = %e, path = %path, "prompt_dump: open failed"),
+    }
+}
+
+/// True when dumping is enabled — lets callers skip building the JSON payload.
+pub fn enabled() -> bool {
+    dump_path().is_some()
+}
+
+/// Dump the exact prompt sent to the model on one ReAct iteration: the system
+/// prompt, the complete (untruncated) message list — which on later iterations
+/// includes accumulated tool results — and the tools offered (iteration 0 only,
+/// empty thereafter to avoid repeating the schema each step).
+pub fn dump_turn_iteration(
+    session_id: &str,
+    iteration: usize,
+    user_message: &str,
+    system_prompt: &str,
+    messages: &[serde_json::Value],
+    tools: &[serde_json::Value],
+) {
+    if !enabled() {
+        return;
+    }
+    append(&serde_json::json!({
+        "kind": "turn",
+        "session_id": session_id,
+        "iteration": iteration,
+        "user_message": user_message,
+        "system_prompt": system_prompt,
+        "system_prompt_len": system_prompt.len(),
+        "messages": messages,
+        "tools": tools,
+    }));
+}
+
+/// Dump the raw (pre-normalization) model response and parsed tool calls for one
+/// ReAct iteration.
+pub fn dump_response(
+    session_id: &str,
+    iteration: usize,
+    raw_response: &str,
+    tool_calls: &[serde_json::Value],
+) {
+    if !enabled() {
+        return;
+    }
+    append(&serde_json::json!({
+        "kind": "response",
+        "session_id": session_id,
+        "iteration": iteration,
+        "raw_response": raw_response,
+        "raw_response_len": raw_response.len(),
+        "tool_calls": tool_calls,
+    }));
+}

--- a/scripts/prompt-dump.ts
+++ b/scripts/prompt-dump.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+/**
+ * prompt-dump.ts — read and pretty-print an agent prompt/response dump.
+ *
+ * The local agent can write the EXACT assembled prompt + raw model response per
+ * ReAct iteration to a JSONL file when `NODESPACE_PROMPT_DUMP` is set (see
+ * packages/agent/src/local_agent/prompt_dump.rs). The daemon log only records the
+ * system-prompt *length* and a short preview, which is insufficient for
+ * diagnosing prompt/tool-call issues. This reader renders the dump so you can see
+ * verbatim what reached the model and what it produced.
+ *
+ * Workflow:
+ *   1. Run the daemon with dumping on:
+ *        NODESPACE_PROMPT_DUMP=/tmp/dump.jsonl <launch nodespaced>
+ *   2. Drive a turn (e.g. `bun run chat ask "Create an invoice database"`).
+ *   3. Inspect:
+ *        bun run prompt:dump /tmp/dump.jsonl            # full, pretty
+ *        bun run prompt:dump /tmp/dump.jsonl --prompt   # system prompts only
+ *        bun run prompt:dump /tmp/dump.jsonl --tools    # tools offered only
+ *        bun run prompt:dump /tmp/dump.jsonl --last     # only the most recent turn
+ *        bun run prompt:dump /tmp/dump.jsonl --raw      # raw JSONL lines
+ *
+ * Each line in the dump is one JSON object:
+ *   {"kind":"turn","iteration":N,"system_prompt":"…","messages":[…],"tools":[…]}
+ *   {"kind":"response","iteration":N,"raw_response":"…","tool_calls":[…]}
+ */
+
+import { readFileSync } from "node:fs";
+
+type TurnRecord = {
+  kind: "turn";
+  session_id: string;
+  iteration: number;
+  user_message: string;
+  system_prompt: string;
+  system_prompt_len: number;
+  messages: Array<{ role: string; content: string }>;
+  tools: Array<{ name: string; description: string; parameters?: unknown }>;
+};
+
+type ResponseRecord = {
+  kind: "response";
+  session_id: string;
+  iteration: number;
+  raw_response: string;
+  raw_response_len: number;
+  tool_calls: Array<{ id?: string; name?: string; arguments?: string }>;
+};
+
+type Record = TurnRecord | ResponseRecord;
+
+const args = process.argv.slice(2);
+const file = args.find((a) => !a.startsWith("--"));
+const flags = new Set(args.filter((a) => a.startsWith("--")));
+
+if (!file) {
+  console.error(
+    "usage: bun run prompt:dump <dump.jsonl> [--prompt|--tools|--last|--raw]",
+  );
+  process.exit(1);
+}
+
+let lines: string[];
+try {
+  lines = readFileSync(file, "utf8").trim().split("\n").filter(Boolean);
+} catch (e) {
+  console.error(`Cannot read ${file}: ${(e as Error).message}`);
+  process.exit(1);
+}
+
+if (flags.has("--raw")) {
+  for (const l of lines) console.log(l);
+  process.exit(0);
+}
+
+let records: Record[] = lines.map((l) => JSON.parse(l));
+
+// --last: keep only records from the most recent session.
+if (flags.has("--last")) {
+  const lastSession = [...records].reverse().find((r) => r.session_id)?.session_id;
+  records = records.filter((r) => r.session_id === lastSession);
+}
+
+const rule = "=".repeat(72);
+
+for (const r of records) {
+  if (r.kind === "turn") {
+    if (flags.has("--tools")) {
+      if (r.iteration === 0) {
+        console.log(`\n${rule}\nTOOLS OFFERED (${r.tools.length})`);
+        for (const t of r.tools) {
+          console.log(`  • ${t.name}: ${t.description.slice(0, 90)}`);
+        }
+      }
+      continue;
+    }
+    if (flags.has("--prompt")) {
+      console.log(
+        `\n${rule}\nTURN iter=${r.iteration} | system_prompt_len=${r.system_prompt_len}\n${rule}`,
+      );
+      console.log(r.system_prompt);
+      continue;
+    }
+    // default: full
+    console.log(
+      `\n${rule}\nTURN iter=${r.iteration} | user: ${r.user_message}`,
+    );
+    console.log(`system_prompt_len=${r.system_prompt_len}`);
+    console.log("--- messages sent ---");
+    for (const m of r.messages) {
+      const c = m.content.length > 200 ? m.content.slice(0, 200) + "…" : m.content;
+      console.log(`  [${m.role}] ${JSON.stringify(c)}`);
+    }
+    if (r.iteration === 0 && r.tools.length) {
+      console.log(`--- tools (${r.tools.length}) ---`);
+      for (const t of r.tools) console.log(`  • ${t.name}`);
+    }
+  } else if (r.kind === "response") {
+    if (flags.has("--prompt") || flags.has("--tools")) continue;
+    console.log(`--- RESPONSE iter=${r.iteration} (raw_len=${r.raw_response_len}) ---`);
+    if (r.raw_response) {
+      const raw =
+        r.raw_response.length > 300 ? r.raw_response.slice(0, 300) + "…" : r.raw_response;
+      console.log(`  raw: ${JSON.stringify(raw)}`);
+    }
+    for (const tc of r.tool_calls) {
+      console.log(`  → tool_call ${tc.name}: ${(tc.arguments ?? "").slice(0, 400)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Overview

A dev-only observability tool for inspecting **exactly** what the local agent sends to the model and what the model returns, per ReAct iteration. Gated entirely behind `NODESPACE_PROMPT_DUMP` — unset = zero-cost no-op, no production behavior change.

The daemon log only records the system-prompt *length* and a ~120-char preview, which is insufficient for diagnosing prompt assembly, tool-call formatting, and skill delivery. This tool was built and used during the local-model evaluation work to get reliable, network-free, verbatim visibility — the alternative to the OTLP→MLflow path (which can intermittently drop traces).

## What it captures

Per ReAct iteration, appended as JSONL:
- `turn` record: full assembled system prompt, complete (untruncated) message list, tools offered with their parameter schemas
- `response` record: raw pre-normalization model output + parsed tool calls

A request that loops (tool error → retry) produces a record pair per iteration in order, so the full back-and-forth is visible.

## Usage

```sh
# run the daemon with dumping on
NODESPACE_PROMPT_DUMP=/tmp/dump.jsonl <launch nodespaced>

# drive a turn, then inspect
bun run prompt:dump /tmp/dump.jsonl            # full
bun run prompt:dump /tmp/dump.jsonl --prompt   # system prompts only
bun run prompt:dump /tmp/dump.jsonl --tools    # tools offered only
bun run prompt:dump /tmp/dump.jsonl --last     # most recent session
bun run prompt:dump /tmp/dump.jsonl --raw      # raw JSONL (pipe to jq)
```

## Changes

- `packages/agent/src/local_agent/prompt_dump.rs` — env-gated, best-effort writer (IO errors never affect a turn)
- `agent_loop.rs` — wired into the ReAct loop (turn + response records)
- `scripts/prompt-dump.ts` + `bun run prompt:dump` — reader/pretty-printer
- Documented in `nodespace-docs/development/prompt-dump.md` (separate PR)

## Acceptance

- [x] Zero-cost no-op when `NODESPACE_PROMPT_DUMP` is unset
- [x] Captures full verbatim prompt + raw response per iteration
- [x] `bun run prompt:dump` reader with prompt/tools/last/raw views
- [x] Passes `bun run quality:fix` (clippy + tsc clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)