### PR TITLE
Fix Pro build: remove invalid _comment key from tauri.pro.conf.json (#156)

### DIFF
--- a/packages/desktop-app/src-tauri/tauri.pro.conf.json
+++ b/packages/desktop-app/src-tauri/tauri.pro.conf.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "_comment": "Pro-edition build override (#156). Pass via `tauri build --config src-tauri/tauri.pro.conf.json` (see nodespace-sync/scripts/build-pro-dmg.sh). It only adds the `nodespaced-pro` sync daemon to the bundled sidecars; the Pro cloud config is baked into the Rust binary at build time via NODESPACE_PRO_* env vars, and `daemon_setup` then installs + launches nodespaced-pro instead of the community nodespaced.",
   "bundle": {
     "externalBin": [
       "binaries/nodespaced",


### PR DESCRIPTION
Running `scripts/build-pro-dmg.sh` surfaced that the Pro build fails schema validation: `tauri.conf.json error: Additional properties are not allowed ('_comment' was unexpected)`. Tauri 2's config schema is strict, so the `_comment` field I added in NodeSpaceAI/nodespace-core#1405 breaks `tauri build --config tauri.pro.conf.json`. Remove it (JSON can't carry comments; the rationale lives in `nodespace-sync/scripts/build-pro-dmg.sh` + NodeSpaceAI/nodespace-sync#156). Trivial config-only fix.