### PR TITLE
Batch A (P0): data-integrity fixes — transactional move_node (#1429) + window-close/reload store guards (#1435, #1436)

### DIFF
--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -1557,18 +1557,30 @@ impl SqliteStore {
                     libsql::params![props, now, parent_id.clone(), node_id.clone()],
                 ).await.context("Failed to update relationship order")?;
             } else {
-                // Delete old parent relationship, create new one
-                self.db.execute(
+                // Cross-parent move: delete the old has_child edge, create the new
+                // one. These MUST be one transaction — if the INSERT fails
+                // (constraint / IO / crash / cancel) after the DELETE committed, the
+                // node is left with NO has_child edge: a silently-orphaned root.
+                // Wrapping in a tx makes it all-or-nothing, matching the atomicity
+                // of `move_children_to_parent` / `delete_subtree_atomic`.
+                let rel_id = uuid::Uuid::new_v4().to_string();
+                let props = serde_json::json!({"order": new_order}).to_string();
+                let tx = self
+                    .db
+                    .transaction()
+                    .await
+                    .context("Failed to begin move_node reparent transaction")?;
+                tx.execute(
                     "DELETE FROM relationship WHERE out_node = ?1 AND relationship_type = 'has_child'",
                     libsql::params![node_id.clone()],
                 ).await.context("Failed to delete old parent relationship")?;
-
-                let rel_id = uuid::Uuid::new_v4().to_string();
-                let props = serde_json::json!({"order": new_order}).to_string();
-                self.db.execute(
+                tx.execute(
                     "INSERT INTO relationship (id, in_node, out_node, relationship_type, properties, version, created_at, modified_at) VALUES (?1, ?2, ?3, 'has_child', ?4, 1, ?5, ?6)",
                     libsql::params![rel_id, parent_id.clone(), node_id.clone(), props, now.clone(), now],
                 ).await.context("Failed to create new parent relationship")?;
+                tx.commit()
+                    .await
+                    .context("Failed to commit move_node reparent transaction")?;
             }
         } else {
             // Make root: delete parent relationship
@@ -4199,6 +4211,55 @@ mod tests {
             parent_of_child1.as_deref(),
             Some(parent_id.as_str()),
             "child1 should still be under original parent after rollback"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_move_node_cross_parent_leaves_exactly_one_edge() -> Result<()> {
+        // #1429: the cross-parent move deletes the old has_child edge and inserts
+        // the new one in ONE transaction. After a successful move the node must
+        // have EXACTLY ONE has_child edge, pointing at the new parent — never zero
+        // (orphaned root, the bug when a non-transactional INSERT failed after the
+        // DELETE committed) and never two (old edge left behind).
+        let (store, _temp) = create_test_store().await?;
+
+        let parent_a = Node::new("text".to_string(), "Parent A".to_string(), json!({}));
+        let parent_a_id = parent_a.id.clone();
+        store.create_node(parent_a, None, None).await?;
+
+        let parent_b = Node::new("text".to_string(), "Parent B".to_string(), json!({}));
+        let parent_b_id = parent_b.id.clone();
+        store.create_node(parent_b, None, None).await?;
+
+        let child = Node::new("text".to_string(), "Child".to_string(), json!({}));
+        let child_id = child.id.clone();
+        store.create_node(child, None, None).await?;
+
+        // Wire under A, then move to B — this exercises the cross-parent branch.
+        store.move_node(&child_id, Some(&parent_a_id), None).await?;
+        store.move_node(&child_id, Some(&parent_b_id), None).await?;
+
+        let mut rows = store
+            .db
+            .query(
+                "SELECT in_node FROM relationship WHERE out_node = ?1 AND relationship_type = 'has_child'",
+                libsql::params![child_id.clone()],
+            )
+            .await?;
+        let mut parents: Vec<String> = Vec::new();
+        while let Some(row) = rows.next().await? {
+            parents.push(row.get(0)?);
+        }
+        assert_eq!(
+            parents,
+            vec![parent_b_id.clone()],
+            "after a cross-parent move the child must have exactly one has_child edge, under the new parent"
+        );
+        assert_eq!(
+            store.get_parent_id(&child_id).await?.as_deref(),
+            Some(parent_b_id.as_str()),
         );
 
         Ok(())

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -285,13 +285,20 @@ class SimplePersistenceCoordinator {
     const promises: Promise<void>[] = [];
     for (const [nodeId, pending] of this.pendingOperations) {
       clearTimeout(pending.timeoutId);
-      // Execute the operation directly - start the execution, then wait on the pending promise
-      pending.operation().then(
-        () => pending.resolve(),
-        (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
-      ).finally(() => {
-        this.pendingOperations.delete(nodeId);
-      });
+      // Only START the operation if it is not already in flight. Without this
+      // guard, a debounced save whose timeout fired just before window-close
+      // (so it is mid-RPC, tracked in executingOperations) would be executed a
+      // SECOND time here — an OCC conflict or duplicate create at the most
+      // data-loss-sensitive moment. Mirror flushAndWaitForNodes: skip the
+      // re-execute, but still await the in-flight promise either way.
+      if (!this.executingOperations.has(nodeId)) {
+        pending.operation().then(
+          () => pending.resolve(),
+          (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
+        ).finally(() => {
+          this.pendingOperations.delete(nodeId);
+        });
+      }
       promises.push(pending.promise.catch(() => {})); // Ignore errors, just wait for completion
     }
 
@@ -1718,6 +1725,39 @@ export class SharedNodeStore {
           log.debug(`batchSetNodes: skipping ai-chat stale snapshot`, { nodeId: node.id, incomingCount, existingCount });
           continue;
         }
+      }
+
+      // Same skip-while-editing guard as setNode (nodespace-sync#76): a concurrent
+      // tree (re)load with a `database` source must NOT clobber a node the user is
+      // actively editing — `doLoadChildrenTree` passes a database source, so a
+      // reload for a parent whose child is mid-keystroke would overwrite the
+      // child's optimistic content. ai-chat is exempt (messages are written
+      // programmatically; skipping causes version drift). Extract the predicate
+      // into a variable — the Svelte strict_equals transform drops parentheses
+      // from inline `a && b && (c || d)` reactive reads, turning it into
+      // `a && b && c || d`.
+      const isFocused = focusManager.editingNodeId === node.id;
+      const hasPending = PersistenceCoordinator.getInstance().hasPending(node.id);
+      const isActivelyEdited = isFocused || hasPending;
+      if (
+        source.type === 'database' &&
+        existingNode &&
+        isActivelyEdited &&
+        node.nodeType !== 'ai-chat'
+      ) {
+        log.debug(
+          `batchSetNodes: skipping clobber of actively-edited node ${node.id} ` +
+            `(focused=${isFocused}, pending=${hasPending})`
+        );
+        // Stash the server-confirmed version only when the broadcast is plausibly
+        // an echo of THIS client's own write; otherwise leave it empty so the next
+        // RPC uses our local version, conflicts, and surfaces the foreign change
+        // (preserves OCC). Mirrors setNode exactly.
+        if (typeof node.version === 'number' && this.isPlausibleOwnEcho(existingNode, node)) {
+          this.serverConfirmedVersions.set(node.id, node.version);
+        }
+        this.persistedNodeIds.add(node.id);
+        continue;
       }
 
       const isHierarchyChange = !existingNode;

--- a/packages/desktop-app/src/tests/services/shared-node-store-coverage.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-coverage.test.ts
@@ -527,6 +527,37 @@ describe('SharedNodeStore - Coverage Completion', () => {
       // Should timeout gracefully
       await expect(store.flushAllPending()).resolves.not.toThrow();
     });
+
+    it('does not double-execute an already in-flight operation on flush (#1435)', async () => {
+      // A controllable in-flight persist: the backend call hangs until we
+      // resolve it manually, so we can flush WHILE the op is still executing.
+      let resolveUpdate!: (v: Node) => void;
+      const updateSpy = vi
+        .spyOn(backendAdapter, 'updateNode')
+        .mockImplementation(
+          () => new Promise<Node>((res) => { resolveUpdate = res; })
+        );
+
+      store.setNode(mockNode, databaseSource);
+      store.updateNode(mockNode.id, { content: 'in-flight' }, viewerSource);
+
+      // Let the 500ms debounce fire: the op moves pending → executing and calls
+      // the backend exactly once (now parked on our unresolved promise).
+      await new Promise((r) => setTimeout(r, 600));
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+
+      // Flush on window-close while the op is still in flight. The executing-op
+      // guard must NOT start a second backend call (the bug: an OCC conflict or
+      // duplicate create at the worst possible moment).
+      const flushPromise = store.flushAllPending();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+
+      // Complete the in-flight op; flush settles by awaiting that same promise.
+      resolveUpdate({ ...mockNode, content: 'in-flight', version: 2 });
+      await flushPromise;
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ========================================================================

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -294,4 +294,60 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     expect(after?.content).toBe('cloud-current');
     expect(after?.version).toBe(15);
   });
+
+  // #1436: batchSetNodes (used by doLoadChildrenTree with a database source)
+  // must apply the SAME skip-while-editing guard as setNode — a concurrent tree
+  // reload would otherwise overwrite a child being edited mid-keystroke.
+  describe('batchSetNodes guard (#1436)', () => {
+    it('skips clobbering a focused node in a database-source batch', () => {
+      const optimistic = makeNode('b1', 'hello world', 1);
+      store.setNode(optimistic, viewerSource);
+      focusManager.focusNode('b1', 'default');
+
+      // A tree (re)load batch lands with the older confirmed snapshot.
+      store.batchSetNodes([makeNode('b1', 'hell', 2)], databaseSource);
+
+      const after = store.getNode('b1');
+      expect(after?.content).toBe('hello world');
+      expect(after?.version).toBe(1);
+    });
+
+    it('skips clobbering a node with pending persistence in a batch even if unfocused', () => {
+      store.setNode(makeNode('b2', 'initial', 1), viewerSource);
+      store.updateNode('b2', { content: 'user-typing-this' }, viewerSource);
+
+      store.batchSetNodes([makeNode('b2', 'initial', 2)], databaseSource);
+
+      const after = store.getNode('b2');
+      expect(after?.content).toBe('user-typing-this');
+      expect(after?.version).toBe(1);
+    });
+
+    it('applies database-source batch updates for non-focused, non-dirty nodes (regression)', () => {
+      store.setNode(makeNode('b3', 'before', 1), databaseSource);
+
+      store.batchSetNodes([makeNode('b3', 'after', 5)], databaseSource);
+
+      expect(store.getNode('b3')?.content).toBe('after');
+      expect(store.getNode('b3')?.version).toBe(5);
+    });
+
+    it('guards only the edited node, applying the rest of the batch', () => {
+      // b4 is being edited; b5 is untouched. One batch reload touches both.
+      store.setNode(makeNode('b4', 'editing-this', 1), viewerSource);
+      focusManager.focusNode('b4', 'default');
+      store.setNode(makeNode('b5', 'old', 1), databaseSource);
+
+      store.batchSetNodes(
+        [makeNode('b4', 'stale', 2), makeNode('b5', 'new', 7)],
+        databaseSource
+      );
+
+      // b4 preserved (guard fired), b5 applied (no guard).
+      expect(store.getNode('b4')?.content).toBe('editing-this');
+      expect(store.getNode('b4')?.version).toBe(1);
+      expect(store.getNode('b5')?.content).toBe('new');
+      expect(store.getNode('b5')?.version).toBe(7);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1 bug-sweep **Batch A**, core half — three P0 data-integrity fixes. Each mirrors a guard/pattern that already exists on a sibling path, so they're small and low-risk.

### `#1429` — make cross-parent `move_node` transactional
`move_node` ran DELETE old `has_child` edge + INSERT new edge as two un-enclosed `db.execute` calls. An INSERT failure after the committed DELETE left the node with **no** parent edge — a silently-orphaned root. `move_children_to_parent` / `delete_subtree_atomic` already wrap their multi-statement work in a transaction.
**Fix:** wrap delete-old + insert-new in one `transaction()` + `commit()`. Make-root / same-parent-reorder are single statements (already atomic).

### `#1435` — `flushPending` executing-op guard
`flushPending` (run by `flushAllPending` on window close) re-invoked `pending.operation()` for **every** entry, including ones already executing — a debounced save mid-RPC fires twice → OCC conflict / duplicate create at the worst moment. Sibling `flushAndWaitForNodes` guards this with `!executingOperations.has(nodeId)`.
**Fix:** add the same guard; still await the in-flight promise.

### `#1436` — `batchSetNodes` skip-while-editing guard
`batchSetNodes` (used by `doLoadChildrenTree` with a `database` source) lacked `setNode`'s `isFocused || hasPending` skip, so a concurrent tree reload overwrote a child being edited mid-keystroke (the sync#76 corruption class).
**Fix:** apply the same skip-while-editing guard + server-confirmed-version stash per node in the database-source loop.

## Tests
- Rust: `test_move_node_cross_parent_leaves_exactly_one_edge` (asserts exactly one edge, under the new parent). `cargo fmt`/`clippy -D warnings` clean.
- Frontend: new `flushPending` double-execute test + 4 `batchSetNodes` guard cases. **Full suite 3890/3890 pass.**
- `test:free-users`: **7/7 pass** — community build behaviorally unchanged.

## Free/community impact
None behaviorally — `#1435`/`#1436` harden existing local-store guards (additive skips), `#1429` makes a store mutation atomic. `test:free-users` green.

> Note: `bun run quality:fix` surfaces 3 **pre-existing** eslint errors in two files this PR does not touch (`person-schema-form.svelte`, `reactive-structure-tree.svelte.ts`); the files I changed are eslint-clean. Flagging rather than expanding scope.

Closes #1429, closes #1435, closes #1436.