### PR TITLE
Editor: cursor-to-end on re-init + focus-guard against sync clobber (closes #1381)

### DIFF
--- a/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
+++ b/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
@@ -400,6 +400,18 @@ export class TextareaController {
         return;
       }
 
+      // While the textarea is focused, the user's keystrokes ARE the content —
+      // the DOM is the source of truth. A reactive content update that lags
+      // behind fast typing (the store hasn't caught up to the latest keystroke)
+      // would reset element.value to a stale string and reposition the cursor,
+      // scrambling characters ("Tests" → "stsTE"). Skip the soft update while
+      // focused: cross-window updates for the edited node are already dropped by
+      // the SharedNodeStore skip-while-editing guard, and forceUpdateContent()
+      // remains for explicit programmatic overrides (paste, blur-sync, etc.).
+      if (typeof document !== 'undefined' && document.activeElement === this.element) {
+        return;
+      }
+
       // Preserve cursor position when updating content from external source
       // Setting element.value resets cursor to position 0
       const cursorPosition = this.element.selectionStart;

--- a/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
+++ b/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
@@ -379,11 +379,25 @@ export class TextareaController {
         // This prevents the cursor from being positioned at 0 before the action can apply
         // the correct position (e.g., 'absolute' position from Enter key node creation)
         if (!hasPendingCursorPosition) {
-          cursorService.setCursorAtBeginningOfLine(this.element, 0, {
-            focus: true,
-            delay: 0,
-            skipSyntax: true
-          });
+          // An empty/new node gets the cursor at the beginning. But when the
+          // textarea (re)initializes while it ALREADY has content and no explicit
+          // cursor position was requested — e.g. a remount the moment a freshly
+          // created node first persists, while the user is mid-typing its first
+          // word — snapping to position 0 makes the next keystrokes land BEFORE the
+          // existing text ("Hello" -> "lloHe"). Put the cursor at the end of the
+          // existing content (where the user was typing) instead.
+          if (content.length > 0) {
+            cursorService.setCursorAtPosition(this.element, content.length, {
+              focus: true,
+              delay: 0
+            });
+          } else {
+            cursorService.setCursorAtBeginningOfLine(this.element, 0, {
+              focus: true,
+              delay: 0,
+              skipSyntax: true
+            });
+          }
         }
       }
 


### PR DESCRIPTION
Fixes the two editor-layer bugs from #1381, found while bringing up the two-window Supabase demo (nodespace-sync #75). Single file: `textarea-controller.svelte.ts`.

## Changes
- **Cursor to end on re-initialize** — when a node with content re-initializes and there's no pending cursor position, place the cursor at `content.length` instead of 0. Fixes the first-word jump (`Hello` → `lloHe`).
- **Focus-guard in `updateContent()`** — if `document.activeElement === this.element`, skip the sync-driven reset; the local value is authoritative while the user is focused (ADR-027 local-first). Fixes fast-typing scramble when a sync update lands mid-typing.

## Verification
- `textarea-controller` unit tests pass.
- Real-browser (Chromium) suites: `enter-key-focus` 15/15, `rapid-keyboard-operations` 13/13, `focus-management` 6/6.
- Confirmed working in the live two-window GUI demo (user-confirmed).

Note: the branch name references "issue-77" (the nodespace-sync enter-ordering work this complements); the tracked core issue is #1381.