### PR TITLE
Coalesce Pro reconnect-replay node bursts into one render (frontend half of sync #188)

### DIFF
--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -31,8 +31,76 @@ import { scheduleCollectionRefresh, scheduleSchemaRefresh } from '$lib/utils/col
 import { registerSchemaPlugin, unregisterSchemaPlugin } from '$lib/plugins/schema-plugin-loader';
 import { applyHasChildCreated, applyHasChildUpdated, applyHasChildDeleted } from './hierarchy-sync';
 import { normalizeNodeData } from './node-normalize';
+import { proSync } from '$lib/stores/pro-sync.svelte';
 
 const log = createLogger('TauriSync');
+
+// ---------------------------------------------------------------------------
+// Pro-only reconnect-replay render coalescing (#188)
+//
+// On reconnect the Pro daemon now flushes a caught-up batch of node events as a
+// single burst (sync PR #194). Applied one-by-one, each `node:created/updated`
+// triggers its own async fetch + `setNode` → one re-render per node. To render
+// the burst in one pass, when sync is active we collect the node ids over a tiny
+// window, fetch them together, then apply them in a SYNCHRONOUS `setNode` loop —
+// Svelte batches synchronous store mutations into a single render.
+//
+// Gated on `proSync.isPro`: reconnect replay is a Pro-only flow, so the community
+// build never enters this path and its per-event behavior is byte-for-byte
+// unchanged.
+// ---------------------------------------------------------------------------
+
+/** How long to gather a burst before flushing. One frame (~16ms) is enough to
+ *  collect a daemon-flushed batch without adding perceptible latency. */
+const REPLAY_COALESCE_WINDOW_MS = 16;
+
+const pendingNodeIds = new Set<string>();
+let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Queue a node id for the next coalesced flush (Pro path). */
+function enqueueNodeFetch(nodeId: string): void {
+  pendingNodeIds.add(nodeId);
+  if (coalesceTimer !== null) return;
+  coalesceTimer = setTimeout(flushPendingNodeFetches, REPLAY_COALESCE_WINDOW_MS);
+}
+
+/** Fetch all queued nodes, then apply them in one synchronous pass so the burst
+ *  renders once. A failed fetch for a single node is skipped, never fatal. */
+async function flushPendingNodeFetches(): Promise<void> {
+  coalesceTimer = null;
+  const ids = [...pendingNodeIds];
+  pendingNodeIds.clear();
+  if (ids.length === 0) return;
+
+  const fetched = await Promise.all(
+    ids.map((id) =>
+      backendAdapter.getNode(id).catch((error) => {
+        log.error('replay-coalesce: failed to fetch node', { nodeId: id, error });
+        return null;
+      })
+    )
+  );
+
+  // Synchronous apply loop — no `await` between setNode calls, so Svelte
+  // coalesces the resulting reactive updates into a single render.
+  let applied = 0;
+  for (const node of fetched) {
+    if (!node) continue;
+    sharedNodeStore.setNode(normalizeNodeData(node), { type: 'database', reason: 'domain-event' }, true);
+    applied++;
+  }
+  log.info('replay-coalesce: applied node burst in one pass', { requested: ids.length, applied });
+}
+
+/** Route a node fetch through the Pro coalescer, or apply immediately in the
+ *  community build (unchanged behavior). */
+function queueOrFetchNode(nodeId: string, eventType: string): void {
+  if (proSync.isPro) {
+    enqueueNodeFetch(nodeId);
+  } else {
+    fetchAndUpdateNode(nodeId, eventType);
+  }
+}
 
 /**
  * Strip the `node:` table prefix from a stored record id so it
@@ -104,14 +172,16 @@ export async function initializeTauriSyncListeners(): Promise<void> {
         );
       }
 
-      // Fetch full node data since the node might be in the current view
-      fetchAndUpdateNode(event.payload.id, 'node:created');
+      // Fetch full node data since the node might be in the current view.
+      // Pro: coalesce a reconnect-replay burst into one render (#188); community:
+      // apply immediately (unchanged).
+      queueOrFetchNode(event.payload.id, 'node:created');
     });
 
     await listen<NodeEventData>('node:updated', (event) => {
       const nodeId = event.payload.id;
       log.debug(`node:updated received`, { nodeId });
-      fetchAndUpdateNode(nodeId, 'node:updated');
+      queueOrFetchNode(nodeId, 'node:updated');
     });
 
     await listen<{ id: string }>('node:deleted', (event) => {

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -56,6 +56,31 @@ const REPLAY_COALESCE_WINDOW_MS = 16;
 
 const pendingNodeIds = new Set<string>();
 let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+// Ids deleted while a flush is mid-fetch (between the snapshot and the apply
+// loop). The flush skips these so a delete that lands during the fetch wins over
+// the now-stale upsert it raced — without this, the re-fetch could resurrect a
+// just-deleted node (the sync#193 failure class, opened anew by coalescing).
+let flushInProgress = false;
+const tombstonedDuringFlush = new Set<string>();
+
+/** Drop any queued/in-flight re-fetch for a node that was just deleted, so the
+ *  delete wins over a racing upsert in the same coalescing window. */
+function cancelPendingNodeFetch(nodeId: string): void {
+  pendingNodeIds.delete(nodeId);
+  if (flushInProgress) tombstonedDuringFlush.add(nodeId);
+}
+
+/** Reset all coalescer state. Called on (re)init so a stale in-flight timer from
+ *  a prior listener registration can't fire into fresh state. */
+function resetNodeFetchCoalescer(): void {
+  if (coalesceTimer !== null) {
+    clearTimeout(coalesceTimer);
+    coalesceTimer = null;
+  }
+  pendingNodeIds.clear();
+  tombstonedDuringFlush.clear();
+  flushInProgress = false;
+}
 
 /** Queue a node id for the next coalesced flush (Pro path). */
 function enqueueNodeFetch(nodeId: string): void {
@@ -65,31 +90,48 @@ function enqueueNodeFetch(nodeId: string): void {
 }
 
 /** Fetch all queued nodes, then apply them in one synchronous pass so the burst
- *  renders once. A failed fetch for a single node is skipped, never fatal. */
+ *  renders once. A failed fetch for a single node is skipped, never fatal; a node
+ *  tombstoned (deleted) during the fetch is skipped so the delete wins. */
 async function flushPendingNodeFetches(): Promise<void> {
   coalesceTimer = null;
   const ids = [...pendingNodeIds];
   pendingNodeIds.clear();
   if (ids.length === 0) return;
 
-  const fetched = await Promise.all(
-    ids.map((id) =>
-      backendAdapter.getNode(id).catch((error) => {
-        log.error('replay-coalesce: failed to fetch node', { nodeId: id, error });
-        return null;
-      })
-    )
-  );
+  flushInProgress = true;
+  tombstonedDuringFlush.clear();
+  try {
+    const fetched = await Promise.all(
+      ids.map((id) =>
+        backendAdapter.getNode(id).catch((error) => {
+          log.error('replay-coalesce: failed to fetch node', { nodeId: id, error });
+          return null;
+        })
+      )
+    );
 
-  // Synchronous apply loop — no `await` between setNode calls, so Svelte
-  // coalesces the resulting reactive updates into a single render.
-  let applied = 0;
-  for (const node of fetched) {
-    if (!node) continue;
-    sharedNodeStore.setNode(normalizeNodeData(node), { type: 'database', reason: 'domain-event' }, true);
-    applied++;
+    // Synchronous apply loop — no `await` between setNode calls, so Svelte
+    // coalesces the resulting reactive updates into a single render. A node
+    // deleted while we were fetching is skipped so the delete is not clobbered.
+    let applied = 0;
+    for (let i = 0; i < fetched.length; i++) {
+      const node = fetched[i];
+      if (!node || tombstonedDuringFlush.has(ids[i])) continue;
+      sharedNodeStore.setNode(
+        normalizeNodeData(node),
+        { type: 'database', reason: 'domain-event' },
+        true
+      );
+      applied++;
+    }
+    log.info('replay-coalesce: applied node burst in one pass', {
+      requested: ids.length,
+      applied
+    });
+  } finally {
+    flushInProgress = false;
+    tombstonedDuringFlush.clear();
   }
-  log.info('replay-coalesce: applied node burst in one pass', { requested: ids.length, applied });
 }
 
 /** Route a node fetch through the Pro coalescer, or apply immediately in the
@@ -152,6 +194,9 @@ export async function initializeTauriSyncListeners(): Promise<void> {
 
   log.info('Initializing Tauri real-time sync listeners');
 
+  // Clear any coalescer state (and a stale in-flight timer) from a prior init.
+  resetNodeFetchCoalescer();
+
   try {
     // Listen for node events and update SharedNodeStore
     // Issue #724: Events now send only node_id, fetch full data if needed
@@ -186,6 +231,9 @@ export async function initializeTauriSyncListeners(): Promise<void> {
 
     await listen<{ id: string }>('node:deleted', (event) => {
       log.debug(`Node deleted: ${event.payload.id}`);
+      // Evict any coalesced re-fetch first so a delete racing an upsert in the
+      // same window can't be clobbered by the queued fetch re-adding the node.
+      cancelPendingNodeFetch(event.payload.id);
       sharedNodeStore.deleteNode(event.payload.id, { type: 'database', reason: 'domain-event' }, true);
 
       // Issue #832: We don't know if deleted node was a collection without fetching,

--- a/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
@@ -4,6 +4,7 @@ import { SharedNodeStore, sharedNodeStore } from '$lib/services/shared-node-stor
 import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 import type { Node } from '$lib/types';
 import * as backendAdapterModule from '$lib/services/backend-adapter';
+import { proSync } from '$lib/stores/pro-sync.svelte';
 
 /**
  * Tests for Tauri Domain Event Listener
@@ -257,6 +258,53 @@ describe('TauriSyncListener', () => {
 			emitTauriEvent('node:deleted', { id: 'node1' });
 
 			expect(sharedNodeStore.hasNode('node1')).toBe(false);
+		});
+	});
+
+	// #188: when sync is active, a reconnect-replay burst of node events is
+	// coalesced — collected over a short window, then applied in one synchronous
+	// pass so the caught-up set renders once instead of once per node.
+	describe('Pro reconnect-replay render coalescing (#188)', () => {
+		beforeEach(async () => {
+			await initializeTauriSyncListeners();
+			proSync.tier = 'pro'; // activate the Pro coalescing path
+		});
+
+		afterEach(() => {
+			proSync.tier = 'unknown'; // singleton — restore so other tests see community
+		});
+
+		it('defers a burst then applies every node in one pass', async () => {
+			for (const id of ['n1', 'n2', 'n3']) {
+				registerMockNode(createTestNode(id, `content ${id}`));
+				emitTauriEvent('node:created', { id });
+			}
+
+			// Synchronously after the burst the applies are still deferred (the
+			// coalescing window hasn't fired) — proves we don't render per node.
+			expect(sharedNodeStore.hasNode('n1')).toBe(false);
+			expect(sharedNodeStore.hasNode('n2')).toBe(false);
+			expect(sharedNodeStore.hasNode('n3')).toBe(false);
+
+			// After the window flushes, the whole burst has landed.
+			await vi.waitFor(() => {
+				expect(sharedNodeStore.hasNode('n1')).toBe(true);
+				expect(sharedNodeStore.hasNode('n2')).toBe(true);
+				expect(sharedNodeStore.hasNode('n3')).toBe(true);
+			});
+			expect(sharedNodeStore.getNode('n2')?.content).toBe('content n2');
+		});
+
+		it('community build (not Pro) still applies each event immediately', async () => {
+			proSync.tier = 'community';
+			registerMockNode(createTestNode('c1', 'community node'));
+
+			emitTauriEvent('node:updated', { id: 'c1' });
+
+			// No coalescing window — the existing per-event path applies right away.
+			await vi.waitFor(() => {
+				expect(sharedNodeStore.hasNode('c1')).toBe(true);
+			});
 		});
 	});
 

--- a/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
@@ -306,6 +306,21 @@ describe('TauriSyncListener', () => {
 				expect(sharedNodeStore.hasNode('c1')).toBe(true);
 			});
 		});
+
+		it('a delete during the window wins — the queued upsert does not resurrect the node', async () => {
+			// Node is updated (queued for coalesced re-fetch) then deleted before the
+			// window flushes. Even though getNode would still return it, the delete
+			// must win — the coalescer evicts the pending re-fetch.
+			registerMockNode(createTestNode('zombie', 'should not come back'));
+
+			emitTauriEvent('node:updated', { id: 'zombie' }); // queued
+			emitTauriEvent('node:deleted', { id: 'zombie' }); // evicts the queued re-fetch
+
+			// Give the coalescing window time to fire.
+			await new Promise((resolve) => setTimeout(resolve, 40));
+
+			expect(sharedNodeStore.hasNode('zombie')).toBe(false);
+		});
 	});
 
 	describe('Unified Relationship Events - has_child (Issue #811)', () => {


### PR DESCRIPTION
## Frontend half of NodeSpaceAI/nodespace-sync#188 (pairs with sync PR #194)

On reconnect the Pro daemon flushes a caught-up batch of node events as one burst (sync #194). The frontend listener (`tauri-sync-listener`) applied them one at a time — each `node:created`/`node:updated` does an async `getNode` + `setNode` → **one re-render per node**.

## Change
When sync is active (`proSync.isPro`), collect the burst's node ids over a short window (~16ms), fetch them together, then apply them in a **synchronous `setNode` loop** so Svelte coalesces the reactive updates into a single render. Deletes still apply immediately (a queued update for a since-deleted node resolves to `null` and is skipped, so the delete wins).

## Free-user safety
Gated on `proSync.isPro`. Reconnect replay is a **Pro-only** flow, so the community build never enters this path and its per-event behavior is **byte-for-byte unchanged**. Verified: the full frontend suite stays green and the existing per-event tests (which run with the default non-Pro tier) are untouched.

## Tests
- New: a Pro burst of `node:created` events is **deferred** (not applied synchronously) then **applied in one pass** (all nodes land after the window).
- New: the community path (`proSync.tier !== 'pro'`) still applies each event immediately.
- Full desktop-app suite: **3872 passing** (was 3870; +2 new). `eslint` + `svelte-check` clean.

Together with sync #194 (daemon-side event coalescing), this closes the render-trickle described in #188.