### PR TITLE
Fix Pro build: stage daemon sidecars in Resources/binaries so the app can launch them

### DIFF
--- a/packages/desktop-app/src-tauri/tauri.pro.conf.json
+++ b/packages/desktop-app/src-tauri/tauri.pro.conf.json
@@ -5,6 +5,11 @@
       "binaries/nodespaced",
       "binaries/nodespace",
       "binaries/nodespaced-pro"
+    ],
+    "resources": [
+      "resources/models/**/*",
+      "binaries/nodespaced-pro-*",
+      "binaries/nodespace-*"
     ]
   }
 }


### PR DESCRIPTION
## Problem

A freshly-installed Pro build launches but shows **"NodeSpace background service is not running"** — the bundled `nodespaced-pro` daemon never starts.

Root cause: the desktop app's `daemon_setup` extractor resolves sidecars from `Contents/Resources/binaries/<name>-<triple>` (`BaseDirectory::Resource`):

```
ERROR Daemon setup failed: Cannot stat bundled sidecar
.../Contents/Resources/binaries/nodespaced-pro-aarch64-apple-darwin: No such file or directory
```

…but Tauri's `externalBin` places the sidecars **bare-named in `Contents/MacOS/`**. The two locations never match, so the daemon is never copied into `~/.nodespace/bin/`, the launchd agent is never written, and no background service runs.

## Fix

Add a `bundle.resources` entry to `tauri.pro.conf.json` so the Pro daemon (`nodespaced-pro`) and the CLI (`nodespace`) are also copied to `Contents/Resources/binaries/<name>-<triple>`, where the extractor looks. Triple-agnostic globs keep this correct on whichever host arch builds. The existing `resources/models/**/*` entry is preserved.

## Verification

Rebuilt the Pro bundle and confirmed:
- `Contents/Resources/binaries/nodespaced-pro-aarch64-apple-darwin` + `nodespace-aarch64-apple-darwin` are now present.
- On launch the app logs `Extracting nodespaced-pro → ~/.nodespace/bin`, `launchd agent bootstrapped`, **`nodespaced is up and healthy`**, and the daemon connects to the cloud (`schema=tenant_demo`, gRPC serving). No "background service" banner.
- Community builds are unaffected (Pro behavior is gated on compile-time `option_env!`; this config is only applied via `--config tauri.pro.conf.json`).

Needed for the shareable build (NodeSpaceAI/nodespace-sync#156) to actually work end-to-end for team-wide testing.