### PR TITLE
Embedding write-wrappers for cloud pull apply (core, sync #97 PR3)

### DIFF
--- a/packages/core/src/services/node_service/embedding.rs
+++ b/packages/core/src/services/node_service/embedding.rs
@@ -37,6 +37,34 @@ impl NodeService {
             })
     }
 
+    /// Replace a node's embeddings with `embeddings` (wholesale, like the local
+    /// generation path). Used by the Pro daemon's cloud **pull** to apply vectors
+    /// synced from another device into the local store (#97). Like the read API,
+    /// it is **independent of the `nlp` feature**: applying a received vector
+    /// doesn't require the generation engine, so a daemon built without llama-cpp
+    /// can still receive embeddings. Empty `embeddings` is a no-op (use
+    /// [`Self::delete_embeddings`] to clear).
+    pub async fn upsert_embeddings(
+        &self,
+        node_id: &str,
+        embeddings: Vec<crate::models::NewEmbedding>,
+    ) -> Result<(), NodeServiceError> {
+        self.store
+            .upsert_embeddings(node_id, embeddings)
+            .await
+            .map_err(|e| {
+                NodeServiceError::query_failed(format!("Failed to upsert embeddings: {}", e))
+            })
+    }
+
+    /// Delete all of a node's embeddings. Used by the Pro daemon's cloud pull to
+    /// apply a remote embeddings delete (#97). Also independent of the `nlp` feature.
+    pub async fn delete_embeddings(&self, node_id: &str) -> Result<(), NodeServiceError> {
+        self.store.delete_embeddings(node_id).await.map_err(|e| {
+            NodeServiceError::query_failed(format!("Failed to delete embeddings: {}", e))
+        })
+    }
+
     /// Set the embedding waker for event-driven processing.
     ///
     /// Silently ignored if called more than once. Works on `Arc<NodeService>`

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -2496,6 +2496,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_embedding_write_wrappers_upsert_read_delete() {
+        // #97 pull-apply path: the non-nlp NodeService write wrappers must
+        // round-trip a received vector into the local store and clear it.
+        let (service, _temp) = create_test_service().await;
+        let id = service
+            .create_node(Node::new(
+                "text".to_string(),
+                "vec node".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+
+        let mut vector = vec![0.0f32; 768];
+        vector[3] = 1.0;
+        let emb = crate::models::NewEmbedding::single_chunk(id.clone(), vector, "hash-3", 10, 4);
+        service.upsert_embeddings(&id, vec![emb]).await.unwrap();
+
+        let got = service.get_embeddings(&id).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].vector[3], 1.0, "applied vector round-trips");
+
+        service.delete_embeddings(&id).await.unwrap();
+        assert!(service.get_embeddings(&id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_get_virtual_date_node_as_parent() {
         let (service, _temp) = create_test_service().await;
 


### PR DESCRIPTION
## What

Core half of the **pull** slice of NodeSpaceAI/nodespace-sync#97. The push half (sync #178, merged) used the read API from #1416; the pull half needs to **apply** vectors synced from another device into the local store, but `upsert_embeddings` / `delete_embeddings` were store-only.

## Changes

- **`NodeService::upsert_embeddings(node_id, Vec<NewEmbedding>)`** — replace a node's vectors wholesale (mirrors the local generation path; the symmetric write to #1416's `get_embeddings`).
- **`NodeService::delete_embeddings(node_id)`** — clear a node's vectors (for a remote embeddings delete).

Both are **deliberately not gated** behind `nlp`, same rationale as the read wrappers: applying a *received* vector doesn't need the generation engine, so a daemon built without llama-cpp (sync #10) can still receive embeddings. Generation stays `#[cfg(feature = "nlp")]`.

## Verification

- New unit test: upsert a synthetic 768-dim vector via the wrapper → read it back via `get_embeddings` (round-trip) → delete → assert empty.
- `cargo test` (new test green) + `cargo clippy --lib` clean. Additive only.

Part of NodeSpaceAI/nodespace-sync#97 (PR 3a; PR 3b = the daemon pull: realtime/replay `embeddings` → these wrappers, + the full two-daemon round-trip harness).