### PR TITLE
Remove auth_status from PersonNode seeding

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -2004,11 +2004,10 @@ impl NodeBehavior for CustomNodeBehavior {
 
 /// Built-in behavior for person nodes
 ///
-/// Person nodes are identity nodes — they carry `name` (optional) and `email`
-/// (optional, format-validated when present), plus `auth_status` for the local
-/// user (ADR-037: seeded as `"local"`, bound to a Supabase identity on Pro
-/// upgrade via nodespace-sync#125). *Role/permission* lives on the `member_of`
-/// relationship, not on the node.
+/// Person nodes are pure identity — they carry `name` (optional) and `email`
+/// (optional, format-validated when present). Auth state (`auth_status`) lives
+/// on `DatabaseSettingsNode`; tenant role lives on the `has_role` edge
+/// (PersonNode → DatabaseSettingsNode). Neither is a PersonNode property.
 pub struct PersonNodeBehavior;
 
 impl PersonNodeBehavior {

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -922,12 +922,14 @@ impl NodeService {
         Ok(service)
     }
 
-    /// ADR-037 (#133): seed exactly one **local** PersonNode — the local user,
-    /// marked `auth_status: "local"`. Idempotent: skips when a person already exists,
-    /// so an existing database is backfilled on next open too. On Pro upgrade this node
-    /// is *bound* to a Supabase identity (nodespace-sync#125) — a single `auth_identities`
-    /// row keyed on the node id — not recreated; there is no "now set up your user" step.
-    /// Name/email stay absent until the user fills them in (PersonNodeBehavior allows it).
+    /// ADR-037 (#133): seed exactly one local PersonNode — the local user.
+    /// Idempotent: skips when a person already exists, so an existing database
+    /// is backfilled on next open too. Name/email stay absent until the user
+    /// fills them in (PersonNodeBehavior allows it). On Pro upgrade this node
+    /// is bound to a Supabase identity (nodespace-sync#125) via a single
+    /// `auth_identities` row — not recreated.
+    ///
+    /// Note: `auth_status` lives on DatabaseSettingsNode (#1398), not here.
     async fn seed_local_person_if_needed(&self) -> Result<(), NodeServiceError> {
         if !self.query_nodes_by_type("person", None).await?.is_empty() {
             return Ok(());
@@ -935,7 +937,7 @@ impl NodeService {
         let person = Node::new(
             "person".to_string(),
             String::new(),
-            serde_json::json!({ "person": { "auth_status": "local" } }),
+            serde_json::json!({}),
         );
         let id = self.create_node(person).await?;
         tracing::info!(node_id = %id, "🌱 Seeded local PersonNode (ADR-037)");

--- a/packages/core/tests/person_seed_test.rs
+++ b/packages/core/tests/person_seed_test.rs
@@ -1,11 +1,10 @@
 //! Local PersonNode seeding tests (Issue #133, ADR-037)
 //!
 //! ADR-037 mandates that every install — free included — seeds exactly one
-//! local PersonNode (the local user, `auth_status: "local"`). On Pro upgrade
-//! this node is *bound* to a Supabase identity (nodespace-sync#125), not
-//! recreated. These tests verify:
+//! local PersonNode (the local user). On Pro upgrade this node is bound to a
+//! Supabase identity (nodespace-sync#125), not recreated. These tests verify:
 //! 1. Constructing a NodeService on a fresh database seeds exactly one person.
-//! 2. The seeded person carries `auth_status: "local"`.
+//! 2. The seeded person has no auth_status (that lives on DatabaseSettingsNode, #1398).
 //! 3. Re-opening the same database does NOT create a second person (idempotent).
 
 #[cfg(test)]
@@ -29,16 +28,14 @@ mod person_seed_tests {
             1,
             "a fresh install must seed exactly one local PersonNode"
         );
-        // Properties are stored namespaced under the node type:
-        // properties["person"]["auth_status"].
-        assert_eq!(
+        // auth_status lives on DatabaseSettingsNode (#1398), not on PersonNode
+        assert!(
             people[0]
                 .properties
                 .get("person")
                 .and_then(|p| p.get("auth_status"))
-                .and_then(|v| v.as_str()),
-            Some("local"),
-            "the seeded PersonNode must be the local user (auth_status: local)"
+                .is_none(),
+            "seeded PersonNode must not carry auth_status — that belongs on DatabaseSettingsNode"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

Follow-up to #1401. The seeded PersonNode incorrectly included `auth_status: "local"` in its properties. Per the revised ADR-037 model (updated this session), `auth_status` belongs on `DatabaseSettingsNode` (#1398), not PersonNode — it describes whether the *database* is synced, not who the person is.

- Remove `auth_status` from `seed_local_person_if_needed` — seeded node now has empty properties
- Update `person_seed_test.rs` to assert `auth_status` is **absent** from the seeded PersonNode
- Update doc comment on seeding method to note where `auth_status` lives

## Test plan
- [ ] `cargo test -p nodespace-core person_seed` — 2 tests pass
- [ ] `cargo clippy -p nodespace-core` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)