### PR TITLE
Fix stale stack claim in CLAUDE.md (libsql/SQLite, not SurrealDB)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Make breaking changes without hesitation. Fix breakage immediately in the same s
 
 ## Project Overview
 
-NodeSpace is an AI-native knowledge management system: Rust backend, Svelte 5 frontend, Tauri 2.0 desktop. Stack: SurrealDB/RocksDB, async/await trait-based Rust, $state/$derived/$effect runes. UI-first approach — build interfaces with mock data before storage integration.
+NodeSpace is an AI-native knowledge management system: Rust backend, Svelte 5 frontend, Tauri 2.0 desktop. Stack: libsql/SQLite (local store — `packages/core/src/db/`), async/await trait-based Rust, $state/$derived/$effect runes. UI-first approach — build interfaces with mock data before storage integration.
 
 **Before starting any task, read:**
 - [`overview.md`](../nodespace-docs/development/overview.md) - Complete development process


### PR DESCRIPTION
The local store is **libsql/SQLite** (`packages/core/src/db/sqlite_store.rs`, `schema.sql`), not SurrealDB/RocksDB — the CLAUDE.md stack line predated the migration. Surfaced during the nodespace-sync full-graph sync epic (NodeSpaceAI/nodespace-sync#162), where the stale claim misled data-layer reasoning (hierarchy lives in the `relationship` edge table, not node columns).