### PR TITLE
Migrate onboarding wizard to shared focusTrap (closes #1414)

### DIFF
--- a/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
+++ b/packages/desktop-app/src/lib/components/onboarding/onboarding-wizard.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { invoke } from '@tauri-apps/api/core';
   import { createLogger } from '$lib/utils/logger';
+  import { focusTrap } from '$lib/actions/focus-trap';
 
   const log = createLogger('OnboardingWizard');
 
@@ -31,6 +32,10 @@
   let isLoading = $state(false);
   let stepSuccess = $state(false);
   let stepError = $state<string | null>(null);
+
+  // The dialog content element — the focus-trap target and the focus anchor for
+  // step transitions (see the $effect below).
+  let dialogEl = $state<HTMLElement>();
 
   // Which steps are active (some may be skipped if prerequisites missing)
   let showSkill = $state(false);
@@ -132,32 +137,37 @@
     onClose();
   }
 
-  // ── dialog keyboard / backdrop ─────────────────────────────────────────────
+  // ── multi-step focus management ────────────────────────────────────────────
 
-  function handleBackdropClick(event: MouseEvent) {
-    if (event.target === event.currentTarget) {
-      onClose();
-    }
-  }
-
-  function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      onClose();
-    }
-  }
+  // `focusTrap` moves focus into the dialog on open, traps Tab, and handles
+  // Escape — but it does so once, on mount. This wizard swaps its primary action
+  // button on every transition (advancing a step, or a configure step
+  // succeeding), which unmounts the button that had focus and drops focus to
+  // <body>, where the trap's key handler can no longer see Escape/Tab. Re-anchor
+  // focus on the new step's primary action after each such transition. Keyed on
+  // exactly the state that changes which primary button is shown, so it never
+  // steals focus mid-interaction (there are no text inputs to interrupt).
+  $effect(() => {
+    const refocusKey = `${currentStep}:${stepSuccess}:${pathWasAlreadyConfigured}`;
+    if (!dialogEl) return;
+    log.debug('Re-anchoring wizard focus', { refocusKey });
+    (dialogEl.querySelector<HTMLElement>('.primary-button') ?? dialogEl).focus();
+  });
 </script>
 
 {#if open}
-  <div
-    class="onboarding-backdrop"
-    onclick={handleBackdropClick}
-    onkeydown={handleKeydown}
-    role="dialog"
-    aria-modal="true"
-    aria-label="First-launch setup"
-    tabindex="-1"
-  >
-    <div class="onboarding-dialog">
+  <div class="onboarding-backdrop" onclick={onClose} role="presentation" tabindex="-1">
+    <div
+      class="onboarding-dialog"
+      bind:this={dialogEl}
+      use:focusTrap={{ onEscape: onClose }}
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-modal="true"
+      aria-label="First-launch setup"
+      tabindex="0"
+    >
       <!-- Close button -->
       <button class="close-button" onclick={onClose} aria-label="Close dialog">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">

--- a/packages/desktop-app/src/tests/components/onboarding-wizard.test.ts
+++ b/packages/desktop-app/src/tests/components/onboarding-wizard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * OnboardingWizard focus-trap tests (#1414)
+ *
+ * The first-launch wizard was migrated from a hand-rolled overlay (Escape on the
+ * backdrop, no focus management) to the shared `focusTrap` action. Because it is
+ * multi-step — advancing a step or a configure step succeeding swaps the primary
+ * action button — these tests drive REAL keyboard focus to confirm focus stays
+ * inside the dialog across transitions and Escape dismisses from within.
+ *
+ * Queries are scoped to the render `container` (and focus is read via the
+ * dialog's `ownerDocument`) rather than the global `screen`/`document.body`, so
+ * the focus assertions are robust to global-document pollution from other test
+ * files in the full-suite run.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { tick } from 'svelte';
+import { render, fireEvent } from '@testing-library/svelte';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import OnboardingWizard from '$lib/components/onboarding/onboarding-wizard.svelte';
+
+const STATUS = {
+  completed: false,
+  pathConfigured: false,
+  skillConfigured: false,
+  claudeCodeDetected: false,
+  pathAlreadyConfigured: false
+};
+
+function mockBackend(overrides: Partial<typeof STATUS> = {}) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    if (cmd === 'check_onboarding_status') return Promise.resolve({ ...STATUS, ...overrides });
+    return Promise.resolve();
+  });
+}
+
+/** The dialog element + its owning document, scoped to this render. */
+function dialogOf(container: HTMLElement) {
+  const dialog = container.querySelector<HTMLElement>('[role="dialog"]');
+  if (!dialog) throw new Error('dialog not rendered');
+  return { dialog, doc: dialog.ownerDocument };
+}
+
+function buttonByText(root: HTMLElement, text: string): HTMLElement {
+  const btn = Array.from(root.querySelectorAll<HTMLElement>('button')).find(
+    (b) => b.textContent?.trim() === text
+  );
+  if (!btn) throw new Error(`button "${text}" not found`);
+  return btn;
+}
+
+describe('OnboardingWizard (focus-trap, #1414)', () => {
+  let onClose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onClose = vi.fn();
+    mockInvoke.mockReset();
+    mockBackend();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(OnboardingWizard, { props: { open: false, onClose } });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('moves focus into the dialog on open and dismisses on Escape from inside', async () => {
+    const { container } = render(OnboardingWizard, { props: { open: true, onClose } });
+    const { dialog, doc } = dialogOf(container);
+    await tick(); // let focusTrap + the focus effect settle
+
+    // Real keyboard focus lands inside the dialog (not a synthetic overlay event).
+    expect(dialog.contains(doc.activeElement)).toBe(true);
+
+    await fireEvent.keyDown(doc.activeElement!, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('anchors focus to the step primary action on open', async () => {
+    const { container } = render(OnboardingWizard, { props: { open: true, onClose } });
+    const { dialog, doc } = dialogOf(container);
+    await tick();
+
+    expect(doc.activeElement).toBe(buttonByText(dialog, 'Add to PATH'));
+  });
+
+  it('re-anchors focus inside the dialog after advancing a step', async () => {
+    // PATH already configured → the path step shows "Next" immediately.
+    mockBackend({ pathAlreadyConfigured: true });
+    const { container } = render(OnboardingWizard, { props: { open: true, onClose } });
+    const { dialog, doc } = dialogOf(container);
+    await tick(); // path step ("Next") rendered + focused
+
+    await fireEvent.click(buttonByText(dialog, 'Next')); // advance to the summary step
+    await tick();
+
+    // Focus did not fall to <body>; it followed into the new step, so the trap's
+    // Escape handling still works.
+    expect(dialog.contains(doc.activeElement)).toBe(true);
+    await fireEvent.keyDown(doc.activeElement!, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on backdrop click but not on dialog-content click', async () => {
+    const { container } = render(OnboardingWizard, { props: { open: true, onClose } });
+    const { dialog } = dialogOf(container);
+
+    await fireEvent.click(dialog); // inside the dialog — must not close
+    expect(onClose).not.toHaveBeenCalled();
+
+    await fireEvent.click(dialog.parentElement!); // the backdrop
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Closes #1414 (the last open item)

#1415 built the shared `focusTrap` action and migrated `version-conflict-modal`, `pro-relogin-modal`, and `delete-confirmation-modal`. The one deferred item was the **onboarding wizard** ("multi-step focus management needs more care"). This finishes it.

## Change
- The wizard's dialog content is now the focusable `role="dialog"` **focusTrap** target (`use:focusTrap={{ onEscape: onClose }}`, `tabindex=0`, `aria-modal`); the backdrop is a plain `role="presentation"` overlay that closes on click. Removed the hand-rolled backdrop `Escape` + click handlers.
- **Multi-step care:** advancing a step or a configure step succeeding swaps the primary action button, which unmounts the focused button and drops focus to `<body>` — where the trap's Escape/Tab handler can't see key presses. An `$effect`, keyed on exactly the state that changes the visible primary action (`currentStep`, `stepSuccess`, `pathWasAlreadyConfigured`), re-anchors focus to the new step's primary button after each transition. No text inputs → it never interrupts typing.

## Tests
New `onboarding-wizard.test.ts` drives **real keyboard focus** (per the issue's standard, not synthetic overlay dispatch): focus lands inside on open, Escape from inside dismisses, focus follows across a step transition, and backdrop-vs-content click behaves. Queries are scoped to the render `container` + `ownerDocument` and assert synchronously after `tick()`, so they're robust to global-document state from other suites (an earlier `screen`/`waitFor` version was flaky under full-suite pollution).

## Validation
- Full desktop suite **3885** passing (+5 new); `bun run test:free-users` green (no community impact); eslint + svelte-check clean.