### PR TITLE
fix(test): green the 2 core schema-test failures

### DIFF
--- a/packages/core/src/schema/mod.rs
+++ b/packages/core/src/schema/mod.rs
@@ -1468,7 +1468,10 @@ mod tests {
         use crate::services::node_service::normalize_schema_id;
         let entity_name = "Customer Invoice";
         let schema_id = normalize_schema_id(entity_name);
-        assert_eq!(schema_id, "customer-invoice");
+        // normalize_schema_id joins on '_' (see its dedicated unit tests); the core
+        // hardcoded schema ids that use hyphens (code-block, …) are not generated
+        // through this path.
+        assert_eq!(schema_id, "customer_invoice");
     }
 
     #[test]

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -134,7 +134,8 @@ async fn create_base_schema(svc: &Arc<NodeService>, name: &str, field_names: &[&
 #[tokio::test]
 async fn test_update_schema_add_valid_title_template() {
     let (svc, _tmp) = create_test_service().await;
-    let schema_id = create_base_schema(&svc, "Person", &["first_name", "last_name"]).await;
+    // NB: not "Person" — that now collides with the core `person` schema (ADR-037).
+    let schema_id = create_base_schema(&svc, "Employee", &["first_name", "last_name"]).await;
 
     let result = handle_update_schema(
         &svc,

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -581,7 +581,7 @@ pub fn is_valid_node_id(node_id: &str) -> bool {
 /// Derive a stable schema node ID from the schema's display name.
 ///
 /// Schema nodes use their normalized name as ID (e.g. "Invoice" → "invoice",
-/// "Customer Profile" → "customer-profile") so they can be referenced
+/// "Customer Profile" → "customer_profile") so they can be referenced
 /// predictably by type name rather than an opaque UUID.
 pub(crate) fn normalize_schema_id(name: &str) -> String {
     name.to_lowercase()
@@ -934,11 +934,7 @@ impl NodeService {
         if !self.query_nodes_by_type("person", None).await?.is_empty() {
             return Ok(());
         }
-        let person = Node::new(
-            "person".to_string(),
-            String::new(),
-            serde_json::json!({}),
-        );
+        let person = Node::new("person".to_string(), String::new(), serde_json::json!({}));
         let id = self.create_node(person).await?;
         tracing::info!(node_id = %id, "🌱 Seeded local PersonNode (ADR-037)");
         Ok(())


### PR DESCRIPTION
The only red in a full core diagnostic — 2 failing schema tests.

- **`test_update_schema_add_valid_title_template`** created a base schema named `"Person"`, which now collides with the **core `person` schema** added by ADR-037 (#1401): `Schema 'Person' already exists`. Renamed the test entity to `"Employee"`. (Regression from #1401.)
- **`test_integration_schema_id_generation`** asserted `"customer-invoice"` (hyphen), but `normalize_schema_id` joins on `_` — its dedicated unit tests (`normalize_schema_id_tests`) confirm `"Customer Profile" → "customer_profile"`. The hyphenated core ids (`code-block`, …) are hardcoded, not generated through this path. Fixed the assertion to `"customer_invoice"` and the stale doc example. (Pre-existing.)

`cargo test -p nodespace-core --lib`: **954 passed, 0 failed** (was 952/2). Test-only + a doc comment; no behavior change.