### PR TITLE
Fix cross-window hierarchy sync rendering (eager lazy client, reparent, reactive edges)

### DIFF
--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -39,6 +39,30 @@ fn toggle_sidebar() -> String {
     "Sidebar toggled!".to_string()
 }
 
+/// True when frontend-console capture is enabled (env `NS_FRONTEND_LOG` set to a
+/// file path). The frontend gates its forwarding on this so normal builds pay no
+/// IPC cost; diagnostics set the env per window to capture the Svelte event flow.
+#[tauri::command]
+fn frontend_log_enabled() -> bool {
+    std::env::var_os("NS_FRONTEND_LOG").is_some()
+}
+
+/// Append a frontend log line to the file named by `NS_FRONTEND_LOG`. No-op if the
+/// env var is unset. Best-effort (diagnostic only) — never fails the caller.
+#[tauri::command]
+fn frontend_log(line: String) {
+    if let Some(path) = std::env::var_os("NS_FRONTEND_LOG") {
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(f, "{line}");
+        }
+    }
+}
+
 /// Report the current daemon health to the frontend.
 ///
 /// Returns "healthy", "starting", or "not_running". The frontend uses this
@@ -209,10 +233,19 @@ pub fn run() {
             // Register shutdown token as managed state for background task coordination.
             app.manage(shutdown_token_for_setup.clone());
 
-            // Spawn async task to start daemon (if needed) then connect gRPC client.
+            // Manage the gRPC client EAGERLY via a lazy channel (connects on first
+            // RPC). Previously `manage(GrpcClient)` ran only after the async connect
+            // below, so a frontend command issued at startup (e.g. the date page's
+            // `get_children_tree`) raced it and got a fatal "state not managed for
+            // field `client`", closing the view (nodespace-sync#162). With the client
+            // managed up front, an early call instead yields a retryable transport
+            // error until the daemon is reachable.
+            #[cfg(unix)]
+            app.manage(crate::services::GrpcClient::connect_lazy());
+
+            // Spawn async task to start the daemon (if needed) and wire up the
+            // watcher, token stream, and Pro probe on the (already-managed) client.
             // setup() is synchronous so we can't block_on here — spawn a task instead.
-            // manage(GrpcClient) happens inside the task; commands that need it will
-            // fail gracefully until the connection is established.
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             {
                 use tauri::Emitter;
@@ -263,67 +296,40 @@ pub fn run() {
                         }
                     }
 
-                    // Connect gRPC client over UDS. Retry briefly in case the
-                    // daemon socket came up just after wait_for_daemon returned.
-                    let grpc_result = {
-                        let mut result = crate::services::GrpcClient::connect().await;
-                        if result.is_err() {
-                            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                            result = crate::services::GrpcClient::connect().await;
-                        }
-                        result
-                    };
-                    match grpc_result {
-                        Ok(grpc_client) => {
-                            // Snapshot the underlying channel before
-                            // we hand `grpc_client` to managed state —
-                            // ProClient rides the same h2 connection.
-                            let channel = grpc_client.channel().await;
-                            app_handle.manage(grpc_client.clone());
-                            tracing::info!("gRPC client connected to nodespaced");
-                            watcher::spawn(app_handle.clone(), session_token);
-                            // Subscribe to token stream for ai-chat node inference events.
-                            commands::local_agent::start_token_stream_subscription(
-                                app_handle.clone(),
-                                grpc_client,
-                            );
+                    // The gRPC client is already managed (lazy) above. Fetch it and
+                    // wire the watcher, token stream, and Pro probe; the underlying
+                    // channel connects on first use.
+                    use tauri::Manager;
+                    let grpc_client = (*app_handle.state::<crate::services::GrpcClient>()).clone();
+                    let channel = grpc_client.channel().await;
+                    watcher::spawn(app_handle.clone(), session_token);
+                    // Subscribe to token stream for ai-chat node inference events.
+                    commands::local_agent::start_token_stream_subscription(
+                        app_handle.clone(),
+                        grpc_client,
+                    );
 
-                            // Pro capability probe: a single
-                            // WatchSyncStatus call on the same channel.
-                            // Community `nodespaced` returns
-                            // `Status::Unimplemented` → tier=Community
-                            // → sync pill stays hidden. Pro
-                            // `nodespaced-pro` answers the probe →
-                            // tier=Pro → pill renders and listens for
-                            // the `sync:status` stream.
-                            let pro = crate::services::ProClient::probe_on_channel(channel).await;
-                            let tier = pro.tier().await;
-                            let last_status = pro.last_status().await;
-                            let payload = serde_json::json!({
-                                "tier": tier,
-                                "initial_status": last_status.as_ref().map(|s| {
-                                    serde_json::json!({
-                                        "state": s.state,
-                                        "detail": s.detail,
-                                    })
-                                }),
-                            });
-                            app_handle.manage(pro);
-                            if let Err(e) = app_handle.emit("pro:tier-detected", payload) {
-                                tracing::warn!(
-                                    error = %e,
-                                    "failed to emit pro:tier-detected"
-                                );
-                            }
-                            tracing::info!(?tier, "Pro capability probe done");
-                        }
-                        Err(e) => {
-                            tracing::error!("Failed to connect to nodespaced: {e:#}");
-                            if let Some(window) = app_handle.get_webview_window("main") {
-                                let _ = window.emit("daemon-status", "not_running");
-                            }
-                        }
+                    // Pro capability probe: a single WatchSyncStatus call on the same
+                    // channel. Community `nodespaced` returns `Status::Unimplemented`
+                    // → tier=Community → sync pill stays hidden. Pro `nodespaced-pro`
+                    // answers → tier=Pro → pill renders and listens for `sync:status`.
+                    let pro = crate::services::ProClient::probe_on_channel(channel).await;
+                    let tier = pro.tier().await;
+                    let last_status = pro.last_status().await;
+                    let payload = serde_json::json!({
+                        "tier": tier,
+                        "initial_status": last_status.as_ref().map(|s| {
+                            serde_json::json!({
+                                "state": s.state,
+                                "detail": s.detail,
+                            })
+                        }),
+                    });
+                    app_handle.manage(pro);
+                    if let Err(e) = app_handle.emit("pro:tier-detected", payload) {
+                        tracing::warn!(error = %e, "failed to emit pro:tier-detected");
                     }
+                    tracing::info!(?tier, "Pro capability probe done");
                 });
             }
 
@@ -383,6 +389,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             toggle_sidebar,
+            frontend_log_enabled,
+            frontend_log,
             check_daemon_status,
             commands::pro_sync::pro_tier,
             commands::pro_sync::pro_subscribe_sync_status,

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -330,6 +330,30 @@ pub fn run() {
                         tracing::warn!(error = %e, "failed to emit pro:tier-detected");
                     }
                     tracing::info!(?tier, "Pro capability probe done");
+
+                    // Re-establish the "daemon unreachable" signal lost when the
+                    // eager lazy client replaced the connect()-or-emit path. The lazy
+                    // channel never fails at startup, so a genuinely-down daemon would
+                    // otherwise leave the UI silently empty. After the probe has
+                    // exercised the channel, confirm reachability with the same socket
+                    // check `check_daemon_status` uses and emit `not_running` so
+                    // app-shell shows its error banner + retry (Issue #1179). `Starting`
+                    // is transient — only `NotRunning` trips the banner.
+                    {
+                        use daemon_setup::{check_daemon_socket, DaemonStatus};
+                        if let Some(home) = dirs::home_dir() {
+                            let socket_path = home.join(crate::constants::DAEMON_SOCKET_RELATIVE);
+                            if matches!(
+                                check_daemon_socket(socket_path.as_path()).await,
+                                DaemonStatus::NotRunning
+                            ) {
+                                tracing::error!("nodespaced unreachable after startup");
+                                if let Some(window) = app_handle.get_webview_window("main") {
+                                    let _ = window.emit("daemon-status", "not_running");
+                                }
+                            }
+                        }
+                    }
                 });
             }
 

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -57,6 +57,14 @@ impl GrpcClient {
 
         tracing::info!(socket = %sock.display(), "Connected to nodespaced");
 
+        Ok(Self::from_channel(channel))
+    }
+
+    /// Wrap an established (or lazy) channel in the full service-client bundle.
+    /// Shared by [`connect`] and [`connect_lazy`] so the set of service clients
+    /// stays in sync as new services are added.
+    #[cfg(unix)]
+    fn from_channel(channel: Channel) -> Self {
         let inner = GrpcClientInner {
             node: NodeServiceClient::new(channel.clone()),
             import: ImportServiceClient::new(channel.clone()),
@@ -66,10 +74,9 @@ impl GrpcClient {
             local_agent: LocalAgentServiceClient::new(channel.clone()),
             channel,
         };
-
-        Ok(Self {
+        Self {
             inner: Arc::new(RwLock::new(inner)),
-        })
+        }
     }
 
     /// Build a client over a LAZY UDS channel — it connects on the first RPC
@@ -84,18 +91,7 @@ impl GrpcClient {
         let sock = resolve_socket_path();
         tracing::info!(socket = %sock.display(), "gRPC client (lazy) — connects on first use");
         let channel = uds_channel_lazy(&sock);
-        let inner = GrpcClientInner {
-            node: NodeServiceClient::new(channel.clone()),
-            import: ImportServiceClient::new(channel.clone()),
-            settings: SettingsServiceClient::new(channel.clone()),
-            embeddings: EmbeddingsServiceClient::new(channel.clone()),
-            agent_session: AgentSessionServiceClient::new(channel.clone()),
-            local_agent: LocalAgentServiceClient::new(channel.clone()),
-            channel,
-        };
-        Self {
-            inner: Arc::new(RwLock::new(inner)),
-        }
+        Self::from_channel(channel)
     }
 
     /// Borrow a clone of the `NodeServiceClient`.

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -72,6 +72,32 @@ impl GrpcClient {
         })
     }
 
+    /// Build a client over a LAZY UDS channel — it connects on the first RPC
+    /// rather than now, so this returns synchronously and can be `.manage()`'d at
+    /// app setup BEFORE the daemon socket is reachable. This removes the startup
+    /// race where the frontend invoked a command (e.g. `get_children_tree`) before
+    /// the async `connect()` had run, getting a fatal "state not managed for field
+    /// `client`" that closed the view. With a lazy client managed up front, an
+    /// early call instead waits / yields a retryable transport error.
+    #[cfg(unix)]
+    pub fn connect_lazy() -> Self {
+        let sock = resolve_socket_path();
+        tracing::info!(socket = %sock.display(), "gRPC client (lazy) — connects on first use");
+        let channel = uds_channel_lazy(&sock);
+        let inner = GrpcClientInner {
+            node: NodeServiceClient::new(channel.clone()),
+            import: ImportServiceClient::new(channel.clone()),
+            settings: SettingsServiceClient::new(channel.clone()),
+            embeddings: EmbeddingsServiceClient::new(channel.clone()),
+            agent_session: AgentSessionServiceClient::new(channel.clone()),
+            local_agent: LocalAgentServiceClient::new(channel.clone()),
+            channel,
+        };
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
+        }
+    }
+
     /// Borrow a clone of the `NodeServiceClient`.
     pub async fn client(&self) -> NodeServiceClient<Channel> {
         self.inner.read().await.node.clone()
@@ -144,6 +170,24 @@ async fn uds_channel(sock: &std::path::Path) -> Result<Channel, tonic::transport
             async move { UnixStream::connect(&sock).await.map(TokioIo::new) }
         }))
         .await
+}
+
+/// Lazy variant of [`uds_channel`] — builds the channel without connecting; the
+/// first RPC establishes (and later re-establishes) the UDS connection.
+#[cfg(unix)]
+fn uds_channel_lazy(sock: &std::path::Path) -> Channel {
+    use hyper_util::rt::TokioIo;
+    use tokio::net::UnixStream;
+    use tonic::transport::{Endpoint, Uri};
+    use tower::service_fn;
+
+    let sock = sock.to_path_buf();
+    Endpoint::from_static("http://localhost").connect_with_connector_lazy(service_fn(
+        move |_: Uri| {
+            let sock = sock.clone();
+            async move { UnixStream::connect(&sock).await.map(TokioIo::new) }
+        },
+    ))
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -95,6 +95,15 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     _updateTrigger++;
   });
 
+  // Also recompute the rendered outline when the hierarchy TREE changes — not only
+  // on node changes. A has_child edge synced from another window or the cloud
+  // mutates structureTree but fires no SharedNodeStore node event, so without this
+  // the new nesting (e.g. an indent done elsewhere) never re-rendered here
+  // (nodespace-sync#162).
+  let _structureUnsubscribe: (() => void) | null = structureTree.onChange(() => {
+    _updateTrigger++;
+  });
+
   // NOTE: Backend now returns children pre-sorted via fractional ordering (ORDER BY order ASC)
   // No frontend sorting needed - we trust the backend's ordering
 
@@ -1472,6 +1481,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       if (_subscriptionUnsubscribe) {
         _subscriptionUnsubscribe();
         _subscriptionUnsubscribe = null;
+      }
+      if (_structureUnsubscribe) {
+        _structureUnsubscribe();
+        _structureUnsubscribe = null;
       }
     },
 

--- a/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
@@ -26,12 +26,34 @@ export class ReactiveStructureTree {
   // so we must reassign after every mutation (see notifyChange())
   children = $state.raw(new Map<string, ChildInfo[]>());
 
+  // Explicit change subscribers. The Svelte-reactive `children` reassignment only
+  // re-renders consumers that read `children` inside a tracked scope; some consumers
+  // recompute off their own trigger (e.g. ReactiveNodeService._updateTrigger, bumped
+  // on SharedNodeStore node events — NOT on hierarchy edges). A synced has_child edge
+  // (indent/outdent from another window or the cloud) mutates the tree with no node
+  // event, so those consumers must subscribe here to recompute (nodespace-sync#162).
+  private changeSubscribers = new Set<() => void>();
+
+  /** Subscribe to any hierarchy change. Returns an unsubscribe fn. */
+  onChange(cb: () => void): () => void {
+    this.changeSubscribers.add(cb);
+    return () => this.changeSubscribers.delete(cb);
+  }
+
   /**
-   * Reassign the children map to trigger Svelte reactivity.
+   * Reassign the children map to trigger Svelte reactivity, then notify explicit
+   * subscribers.
    * $state.raw() only tracks reassignment, not in-place Map mutations.
    */
   private notifyChange() {
     this.children = new Map(this.children);
+    for (const cb of this.changeSubscribers) {
+      try {
+        cb();
+      } catch {
+        /* a misbehaving subscriber must not break the tree */
+      }
+    }
   }
 
   /**
@@ -113,17 +135,26 @@ export class ReactiveStructureTree {
       return;
     }
 
-    // Check if child already has a DIFFERENT parent (tree invariant violation)
+    // Child already under a DIFFERENT parent → REPARENT (move it), don't reject.
+    // A node has exactly one parent, so a new has_child edge under a different
+    // parent means the node moved (indent/outdent/drag). Cloud sync delivers the
+    // new-parent edge and the old-parent edge-delete as independent events that can
+    // arrive in either order — and a move applied on the receiver's daemon emits a
+    // RelationshipCreated for the new parent but no delete for the old (the daemon
+    // reparents in one step). Rejecting here left the node stranded under its old
+    // parent on every OTHER window (nodespace-sync#162: indent/outdent not
+    // reflected across windows / cloud sync). Prune the old parent, then add below.
     const currentParent = this.getParent(childId);
     if (currentParent && currentParent !== parentId) {
-      log.error(
-        `Tree invariant violation: ${childId} already has parent ${currentParent}, cannot add to ${parentId}`,
-        rel
-      );
-      // In a tree structure, a node can only have one parent
-      // This indicates either a database inconsistency or a bug in event emission
-      // For now, we'll ignore the duplicate edge to preserve tree structure
-      return;
+      const oldChildren = this.children.get(currentParent);
+      if (oldChildren) {
+        const pruned = oldChildren.filter((c) => c.nodeId !== childId);
+        if (pruned.length === 0) {
+          this.children.delete(currentParent);
+        } else {
+          this.children.set(currentParent, pruned);
+        }
+      }
     }
 
     // Binary search to find insertion position

--- a/packages/desktop-app/src/lib/utils/logger.ts
+++ b/packages/desktop-app/src/lib/utils/logger.ts
@@ -83,6 +83,52 @@ const DEFAULT_LEVEL: LogLevel = isProd
  * // Advanced: Direct instantiation for testing
  * const log = new Logger({ enabled: true, level: 'debug', prefix: 'Test' });
  */
+// ── Frontend-console capture (diagnostic) ──────────────────────────────────────
+// When `NS_FRONTEND_LOG` is set (a file path), the app's `frontend_log` Tauri
+// command appends each frontend log line to that file. Gated by a one-time
+// `frontend_log_enabled` query, so normal builds, the browser, and tests pay no
+// cost. A long-term aid for diagnosing cross-window / cloud-sync behaviour in the
+// real GUI (where the Svelte console isn't otherwise capturable headlessly).
+let forwardState: 'unknown' | 'on' | 'off' = 'unknown';
+let forwardInit: Promise<void> | null = null;
+
+function forwardToFile(level: LogLevel, message: string, data?: unknown): void {
+  void (async () => {
+    try {
+      if (forwardState === 'unknown') {
+        if (!forwardInit) {
+          forwardInit = (async () => {
+            try {
+              const { invoke } = await import('@tauri-apps/api/core');
+              forwardState = (await invoke<boolean>('frontend_log_enabled')) ? 'on' : 'off';
+            } catch {
+              forwardState = 'off';
+            }
+          })();
+        }
+        await forwardInit;
+      }
+      if (forwardState !== 'on') return;
+      const { invoke } = await import('@tauri-apps/api/core');
+      let line = `${new Date().toISOString()} [${level.toUpperCase()}] ${message}`;
+      if (data !== undefined) {
+        try {
+          line += ` ${JSON.stringify(data)}`;
+        } catch {
+          line += ` ${String(data)}`;
+        }
+      }
+      await invoke('frontend_log', { line });
+    } catch {
+      /* best-effort diagnostic only */
+    }
+  })();
+}
+
+// Probe capture-enabled at module load so debug logging activates promptly when
+// NS_FRONTEND_LOG is set (before the first cross-window sync events arrive).
+forwardToFile('info', '[logger] frontend-console capture initialised');
+
 export class Logger {
   private config: LoggerConfig;
 
@@ -97,6 +143,10 @@ export class Logger {
 
   private shouldLog(level: LogLevel): boolean {
     if (!this.config.enabled) return false;
+
+    // When frontend-console capture is on (NS_FRONTEND_LOG set), log every level
+    // so the captured file is complete even though release builds default to warn.
+    if (forwardState === 'on') return true;
 
     const currentLevelIndex = LOG_LEVELS.indexOf(this.config.level);
     const requestedLevelIndex = LOG_LEVELS.indexOf(level);
@@ -120,6 +170,7 @@ export class Logger {
       } else {
         console.debug(this.formatMessage(message));
       }
+      forwardToFile('debug', this.formatMessage(message), data);
     }
   }
 
@@ -134,6 +185,7 @@ export class Logger {
       } else {
         console.log(this.formatMessage(message));
       }
+      forwardToFile('info', this.formatMessage(message), data);
     }
   }
 
@@ -148,6 +200,7 @@ export class Logger {
       } else {
         console.warn(this.formatMessage(message));
       }
+      forwardToFile('warn', this.formatMessage(message), data);
     }
   }
 
@@ -162,6 +215,7 @@ export class Logger {
       } else {
         console.error(this.formatMessage(message));
       }
+      forwardToFile('error', this.formatMessage(message), data);
     }
   }
 

--- a/packages/desktop-app/src/lib/utils/logger.ts
+++ b/packages/desktop-app/src/lib/utils/logger.ts
@@ -93,6 +93,9 @@ let forwardState: 'unknown' | 'on' | 'off' = 'unknown';
 let forwardInit: Promise<void> | null = null;
 
 function forwardToFile(level: LogLevel, message: string, data?: unknown): void {
+  // Tests pay no cost: never touch the Tauri `invoke` bridge under VITEST, or the
+  // one-time `frontend_log_enabled` probe pollutes invoke-call assertions elsewhere.
+  if (isTest) return;
   void (async () => {
     try {
       if (forwardState === 'unknown') {

--- a/packages/desktop-app/src/tests/integration/rapid-hierarchy-operations.test.ts
+++ b/packages/desktop-app/src/tests/integration/rapid-hierarchy-operations.test.ts
@@ -55,7 +55,8 @@ vi.mock('$lib/stores/reactive-structure-tree.svelte', () => ({
     moveInMemoryRelationship: vi.fn(),
     getChildren: vi.fn(() => []),
     getChildrenWithOrder: vi.fn(() => []),
-    getParent: vi.fn(() => null)
+    getParent: vi.fn(() => null),
+    onChange: vi.fn(() => () => {})
   }
 }));
 

--- a/packages/desktop-app/src/tests/services/browser-sync-service.test.ts
+++ b/packages/desktop-app/src/tests/services/browser-sync-service.test.ts
@@ -214,11 +214,13 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       expect(structureTree.getChildren('parent1')).toContain('child1');
     });
 
-    it('should handle duplicate relationship to same parent (second edge rejected due to tree invariant)', async () => {
-      // Scenario: Two relationships to the same parent (duplicate) before node:created
-      // Note: ReactiveStructureTree enforces a tree structure (not DAG),
-      // so a node can only have one parent. Attempting to add a second parent
-      // is logged as a tree invariant violation and rejected.
+    it('should reparent on a second relationship to a different parent (single-parent tree)', async () => {
+      // Scenario: Two has_child edges naming DIFFERENT parents for the same child
+      // arrive before node:created. ReactiveStructureTree enforces a single-parent
+      // tree, so the second edge is treated as a MOVE: the child is pruned from the
+      // first parent and re-attached under the second (nodespace-sync#162). A move
+      // applied on another window/cloud delivers the new-parent edge with no old-parent
+      // delete, so reparenting (not rejecting) is what keeps windows consistent.
 
       const nodeData = createTestNode('child');
       registerMockNode(nodeData);
@@ -244,14 +246,12 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       // First relationship arrives
       testableService.handleEvent(relationship1);
 
-      // Second relationship to different parent arrives (violates tree structure)
-      // This is logged as an error but doesn't crash
+      // Second relationship to a different parent arrives → reparent (move)
       testableService.handleEvent(relationship2);
 
-      // First parent relationship exists
-      expect(structureTree.getChildren('parent1')).toContain('child');
-      // Second parent relationship is rejected (tree invariant violation)
-      expect(structureTree.getChildren('parent2')).not.toContain('child');
+      // Child has moved to the new parent: pruned from parent1, present under parent2
+      expect(structureTree.getChildren('parent1')).not.toContain('child');
+      expect(structureTree.getChildren('parent2')).toContain('child');
 
       // Now create the node (Issue #724: ID-only)
       testableService.handleEvent({
@@ -265,9 +265,9 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
         expect(sharedNodeStore.getNode('child')).toBeDefined();
       });
 
-      // Verify state is consistent with tree structure
-      expect(structureTree.getChildren('parent1')).toContain('child');
-      expect(structureTree.getChildren('parent2')).not.toContain('child');
+      // State stays consistent after the node is materialised: child under parent2 only
+      expect(structureTree.getChildren('parent1')).not.toContain('child');
+      expect(structureTree.getChildren('parent2')).toContain('child');
     });
   });
 

--- a/packages/desktop-app/src/tests/services/reactive-node-service.test.ts
+++ b/packages/desktop-app/src/tests/services/reactive-node-service.test.ts
@@ -66,7 +66,8 @@ vi.mock('$lib/stores/reactive-structure-tree.svelte', () => ({
     moveInMemoryRelationship: vi.fn(),
     getChildren: vi.fn(() => []),
     getChildrenWithOrder: vi.fn(() => []),
-    getParent: vi.fn(() => null)
+    getParent: vi.fn(() => null),
+    onChange: vi.fn(() => () => {})
   }
 }));
 

--- a/packages/desktop-app/src/tests/unit/outdent-ordering.test.ts
+++ b/packages/desktop-app/src/tests/unit/outdent-ordering.test.ts
@@ -69,6 +69,7 @@ vi.mock('$lib/stores/reactive-structure-tree.svelte', () => ({
     getParent: vi.fn(() => null),
     removeChild: vi.fn(),
     addChild: vi.fn(),
+    onChange: vi.fn(() => () => {}),
     children: new Map()
   }
 }));

--- a/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
+++ b/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
@@ -503,29 +503,21 @@ describe('ReactiveStructureTree', () => {
       expect(childInfo.find(c => c.nodeId === 'child1')?.order).toBe(5.0);
     });
 
-    it('should prevent adding child with different parent (tree invariant)', () => {
+    it('reparents (moves) a child when added under a different parent', () => {
+      // The one-parent invariant is preserved by MOVING, not by rejecting: a
+      // has_child edge under a new parent (an indent synced from another window)
+      // means the node moved. Rejecting it left the node stranded under its old
+      // parent across windows (nodespace-sync#162).
       structureTree.children.clear();
 
-      // Add child to parent1
-      structureTree.__testOnly_addChild({
-        parentId: 'parent1',
-        childId: 'child1',
-        order: 1.0
-      });
+      structureTree.__testOnly_addChild({ parentId: 'parent1', childId: 'child1', order: 1.0 });
 
-      // Try to add same child to parent2 (should be rejected due to tree invariant)
-      structureTree.__testOnly_addChild({
-        parentId: 'parent2',
-        childId: 'child1',
-        order: 1.0
-      });
+      // Same child added under parent2 → it moves there.
+      structureTree.__testOnly_addChild({ parentId: 'parent2', childId: 'child1', order: 1.0 });
 
-      // Verify child1 only belongs to parent1 (tree invariant preserved)
-      expect(structureTree.getChildren('parent1')).toEqual(['child1']);
-      expect(structureTree.getChildren('parent2')).toEqual([]);
-
-      // Verify child1's parent is still parent1
-      expect(structureTree.getParent('child1')).toBe('parent1');
+      expect(structureTree.getChildren('parent1')).toEqual([]); // pruned from old parent
+      expect(structureTree.getChildren('parent2')).toEqual(['child1']); // now under new parent
+      expect(structureTree.getParent('child1')).toBe('parent2');
     });
   });
 
@@ -826,6 +818,34 @@ describe('ReactiveStructureTree', () => {
 
       // Verify child3 inserted in correct position
       expect(structureTree.getChildren('parent2')).toEqual(['child2', 'child3', 'child4']);
+    });
+  });
+
+  describe('addChild reparents across parents (cloud-sync indent/outdent)', () => {
+    it('moves a child to the new parent when addChild names a different parent', () => {
+      // A node already under `old` parent (e.g. a line under today's date page).
+      structureTree.addChild({ parentId: 'old', childId: 'n', order: 1 });
+      expect(structureTree.getChildren('old')).toEqual(['n']);
+
+      // A has_child edge under a DIFFERENT parent arrives (indent on another
+      // window): the daemon reparents in one step, so only a relationship:created
+      // for the new parent is delivered — possibly before any old-edge delete.
+      // It must MOVE the node, not be rejected as an "invariant violation"
+      // (nodespace-sync#162: indent not reflected across windows).
+      structureTree.addChild({ parentId: 'p1', childId: 'n', order: 1 });
+
+      expect(structureTree.getChildren('p1')).toEqual(['n']);
+      expect(structureTree.getChildren('old')).toEqual([]); // pruned from old parent
+      expect(structureTree.getParent('n')).toBe('p1');
+    });
+
+    it('a later relationship:deleted for the old edge is a harmless no-op', () => {
+      structureTree.addChild({ parentId: 'old', childId: 'n', order: 1 });
+      structureTree.addChild({ parentId: 'p1', childId: 'n', order: 1 }); // reparent
+      // Old-edge delete arrives afterwards (out-of-order) — must not remove n from p1.
+      structureTree.removeChild({ parentId: 'old', childId: 'n', order: 0 });
+      expect(structureTree.getChildren('p1')).toEqual(['n']);
+      expect(structureTree.getParent('n')).toBe('p1');
     });
   });
 });


### PR DESCRIPTION
## What

The desktop-app side of the sync-polish epic (NodeSpaceAI/nodespace-sync#162). Two windows of the same account were not rendering synced hierarchy changes — typing in window A appeared as flat/missing nodes in window B even though both daemons held the correct graph. Root-caused to three frontend issues, all fixed here:

1. **Startup race** — `manage(GrpcClient)` ran only *after* the async connect, so an early frontend command (the date page's `get_children_tree`) hit a fatal `state not managed for field client` that closed the view. The gRPC client is now managed **eagerly via a lazy channel** (connects on first RPC); an early call yields a retryable transport error instead.
2. **Reparent rejected** — `addChildInternal` rejected a `has_child` edge whose child already had a different parent, stranding moved nodes on every *other* window. It now **reparents** (prunes the old parent), which is what a synced indent/outdent delivers.
3. **No re-render on synced edges** — a synced edge mutates the tree with no node event, so consumers that recompute off a node trigger never updated. Added `structureTree.onChange` → `_updateTrigger`.

Plus a frontend-console→file capture (`NS_FRONTEND_LOG` + `frontend_log` command, gated so normal builds pay no cost) that made this diagnosable headlessly.

## Review fixes (2nd commit)

- **Restore daemon-unreachable signal** — the eager lazy client never fails at connect, so the app-shell error banner (Issue #1179) stopped showing when the daemon is genuinely down. Re-emit `daemon-status: not_running` after a post-startup socket check (`Starting` stays transient).
- **Dedupe** `connect()`/`connect_lazy()` via a shared `from_channel`.
- **Test regressions fixed**: `onChange` added to three `structureTree` mocks; `browser-sync` second-parent case updated to expect reparent; `logger.forwardToFile` is a no-op under VITEST so its one-time probe no longer pollutes invoke-call assertions.

## Validation

- **Frontend: 3850/3850 vitest pass.** Rust: 25/25 lib tests pass. `cargo check` clean.
- Live two-window demo: `rel test` → Enter → Tab → child nests correctly in the other window; OCC conflict banners no longer reproduce.
- All node types (task, checkbox, header, code-block, quote-block, query) round-trip both directions with `node_type` + `properties` intact.

## Free-user (Community) impact

None negative. The `frontend_log` commands are no-ops without `NS_FRONTEND_LOG`; the Pro probe still returns Community → sync pill hidden. The reparent + eager-client changes are local-hierarchy/startup paths shared by all users and are covered by the full passing suite. The daemon-unreachable banner is **restored** for free users.

Relates to NodeSpaceAI/nodespace-sync#162.
