### PR TITLE
Batch C (P2): append-order sentinel (#1431) + conflict-vs-NotFound (#1432) + foreign-write signal (#1437)

### DIFF
--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -517,17 +517,19 @@ impl SqliteStore {
             libsql::params![parent_id.to_string()],
         ).await.context("Failed to get last child order")?;
 
-        let last_order = if let Some(row) = rows.next().await? {
-            row.get::<Option<f64>>(0)?.unwrap_or(0.0)
+        // #1431: distinguish "no siblings" from "a sibling at order <= 0".
+        // Fractional ordering legitimately yields orders <= 0 (a prepend gives
+        // 0.0, then -1.0…), and `unwrap_or(0.0)` maps a NULL order to 0.0. The old
+        // `last_order > 0.0` sentinel misread a lone child at 0.0 as "no children",
+        // so the next append also got 1.0 → two siblings collided at 1.0. Track
+        // presence as Option and append after the max regardless of sign.
+        let last_order: Option<f64> = if let Some(row) = rows.next().await? {
+            Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
         } else {
-            0.0
+            None
         };
 
-        let new_order = if last_order > 0.0 {
-            FractionalOrderCalculator::calculate_order(Some(last_order), None)
-        } else {
-            FractionalOrderCalculator::calculate_order(None, None)
-        };
+        let new_order = FractionalOrderCalculator::calculate_order(last_order, None);
 
         let properties = if properties.is_null() {
             serde_json::json!({})
@@ -777,6 +779,25 @@ impl SqliteStore {
         });
 
         Ok(node)
+    }
+
+    /// Version of the REAL persisted `node` row, or `None` if no such row exists.
+    /// Unlike `get_node`, this does NOT virtualize a date-page node — so a
+    /// concurrently-deleted date page reports `None`, not a phantom version 1.
+    /// Used to disambiguate a no-op version-checked update (#1432).
+    pub async fn persisted_version(&self, id: &str) -> Result<Option<i64>> {
+        let mut rows = self
+            .db
+            .query(
+                "SELECT version FROM node WHERE id = ?1",
+                libsql::params![id.to_string()],
+            )
+            .await
+            .context("Failed to read persisted node version")?;
+        Ok(match rows.next().await? {
+            Some(row) => Some(row.get::<i64>(0)?),
+            None => None,
+        })
     }
 
     pub async fn update_node_with_version_check(
@@ -3165,17 +3186,15 @@ impl SqliteStore {
             .await
             .context("Failed to get last order for relationship")?;
 
-        let last_order = if let Some(row) = rows.next().await? {
-            row.get::<Option<f64>>(0)?.unwrap_or(0.0)
+        // #1431: presence-not-sign — append after the max sibling even when its
+        // order is <= 0 (a `> 0.0` sentinel misreads a lone child at 0.0 as none).
+        let last_order: Option<f64> = if let Some(row) = rows.next().await? {
+            Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
         } else {
-            0.0
+            None
         };
 
-        Ok(if last_order > 0.0 {
-            FractionalOrderCalculator::calculate_order(Some(last_order), None)
-        } else {
-            FractionalOrderCalculator::calculate_order(None, None)
-        })
+        Ok(FractionalOrderCalculator::calculate_order(last_order, None))
     }
 
     pub async fn get_next_member_order(&self, collection_id: &str) -> Result<f64> {
@@ -3219,19 +3238,13 @@ impl SqliteStore {
             .await
             .context("Failed to get last member order")?;
 
-        let last_order = if let Some(row) = order_rows.next().await? {
-            row.get::<Option<f64>>(0)?.unwrap_or(0.0)
+        // #1431: presence-not-sign — append after the max member even at order <= 0.
+        let last_order: Option<f64> = if let Some(row) = order_rows.next().await? {
+            Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
         } else {
-            0.0
+            None
         };
-        let new_order = FractionalOrderCalculator::calculate_order(
-            if last_order > 0.0 {
-                Some(last_order)
-            } else {
-                None
-            },
-            None,
-        );
+        let new_order = FractionalOrderCalculator::calculate_order(last_order, None);
 
         let rel_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
@@ -3997,6 +4010,57 @@ mod tests {
             1,
             "backfill should re-index the node"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_order_uses_negative_sibling_not_default() -> Result<()> {
+        // #1431: appending after a sibling whose order is <= 0 must compute from
+        // that real max, not fall back to the first-item default. A sibling at
+        // -1.0 (a legitimate prepend result) → next order 0.0 (= -1.0 + 1.0), NOT
+        // the buggy 1.0 the `last_order > 0.0` sentinel produced.
+        let (store, _t) = create_test_store().await?;
+
+        let coll = Node::new("collection".to_string(), "C".to_string(), json!({}));
+        let cid = coll.id.clone();
+        store.create_node(coll, None, None).await?;
+        let m = Node::new("text".to_string(), "m".to_string(), json!({}));
+        let mid = m.id.clone();
+        store.create_node(m, None, None).await?;
+        store.add_to_collection(&mid, &cid).await?; // member_of: in_node=member, out_node=collection
+
+        store
+            .db
+            .execute(
+                "UPDATE relationship SET properties = json_set(properties, '$.order', -1.0) \
+                 WHERE in_node = ?1 AND out_node = ?2 AND relationship_type = 'member_of'",
+                libsql::params![mid.clone(), cid.clone()],
+            )
+            .await?;
+
+        let next = store.get_next_member_order(&cid).await?;
+        assert_eq!(
+            next, 0.0,
+            "append after a sibling at -1.0 should be 0.0, not the 1.0 first-item default"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_persisted_version_distinguishes_missing_from_present() -> Result<()> {
+        // #1432: the primitive that disambiguates a no-op version-checked update —
+        // a real row reports Some(version); a missing row (incl. a date-format id
+        // that get_node would virtualize) reports None, NOT a phantom version.
+        let (store, _t) = create_test_store().await?;
+
+        let node = Node::new("text".to_string(), "x".to_string(), json!({}));
+        let nid = node.id.clone();
+        let created = store.create_node(node, None, None).await?;
+        assert_eq!(store.persisted_version(&nid).await?, Some(created.version));
+
+        assert_eq!(store.persisted_version("does-not-exist").await?, None);
+        // A date-format id with no real row must report None (no virtual v1).
+        assert_eq!(store.persisted_version("2026-01-01").await?, None);
         Ok(())
     }
 

--- a/packages/core/src/services/node_service/crud.rs
+++ b/packages/core/src/services/node_service/crud.rs
@@ -988,20 +988,25 @@ impl NodeService {
         {
             Some(updated_node) => Ok(updated_node),
             None => {
-                // Version conflict - need to fetch current version for error message
-                let current_version = self
+                // #1432: the version-gated UPDATE matched no row for one of two
+                // reasons — the node was concurrently DELETED, or its version
+                // moved. Disambiguate against the REAL persisted row: `get_node`
+                // virtualizes a date page, so it would report a phantom version 1
+                // for a deleted date node → a false `version_conflict{actual:1}`
+                // instead of `NotFound` (and an absent regular node → `actual:0`).
+                match self
                     .store
-                    .get_node(node_id)
+                    .persisted_version(node_id)
                     .await
                     .map_err(|e| NodeServiceError::query_failed(e.to_string()))?
-                    .map(|n| n.version)
-                    .unwrap_or(0);
-
-                Err(NodeServiceError::version_conflict(
-                    node_id,
-                    expected_version,
-                    current_version,
-                ))
+                {
+                    None => Err(NodeServiceError::node_not_found(node_id)),
+                    Some(actual) => Err(NodeServiceError::version_conflict(
+                        node_id,
+                        expected_version,
+                        actual,
+                    )),
+                }
             }
         }
     }

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -1433,6 +1433,24 @@ export class SharedNodeStore {
       // and surface the divergence.
       if (typeof node.version === 'number' && this.isPlausibleOwnEcho(existingNode, node)) {
         this.serverConfirmedVersions.set(node.id, node.version);
+      } else {
+        // #1437: this is a FOREIGN write to a node the user is actively editing
+        // (not our own echo). We skip the clobber above to protect the optimistic
+        // text, but previously left NO signal — relying on a later OCC to surface
+        // the divergence, which may never fire if our local version was already
+        // synced. So the user keeps typing over a stale base, unaware another
+        // writer changed the node. Proactively raise a version-mismatch
+        // notification (deduped per node) so the conflict is visible.
+        const alreadyFlagged = conflictNotifications.notifications.some(
+          (n) => n.nodeId === node.id && n.conflictType === 'version-mismatch'
+        );
+        if (!alreadyFlagged) {
+          conflictNotifications.add({
+            nodeId: node.id,
+            message: CONFLICT_MESSAGE['version-mismatch'],
+            conflictType: 'version-mismatch'
+          });
+        }
       }
       // `persistedNodeIds.add` is safe here precisely because the guard
       // only runs when `existingNode` is truthy — a database event for a

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
 import { focusManager } from '../../lib/services/focus-manager.svelte';
 import { structureTree } from '../../lib/stores/reactive-structure-tree.svelte';
+import { conflictNotifications } from '../../lib/stores/conflict-notifications.svelte';
 import type { Node } from '../../lib/types';
 import type { UpdateSource } from '../../lib/types/update-protocol';
 
@@ -46,6 +47,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     SharedNodeStore.resetInstance();
     store = SharedNodeStore.getInstance();
     focusManager.clearEditing();
+    conflictNotifications.dismissAll();
   });
 
   afterEach(() => {
@@ -348,6 +350,52 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
       expect(store.getNode('b4')?.version).toBe(1);
       expect(store.getNode('b5')?.content).toBe('new');
       expect(store.getNode('b5')?.version).toBe(7);
+    });
+  });
+
+  // #1437: a foreign write to an actively-edited node is skipped to protect the
+  // optimistic text — but it must NOT be silent. Surface a version-mismatch
+  // conflict notification so the user knows another writer changed the node.
+  describe('foreign-write conflict signal (#1437)', () => {
+    const versionMismatchFor = (nodeId: string) =>
+      conflictNotifications.notifications.filter(
+        (n) => n.nodeId === nodeId && n.conflictType === 'version-mismatch'
+      );
+
+    it('raises a version-mismatch notification when a foreign broadcast hits a focused node', () => {
+      store.setNode(makeNode('shared', 'hello world', 5), viewerSource);
+      focusManager.focusNode('shared', 'default');
+      store.__test_setLastPersistedContent('shared', 'hello world');
+
+      // Bob's foreign write (not a prefix/echo of alice's optimistic content).
+      store.setNode(makeNode('shared', 'totally different text', 7), databaseSource);
+
+      expect(versionMismatchFor('shared')).toHaveLength(1);
+      // Optimistic content still protected (the clobber was skipped).
+      expect(store.getNode('shared')?.content).toBe('hello world');
+    });
+
+    it('does NOT notify for an own-echo broadcast', () => {
+      store.setNode(makeNode('echo', 'hello world', 5), viewerSource);
+      focusManager.focusNode('echo', 'default');
+      // isPlausibleOwnEcho is true iff the incoming content equals our last-sent
+      // content — the daemon echoing back exactly what we persisted.
+      store.__test_setLastPersistedContent('echo', 'hello world');
+
+      store.setNode(makeNode('echo', 'hello world', 6), databaseSource);
+
+      expect(versionMismatchFor('echo')).toHaveLength(0);
+    });
+
+    it('dedupes repeated foreign broadcasts for the same node', () => {
+      store.setNode(makeNode('dup', 'hello world', 5), viewerSource);
+      focusManager.focusNode('dup', 'default');
+      store.__test_setLastPersistedContent('dup', 'hello world');
+
+      store.setNode(makeNode('dup', 'foreign one', 7), databaseSource);
+      store.setNode(makeNode('dup', 'foreign two', 8), databaseSource);
+
+      expect(versionMismatchFor('dup')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 bug-sweep **Batch C** (P2), core edge cases — three independent fixes.

### `#1431` — append-order sentinel misreads orders ≤ 0
"Append at end" treated `last_order > 0.0` as "siblings exist", but fractional ordering legitimately yields orders ≤ 0 (a prepend → 0.0, then -1.0…). A lone sibling at ≤ 0 was misread as "no siblings", so the append used the first-item default instead of computing from the real max → sibling-order collisions.
**Fix:** track presence as `Option<f64>` at all three append sites; append after the max regardless of sign.

### `#1432` — `version_conflict{actual:0}` instead of `NotFound` on concurrent delete
`update_node` mapped a no-op version-checked UPDATE to `version_conflict{actual:0}` for *both* a version mismatch and a concurrent delete, re-reading the version via `get_node` (which virtualizes a date page → phantom version 1).
**Fix:** new `persisted_version` (real row, no virtualization) — missing → `node_not_found`; present → `version_conflict` with the real version.

### `#1437` — foreign write to a focused node was silently dropped
A foreign `database` broadcast for an actively-edited node was skipped (to protect optimistic text) with **no signal**, relying on a later OCC that may never fire — the user keeps typing over a stale base, unaware.
**Fix:** raise a deduped `version-mismatch` conflict notification in the not-own-echo branch.

## Tests
- New: negative-order append; `persisted_version` missing-vs-present (incl. date id); foreign-write notifies / own-echo doesn't / dedupes.
- **Core lib 959/959 + full frontend 3888/3888** pass; `clippy -D warnings`/`fmt`/eslint clean; **`test:free-users` 7/7**.

## Free/community impact
Community-build fixes (core + frontend) — additive correctness/UX, no Pro coupling; free-users green.

Closes #1431, closes #1432, closes #1437.