### PR TITLE
Gemma 4 12B runs away (4096-token cap every turn) + OAI parser ffi error -3 through NodeSpace's inference path, despite clean output via raw llama-server

### DIFF
--- a/packages/agent/src/local_agent/inference.rs
+++ b/packages/agent/src/local_agent/inference.rs
@@ -74,10 +74,15 @@ impl ChatInferenceEngine for LlamaChatInferenceEngine {
         });
 
         let temperature = request.temperature.unwrap_or(self.default_temperature);
-        // 4096 fallback for GGUF path when no cap is requested (tool-calling iterations
-        // pass max_tokens: None). Ollama uses stream:false for tool turns so its
-        // effective cap is the model's own EOS — the two backends diverge here intentionally.
-        let max_tokens = request.max_tokens.unwrap_or(4096);
+        // 2048 fallback for GGUF path when no cap is requested (tool-calling iterations
+        // pass max_tokens: None to avoid truncating argument JSON mid-field). Ollama uses
+        // stream:false for tool turns so its effective cap is the model's own EOS — the two
+        // backends diverge here intentionally.
+        //
+        // 2048 is sufficient for any realistic tool-call argument blob and bounds runaway
+        // generation (e.g. Gemma 4 12B hitting the old 4096 ceiling on every turn). The
+        // final text-only response uses MAX_RESPONSE_TOKENS (also 2048) via agent_loop.rs.
+        let max_tokens = request.max_tokens.unwrap_or(2048);
 
         // Bridge ChatChunk → StreamingChunk
         let usage_result = self

--- a/packages/agent/src/local_agent/inference.rs
+++ b/packages/agent/src/local_agent/inference.rs
@@ -80,8 +80,9 @@ impl ChatInferenceEngine for LlamaChatInferenceEngine {
         // backends diverge here intentionally.
         //
         // 2048 is sufficient for any realistic tool-call argument blob and bounds runaway
-        // generation (e.g. Gemma 4 12B hitting the old 4096 ceiling on every turn). The
-        // final text-only response uses MAX_RESPONSE_TOKENS (also 2048) via agent_loop.rs.
+        // generation (e.g. Gemma 4 12B hitting the old 4096 ceiling on every turn). This
+        // mirrors MAX_RESPONSE_TOKENS (agent_loop.rs) so the per-turn token budget is
+        // symmetric: tool iterations and final replies are both capped at 2048.
         let max_tokens = request.max_tokens.unwrap_or(2048);
 
         // Bridge ChatChunk → StreamingChunk

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -359,12 +359,6 @@ impl ChatEngine {
         // is detected as PEG_GEMMA4, guarding against incomplete vocabulary metadata.
         let mut additional_stops = tmpl_result.additional_stops.clone();
         augment_gemma4_stops(tmpl_result.chat_format, &mut additional_stops);
-        if tmpl_result.chat_format == 3 {
-            tracing::debug!(
-                "Gemma 4 (chat_format=3): augmented additional_stops = {:?}",
-                additional_stops
-            );
-        }
 
         // --- Prepare context and batch ---
         // Find the longest token prefix shared with the last decoded prompt.
@@ -582,6 +576,9 @@ impl ChatEngine {
         }
 
         // Finalize: signal end-of-stream with empty string and is_partial=false.
+        // Best-effort — if generation exited via the consecutive-error circuit breaker
+        // the parser may be in an unrecoverable state; the warn-and-continue below
+        // is intentional (we still want to drain the channel splitter and emit Done).
         match oai_parser.update("", false) {
             Ok(deltas) => {
                 for delta_json in deltas {
@@ -735,21 +732,30 @@ fn partial_marker_suffix_len(text: &str, marker: &str) -> usize {
         .unwrap_or(0)
 }
 
+/// llama.cpp `common_chat_format` value for Gemma 4's PEG-based chat template.
+/// Used to detect when Gemma 4-specific stop tokens must be injected.
+#[cfg(any(feature = "chat-service", test))]
+const CHAT_FORMAT_PEG_GEMMA4: i32 = 3;
+
 #[cfg(any(feature = "chat-service", test))]
 /// Augment `additional_stops` with the full set of Gemma 4 turn-end tokens when
-/// `chat_format` indicates PEG_GEMMA4 (value 3).
+/// `chat_format` indicates PEG_GEMMA4.
 ///
 /// The ggml-org Gemma 4 12B GGUF does not mark `<turn|>` as an EOG token in its
 /// vocabulary, so llama.cpp's template engine may omit it from `additional_stops`.
 /// Injecting the full token set here ensures we stop on both `<end_of_turn>` and
 /// `<turn|>` regardless of vocabulary metadata quality.
 fn augment_gemma4_stops(chat_format: i32, stops: &mut Vec<String>) {
-    if chat_format == 3 {
+    if chat_format == CHAT_FORMAT_PEG_GEMMA4 {
         for stop in &["<end_of_turn>", "<turn|>"] {
             if !stops.iter().any(|s| s == stop) {
                 stops.push(stop.to_string());
             }
         }
+        tracing::debug!(
+            "Gemma 4 (PEG_GEMMA4): augmented additional_stops = {:?}",
+            stops
+        );
     }
 }
 
@@ -1380,7 +1386,7 @@ mod tests {
     fn augment_gemma4_injects_missing_turn_tokens() {
         // Neither token present — both must be added.
         let mut stops: Vec<String> = vec![];
-        augment_gemma4_stops(3, &mut stops);
+        augment_gemma4_stops(CHAT_FORMAT_PEG_GEMMA4, &mut stops);
         assert!(
             stops.iter().any(|s| s == "<end_of_turn>"),
             "must inject <end_of_turn>"
@@ -1390,14 +1396,19 @@ mod tests {
 
     #[test]
     fn augment_gemma4_does_not_duplicate_existing_stops() {
-        // Template already included <end_of_turn> — must not be duplicated.
+        // Template already included <end_of_turn> at index 0 — must not be duplicated
+        // and its position must be preserved.
         let mut stops = vec!["<end_of_turn>".to_string()];
-        augment_gemma4_stops(3, &mut stops);
+        augment_gemma4_stops(CHAT_FORMAT_PEG_GEMMA4, &mut stops);
         let eot_count = stops
             .iter()
             .filter(|s| s.as_str() == "<end_of_turn>")
             .count();
         assert_eq!(eot_count, 1, "<end_of_turn> must not be duplicated");
+        assert_eq!(
+            stops[0], "<end_of_turn>",
+            "pre-existing entry must stay at its original index"
+        );
         assert!(
             stops.iter().any(|s| s == "<turn|>"),
             "<turn|> must still be added"

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -352,9 +352,19 @@ impl ChatEngine {
         tracing::debug!("Prompt tokenized: {} tokens", prompt_tokens);
 
         // --- Extract model info before taking mutable borrow for context ---
-        let eos_token = llama.model.token_eos();
         // Additional stop sequences from the chat template (e.g. Gemma 4's "<end_of_turn>").
-        let additional_stops = tmpl_result.additional_stops.clone();
+        // For Gemma 4 (chat_format=3), the ggml-org GGUF does not mark <turn|> as EOG in
+        // its vocabulary, so llama.cpp's template engine may not include it in additional_stops.
+        // We inject the full set of Gemma 4 turn-end tokens unconditionally when the format
+        // is detected as PEG_GEMMA4, guarding against incomplete vocabulary metadata.
+        let mut additional_stops = tmpl_result.additional_stops.clone();
+        augment_gemma4_stops(tmpl_result.chat_format, &mut additional_stops);
+        if tmpl_result.chat_format == 3 {
+            tracing::debug!(
+                "Gemma 4 (chat_format=3): augmented additional_stops = {:?}",
+                additional_stops
+            );
+        }
 
         // --- Prepare context and batch ---
         // Find the longest token prefix shared with the last decoded prompt.
@@ -463,6 +473,7 @@ impl ChatEngine {
         let mut completion_tokens: u32 = 0;
         let mut n_cur = tokens.len();
         let mut context_overflowed = false;
+        let mut oai_parser_errors: u32 = 0;
 
         loop {
             if completion_tokens >= max_tokens {
@@ -480,9 +491,15 @@ impl ChatEngine {
             let new_token = sampler.sample(ctx, batch.n_tokens() - 1);
             sampler.accept(new_token);
 
-            // Check for end of sequence
-            if new_token == eos_token {
-                tracing::debug!("EOS token after {} completion tokens", completion_tokens);
+            // Use is_eog_token() rather than a bare EOS comparison: models like Gemma 4
+            // have multiple EOG tokens (EOS, <end_of_turn>, <turn|>) and is_eog_token
+            // covers all of them via llama.cpp's vocabulary flags.
+            if model_ref.is_eog_token(new_token) {
+                tracing::debug!(
+                    "EOG token ({}) after {} completion tokens",
+                    new_token.0,
+                    completion_tokens
+                );
                 break;
             }
 
@@ -516,6 +533,7 @@ impl ChatEngine {
             // update() takes only the new text added since the previous call.
             match oai_parser.update(&piece, true) {
                 Ok(deltas) => {
+                    oai_parser_errors = 0;
                     for delta_json in deltas {
                         emit_oai_delta(
                             &delta_json,
@@ -526,7 +544,19 @@ impl ChatEngine {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("OAI parser update error: {}", e);
+                    oai_parser_errors += 1;
+                    tracing::warn!("OAI parser update error ({}/5): {}", oai_parser_errors, e);
+                    // After 5 consecutive parse errors the parser is in an unrecoverable
+                    // state (e.g. ffi error -3 from a malformed Metal decode mid-stream).
+                    // Stop generation cleanly rather than continuing to produce garbage or
+                    // letting the model run to the token cap.
+                    if oai_parser_errors >= 5 {
+                        tracing::error!(
+                            "OAI parser unrecoverable after {} consecutive errors — stopping generation",
+                            oai_parser_errors
+                        );
+                        break;
+                    }
                 }
             }
 
@@ -703,6 +733,24 @@ fn partial_marker_suffix_len(text: &str, marker: &str) -> usize {
                 .starts_with(&text.as_bytes()[text.len() - k..])
         })
         .unwrap_or(0)
+}
+
+#[cfg(any(feature = "chat-service", test))]
+/// Augment `additional_stops` with the full set of Gemma 4 turn-end tokens when
+/// `chat_format` indicates PEG_GEMMA4 (value 3).
+///
+/// The ggml-org Gemma 4 12B GGUF does not mark `<turn|>` as an EOG token in its
+/// vocabulary, so llama.cpp's template engine may omit it from `additional_stops`.
+/// Injecting the full token set here ensures we stop on both `<end_of_turn>` and
+/// `<turn|>` regardless of vocabulary metadata quality.
+fn augment_gemma4_stops(chat_format: i32, stops: &mut Vec<String>) {
+    if chat_format == 3 {
+        for stop in &["<end_of_turn>", "<turn|>"] {
+            if !stops.iter().any(|s| s == stop) {
+                stops.push(stop.to_string());
+            }
+        }
+    }
 }
 
 /// Remove Gemma 4 special-token strings from a content string.
@@ -1318,5 +1366,51 @@ mod tests {
             "emit_oai_delta must emit ToolCallArgs containing 'Invoice'; got: {:?}",
             chunks
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // augment_gemma4_stops — Gemma 4 runaway fix (issue #1365)
+    //
+    // The ggml-org GGUF does not mark <turn|> as EOG, so llama.cpp's template
+    // engine may omit it from additional_stops. augment_gemma4_stops injects
+    // the full token set when chat_format=3 (PEG_GEMMA4).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn augment_gemma4_injects_missing_turn_tokens() {
+        // Neither token present — both must be added.
+        let mut stops: Vec<String> = vec![];
+        augment_gemma4_stops(3, &mut stops);
+        assert!(
+            stops.iter().any(|s| s == "<end_of_turn>"),
+            "must inject <end_of_turn>"
+        );
+        assert!(stops.iter().any(|s| s == "<turn|>"), "must inject <turn|>");
+    }
+
+    #[test]
+    fn augment_gemma4_does_not_duplicate_existing_stops() {
+        // Template already included <end_of_turn> — must not be duplicated.
+        let mut stops = vec!["<end_of_turn>".to_string()];
+        augment_gemma4_stops(3, &mut stops);
+        let eot_count = stops
+            .iter()
+            .filter(|s| s.as_str() == "<end_of_turn>")
+            .count();
+        assert_eq!(eot_count, 1, "<end_of_turn> must not be duplicated");
+        assert!(
+            stops.iter().any(|s| s == "<turn|>"),
+            "<turn|> must still be added"
+        );
+    }
+
+    #[test]
+    fn augment_gemma4_does_not_modify_non_gemma4_format() {
+        // chat_format=0 (CONTENT_ONLY) or 1 (Mistral) — must leave stops unchanged.
+        let mut stops: Vec<String> = vec![];
+        augment_gemma4_stops(0, &mut stops);
+        assert!(stops.is_empty(), "must not add stops for non-Gemma4 format");
+        augment_gemma4_stops(1, &mut stops);
+        assert!(stops.is_empty(), "must not add stops for non-Gemma4 format");
     }
 }


### PR DESCRIPTION
Closes #1365