### PR TITLE
Pro re-login modal on AUTH_REQUIRED (T18, #1304)

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -28,6 +28,7 @@
   import { openUrl, isExternalUrl, isNodespaceUrl } from '$lib/utils/external-links';
   import OnboardingWizard from '$lib/components/onboarding/onboarding-wizard.svelte';
   import ProSyncPill from '$lib/components/pro-sync-pill.svelte';
+  import ProReloginModal from '$lib/components/pro-relogin-modal.svelte';
   import { proSync } from '$lib/stores/pro-sync.svelte';
   import ConflictToast from '$lib/components/conflict-toast.svelte';
 
@@ -40,6 +41,42 @@
 
   // First-launch onboarding wizard (Issue #1180).
   let showOnboarding = $state(false);
+
+  // Pro re-login prompt (T18, #1304). The daemon emits AUTH_REQUIRED when the
+  // persisted refresh token can't be renewed; we surface a modal offering a
+  // fresh sign-in or working offline. `reloginDismissed` is per-episode so
+  // "Work Offline" doesn't keep nagging, and is re-armed once the daemon
+  // leaves the auth-required state so a later failure prompts again.
+  let reloginDismissed = $state(false);
+  let reloginPending = $state(false);
+
+  let showReloginModal = $derived(
+    proSync.isPro && proSync.state === 'auth-required' && !reloginDismissed
+  );
+
+  $effect(() => {
+    if (proSync.state !== 'auth-required' && reloginDismissed) {
+      reloginDismissed = false;
+    }
+  });
+
+  async function handleReloginSignIn() {
+    if (reloginPending) return;
+    reloginPending = true;
+    try {
+      // Same PKCE flow the sync pill uses; the daemon opens the browser and
+      // the modal closes as `sync:status` transitions away from auth-required.
+      await invoke('pro_initiate_oauth');
+    } catch (e) {
+      log.warn('pro_initiate_oauth (relogin) failed', { error: e });
+    } finally {
+      reloginPending = false;
+    }
+  }
+
+  function handleReloginWorkOffline() {
+    reloginDismissed = true;
+  }
 
   /**
    * Sets up MCP event listeners for real-time UI updates
@@ -630,6 +667,15 @@
 
     <!-- Conflict resolution notifications (Issue #642) -->
     <ConflictToast />
+
+    <!-- Pro re-login prompt when the daemon's session can't be refreshed (T18, #1304) -->
+    <ProReloginModal
+      open={showReloginModal}
+      detail={proSync.detail}
+      pending={reloginPending}
+      onSignIn={handleReloginSignIn}
+      onWorkOffline={handleReloginWorkOffline}
+    />
   </NodeServiceContext>
 </ThemeProvider>
 

--- a/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
+++ b/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
@@ -1,0 +1,169 @@
+<!--
+  Pro-tier re-login modal (T18, #1304).
+
+  Surfaced by the app shell when the Pro daemon reports `AUTH_REQUIRED`
+  (`SyncStatusEvent.state` = 4) — i.e. the persisted refresh token could
+  not be renewed, so CloudSyncService needs a fresh interactive sign-in.
+
+  Purely presentational: the shell owns the visibility + the actions.
+  - "Sign In Again" kicks off the PKCE flow (`pro_initiate_oauth`); the
+    daemon opens the browser and the modal closes as `sync:status`
+    transitions away from `auth-required`.
+  - "Work Offline" dismisses the modal for this auth-required episode.
+    Local edits keep saving and replay once a session is restored, so
+    nothing is lost by staying offline.
+-->
+
+<script lang="ts">
+  interface Props {
+    /** Whether the modal is visible. */
+    open?: boolean;
+    /** Free-form daemon detail (e.g. the refresh error); shown if present. */
+    detail?: string;
+    /** True while an InitiateOAuth call is in flight — disables the buttons. */
+    pending?: boolean;
+    /** Start a fresh interactive sign-in. */
+    onSignIn: () => void;
+    /** Keep working without syncing for now. */
+    onWorkOffline: () => void;
+  }
+
+  let { open = false, detail = '', pending = false, onSignIn, onWorkOffline }: Props = $props();
+</script>
+
+{#if open}
+  <div
+    class="relogin-overlay"
+    onclick={onWorkOffline}
+    onkeydown={(e) => e.key === 'Escape' && onWorkOffline()}
+    role="presentation"
+    tabindex="-1"
+  >
+    <div
+      class="relogin-content"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-labelledby="relogin-title"
+      aria-describedby="relogin-body"
+      aria-modal="true"
+      tabindex="0"
+    >
+      <h2 id="relogin-title">Sign-in required</h2>
+      <p id="relogin-body" class="relogin-body">
+        Your NodeSpace Pro session expired and couldn't be renewed automatically. Sign in again to
+        keep syncing across your devices — or keep working offline. Your changes are saved locally
+        and will sync once you're signed back in.
+      </p>
+
+      {#if detail}
+        <p class="relogin-detail">{detail}</p>
+      {/if}
+
+      <div class="relogin-actions">
+        <button class="btn btn-secondary" type="button" onclick={onWorkOffline} disabled={pending}>
+          Work Offline
+        </button>
+        <button class="btn btn-primary" type="button" onclick={onSignIn} disabled={pending}>
+          {pending ? 'Opening…' : 'Sign In Again'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .relogin-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .relogin-content {
+    background: var(--surface-1, #ffffff);
+    color: var(--text-primary, #1f2937);
+    border-radius: 8px;
+    padding: 24px;
+    width: min(440px, calc(100vw - 48px));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .relogin-content h2 {
+    margin: 0 0 12px 0;
+    font-size: 20px;
+  }
+
+  .relogin-body {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-secondary, #4b5563);
+  }
+
+  .relogin-detail {
+    margin: 12px 0 0 0;
+    padding: 8px 10px;
+    background: var(--surface-2, #f3f4f6);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--text-secondary, #6b7280);
+    word-break: break-word;
+  }
+
+  .relogin-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: 24px;
+  }
+
+  .btn {
+    padding: 10px 18px;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .btn:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  .btn-primary {
+    background-color: #2563eb;
+    color: #ffffff;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background-color: #1d4ed8;
+  }
+
+  .btn-secondary {
+    background-color: var(--surface-2, #e5e7eb);
+    color: var(--text-primary, #1f2937);
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background-color: var(--surface-3, #d1d5db);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .relogin-content {
+      background: var(--surface-1, #1f2937);
+      color: var(--text-primary, #e5e7eb);
+    }
+    .btn-secondary {
+      background-color: var(--surface-2, #374151);
+      color: var(--text-primary, #e5e7eb);
+    }
+    .btn-secondary:hover:not(:disabled) {
+      background-color: var(--surface-3, #4b5563);
+    }
+  }
+</style>

--- a/packages/desktop-app/src/tests/components/pro-relogin-modal.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-relogin-modal.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ProReloginModal Component Tests (T18, #1304)
+ *
+ * The modal the app shell surfaces when the Pro daemon reports AUTH_REQUIRED
+ * (refresh token couldn't be renewed). Presentational only — the shell owns
+ * visibility and the actions. Covers: gated rendering, both action callbacks,
+ * Escape == work-offline, the pending (in-flight) state, and the optional
+ * daemon detail line.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ProReloginModal from '$lib/components/pro-relogin-modal.svelte';
+
+describe('ProReloginModal', () => {
+  let onSignIn: ReturnType<typeof vi.fn>;
+  let onWorkOffline: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSignIn = vi.fn();
+    onWorkOffline = vi.fn();
+  });
+
+  it('does not render when open is false', () => {
+    render(ProReloginModal, { props: { open: false, onSignIn, onWorkOffline } });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders the prompt and both actions when open', () => {
+    render(ProReloginModal, { props: { open: true, onSignIn, onWorkOffline } });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Sign-in required')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sign In Again' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Work Offline' })).toBeTruthy();
+  });
+
+  it('invokes onSignIn when "Sign In Again" is clicked', async () => {
+    render(ProReloginModal, { props: { open: true, onSignIn, onWorkOffline } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Sign In Again' }));
+    expect(onSignIn).toHaveBeenCalledTimes(1);
+    expect(onWorkOffline).not.toHaveBeenCalled();
+  });
+
+  it('invokes onWorkOffline when "Work Offline" is clicked', async () => {
+    render(ProReloginModal, { props: { open: true, onSignIn, onWorkOffline } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Work Offline' }));
+    expect(onWorkOffline).toHaveBeenCalledTimes(1);
+    expect(onSignIn).not.toHaveBeenCalled();
+  });
+
+  it('treats Escape (overlay keydown) as work-offline', async () => {
+    render(ProReloginModal, { props: { open: true, onSignIn, onWorkOffline } });
+    // The overlay carries the Escape handler; it wraps the dialog.
+    const dialog = screen.getByRole('dialog');
+    const overlay = dialog.parentElement as HTMLElement;
+    await fireEvent.keyDown(overlay, { key: 'Escape' });
+    expect(onWorkOffline).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables both actions and shows progress while pending', () => {
+    render(ProReloginModal, { props: { open: true, pending: true, onSignIn, onWorkOffline } });
+    const signIn = screen.getByRole('button', { name: 'Opening…' });
+    expect(signIn.hasAttribute('disabled')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Work Offline' }).hasAttribute('disabled')).toBe(
+      true
+    );
+  });
+
+  it('shows the daemon detail when provided', () => {
+    render(ProReloginModal, {
+      props: { open: true, detail: 'refresh token expired', onSignIn, onWorkOffline }
+    });
+    expect(screen.getByText('refresh token expired')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Completes **T18 (#1304)** — the sync status indicator + re-login modal. The status pill (`pro-sync-pill.svelte`) already maps every `SyncStatusEvent.State` (connected / syncing / disconnected / error / auth-required), so this PR adds the one missing acceptance criterion: **a re-login modal triggered on refresh failure, with "Sign In Again" / "Work Offline".**

## Changes (frontend-only, additive)

- **`pro-relogin-modal.svelte`** (new) — presentational dialog. "Sign In Again" runs the PKCE flow (`pro_initiate_oauth`, same as the pill); "Work Offline" dismisses. Themed, accessible (`role="dialog"`, `aria-modal`, Escape = work-offline).
- **`app-shell.svelte`** — owns visibility: shows when `proSync.isPro && proSync.state === 'auth-required' && !dismissed`. `Work Offline` dismisses **per-episode** (so it doesn't keep nagging) and an `$effect` **re-arms** the dismissal once the daemon leaves `auth-required`, so a later refresh failure prompts again. The sign-in handler guards against double-invoke with a `pending` flag (shared with the modal to disable its buttons).

The daemon already emits `AUTH_REQUIRED` on refresh failure (session persistence, sync #154); this is purely the UI reaction. **Nothing in the sync push/pull path changes** — the two-window/two-device demo is unaffected.

## Verification

- New test `pro-relogin-modal.test.ts` — 7 cases (gated render, both action callbacks, Escape = work-offline, `pending` disables actions + shows progress, optional detail line).
- Full unit suite: **3857/3857 pass** (3850 baseline + 7). Lint + prettier clean on all touched files.

Closes #1304.