### PR TITLE
Add free-user guardrail test suite (test:free-users)

### DIFF
--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -19,6 +19,7 @@
     "sync": "bunx svelte-kit sync",
     "build": "bun run sync && bunx vite build",
     "test": "bunx vitest run",
+    "test:free-users": "bunx vitest run src/tests/free-user-guardrail.test.ts",
     "test:watch": "bunx vitest",
     "test:browser": "bunx vitest run --config vitest.browser.config.ts",
     "test:browser:watch": "bunx vitest --config vitest.browser.config.ts",

--- a/packages/desktop-app/src/tests/free-user-guardrail.test.ts
+++ b/packages/desktop-app/src/tests/free-user-guardrail.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Free-User Guardrail Suite
+ * =========================
+ *
+ * A single, always-runnable suite that asserts every Pro/sync-gated **frontend**
+ * feature stays completely inert in the community (free) build — i.e. when
+ * `proSync.isPro` is false. The open-core rule is that Pro/sync work must keep the
+ * community build behaviorally unchanged; this suite turns that rule into a
+ * regression test you can run after any cross-repo or Pro-feature change.
+ *
+ *   bun run test:free-users
+ *
+ * If a future Pro feature adds a frontend surface, add its "inert in community"
+ * assertion here so the guarantee stays enforced in one place.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Node } from '$lib/types';
+
+// Mock the Tauri bridge so we can assert Pro-gated daemon commands are NEVER
+// invoked in the community build. `mock`-prefixed names satisfy vitest's hoisting.
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+const mockListeners = new Map<string, (event: { payload: unknown }) => void>();
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (name: string, handler: (event: { payload: unknown }) => void) => {
+    mockListeners.set(name, handler);
+    return () => mockListeners.delete(name);
+  })
+}));
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { recoveredItems } from '$lib/stores/recovered-items.svelte';
+import { sharedNodeStore, SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import * as backendAdapterModule from '$lib/services/backend-adapter';
+import { initializeTauriSyncListeners } from '$lib/services/tauri-sync-listener';
+
+function testNode(id: string, content = 'community content'): Node {
+  return {
+    id,
+    nodeType: 'text',
+    content,
+    properties: {},
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
+}
+
+describe('Free-user guardrail: Pro features stay inert in the community build', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockListeners.clear();
+    SharedNodeStore.resetInstance();
+    // Community/free build: not Pro.
+    proSync.tier = 'community';
+    recoveredItems.items = [];
+    recoveredItems.loaded = false;
+    (global.window as unknown as { __TAURI__?: unknown }).__TAURI__ = {};
+    vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockImplementation(
+      async (id: string) => testNode(id)
+    );
+  });
+
+  afterEach(() => {
+    proSync.tier = 'unknown';
+    sharedNodeStore.clearAll();
+    SharedNodeStore.resetInstance();
+    delete (global.window as unknown as { __TAURI__?: unknown }).__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  it('community tier → proSync.isPro is false', () => {
+    expect(proSync.isPro).toBe(false);
+  });
+
+  it("the default 'unknown' tier (fresh app, before any probe) is also not Pro", () => {
+    proSync.tier = 'unknown';
+    expect(proSync.isPro).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Recovered Items (core#1303) — the conflict-loser viewer/restore UI.
+  // The daemon writes its local-only log only in Pro; the frontend store must
+  // never even ask for it in community, so no badge/snackbar can ever appear.
+  // -------------------------------------------------------------------------
+  describe('Recovered Items viewer is inert', () => {
+    it('load() is a no-op and never invokes the daemon command', async () => {
+      await recoveredItems.load();
+
+      expect(recoveredItems.items).toEqual([]);
+      expect(recoveredItems.loaded).toBe(true);
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('reports no recovered item for any node (no badge ever renders)', () => {
+      expect(recoveredItems.hasFor('any-node-id')).toBe(false);
+      expect(recoveredItems.itemFor('any-node-id')).toBeUndefined();
+    });
+
+    it("the default 'unknown' tier is inert too (no daemon call on first paint)", async () => {
+      proSync.tier = 'unknown';
+      await recoveredItems.load();
+
+      expect(recoveredItems.items).toEqual([]);
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #188 reconnect-replay render coalescing — Pro-only. In community, incoming
+  // node events must still apply through the unchanged per-event path; the
+  // coalescing window must NOT engage. The guarantee for free users is simply:
+  // live node updates still land in the store.
+  // -------------------------------------------------------------------------
+  describe('Reconnect-replay coalescer (#188) does not alter community behavior', () => {
+    it('a node:updated event still applies to the store (per-event path)', async () => {
+      await initializeTauriSyncListeners();
+      const handler = mockListeners.get('node:updated');
+      expect(handler).toBeDefined();
+
+      handler!({ payload: { id: 'c1' } });
+
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('c1')).toBe(true);
+      });
+      // Fetched via the normal per-event path, not a Pro daemon command.
+      expect(backendAdapterModule.backendAdapter.getNode).toHaveBeenCalledWith('c1');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('a node:deleted event still removes the node in community', async () => {
+      sharedNodeStore.setNode(testNode('c2'), { type: 'database', reason: 'test' }, false);
+      expect(sharedNodeStore.hasNode('c2')).toBe(true);
+
+      await initializeTauriSyncListeners();
+      mockListeners.get('node:deleted')!({ payload: { id: 'c2' } });
+
+      expect(sharedNodeStore.hasNode('c2')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What
A single, always-runnable suite (`src/tests/free-user-guardrail.test.ts` + a `bun run test:free-users` script) that asserts every Pro/sync-gated **frontend** feature stays inert in the community (free) build — i.e. when `proSync.isPro` is false. It turns the open-core *"Pro/sync work must keep the community build behaviorally unchanged"* rule into a regression test you can run after any cross-repo or Pro-feature change.

## Coverage
- `proSync.isPro` is false for the `community` tier **and** the default `unknown` tier (fresh app, before any probe).
- **Recovered Items (core#1303):** `recoveredItems.load()` is a no-op, **never invokes** the `pro_list_recovered_items` daemon command, and `hasFor`/`itemFor` report nothing — so no inline badge or snackbar can ever render in community.
- **#188 reconnect-replay coalescer:** the community build still applies `node:updated` / `node:deleted` through the unchanged per-event path (no coalescing window engages), with **no** Pro daemon command invoked.

## Notes
- Test-only + one package.json script. No production code touched → free-user-safe by construction.
- Extend this file whenever a new Pro feature adds a frontend surface, so the guarantee stays enforced in one place.
- Full desktop suite: **3880 passing** (3873 + 7 new). eslint + svelte-check clean. `bun run test:free-users` green.