### PR TITLE
S6 (UI half): 'signed in as <email>' + manual sign-out in the Pro pill (#226)

### DIFF
--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -33,6 +33,12 @@ service CloudSyncService {
   // No-op if the orchestrator is already in SYNCING.
   rpc TriggerSync (TriggerSyncRequest) returns (TriggerSyncResponse);
 
+  // Explicit sign-out (#199 S6). Drops the in-memory token, wipes the
+  // persisted refresh token from the OS keychain (so a daemon restart
+  // does NOT auto-resume), and tears down the live sync connection —
+  // the orchestrator loop then reports AUTH_REQUIRED. Idempotent.
+  rpc SignOut (SignOutRequest) returns (SignOutResponse);
+
   // --- Team membership (M5, #147). Thin adapters over the cloud
   // membership RPCs; the daemon forwards the signed-in user's JWT, so
   // the same admin / last-admin / open-vs-restricted gates apply
@@ -100,10 +106,18 @@ message SyncStatusEvent {
   State state = 1;
   // Free-form context, e.g. error message or current LIVE SELECT cursor.
   string detail = 2;
+  // Email of the signed-in user, decoded from the session JWT. Empty when
+  // signed out / not yet authenticated. Drives the "signed in as <email>"
+  // affordance (#199 S6), including on the silent-resume path where the
+  // frontend never sees an OAuth response and so otherwise has no identity.
+  string user_email = 3;
 }
 
 message TriggerSyncRequest {}
 message TriggerSyncResponse {}
+
+message SignOutRequest {}
+message SignOutResponse {}
 
 // --- Team membership (M5, #147) ----------------------------------
 // permission is "admin" | "modify" | "readOnly". collection_id / person_id are

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -14,7 +14,7 @@ use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{
     AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, InitiateOAuthRequest,
     LeaveCollectionRequest, ListMembersRequest, RemoveMemberRequest, RequestJoinRequest,
-    SetMemberRequest, WatchSyncStatusRequest,
+    SetMemberRequest, SignOutRequest, WatchSyncStatusRequest,
 };
 use crate::services::{ProClient, ProTier};
 use tonic::transport::Channel;
@@ -87,6 +87,7 @@ pub async fn pro_subscribe_sync_status(app: AppHandle) -> Result<(), String> {
                     let payload = serde_json::json!({
                         "state": evt.state,
                         "detail": evt.detail,
+                        "user_email": evt.user_email,
                     });
                     if let Err(e) = app_handle.emit("sync:status", payload) {
                         tracing::warn!(error = %e, "failed to emit sync:status");
@@ -122,6 +123,7 @@ fn emit_disconnected(app: &AppHandle, reason: String) {
     let payload = serde_json::json!({
         "state": PbState::Disconnected as i32,
         "detail": reason,
+        "user_email": "",
     });
     if let Err(e) = app.emit("sync:status", payload) {
         tracing::warn!(error = %e, "failed to emit synthetic sync:status DISCONNECTED");
@@ -158,6 +160,25 @@ pub async fn pro_initiate_oauth(
         .map_err(|e| format!("InitiateOAuth failed: {e}"))?
         .into_inner();
     Ok(resp.attempt_id)
+}
+
+/// Sign out of Pro (#199 S6). Tells the daemon to drop its session and wipe the
+/// persisted refresh token from the OS keychain, so a restart won't auto-resume.
+/// The resulting AUTH_REQUIRED transition flows back through the `sync:status`
+/// stream. No-ops in community mode (no `ProClient`), matching the other Pro
+/// commands' side-effect-free contract.
+#[tauri::command]
+pub async fn pro_signout(app: AppHandle) -> Result<(), String> {
+    let Some(pro) = app.try_state::<ProClient>() else {
+        return Ok(());
+    };
+    let mut client = pro.client().await;
+    client
+        .sign_out(SignOutRequest {})
+        .await
+        .map_err(|e| format!("SignOut failed: {e}"))?;
+    tracing::info!("Pro: SignOut");
+    Ok(())
 }
 
 // --- Team membership commands (M5, #147) ----------------------------------

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -341,6 +341,7 @@ pub fn run() {
                             serde_json::json!({
                                 "state": s.state,
                                 "detail": s.detail,
+                                "user_email": s.user_email,
                             })
                         }),
                     });
@@ -439,6 +440,7 @@ pub fn run() {
             commands::pro_sync::pro_tier,
             commands::pro_sync::pro_subscribe_sync_status,
             commands::pro_sync::pro_initiate_oauth,
+            commands::pro_sync::pro_signout,
             commands::pro_sync::pro_set_member,
             commands::pro_sync::pro_remove_member,
             commands::pro_sync::pro_leave_collection,

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -57,9 +57,25 @@
   // While an InitiateOAuth call is in flight, disable the pill so a
   // double-click doesn't spawn two browser windows.
   let pending = $state(false);
+  // Account menu (shown when signed in) + its in-flight sign-out.
+  let menuOpen = $state(false);
+  let signingOut = $state(false);
+
+  // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
+  // pill opens the account menu ("signed in as <email>" + Sign out) instead of
+  // starting a new sign-in.
+  let signedIn = $derived(proSync.userEmail !== '');
+  let clickable = $derived(SIGN_IN_STATES.includes(proSync.state) || signedIn);
+  let pillTitle = $derived(
+    signedIn ? `Signed in as ${proSync.userEmail}` : proSync.detail || labels[proSync.state]
+  );
 
   async function onClick() {
     if (pending) return;
+    if (signedIn) {
+      menuOpen = !menuOpen;
+      return;
+    }
     if (!SIGN_IN_STATES.includes(proSync.state)) return;
     pending = true;
     try {
@@ -74,26 +90,76 @@
     }
   }
 
-  let clickable = $derived(SIGN_IN_STATES.includes(proSync.state));
+  function closeMenu() {
+    menuOpen = false;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && menuOpen) closeMenu();
+  }
+
+  async function onSignOut() {
+    if (signingOut) return;
+    signingOut = true;
+    try {
+      await proSync.signOut();
+      log.info('signed out');
+    } finally {
+      signingOut = false;
+      menuOpen = false;
+    }
+  }
 </script>
 
+<svelte:window onkeydown={onKeydown} />
+
 {#if proSync.isPro}
-  <button
-    class="pro-sync-pill"
-    class:clickable
-    data-tone={tones[proSync.state]}
-    title={proSync.detail || labels[proSync.state]}
-    type="button"
-    aria-label="NodeSpace Pro sync status: {labels[proSync.state]}"
-    disabled={pending || !clickable}
-    onclick={onClick}
-  >
-    <span class="dot" aria-hidden="true"></span>
-    <span class="label">{labels[proSync.state]}</span>
-  </button>
+  <div class="pro-sync-pill-wrap">
+    <button
+      class="pro-sync-pill"
+      class:clickable
+      data-tone={tones[proSync.state]}
+      title={pillTitle}
+      type="button"
+      aria-label="NodeSpace Pro sync status: {labels[proSync.state]}"
+      aria-haspopup={signedIn ? 'menu' : undefined}
+      aria-expanded={signedIn ? menuOpen : undefined}
+      disabled={pending || !clickable}
+      onclick={onClick}
+    >
+      <span class="dot" aria-hidden="true"></span>
+      <span class="label">{labels[proSync.state]}</span>
+    </button>
+
+    {#if menuOpen && signedIn}
+      <!-- Transparent backdrop so a click anywhere else closes the menu. -->
+      <button class="menu-backdrop" type="button" aria-label="Close account menu" onclick={closeMenu}
+      ></button>
+      <div class="menu" role="menu">
+        <div class="menu-identity">
+          <span class="menu-identity-label">Signed in as</span>
+          <span class="menu-email">{proSync.userEmail}</span>
+        </div>
+        <button
+          class="menu-signout"
+          type="button"
+          role="menuitem"
+          disabled={signingOut}
+          onclick={onSignOut}
+        >
+          {signingOut ? 'Signing out…' : 'Sign out'}
+        </button>
+      </div>
+    {/if}
+  </div>
 {/if}
 
 <style>
+  .pro-sync-pill-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+
   .pro-sync-pill {
     display: inline-flex;
     align-items: center;
@@ -146,6 +212,76 @@
     box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.18);
   }
 
+  /* Account menu (#199 S6) — shown when signed in. */
+  .menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: default;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 21;
+    min-width: 180px;
+    max-width: 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color, #d1d5db);
+    background: var(--surface-1, #ffffff);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  }
+
+  .menu-identity {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 2px 4px 6px;
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
+  }
+
+  .menu-identity-label {
+    font-size: 11px;
+    color: var(--text-secondary, #6b7280);
+  }
+
+  .menu-email {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary, #1f2937);
+    overflow-wrap: anywhere;
+  }
+
+  .menu-signout {
+    appearance: none;
+    text-align: left;
+    padding: 6px 8px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: var(--text-primary, #1f2937);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .menu-signout:hover:not(:disabled) {
+    background: var(--surface-2, #f3f4f6);
+  }
+
+  .menu-signout:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
   @media (prefers-color-scheme: dark) {
     .pro-sync-pill {
       background: var(--surface-1, #1f2937);
@@ -153,6 +289,22 @@
       color: var(--text-primary, #e5e7eb);
     }
     .pro-sync-pill:hover {
+      background: var(--surface-2, #374151);
+    }
+    .menu {
+      background: var(--surface-1, #1f2937);
+      border-color: var(--border-color, #374151);
+    }
+    .menu-identity {
+      border-bottom-color: var(--border-color, #374151);
+    }
+    .menu-email {
+      color: var(--text-primary, #e5e7eb);
+    }
+    .menu-signout {
+      color: var(--text-primary, #e5e7eb);
+    }
+    .menu-signout:hover:not(:disabled) {
       background: var(--surface-2, #374151);
     }
   }

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -67,6 +67,13 @@ class ProSyncStore {
   tier = $state<ProTier>('unknown');
   state = $state<SyncState>('unspecified');
   detail = $state<string>('');
+  /**
+   * Email of the signed-in user, from the daemon's `SyncStatusEvent.user_email`
+   * (decoded from the session JWT). Empty when signed out / not yet authenticated.
+   * Drives the "signed in as <email>" affordance (#199 S6) — needed because on the
+   * silent-resume path the frontend never sees an OAuth response.
+   */
+  userEmail = $state<string>('');
 
   isPro = $derived(this.tier === 'pro');
 
@@ -97,7 +104,7 @@ class ProSyncStore {
 
     this.unlistenTier = await listen<{
       tier: ProTier;
-      initial_status: { state: number; detail: string } | null;
+      initial_status: { state: number; detail: string; user_email?: string } | null;
     }>('pro:tier-detected', async (event) => {
       const p = event.payload;
       log.info('tier detected', { tier: p.tier });
@@ -105,6 +112,7 @@ class ProSyncStore {
       if (p.initial_status) {
         this.state = decodeState(p.initial_status.state);
         this.detail = p.initial_status.detail;
+        this.userEmail = p.initial_status.user_email ?? '';
       }
       // The first pro_subscribe_sync_status invoke below races the
       // backend's async init (Tauri setup spawns the connect on the
@@ -120,11 +128,12 @@ class ProSyncStore {
       }
     });
 
-    this.unlistenStatus = await listen<{ state: number; detail: string }>(
+    this.unlistenStatus = await listen<{ state: number; detail: string; user_email?: string }>(
       'sync:status',
       (event) => {
         this.state = decodeState(event.payload.state);
         this.detail = event.payload.detail;
+        this.userEmail = event.payload.user_email ?? '';
       }
     );
 
@@ -136,6 +145,23 @@ class ProSyncStore {
     }
 
     return () => this.stop();
+  }
+
+  /**
+   * Manual sign-out (#199 S6). Tells the daemon to drop its session and wipe the
+   * persisted refresh token from the keychain (so a restart won't auto-resume),
+   * then optimistically reflects signed-out locally. The daemon's AUTH_REQUIRED
+   * transition confirms via `sync:status`. No-op in community mode (the backend
+   * command returns early with no `ProClient`).
+   */
+  async signOut(): Promise<void> {
+    try {
+      await invoke('pro_signout');
+    } catch (e) {
+      log.warn('pro_signout invoke failed', { error: e });
+    }
+    this.state = 'auth-required';
+    this.userEmail = '';
   }
 
   stop() {

--- a/packages/desktop-app/src/tests/stores/pro-sync.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync.test.ts
@@ -1,0 +1,70 @@
+/**
+ * ProSync store — signed-in identity + manual sign-out (#199 S6).
+ *
+ * Asserts the store surfaces `SyncStatusEvent.user_email` (the "signed in as
+ * <email>" affordance) from the `sync:status` stream and clears it on sign-out,
+ * and that `signOut()` drives the daemon command + optimistically resets state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+// Capture the `sync:status` / `pro:tier-detected` handlers so tests can drive them.
+const listeners = new Map<string, (event: { payload: unknown }) => void>();
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (name: string, handler: (event: { payload: unknown }) => void) => {
+    listeners.set(name, handler);
+    return () => listeners.delete(name);
+  })
+}));
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+
+function emit(name: string, payload: unknown) {
+  listeners.get(name)?.({ payload });
+}
+
+describe('ProSync store — signed-in identity + sign-out (#199 S6)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue('pro');
+    await proSync.start();
+    emit('pro:tier-detected', { tier: 'pro', initial_status: null });
+  });
+
+  it('surfaces user_email from sync:status and clears it when signed out', () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    expect(proSync.state).toBe('connected');
+    expect(proSync.userEmail).toBe('mayank@nodespace.dev');
+
+    // A signed-out (AUTH_REQUIRED) event with no email clears the affordance.
+    emit('sync:status', { state: 4, detail: 'signed out', user_email: '' });
+    expect(proSync.state).toBe('auth-required');
+    expect(proSync.userEmail).toBe('');
+  });
+
+  it('tolerates a missing user_email field (older payloads) as empty', () => {
+    emit('sync:status', { state: 6, detail: '' });
+    expect(proSync.userEmail).toBe('');
+  });
+
+  it('signOut() invokes pro_signout and optimistically resets', async () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    mockInvoke.mockClear();
+    mockInvoke.mockResolvedValue(undefined);
+
+    await proSync.signOut();
+
+    expect(mockInvoke).toHaveBeenCalledWith('pro_signout');
+    expect(proSync.userEmail).toBe('');
+    expect(proSync.state).toBe('auth-required');
+  });
+});


### PR DESCRIPTION
UI half of #226 (S6 of the auto-sign-in epic, nodespace-sync#199). Pairs with nodespace-sync#236 (the daemon half — `user_email` on `SyncStatusEvent` + a `SignOut` RPC). This PR consumes those two surfaces.

## What this adds
- **Proto mirror** — `user_email` on `SyncStatusEvent` + a `SignOut` RPC (vendored copy under `src-tauri/proto/`, kept in lockstep with the daemon's).
- **`pro_subscribe_sync_status`** now forwards `user_email` on the `sync:status` event; the synthetic DISCONNECTED event clears it, and `pro:tier-detected`'s `initial_status` carries it too (for a resume-race CONNECTED probe).
- **`pro_signout` command** — calls the daemon's `SignOut` (which drops the token + wipes the persisted refresh token from the keychain). No-op in community mode, matching the other Pro commands.
- **`proSync` store** gains `userEmail` (from the stream) and an async `signOut()` that invokes the command and optimistically resets to signed-out.
- **Sync pill** — when signed in, clicking it opens a small account menu: "**Signed in as \<email\>**" + a **Sign out** button. Signed-out states keep the existing click-to-sign-in. Escape / outside-click close the menu.

## Why the daemon has to surface the email
On the **silent-resume** path (S3) the app boots straight into the workspace and the daemon refreshes the session from the keychain — the frontend never sees an OAuth response, so it has no other way to know who is signed in. The daemon decodes it from the session JWT and streams it.

## Scope / safety
- **Community/free build unaffected** — the pill only renders under `proSync.isPro`, `pro_signout` no-ops without a `ProClient`, and the free-user guardrail suite stays green.
- The "boot straight to workspace, no sign-in flash" half of S6 was already satisfied (the workspace renders immediately; the relogin modal only overlays on `auth-required`), so this PR is the remaining affordance + sign-out.

## Tests
- `src/tests/stores/pro-sync.test.ts` — `user_email` surfaced from `sync:status` and cleared on sign-out; missing-field tolerance; `signOut()` invokes `pro_signout` and resets state.
- `bun run test` (pro-sync + free-user-guardrail): 10 passed. `eslint --fix` 0 problems; `svelte-check` 0 errors. `cargo check`/`clippy`/`fmt` clean on `nodespace-app`.