### PR TITLE
Honor NODESPACED_SOCKET in daemon-reachability checks (fix false 'service not running' banner)

### DIFF
--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -73,11 +73,8 @@ async fn check_daemon_status() -> String {
     {
         use daemon_setup::{check_daemon_socket, DaemonStatus};
 
-        let home = match dirs::home_dir() {
-            Some(h) => h,
-            None => return "not_running".to_string(),
-        };
-        let socket_path = home.join(crate::constants::DAEMON_SOCKET_RELATIVE);
+        // Probe the SAME socket the gRPC client dials (honors NODESPACED_SOCKET).
+        let socket_path = crate::services::grpc_client::resolve_socket_path();
         return match check_daemon_socket(socket_path.as_path()).await {
             DaemonStatus::Healthy => "healthy".to_string(),
             DaemonStatus::Starting => "starting".to_string(),
@@ -341,16 +338,17 @@ pub fn run() {
                     // is transient — only `NotRunning` trips the banner.
                     {
                         use daemon_setup::{check_daemon_socket, DaemonStatus};
-                        if let Some(home) = dirs::home_dir() {
-                            let socket_path = home.join(crate::constants::DAEMON_SOCKET_RELATIVE);
-                            if matches!(
-                                check_daemon_socket(socket_path.as_path()).await,
-                                DaemonStatus::NotRunning
-                            ) {
-                                tracing::error!("nodespaced unreachable after startup");
-                                if let Some(window) = app_handle.get_webview_window("main") {
-                                    let _ = window.emit("daemon-status", "not_running");
-                                }
+                        // Probe the SAME socket the gRPC client dials (honors
+                        // NODESPACED_SOCKET), not the hardcoded default — else a
+                        // socket override falsely reports the daemon down.
+                        let socket_path = crate::services::grpc_client::resolve_socket_path();
+                        if matches!(
+                            check_daemon_socket(socket_path.as_path()).await,
+                            DaemonStatus::NotRunning
+                        ) {
+                            tracing::error!("nodespaced unreachable after startup");
+                            if let Some(window) = app_handle.get_webview_window("main") {
+                                let _ = window.emit("daemon-status", "not_running");
                             }
                         }
                     }

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -194,3 +194,36 @@ pub enum GrpcClientError {
     #[error("Failed to connect to nodespaced: {0}")]
     Connect(tonic::transport::Error),
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::resolve_socket_path;
+
+    /// Regression for the false "background service not running" banner: the
+    /// daemon-reachability checks must resolve the SAME socket the gRPC client
+    /// dials, i.e. honor `NODESPACED_SOCKET` over the default. Single-threaded so
+    /// the process-global env mutation doesn't race other tests.
+    #[test]
+    fn resolve_socket_path_honors_env_override_then_falls_back() {
+        let prev = std::env::var_os("NODESPACED_SOCKET");
+
+        std::env::set_var("NODESPACED_SOCKET", "/tmp/ns-demo-a.sock");
+        assert_eq!(
+            resolve_socket_path(),
+            std::path::PathBuf::from("/tmp/ns-demo-a.sock"),
+            "NODESPACED_SOCKET override must win"
+        );
+
+        std::env::remove_var("NODESPACED_SOCKET");
+        assert!(
+            resolve_socket_path().ends_with(".nodespace/daemon.sock"),
+            "with no override, fall back to the default socket"
+        );
+
+        // Restore prior state so we don't leak into other tests.
+        match prev {
+            Some(v) => std::env::set_var("NODESPACED_SOCKET", v),
+            None => std::env::remove_var("NODESPACED_SOCKET"),
+        }
+    }
+}

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -138,9 +138,12 @@ impl GrpcClient {
 /// Resolve the daemon socket path.
 ///
 /// Checks `NODESPACED_SOCKET` env var first, then falls back to
-/// `~/.nodespace/daemon.sock`.
+/// `~/.nodespace/daemon.sock`. `pub(crate)` so the daemon-reachability checks in
+/// `lib.rs` probe the SAME socket the client actually dials — otherwise a
+/// `NODESPACED_SOCKET` override (two-window demo, custom setups) makes them check
+/// the wrong path and falsely report "not running".
 #[cfg(unix)]
-fn resolve_socket_path() -> std::path::PathBuf {
+pub(crate) fn resolve_socket_path() -> std::path::PathBuf {
     if let Ok(p) = std::env::var("NODESPACED_SOCKET") {
         return std::path::PathBuf::from(p);
     }


### PR DESCRIPTION
## Problem

Follow-up to #1410. The daemon-reachability checks resolve the socket differently than the gRPC client:

- The client dials `grpc_client::resolve_socket_path()`, which honors **`NODESPACED_SOCKET`** first, then falls back to `~/.nodespace/daemon.sock`.
- But the post-startup reachability check (`lib.rs`) and `check_daemon_status` (the Retry button) **hardcoded** `~/.nodespace/daemon.sock`.

When `NODESPACED_SOCKET` points elsewhere — the two-window demo (`/tmp/ns-demo-*.sock`), or any custom-socket setup — the app connects and works fine, but the checks probe the absent default path and falsely emit `daemon-status: not_running` → a spurious **"NodeSpace background service is not running"** banner. Because `check_daemon_status` has the same flaw, **Retry can't clear it** either.

## Fix

Make `resolve_socket_path()` `pub(crate)` and use it in both checks, so they probe the same socket the client actually dials.

## Impact

- **Shipped app: unchanged** — it leaves `NODESPACED_SOCKET` unset, so resolution falls back to the default socket exactly as before. Verified on a physical device: community daemon on the default socket shows no false banner, and a genuinely-down daemon still correctly raises the banner.
- **Custom-socket / demo setups: fixed** — no more false banner, and Retry works.

Found while validating on the two-window demo. Follow-up to #1410.
