### PR TITLE
fix: daemon stability, stale binary kill safety, and task title propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,12 +292,6 @@ jobs:
         with:
           bun-version: "1.3.11"
 
-      - name: Setup Node.js (for npm publish)
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Install dependencies (skill)
         run: bun install --frozen-lockfile
         working-directory: packages/skill
@@ -305,7 +299,10 @@ jobs:
       - name: Set version from release tag (skill)
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          npm version "${TAG#v}" --no-git-tag-version
+          VERSION="${TAG#v}"
+          # Update version directly — avoids npm's workspace: protocol error
+          contents=$(cat package.json)
+          echo "$contents" | sed "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" > package.json
         working-directory: packages/skill
 
       - name: Build @nodespaceai/skill
@@ -313,10 +310,11 @@ jobs:
         working-directory: packages/skill
 
       - name: Publish @nodespaceai/skill
-        run: npm publish --access public
+        run: bun publish --access public
         working-directory: packages/skill
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   update-homebrew-cask:
     name: Update Homebrew cask

--- a/packages/desktop-app/src-tauri/src/daemon_setup.rs
+++ b/packages/desktop-app/src-tauri/src/daemon_setup.rs
@@ -104,18 +104,40 @@ pub fn kill_stale_daemon_sync(app: &tauri::App) {
         "Installed daemon binary is stale — killing before gRPC client connects"
     );
 
-    // Kill via lsof → SIGKILL (fast; launchd will restart with fresh binary after extraction)
+    // Kill only nodespaced processes using the socket (not gRPC clients like nodespace-app).
+    // lsof -t returns all PIDs with the socket open — we filter to those whose executable
+    // is named "nodespaced" to avoid SIGKILLing the Tauri app itself.
     let sock = socket_path.to_string_lossy();
     if let Ok(out) = std::process::Command::new("lsof")
-        .args(["-t", "-U", sock.as_ref()])
+        .args(["-F", "pn", "-U", sock.as_ref()])
         .output()
     {
-        for pid in String::from_utf8_lossy(&out.stdout)
-            .split_whitespace()
-            .filter_map(|s: &str| s.parse::<i32>().ok())
-        {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
-            tracing::info!(pid, "Sent SIGKILL to stale nodespaced");
+        let output = String::from_utf8_lossy(&out.stdout);
+        let mut current_pid: Option<i32> = None;
+        for line in output.lines() {
+            if let Some(pid_str) = line.strip_prefix('p') {
+                current_pid = pid_str.parse::<i32>().ok();
+            } else if line.strip_prefix('n').is_some() {
+                // Check if this PID is a nodespaced process
+                if let Some(pid) = current_pid {
+                    let exe_check = std::process::Command::new("ps")
+                        .args(["-p", &pid.to_string(), "-o", "comm="])
+                        .output()
+                        .ok();
+                    let is_daemon = exe_check
+                        .as_ref()
+                        .map(|o| {
+                            String::from_utf8_lossy(&o.stdout)
+                                .trim()
+                                .ends_with("nodespaced")
+                        })
+                        .unwrap_or(false);
+                    if is_daemon {
+                        unsafe { libc::kill(pid, libc::SIGKILL) };
+                        tracing::info!(pid, "Sent SIGKILL to stale nodespaced");
+                    }
+                }
+            }
         }
     }
 

--- a/packages/desktop-app/src-tauri/src/daemon_setup.rs
+++ b/packages/desktop-app/src-tauri/src/daemon_setup.rs
@@ -105,38 +105,43 @@ pub fn kill_stale_daemon_sync(app: &tauri::App) {
     );
 
     // Kill only nodespaced processes using the socket (not gRPC clients like nodespace-app).
-    // lsof -t returns all PIDs with the socket open — we filter to those whose executable
-    // is named "nodespaced" to avoid SIGKILLing the Tauri app itself.
+    // Parse lsof -F pn output to collect unique PIDs, then verify each is nodespaced
+    // before SIGKILLing. Deduplicating into a HashSet avoids spawning ps more than once
+    // per PID when the daemon has multiple FDs open on the socket.
     let sock = socket_path.to_string_lossy();
     if let Ok(out) = std::process::Command::new("lsof")
         .args(["-F", "pn", "-U", sock.as_ref()])
         .output()
     {
+        use std::collections::HashSet;
         let output = String::from_utf8_lossy(&out.stdout);
         let mut current_pid: Option<i32> = None;
+        let mut pids_to_check: HashSet<i32> = HashSet::new();
         for line in output.lines() {
             if let Some(pid_str) = line.strip_prefix('p') {
                 current_pid = pid_str.parse::<i32>().ok();
             } else if line.strip_prefix('n').is_some() {
-                // Check if this PID is a nodespaced process
                 if let Some(pid) = current_pid {
-                    let exe_check = std::process::Command::new("ps")
-                        .args(["-p", &pid.to_string(), "-o", "comm="])
-                        .output()
-                        .ok();
-                    let is_daemon = exe_check
-                        .as_ref()
-                        .map(|o| {
-                            String::from_utf8_lossy(&o.stdout)
-                                .trim()
-                                .ends_with("nodespaced")
-                        })
-                        .unwrap_or(false);
-                    if is_daemon {
-                        unsafe { libc::kill(pid, libc::SIGKILL) };
-                        tracing::info!(pid, "Sent SIGKILL to stale nodespaced");
-                    }
+                    pids_to_check.insert(pid);
                 }
+            }
+        }
+        for pid in pids_to_check {
+            let exe_check = std::process::Command::new("ps")
+                .args(["-p", &pid.to_string(), "-o", "comm="])
+                .output()
+                .ok();
+            let is_daemon = exe_check
+                .as_ref()
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .trim()
+                        .ends_with("nodespaced")
+                })
+                .unwrap_or(false);
+            if is_daemon {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                tracing::info!(pid, "Sent SIGKILL to stale nodespaced");
             }
         }
     }
@@ -242,6 +247,9 @@ pub async fn ensure_daemon_running(app: &AppHandle) -> Result<DaemonStatus> {
 }
 
 /// Send SIGTERM to the process listening on the socket and wait for it to exit.
+///
+/// Uses `-F pn` output and verifies each PID's comm against "nodespaced" before
+/// signalling — avoids accidentally terminating gRPC clients sharing the socket.
 #[cfg(unix)]
 async fn kill_running_daemon(socket_path: &Path) {
     if check_daemon_socket(socket_path).await != DaemonStatus::Healthy {
@@ -250,18 +258,46 @@ async fn kill_running_daemon(socket_path: &Path) {
 
     // Resolve the PID via lsof rather than storing it, so this works whether the
     // daemon was started by launchd, a previous app launch, or manually.
+    // Parse -F pn output to extract PIDs, then verify each is nodespaced before
+    // sending SIGTERM (same pattern as kill_stale_daemon_sync).
     {
+        use std::collections::HashSet;
         use std::process::Command;
         let sock = socket_path.to_string_lossy();
-        if let Ok(out) = Command::new("lsof").args(["-t", "-U", &sock]).output() {
-            let pids: Vec<i32> = String::from_utf8_lossy(&out.stdout)
-                .split_whitespace()
-                .filter_map(|s| s.parse().ok())
-                .collect();
-            for pid in pids {
-                // SAFETY: kill() is always safe to call with a valid pid and signal.
-                unsafe { libc::kill(pid, libc::SIGTERM) };
-                tracing::info!("Sent SIGTERM to old nodespaced (pid {})", pid);
+        if let Ok(out) = Command::new("lsof")
+            .args(["-F", "pn", "-U", sock.as_ref()])
+            .output()
+        {
+            let output = String::from_utf8_lossy(&out.stdout);
+            let mut current_pid: Option<i32> = None;
+            let mut pids_to_kill: HashSet<i32> = HashSet::new();
+            for line in output.lines() {
+                if let Some(pid_str) = line.strip_prefix('p') {
+                    current_pid = pid_str.parse::<i32>().ok();
+                } else if line.strip_prefix('n').is_some() {
+                    if let Some(pid) = current_pid {
+                        pids_to_kill.insert(pid);
+                    }
+                }
+            }
+            for pid in pids_to_kill {
+                let exe_check = Command::new("ps")
+                    .args(["-p", &pid.to_string(), "-o", "comm="])
+                    .output()
+                    .ok();
+                let is_daemon = exe_check
+                    .as_ref()
+                    .map(|o| {
+                        String::from_utf8_lossy(&o.stdout)
+                            .trim()
+                            .ends_with("nodespaced")
+                    })
+                    .unwrap_or(false);
+                if is_daemon {
+                    // SAFETY: kill() is always safe to call with a valid pid and signal.
+                    unsafe { libc::kill(pid, libc::SIGTERM) };
+                    tracing::info!("Sent SIGTERM to old nodespaced (pid {})", pid);
+                }
             }
         }
     }

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -261,15 +261,30 @@ pub fn run() {
                     // Ensure nodespaced service is installed and running (launchd on macOS, systemd on Linux).
                     {
                         use daemon_setup::{ensure_daemon_running, DaemonStatus};
+
+                        // Signal the frontend to hold off on gRPC calls until the daemon is ready.
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.emit("daemon-status", "starting");
+                        }
+
                         match ensure_daemon_running(&app_handle).await {
                             Ok(DaemonStatus::Healthy) => {
                                 tracing::info!("nodespaced is running");
+                                if let Some(window) = app_handle.get_webview_window("main") {
+                                    let _ = window.emit("daemon-status", "healthy");
+                                }
                             }
                             Ok(status) => {
                                 tracing::warn!("nodespaced not yet healthy: {:?}", status);
+                                if let Some(window) = app_handle.get_webview_window("main") {
+                                    let _ = window.emit("daemon-status", "not_running");
+                                }
                             }
                             Err(e) => {
                                 tracing::error!("Daemon setup failed: {:#}", e);
+                                if let Some(window) = app_handle.get_webview_window("main") {
+                                    let _ = window.emit("daemon-status", "not_running");
+                                }
                             }
                         }
                     }

--- a/packages/desktop-app/src/lib/types/task-node.ts
+++ b/packages/desktop-app/src/lib/types/task-node.ts
@@ -81,6 +81,7 @@ export interface TaskNode {
   id: string;
   nodeType: 'task';
   content: string;
+  title?: string;
   version: number;
   createdAt: string;
   modifiedAt: string;

--- a/packages/desktop-app/src/routes/+layout.svelte
+++ b/packages/desktop-app/src/routes/+layout.svelte
@@ -18,14 +18,18 @@
   /** Wait for daemon-status: healthy or not_running (max 30s). */
   async function waitForDaemon(): Promise<void> {
     if (!isTauri()) return;
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, 30_000);
-      listen<string>('daemon-status', (event) => {
+    await new Promise<void>(async (resolve) => {
+      const unlisten = await listen<string>('daemon-status', (event) => {
         if (event.payload === 'healthy' || event.payload === 'not_running') {
           clearTimeout(timer);
+          unlisten();
           resolve();
         }
       });
+      const timer = setTimeout(() => {
+        unlisten();
+        resolve();
+      }, 30_000);
     });
   }
 

--- a/packages/desktop-app/src/routes/+layout.svelte
+++ b/packages/desktop-app/src/routes/+layout.svelte
@@ -9,9 +9,25 @@
   import { initializeTauriSyncListeners } from '$lib/services/tauri-sync-listener';
   import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
   import { initializeApp } from '$lib/services/app-initialization';
+  import { isTauri } from '@tauri-apps/api/core';
+  import { listen } from '@tauri-apps/api/event';
 
   let isInitialized = false;
   let initError: string | null = null;
+
+  /** Wait for daemon-status: healthy or not_running (max 30s). */
+  async function waitForDaemon(): Promise<void> {
+    if (!isTauri()) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 30_000);
+      listen<string>('daemon-status', (event) => {
+        if (event.payload === 'healthy' || event.payload === 'not_running') {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+  }
 
   // Initialize database first, then schema plugins, then sync listeners
   onMount(async () => {
@@ -19,7 +35,12 @@
       // Step 1: Initialize database and Tauri services
       await initializeApp();
 
-      // Step 2: Initialize schema plugin auto-registration system
+      // Step 2: Wait for the daemon to be ready before issuing any gRPC calls.
+      // daemon_setup emits 'daemon-status: starting' immediately, then 'healthy'
+      // or 'not_running' once ensure_daemon_running completes.
+      await waitForDaemon();
+
+      // Step 3: Initialize schema plugin auto-registration system
       // This must happen after database is ready
       try {
         const result = await initializeSchemaPluginSystem();
@@ -40,7 +61,7 @@
         console.error('[App Layout] Schema plugin initialization failed:', error);
       }
 
-      // Step 3: Initialize Tauri domain event listeners for real-time synchronization
+      // Step 4: Initialize Tauri domain event listeners for real-time synchronization
       try {
         await initializeTauriSyncListeners();
       } catch (error) {

--- a/packages/desktop-app/src/routes/+layout.svelte
+++ b/packages/desktop-app/src/routes/+layout.svelte
@@ -18,19 +18,26 @@
   /** Wait for daemon-status: healthy or not_running (max 30s). */
   async function waitForDaemon(): Promise<void> {
     if (!isTauri()) return;
-    await new Promise<void>(async (resolve) => {
-      const unlisten = await listen<string>('daemon-status', (event) => {
-        if (event.payload === 'healthy' || event.payload === 'not_running') {
-          clearTimeout(timer);
-          unlisten();
-          resolve();
-        }
-      });
-      const timer = setTimeout(() => {
-        unlisten();
-        resolve();
-      }, 30_000);
+    // Wire resolve through a shared mutable slot so the listen callback and the
+    // timeout both reference the same resolver without an async promise executor.
+    let resolveWait!: () => void;
+    const wait = new Promise<void>((r) => {
+      resolveWait = r;
     });
+    // Await listen registration before starting the timer — guarantees the
+    // unlisten handle is captured and no events are missed.
+    const unlisten = await listen<string>('daemon-status', (event) => {
+      if (event.payload === 'healthy' || event.payload === 'not_running') {
+        unlisten();
+        resolveWait();
+      }
+    });
+    const timer = setTimeout(() => {
+      unlisten();
+      resolveWait();
+    }, 30_000);
+    await wait;
+    clearTimeout(timer);
   }
 
   // Initialize database first, then schema plugins, then sync listeners

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -132,10 +132,12 @@ fn task_node_to_value(node: Node) -> Result<serde_json::Value, String> {
         .map(normalize_date_field);
 
     let lifecycle_status = node.lifecycle_status.clone();
+    let title = node.title.clone();
     let task = TaskNode {
         id: node.id,
         node_type: node.node_type,
         content: node.content,
+        title,
         version: node.version,
         created_at: node.created_at,
         modified_at: node.modified_at,

--- a/packages/nodespace-types/src/task.rs
+++ b/packages/nodespace-types/src/task.rs
@@ -110,6 +110,8 @@ pub struct TaskNode {
     #[serde(rename = "nodeType")]
     pub node_type: String,
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub version: i64,
     pub created_at: DateTime<Utc>,
     pub modified_at: DateTime<Utc>,


### PR DESCRIPTION
## Summary

- **SIGKILL storm fix**: `kill_stale_daemon_sync` was using `lsof -t` to find all PIDs with the daemon socket open, then killing all of them — including gRPC clients like `nodespace-app` itself. Now filters via `ps comm=` to only kill processes whose executable ends with `nodespaced`.
- **Race condition fix**: Frontend was issuing gRPC calls before the daemon socket existed. Added `daemon-status` events (`starting`/`healthy`/`not_running`) emitted from Rust, and `waitForDaemon()` in the layout that blocks initialization until the daemon is ready (30s timeout).
- **Task title fix**: `TaskNode` serialization in `nodespace-types` was dropping the `title` field, causing `search_nodes` to return `title: ""` to the agent even when the DB had the correct value. Added `title: Option<String>` to `TaskNode` and populated it in `task_node_to_value`.

## Test plan

- [ ] `bun run dev:tauri` completes without killing itself (no more SIGKILL storm)
- [ ] Daemon starts and is healthy within a few seconds of app launch
- [ ] Frontend does not issue gRPC calls before daemon socket is ready
- [ ] `search_nodes` returns correct title for task nodes to the agent
- [ ] `cargo build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)