### PR TITLE
Fix rapid Enter in an empty node piling blank nodes upward (#1421)

### DIFF
--- a/packages/desktop-app/src/lib/commands/keyboard/create-node.command.ts
+++ b/packages/desktop-app/src/lib/commands/keyboard/create-node.command.ts
@@ -179,9 +179,16 @@ export class CreateNodeCommand implements KeyboardCommand {
    * - Within inline format opening syntax at beginning (e.g., |**, *|*)
    */
   private shouldCreateNodeAbove(content: string, position: number): boolean {
-    // Always create above when cursor is at the very beginning
+    // Create above when cursor is at the very beginning of a NON-EMPTY node —
+    // the intent is to push the existing content down and leave an empty line
+    // above. An empty node has nothing to preserve below, and its cursor is
+    // always at position 0, so the old unconditional `position <= 0` made every
+    // Enter on an empty node insert *above* and keep focus on it
+    // (`focusOriginalNode`) — blank nodes piled upward and focus never advanced,
+    // diverging across sync (#1421). For an empty node, fall through to normal
+    // "create below + advance focus" splitting.
     if (position <= 0) {
-      return true;
+      return content.trim().length > 0;
     }
 
     // For headers, create above when cursor is within or at the end of the syntax area

--- a/packages/desktop-app/src/tests/commands/keyboard/create-node.command.test.ts
+++ b/packages/desktop-app/src/tests/commands/keyboard/create-node.command.test.ts
@@ -325,6 +325,40 @@ describe('CreateNodeCommand', () => {
     });
   });
 
+  // Regression for #1421: rapid Enter in an empty node piled blank nodes UPWARD.
+  // An empty node always has cursor position 0, so the "create above" branch
+  // (meant for cursor-at-start of a NON-empty node, to push its content down)
+  // fired on every Enter — inserting before the node and keeping focus on it
+  // (`focusOriginalNode`), so nodes stacked above instead of advancing down.
+  describe('execute - empty node (#1421)', () => {
+    it('creates a sibling BELOW (not above) when the node is empty', async () => {
+      const context = createContext({ key: 'Enter', content: '', cursorPosition: 0 });
+
+      await command.execute(context);
+
+      expect(createNewNodeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          afterNodeId: 'test-node',
+          insertAtBeginning: false // create below + advance focus, not above
+        })
+      );
+      // and must NOT keep focus on the original (which caused the upward pile-up)
+      expect(createNewNodeSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ focusOriginalNode: true })
+      );
+    });
+
+    it('still creates ABOVE for a non-empty node with cursor at start', async () => {
+      const context = createContext({ key: 'Enter', content: 'keep me', cursorPosition: 0 });
+
+      await command.execute(context);
+
+      expect(createNewNodeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ insertAtBeginning: true, focusOriginalNode: true })
+      );
+    });
+  });
+
   // Helper function to create mock context
   function createContext(options: {
     key: string;


### PR DESCRIPTION
## What

Fixes #1421 — rapid Enter inside a nested node piled blank nodes **upward** and the focused node drifted down; a single slow Enter appeared to do nothing.

## Root cause

`CreateNodeCommand.shouldCreateNodeAbove` returned `true` whenever the cursor was at position 0 — but an **empty node's cursor is always at 0**. So every Enter on an empty node took the "create above" branch (`insertAtBeginning: true` + `focusOriginalNode: true`): it inserts a blank *before* the node and keeps focus on the original. Result: repeated Enter stacked blank nodes upward (with ever-finer fractional insert-*before* orders), focus never advanced, and the fractional orders diverged across two synced devices.

The "create above" intent is to push a **non-empty** node's content down and leave a blank above it. An empty node has nothing to preserve, so Enter should create a sibling **below** and advance focus (standard outliner behavior).

## Fix

Gate the `position <= 0` branch on non-empty content (`return content.trim().length > 0`). Empty nodes fall through to normal split-below.

## Tests

- Added a regression test: empty node + Enter → `insertAtBeginning: false` (below + advance); pre-fix it failed (was `true`).
- Kept a guard: non-empty node with cursor at start still creates above.
- `create-node.command` + keyboard / node-service / rapid-hierarchy suites pass; full frontend suite green (one flaky perf test, passes in isolation).

## Verified live

Two-window demo: typing a child then pressing Enter rapidly now adds clean empty nodes **below** with the cursor advancing, and both windows converge (no divergence).

Closes #1421.
