### PR TITLE
feat(#21): release builds default to pro.nodespace.ai for auth

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -13,10 +13,14 @@ use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{InitiateOAuthRequest, WatchSyncStatusRequest};
 use crate::services::{ProClient, ProTier};
 
-/// Default cloud-worker URL when the frontend doesn't supply one.
-/// Matches `nodespace-sync/cloud-worker`'s default bind
-/// (`127.0.0.1:8787`); override via the optional `worker_url` arg.
+/// Default auth-Worker URL when the frontend doesn't supply one. Release builds
+/// hit the deployed canonical domain (`pro.nodespace.ai`, nodespace-cloud#21);
+/// debug builds hit the local `wrangler dev` worker (`127.0.0.1:8787`, what
+/// `device-sync.sh` runs). Either is overridable via the optional `worker_url` arg.
+#[cfg(debug_assertions)]
 const DEFAULT_WORKER_URL: &str = "http://127.0.0.1:8787";
+#[cfg(not(debug_assertions))]
+const DEFAULT_WORKER_URL: &str = "https://pro.nodespace.ai";
 
 /// Flag tracking whether the status-stream task is already running.
 /// Module-level so repeated calls to `pro_subscribe_sync_status` from


### PR DESCRIPTION
`pro.nodespace.ai` is deployed + live (`/healthz`=200, nodespace-cloud#21). Splits the desktop app's `DEFAULT_WORKER_URL` by build profile: **release → `https://pro.nodespace.ai`** (canonical deployed auth Worker), **debug → `http://127.0.0.1:8787`** (the local `wrangler dev` worker `device-sync.sh` runs). Both overridable via the optional `worker_url` arg; local dev unaffected. Compiles clean.