### PR TITLE
Batch D (P2): collection pagination (#1430) + transactional bulk_delete (#1433) + bulk_update merge (#1434)

### DIFF
--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -1197,6 +1197,44 @@ impl SqliteStore {
             bind_values.push(libsql::Value::Text(nt.clone()));
         }
 
+        // #1430: id-scoping (e.g. a collection's members). Build `id IN (…)` and
+        // CHUNK it under SQLite's bound-parameter ceiling so a large member set
+        // can't overflow the limit. Each chunk also carries the title/node_type
+        // conditions already collected. The caller (NodeService::query_nodes)
+        // applies order_by + limit/offset in memory, so per-chunk order is
+        // irrelevant here. Empty id set ⇒ no rows can match.
+        if let Some(ref ids) = query.ids {
+            if ids.is_empty() {
+                return Ok(Vec::new());
+            }
+            const ID_CHUNK: usize = 900;
+            let mut nodes = Vec::new();
+            for chunk in ids.chunks(ID_CHUNK) {
+                let mut conds = conditions.clone();
+                let mut binds = bind_values.clone();
+                let start = binds.len();
+                let placeholders: Vec<String> = chunk
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format!("?{}", start + i + 1))
+                    .collect();
+                conds.push(format!("id IN ({})", placeholders.join(", ")));
+                for id in chunk {
+                    binds.push(libsql::Value::Text(id.clone()));
+                }
+                let sql = format!("SELECT * FROM node WHERE {}", conds.join(" AND "));
+                let mut rows = self
+                    .db
+                    .query(&sql, binds)
+                    .await
+                    .context("Failed to query nodes by id set")?;
+                while let Some(row) = rows.next().await? {
+                    nodes.push(Self::row_to_node(&row)?);
+                }
+            }
+            return Ok(nodes);
+        }
+
         let where_clause = if !conditions.is_empty() {
             format!("WHERE {}", conditions.join(" AND "))
         } else {

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -902,6 +902,57 @@ impl SqliteStore {
         })
     }
 
+    /// Atomically delete multiple nodes in a SINGLE transaction (#1433). Either
+    /// every existing target row is removed or none are — a mid-batch failure rolls
+    /// the whole thing back, so a caller that gets `Err` can rely on nothing having
+    /// been deleted. FK CASCADE removes each node's relationships + embeddings (same
+    /// as `delete_node`); children not in `ids` are left in place (edges cascade).
+    /// Emits one `Deleted` notification per node that existed, AFTER commit. Returns
+    /// the nodes that were deleted.
+    pub async fn bulk_delete(&self, ids: &[String], source: Option<String>) -> Result<Vec<Node>> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        // Snapshot the rows that actually exist (for the post-commit notifications).
+        let existing = self.get_nodes_by_ids(ids).await?;
+        let to_delete: Vec<Node> = ids
+            .iter()
+            .filter_map(|id| existing.get(id).cloned())
+            .collect();
+        if to_delete.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let tx = self
+            .db
+            .transaction()
+            .await
+            .context("Failed to begin bulk delete transaction")?;
+        let placeholders: Vec<String> = (1..=to_delete.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!("DELETE FROM node WHERE id IN ({})", placeholders.join(", "));
+        let params: Vec<libsql::Value> = to_delete
+            .iter()
+            .map(|n| libsql::Value::Text(n.id.clone()))
+            .collect();
+        tx.execute(&sql, params)
+            .await
+            .context("Failed to delete nodes in bulk")?;
+        tx.commit()
+            .await
+            .context("Failed to commit bulk delete transaction")?;
+
+        for node in &to_delete {
+            self.notify(StoreChange {
+                operation: StoreOperation::Deleted,
+                node: node.clone(),
+                source: source.clone(),
+                previous_node: None,
+                playbook_context: None,
+            });
+        }
+        Ok(to_delete)
+    }
+
     /// Atomically delete a node and its entire `has_child` subtree in a single transaction.
     ///
     /// **OCC contract:** Version-checks only the target node at `expected_version`. Descendants
@@ -4061,6 +4112,36 @@ mod tests {
         assert_eq!(store.persisted_version("does-not-exist").await?, None);
         // A date-format id with no real row must report None (no virtual v1).
         assert_eq!(store.persisted_version("2026-01-01").await?, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bulk_delete_removes_all_in_one_transaction() -> Result<()> {
+        // #1433: bulk_delete deletes every existing target (all-or-nothing) and
+        // returns the deleted nodes; a missing id is simply skipped.
+        let (store, _t) = create_test_store().await?;
+
+        let mut ids = Vec::new();
+        for i in 0..3 {
+            let n = Node::new("text".to_string(), format!("n{i}"), json!({}));
+            ids.push(n.id.clone());
+            store.create_node(n, None, None).await?;
+        }
+        ids.push("never-existed".to_string());
+
+        let deleted = store.bulk_delete(&ids, None).await?;
+        assert_eq!(
+            deleted.len(),
+            3,
+            "only the 3 existing nodes are reported deleted"
+        );
+
+        for id in ids.iter().take(3) {
+            assert!(
+                store.get_node(id).await?.is_none(),
+                "node {id} should be gone"
+            );
+        }
         Ok(())
     }
 

--- a/packages/core/src/ops/node_ops.rs
+++ b/packages/core/src/ops/node_ops.rs
@@ -416,12 +416,12 @@ pub async fn query_nodes(
         );
     }
 
-    // #1430: pagination differs for a collection-scoped query. Membership is a
-    // POST-SQL filter, so pushing offset/limit to the SQL layer paginates the
-    // WRONG (unfiltered) set, and the old fixed 1000 over-fetch silently dropped
-    // any member outside the newest 1000 rows. Instead, SCOPE the query to the
-    // collection's members (bounded) via `with_ids` and apply offset/limit IN
-    // MEMORY below, after the membership filter.
+    // #1430: pagination differs for a collection-scoped query. Pushing offset/limit
+    // to SQL paginated the WRONG set (membership is filtered after the query), and
+    // the old fixed 1000 over-fetch silently dropped any member outside the newest
+    // 1000 rows. Instead SCOPE the SQL to the collection's members via `with_ids` —
+    // which `NodeQuery.ids` now translates to a chunked `id IN (…)` (bounded by the
+    // member set, NOT a full-table scan) — and apply offset/limit IN MEMORY below.
     match &collection_member_ids {
         Some(member_ids) if member_ids.is_empty() => {
             // Empty collection → no members can match; skip the query entirely.
@@ -489,10 +489,11 @@ pub async fn query_nodes(
         .await
         .map_err(|e| OpsError::Internal(format!("Failed to query nodes: {}", e)))?;
 
-    // Post-filter by collection membership, then paginate IN MEMORY (#1430). The
-    // query is already scoped to members via `with_ids`; re-intersect defensively,
-    // then apply offset + limit over the membership-filtered, CreatedDesc-ordered
-    // set — so `offset>0` and `limit` page the actual members, not the global set.
+    // Paginate IN MEMORY (#1430). The SQL is already id-scoped to members (the
+    // `id IN (…)` from `with_ids`), so this `member_ids.contains` is a genuine
+    // defensive double-check, not the thing producing correctness. Apply offset +
+    // limit over the membership set (CreatedDesc-ordered) so `offset>0` and `limit`
+    // page the actual members, not the global set.
     let filtered_nodes = if let Some(member_ids) = collection_member_ids {
         let mut result: Vec<_> = nodes
             .into_iter()

--- a/packages/core/src/ops/node_ops.rs
+++ b/packages/core/src/ops/node_ops.rs
@@ -416,16 +416,30 @@ pub async fn query_nodes(
         );
     }
 
-    // Over-fetch when collection filtering
-    let effective_limit = if collection_member_ids.is_some() {
-        input.limit.map(|l| l * 3).unwrap_or(1000)
-    } else {
-        input.limit.unwrap_or(100)
-    };
-    filter = filter.with_limit(effective_limit);
-
-    if let Some(offset) = input.offset {
-        filter = filter.with_offset(offset);
+    // #1430: pagination differs for a collection-scoped query. Membership is a
+    // POST-SQL filter, so pushing offset/limit to the SQL layer paginates the
+    // WRONG (unfiltered) set, and the old fixed 1000 over-fetch silently dropped
+    // any member outside the newest 1000 rows. Instead, SCOPE the query to the
+    // collection's members (bounded) via `with_ids` and apply offset/limit IN
+    // MEMORY below, after the membership filter.
+    match &collection_member_ids {
+        Some(member_ids) if member_ids.is_empty() => {
+            // Empty collection → no members can match; skip the query entirely.
+            return Ok(QueryNodesOutput {
+                nodes: vec![],
+                count: 0,
+                collection_id,
+            });
+        }
+        Some(member_ids) => {
+            filter = filter.with_ids(member_ids.iter().cloned().collect());
+        }
+        None => {
+            filter = filter.with_limit(input.limit.unwrap_or(100));
+            if let Some(offset) = input.offset {
+                filter = filter.with_offset(offset);
+            }
+        }
     }
 
     // Apply structured filters
@@ -475,12 +489,19 @@ pub async fn query_nodes(
         .await
         .map_err(|e| OpsError::Internal(format!("Failed to query nodes: {}", e)))?;
 
-    // Post-filter by collection membership
+    // Post-filter by collection membership, then paginate IN MEMORY (#1430). The
+    // query is already scoped to members via `with_ids`; re-intersect defensively,
+    // then apply offset + limit over the membership-filtered, CreatedDesc-ordered
+    // set — so `offset>0` and `limit` page the actual members, not the global set.
     let filtered_nodes = if let Some(member_ids) = collection_member_ids {
         let mut result: Vec<_> = nodes
             .into_iter()
             .filter(|n| member_ids.contains(&n.id))
             .collect();
+        let offset = input.offset.unwrap_or(0);
+        if offset > 0 {
+            result = result.into_iter().skip(offset).collect();
+        }
         if let Some(limit) = input.limit {
             result.truncate(limit);
         }

--- a/packages/core/src/services/node_service/bulk.rs
+++ b/packages/core/src/services/node_service/bulk.rs
@@ -487,44 +487,70 @@ impl NodeService {
             ))
         })?;
 
-        // Step 2: Validate all nodes BEFORE performing atomic update.
-        // This ensures we fail fast before any database changes.
-        // Note: this validation snapshot is taken before the store transaction; any
-        // concurrent write landing between here and store.bulk_update is silently
-        // overwritten — intentional under the last-write-wins contract (see store doc).
+        // Step 2: Build the MERGED update candidate for each node, validate it, and
+        // record the property-change set for the event.
+        //
+        // #1434: previously bulk_update wholesale-REPLACED properties with the raw
+        // client value (`updated.properties = properties.clone()`) and emitted an
+        // empty `changed_properties`. That diverged from the single-update path
+        // (which normalizes flat client props → deep-merges into the existing
+        // namespaced props) AND silently no-opped every property-change-driven
+        // subscriber/playbook rule. Mirror single-update here: normalize + deep-merge,
+        // validate the merged candidate, persist the merged value, and emit the real
+        // `changed_properties` computed from old→new.
+        //
+        // Validation snapshot is taken before the store transaction; any concurrent
+        // write landing between here and store.bulk_update is overwritten — intentional
+        // under the last-write-wins contract (see store doc).
+        let mut merged_updates: Vec<(String, crate::models::NodeUpdate)> =
+            Vec::with_capacity(updates.len());
+        let mut pending_events: Vec<(String, Node, Vec<crate::db::events::PropertyChange>)> =
+            Vec::with_capacity(updates.len());
+
         for (id, update) in &updates {
-            // Look up existing node from batch result
             let existing = existing_nodes
                 .get(id)
                 .ok_or_else(|| NodeServiceError::node_not_found(id))?;
 
             let mut updated = existing.clone();
-
-            // Apply partial updates to build validation candidate
             if let Some(node_type) = &update.node_type {
                 updated.node_type = node_type.clone();
             }
-
             if let Some(content) = &update.content {
                 updated.content = content.clone();
             }
 
-            // NOTE: Sibling ordering is now handled via has_child relationship order field.
-            // Bulk updates don't support sibling reordering - use move_node instead.
+            // NOTE: Sibling ordering is handled via the has_child order field; bulk
+            // updates don't reorder — use move_node.
 
+            let mut changed_properties = Vec::new();
             if let Some(properties) = &update.properties {
-                updated.properties = properties.clone();
+                let old_props = updated.properties.clone();
+                if updated.node_type == "schema" {
+                    // Schema nodes use a flat (non-namespaced) format — deep-merge as-is.
+                    Self::deep_merge_namespaced_properties(
+                        &mut updated.properties,
+                        properties.clone(),
+                    );
+                } else {
+                    let normalized = Self::normalize_flat_properties_to_namespace(
+                        &updated.node_type,
+                        properties,
+                        None,
+                    );
+                    Self::deep_merge_namespaced_properties(&mut updated.properties, normalized);
+                }
+                changed_properties =
+                    super::compute_property_changes(&old_props, &updated.properties);
             }
 
-            // Validate behavior (PROTECTED rules)
+            // Validate the MERGED candidate (PROTECTED + USER-EXTENSIBLE rules).
             self.behaviors.validate_node(&updated).map_err(|e| {
                 NodeServiceError::bulk_operation_failed(format!(
                     "Failed to validate node {}: {}",
                     id, e
                 ))
             })?;
-
-            // Validate schema (USER-EXTENSIBLE rules)
             if updated.node_type != "schema" {
                 self.validate_node_against_schema(&updated)
                     .await
@@ -535,38 +561,43 @@ impl NodeService {
                         ))
                     })?;
             }
+
+            // Persist the caller's intent for type/content/title/lifecycle, but the
+            // MERGED value for properties (so the stored row matches single-update).
+            merged_updates.push((
+                id.clone(),
+                crate::models::NodeUpdate {
+                    node_type: update.node_type.clone(),
+                    content: update.content.clone(),
+                    properties: update
+                        .properties
+                        .as_ref()
+                        .map(|_| updated.properties.clone()),
+                    title: update.title.clone(),
+                    lifecycle_status: update.lifecycle_status.clone(),
+                },
+            ));
+            pending_events.push((id.clone(), updated, changed_properties));
         }
 
-        // Step 3: All validations passed - perform atomic bulk update.
-        self.store.bulk_update(updates.clone()).await.map_err(|e| {
+        // Step 3: All validations passed — perform the atomic bulk update.
+        self.store.bulk_update(merged_updates).await.map_err(|e| {
             NodeServiceError::bulk_operation_failed(format!(
                 "Failed to execute bulk update transaction: {}",
                 e
             ))
         })?;
 
-        // Issue #1306: Emit one NodeUpdated event per updated node.
-        // `store.bulk_update` runs a single SQL transaction without per-row notify calls,
-        // so we emit explicitly here rather than relying on the store notifier.
-        for (id, update) in &updates {
-            if let Some(existing) = existing_nodes.get(id) {
-                let mut updated_node = existing.clone();
-                if let Some(nt) = &update.node_type {
-                    updated_node.node_type = nt.clone();
-                }
-                if let Some(c) = &update.content {
-                    updated_node.content = c.clone();
-                }
-                if let Some(p) = &update.properties {
-                    updated_node.properties = p.clone();
-                }
-                self.emit_event(DomainEvent::NodeUpdated {
-                    node_id: id.clone(),
-                    node_type: updated_node.node_type.clone(),
-                    node: updated_node,
-                    changed_properties: vec![],
-                });
-            }
+        // Issue #1306: emit one NodeUpdated event per node (store.bulk_update runs a
+        // single SQL transaction with no per-row notify), now carrying the real
+        // changed_properties so property-change automation fires (#1434).
+        for (id, node, changed_properties) in pending_events {
+            self.emit_event(DomainEvent::NodeUpdated {
+                node_id: id,
+                node_type: node.node_type.clone(),
+                node,
+                changed_properties,
+            });
         }
 
         Ok(())
@@ -606,20 +637,21 @@ impl NodeService {
             return Ok(());
         }
 
-        // Coalesce delete events: one event per node regardless of cascade writes
-        // (Issue #1306).
+        // #1433: delete in ONE transaction so the documented all-or-nothing contract
+        // actually holds. The old loop called store.delete_node per id (each its own
+        // autocommit), so a failure on the Nth left the first N-1 committed while the
+        // caller got Err and reasonably assumed nothing was deleted → orphaned state /
+        // double-delete on retry. Coalesce the Deleted events: one per node (#1306).
         let _batch = self.begin_batch_emit();
-        for id in &ids {
-            self.store
-                .delete_node(id, self.client_id.clone())
-                .await
-                .map_err(|e| {
-                    NodeServiceError::bulk_operation_failed(format!(
-                        "Failed to delete node {}: {}",
-                        id, e
-                    ))
-                })?;
-        }
+        self.store
+            .bulk_delete(&ids, self.client_id.clone())
+            .await
+            .map_err(|e| {
+                NodeServiceError::bulk_operation_failed(format!(
+                    "Failed to bulk delete nodes: {}",
+                    e
+                ))
+            })?;
         // _batch drops here → one flush per deleted node
 
         Ok(())

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -2780,8 +2780,9 @@ mod tests {
         assert_eq!(after_type_update.node_type, "text");
 
         // Update only properties — content and node_type must be preserved.
-        // Note: bulk_update replaces properties entirely (unlike single-node update_node
-        // which merges key-by-key).
+        // #1434: bulk_update now NORMALIZES + deep-MERGES properties exactly like the
+        // single-node update_node path (it previously wholesale-replaced with the raw
+        // client value, diverging from single-update and skipping normalization).
         service
             .bulk_update(vec![(
                 id.clone(),
@@ -2792,7 +2793,11 @@ mod tests {
         let after_props_update = service.get_node(&id).await.unwrap().unwrap();
         assert_eq!(after_props_update.content, "New content");
         assert_eq!(after_props_update.node_type, "text");
-        assert_eq!(after_props_update.properties, json!({"key": "value"}));
+        let props = after_props_update.properties.to_string();
+        assert!(
+            props.contains("key") && props.contains("value"),
+            "property must be merged + normalized into the node: {props}"
+        );
     }
 
     #[tokio::test]

--- a/packages/core/src/services/node_service/query.rs
+++ b/packages/core/src/services/node_service/query.rs
@@ -55,6 +55,7 @@ impl NodeService {
         // Convert NodeFilter to NodeQuery
         let query = crate::models::NodeQuery {
             id: None,
+            ids: filter.ids.clone(),
             node_type: filter.node_type.clone(),
             content_contains: filter.content_contains.clone(),
             title_contains: filter.title_contains.clone(),

--- a/packages/core/tests/event_emission_test.rs
+++ b/packages/core/tests/event_emission_test.rs
@@ -141,6 +141,134 @@ mod event_emission_tests {
     }
 
     #[tokio::test]
+    async fn test_collection_query_paginates_members_not_global_set() -> Result<()> {
+        // #1430: offset/limit must paginate the COLLECTION'S members (in memory),
+        // not the global unfiltered set, and non-members must be excluded.
+        let (service, _temp_dir) = create_test_service().await?;
+
+        let coll = nodespace_core::models::Node::new(
+            "collection".to_string(),
+            "Team".to_string(),
+            json!({}),
+        );
+        let coll_id = coll.id.clone();
+        service.create_node(coll).await?;
+
+        // 3 members + 2 non-members (never added to the collection).
+        for i in 0..3 {
+            let m =
+                nodespace_core::models::Node::new("text".to_string(), format!("m{i}"), json!({}));
+            let mid = m.id.clone();
+            service.create_node(m).await?;
+            service.store().add_to_collection(&mid, &coll_id).await?;
+        }
+        for i in 0..2 {
+            let other =
+                nodespace_core::models::Node::new("text".to_string(), format!("x{i}"), json!({}));
+            service.create_node(other).await?;
+        }
+
+        let service = Arc::new(service);
+        let query = |offset: Option<usize>, limit: Option<usize>| {
+            let svc = service.clone();
+            let coll_id = coll_id.clone();
+            async move {
+                nodespace_core::ops::node_ops::query_nodes(
+                    &svc,
+                    nodespace_core::ops::node_ops::QueryNodesInput {
+                        node_type: None,
+                        parent_id: None,
+                        root_id: None,
+                        limit,
+                        offset,
+                        collection_id: Some(coll_id),
+                        collection: None,
+                        filters: None,
+                    },
+                )
+                .await
+            }
+        };
+
+        // All 3 members (non-members excluded).
+        assert_eq!(query(None, Some(10)).await?.count, 3);
+        // offset skips members, not the global set.
+        assert_eq!(query(Some(1), Some(10)).await?.count, 2);
+        assert_eq!(query(Some(1), Some(1)).await?.count, 1);
+        // offset past the end → empty.
+        assert_eq!(query(Some(10), Some(10)).await?.count, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bulk_update_emits_changed_properties_and_merges() -> Result<()> {
+        // #1434: bulk_update must emit a NON-empty changed_properties (so
+        // property-change automation fires) and MERGE properties (not wholesale
+        // replace), matching the single-update path.
+        let (service, _temp_dir) = create_test_service().await?;
+        let node = create_root_node(&service, "text").await?;
+        let node_id = node.id.clone();
+
+        // Baseline property via the single-update path.
+        service
+            .with_client(TEST_CLIENT_ID)
+            .update_node_unchecked(
+                &node_id,
+                nodespace_core::models::NodeUpdate {
+                    properties: Some(json!({ "keep": "yes" })),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        let mut rx = service.subscribe_to_events();
+
+        // Bulk-update a DIFFERENT property.
+        service
+            .with_client(TEST_CLIENT_ID)
+            .bulk_update(vec![(
+                node_id.clone(),
+                nodespace_core::models::NodeUpdate {
+                    properties: Some(json!({ "add": "new" })),
+                    ..Default::default()
+                },
+            )])
+            .await?;
+
+        let envelope = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("Event should be emitted within 1 second")
+            .expect("Should receive event");
+        match &envelope.event {
+            DomainEvent::NodeUpdated {
+                node_id: id,
+                changed_properties,
+                ..
+            } => {
+                assert_eq!(id, &node_id);
+                assert!(
+                    !changed_properties.is_empty(),
+                    "bulk_update must emit changed_properties (was hardcoded empty)"
+                );
+            }
+            _ => panic!("Expected NodeUpdated event, got {:?}", envelope.event),
+        }
+
+        // Merge, not wholesale replace — the pre-existing property survives.
+        let updated = service.get_node(&node_id).await?.expect("node exists");
+        let props = updated.properties.to_string();
+        assert!(
+            props.contains("keep") && props.contains("yes"),
+            "pre-existing property must survive the bulk update (merge): {props}"
+        );
+        assert!(
+            props.contains("add") && props.contains("new"),
+            "new property must be present after the bulk update: {props}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_delete_node_emits_node_deleted_event() -> Result<()> {
         let (service, _temp_dir) = create_test_service().await?;
 

--- a/packages/core/tests/event_emission_test.rs
+++ b/packages/core/tests/event_emission_test.rs
@@ -201,6 +201,62 @@ mod event_emission_tests {
     }
 
     #[tokio::test]
+    async fn test_collection_query_returns_members_despite_many_newer_nonmembers() -> Result<()> {
+        // #1430 regression guard: members must be returned even when MANY newer
+        // non-member nodes exist. The SQL is id-scoped to the member set, so it can
+        // never be crowded out. This FAILS under a capped-global-limit approach
+        // (the newest N rows would all be non-members → 0 members) and under the
+        // old fixed-1000 over-fetch (members beyond the newest 1000 dropped).
+        let (service, _temp_dir) = create_test_service().await?;
+
+        let coll = nodespace_core::models::Node::new(
+            "collection".to_string(),
+            "Team".to_string(),
+            json!({}),
+        );
+        let coll_id = coll.id.clone();
+        service.create_node(coll).await?;
+
+        // 3 members created FIRST.
+        for i in 0..3 {
+            let m =
+                nodespace_core::models::Node::new("text".to_string(), format!("m{i}"), json!({}));
+            let mid = m.id.clone();
+            service.create_node(m).await?;
+            service.store().add_to_collection(&mid, &coll_id).await?;
+        }
+        // 25 NON-member nodes created AFTER (newer) — would dominate a global limit.
+        for i in 0..25 {
+            service
+                .create_node(nodespace_core::models::Node::new(
+                    "text".to_string(),
+                    format!("x{i}"),
+                    json!({}),
+                ))
+                .await?;
+        }
+
+        let service = Arc::new(service);
+        let out = nodespace_core::ops::node_ops::query_nodes(
+            &service,
+            nodespace_core::ops::node_ops::QueryNodesInput {
+                node_type: None,
+                parent_id: None,
+                root_id: None,
+                limit: Some(10),
+                offset: None,
+                collection_id: Some(coll_id),
+                collection: None,
+                filters: None,
+            },
+        )
+        .await?;
+        // All 3 members returned (not crowded out by the 25 newer non-members).
+        assert_eq!(out.count, 3);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_bulk_update_emits_changed_properties_and_merges() -> Result<()> {
         // #1434: bulk_update must emit a NON-empty changed_properties (so
         // property-change automation fires) and MERGE properties (not wholesale

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -373,6 +373,7 @@ impl GrpcNodeService for NodeServiceImpl {
 
         let query = NodeQuery {
             id: req.id,
+            ids: None,
             mentioned_by: req.mentioned_by,
             content_contains: req.content_contains,
             title_contains: req.title_contains,

--- a/packages/nodespace-types/src/node.rs
+++ b/packages/nodespace-types/src/node.rs
@@ -118,6 +118,11 @@ impl Node {
 pub struct NodeQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Restrict the result to this explicit set of ids (e.g. a collection's
+    /// members). Translated to an `id IN (…)` clause, chunked under SQLite's
+    /// bound-parameter ceiling (#1430). `None` = no id restriction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Phase 1 bug-sweep **Batch D** (P2), core bulk/query fixes.

### `#1430` — collection pagination paginated the wrong set
Collection-filtered queries pushed `offset`/`limit` to SQL, but membership is filtered **in memory after** the query — so `offset>0` paged the unfiltered set and a fixed **1000** over-fetch silently dropped members outside the newest 1000 rows.
**Fix:** scope the query to the collection's members (`NodeFilter::with_ids`, bounded) and apply `offset`/`limit` in memory after the membership filter; short-circuit empty collections.

### `#1433` — bulk_delete was not transactional
Documented all-or-nothing, but looped `store.delete_node` (each its own autocommit) → the Nth failing left the first N-1 committed.
**Fix:** new transactional `store.bulk_delete` (single tx, FK cascade, one `Deleted` event per node post-commit); service routes through it.

### `#1434` — bulk_update empty changed_properties + wholesale replace
Emitted `NodeUpdated` with hardcoded empty `changed_properties` and wholesale-replaced (un-normalized) properties, diverging from single-update and no-opping property-change automation.
**Fix:** normalize + deep-merge like `update_node`, validate the merged candidate, persist the merged value, emit the real `changed_properties`.

## Tests
- New: collection pagination over members vs global set; transactional multi-delete; bulk_update merge + non-empty changed_properties.
- Updated the existing `partial_fields_preserves_unspecified` test to the new merge+normalize contract (it encoded the old wholesale-replace behavior #1434 fixes).
- **Full core suite green** (958 lib + all integration); `clippy --tests -D warnings`/`fmt` clean; **`test:free-users` 7/7**.

## Free/community impact
Community-build fixes (core data layer) — additive correctness; free-users green.

Closes #1430, closes #1433, closes #1434.