### PR TITLE
#133: PersonNodeBehavior + person core schema (ADR-037 identity type)

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -1870,6 +1870,81 @@ impl NodeBehavior for ToolNodeBehavior {
     }
 }
 
+/// Behavior for `person` nodes — the identity primitive for the ADR-037 access
+/// model ("members of a restricted collection = person nodes only").
+///
+/// Owns the PersonNode *type* only (validation + a computed display name). No
+/// PersonNode instance is created here; the first PersonNode is created, named,
+/// and bound to a Supabase identity at Pro sync-onboarding (nodespace-sync#125).
+pub struct PersonNodeBehavior;
+
+impl NodeBehavior for PersonNodeBehavior {
+    fn type_name(&self) -> &'static str {
+        "person"
+    }
+
+    fn validate(&self, node: &Node) -> Result<(), NodeValidationError> {
+        // A person must have a name (stored in content) — membership and the
+        // computed display name both rely on it.
+        if node.content.trim().is_empty() {
+            return Err(NodeValidationError::MissingField(
+                "Person name (content) cannot be empty".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn can_have_children(&self) -> bool {
+        false // A person is an identity, not a structural container.
+    }
+
+    fn supports_markdown(&self) -> bool {
+        false // Names are plain text.
+    }
+
+    fn default_metadata(&self) -> serde_json::Value {
+        serde_json::json!({})
+    }
+
+    /// A person's name is its embeddable content (so people are searchable).
+    fn get_embeddable_content(&self, node: &Node) -> Option<String> {
+        let name = node.content.trim();
+        if name.is_empty() {
+            None
+        } else {
+            Some(name.to_string())
+        }
+    }
+
+    /// People are grantees, not content — they don't contribute to parent embeddings.
+    fn get_parent_contribution(&self, _node: &Node) -> Option<String> {
+        None
+    }
+}
+
+impl PersonNodeBehavior {
+    /// Computed display name for a person: an explicit `custom:displayName`
+    /// property override if present and non-empty, else the node content (the
+    /// name), else a stable placeholder. The single place the rest of the app
+    /// should derive a person's shown name from.
+    pub fn display_name(&self, node: &Node) -> String {
+        node.properties
+            .get("custom:displayName")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                let c = node.content.trim();
+                if c.is_empty() {
+                    "Unknown Person".to_string()
+                } else {
+                    c.to_string()
+                }
+            })
+    }
+}
+
 /// Maximum allowed nesting depth for tool parameter schemas.
 ///
 /// Bounded nesting prevents external tools from registering schemas that could
@@ -2102,6 +2177,7 @@ impl NodeBehaviorRegistry {
         registry.register(Arc::new(PromptNodeBehavior));
         registry.register(Arc::new(SkillNodeBehavior));
         registry.register(Arc::new(ToolNodeBehavior));
+        registry.register(Arc::new(PersonNodeBehavior));
 
         registry
     }
@@ -2800,7 +2876,8 @@ mod tests {
         assert!(types.contains(&"prompt".to_string()));
         assert!(types.contains(&"skill".to_string()));
         assert!(types.contains(&"tool".to_string()));
-        assert_eq!(types.len(), 16);
+        assert!(types.contains(&"person".to_string()));
+        assert_eq!(types.len(), 17);
     }
 
     #[test]
@@ -4407,6 +4484,47 @@ mod tests {
             behavior.get_embeddable_content(&empty).is_none(),
             "Custom type with empty content should NOT be embeddable"
         );
+    }
+
+    // PersonNodeBehavior tests (ADR-037, #133) --------------------------------
+
+    #[test]
+    fn person_node_validates_name_and_registers() {
+        let behavior = PersonNodeBehavior;
+        assert_eq!(behavior.type_name(), "person");
+        assert!(!behavior.can_have_children());
+
+        let alice = Node::new("person".to_string(), "Alice".to_string(), json!({}));
+        assert!(behavior.validate(&alice).is_ok());
+        // a person's name is embeddable (searchable)
+        assert_eq!(
+            behavior.get_embeddable_content(&alice).as_deref(),
+            Some("Alice")
+        );
+
+        // an unnamed person is rejected
+        let nameless = Node::new("person".to_string(), "   ".to_string(), json!({}));
+        assert!(behavior.validate(&nameless).is_err());
+
+        // registered as a built-in type
+        assert!(NodeBehaviorRegistry::new().get("person").is_some());
+    }
+
+    #[test]
+    fn person_display_name_prefers_override_then_content() {
+        let behavior = PersonNodeBehavior;
+        let n = Node::new("person".to_string(), "Alice Smith".to_string(), json!({}));
+        assert_eq!(behavior.display_name(&n), "Alice Smith");
+
+        let overridden = Node::new(
+            "person".to_string(),
+            "alice".to_string(),
+            json!({"custom:displayName": "Alice S."}),
+        );
+        assert_eq!(behavior.display_name(&overridden), "Alice S.");
+
+        let empty = Node::new("person".to_string(), "".to_string(), json!({}));
+        assert_eq!(behavior.display_name(&empty), "Unknown Person");
     }
 
     // ToolNodeBehavior tests (issue #1353) ------------------------------------

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -183,6 +183,21 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             title_template: None,
             properties_header_summary_template: None,
         },
+        // Person schema - the ADR-037 identity primitive (content = name; no extra
+        // fields). PersonNodeBehavior owns validation + the computed display name.
+        SchemaNode {
+            id: "person".to_string(),
+            content: "Person".to_string(),
+            version: 1,
+            created_at: now,
+            modified_at: now,
+            is_core: true,
+            schema_version: 1,
+            fields: vec![],
+            relationships: vec![],
+            title_template: None,
+            properties_header_summary_template: None,
+        },
         // Date schema - daily note containers (no extra fields)
         SchemaNode {
             id: "date".to_string(),
@@ -879,7 +894,9 @@ mod tests {
     #[test]
     fn test_get_core_schemas_returns_all() {
         let schemas = get_core_schemas();
-        assert_eq!(schemas.len(), 15);
+        assert_eq!(schemas.len(), 16);
+        // ADR-037 #133: the person identity type is a core schema.
+        assert!(schemas.iter().any(|s| s.id == "person"));
     }
 
     #[test]

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -916,7 +916,29 @@ impl NodeService {
         // properties.description but no child nodes (databases created before this change).
         service.backfill_schema_description_subtrees().await?;
 
+        // ADR-037 (#133): every install has exactly one local PersonNode (the user).
+        service.seed_local_person_if_needed().await?;
+
         Ok(service)
+    }
+
+    /// ADR-037 (#133): seed exactly one **local** PersonNode — the local user,
+    /// `auth_status: "local"`. Idempotent: skips when a person already exists, so an
+    /// existing database is backfilled on next open too. On Pro upgrade this node is
+    /// *bound* to a Supabase identity (nodespace-sync#125), not recreated — there is
+    /// no "now set up your user" migration step.
+    async fn seed_local_person_if_needed(&self) -> Result<(), NodeServiceError> {
+        if !self.query_nodes_by_type("person", None).await?.is_empty() {
+            return Ok(());
+        }
+        let person = Node::new(
+            "person".to_string(),
+            "Me".to_string(),
+            serde_json::json!({ "auth_status": "local" }),
+        );
+        let id = self.create_node(person).await?;
+        tracing::info!(node_id = %id, "🌱 Seeded local PersonNode (ADR-037)");
+        Ok(())
     }
 
     /// Seed core schema definitions if database is fresh

--- a/packages/core/tests/person_seed_test.rs
+++ b/packages/core/tests/person_seed_test.rs
@@ -1,0 +1,70 @@
+//! Local PersonNode seeding tests (Issue #133, ADR-037)
+//!
+//! ADR-037 mandates that every install — free included — seeds exactly one
+//! local PersonNode (the local user, `auth_status: "local"`). On Pro upgrade
+//! this node is *bound* to a Supabase identity (nodespace-sync#125), not
+//! recreated. These tests verify:
+//! 1. Constructing a NodeService on a fresh database seeds exactly one person.
+//! 2. The seeded person carries `auth_status: "local"`.
+//! 3. Re-opening the same database does NOT create a second person (idempotent).
+
+#[cfg(test)]
+mod person_seed_tests {
+    use anyhow::Result;
+    use nodespace_core::db::SqliteStore;
+    use nodespace_core::services::NodeService;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn fresh_install_seeds_exactly_one_local_person() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let db_path = temp_dir.path().join("test.db");
+        let mut store = Arc::new(SqliteStore::new(db_path).await?);
+        let service = NodeService::new(&mut store).await?;
+
+        let people = service.query_nodes_by_type("person", None).await?;
+        assert_eq!(
+            people.len(),
+            1,
+            "a fresh install must seed exactly one local PersonNode"
+        );
+        // Properties are stored namespaced under the node type (Issue #838):
+        // properties["person"]["auth_status"].
+        assert_eq!(
+            people[0]
+                .properties
+                .get("person")
+                .and_then(|p| p.get("auth_status"))
+                .and_then(|v| v.as_str()),
+            Some("local"),
+            "the seeded PersonNode must be the local user (auth_status: local)"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reopening_database_does_not_seed_a_second_person() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let db_path = temp_dir.path().join("test.db");
+
+        // First open seeds the local person.
+        {
+            let mut store = Arc::new(SqliteStore::new(db_path.clone()).await?);
+            let service = NodeService::new(&mut store).await?;
+            assert_eq!(service.query_nodes_by_type("person", None).await?.len(), 1);
+        }
+
+        // Second open of the same database must be idempotent — still one person.
+        let mut store = Arc::new(SqliteStore::new(db_path).await?);
+        let service = NodeService::new(&mut store).await?;
+        assert_eq!(
+            service.query_nodes_by_type("person", None).await?.len(),
+            1,
+            "re-opening an existing database must not seed a second PersonNode"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implements **PersonNode** as a core node type — the identity primitive the [ADR-037 access model](https://github.com/NodeSpaceAI/nodespace-docs/blob/main/decisions/037-collection-access-model.md) builds on ("members of a restricted collection = person nodes only"). Closes #133.

Owns the **type only** (schema + behavior). No PersonNode *instance* is seeded — the first PersonNode is created + named + bound to a Supabase identity at Pro sync-onboarding (nodespace-sync#125).

## Changes
- **`PersonNodeBehavior`** (`behaviors/mod.rs`): `validate` (name/content non-empty), `can_have_children=false`, plain-text, name is the embeddable content (people are searchable), no parent contribution. Plus a **computed `display_name`** — `custom:displayName` override → content → `"Unknown Person"` placeholder.
- Registered in `NodeBehaviorRegistry::new()`.
- **`person` core schema** (`core_schemas.rs`): `content` = name, `is_core`, no extra fields.
- Tests: validation + display-name precedence; registry/schema count asserts updated.

Unblocks the Pro-side enforcement (nodespace-sync#125 auth_identities/onboarding, #126 admin) and is the person-only check for nodespace-core#1372.

`cargo test` (behaviors + core_schemas) green, clippy clean.