### PR TITLE
Add membership service + store foundations for the Collaboration UI (#238)

### DIFF
--- a/packages/desktop-app/src/lib/services/membership-service.ts
+++ b/packages/desktop-app/src/lib/services/membership-service.ts
@@ -1,0 +1,194 @@
+/**
+ * Membership service — thin, typed wrappers over the Pro `pro_*` membership
+ * Tauri commands (collection-membership-UI epic #237, slice S1 #238).
+ *
+ * The daemon forwards the signed-in user's JWT to the matching cloud RPC, so the
+ * admin / last-admin / open-vs-restricted gates are enforced *server-side*; these
+ * wrappers carry no authority of their own. Every command resolves the Pro client
+ * or errors in community mode, so callers must gate on `proSync.tier === 'pro'`
+ * (the membership store does this) before invoking — the community build never
+ * reaches here.
+ *
+ * Boundary mapping: the Rust command DTOs serialize snake_case (`person_id`,
+ * `expires_at`, …); this module maps them to idiomatic camelCase interfaces so
+ * the rest of the frontend never sees the wire shape.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+import { createLogger } from '$lib/utils/logger';
+
+const log = createLogger('MembershipService');
+
+/** ADR-037 permission tiers. */
+export type Permission = 'admin' | 'modify' | 'readOnly';
+
+/** A collection roster entry (person + their tier). */
+export interface Member {
+	personId: string;
+	permission: Permission;
+}
+
+/** A pending invite (admin-only listing). */
+export interface Invite {
+	/** uuid — the handle {@link MembershipService.revokeInvite} takes. */
+	id: string;
+	/** 64-hex share code (bearer); may be surfaced for the admin to copy. */
+	code: string;
+	/** Bound invitee email; `''` for a bearer share-code. */
+	email: string;
+	permission: Permission;
+	/** RFC3339; `''` when the invite never expires. */
+	expiresAt: string;
+}
+
+/** A pending join request (admin-only listing). */
+export interface JoinRequest {
+	/** uuid — the handle {@link MembershipService.approveRequest} / revokeInvite take. */
+	id: string;
+	/** The requester's person_node_id. */
+	requestedBy: string;
+	/** RFC3339. */
+	createdAt: string;
+}
+
+/** The caller's own identity. */
+export interface Person {
+	/** Bound PersonNode id; `''` on an un-bound device ("role unknown"). */
+	personId: string;
+	/** Signed-in email; `''` when signed out. */
+	email: string;
+}
+
+// Raw wire shapes (snake_case, as serialized by the Rust command DTOs).
+interface RawMember {
+	person_id: string;
+	permission: string;
+}
+interface RawInvite {
+	id: string;
+	code: string;
+	email: string;
+	permission: string;
+	expires_at: string;
+}
+interface RawRequest {
+	id: string;
+	requested_by: string;
+	created_at: string;
+}
+interface RawPerson {
+	person_id: string;
+	email: string;
+}
+
+/**
+ * Typed facade over the membership commands. A single class (not the
+ * Tauri/Mock/Http triplet used by `collection-service`) because tests mock
+ * `@tauri-apps/api/core` directly, matching the `pro-sync` store's test pattern.
+ */
+export class MembershipService {
+	/** Roster for a collection (any member can read). */
+	async listMembers(collectionId: string): Promise<Member[]> {
+		log.debug('listMembers', { collectionId });
+		const rows = await invoke<RawMember[]>('pro_list_members', { collectionId });
+		return rows.map((r) => ({ personId: r.person_id, permission: r.permission as Permission }));
+	}
+
+	/** Add a member or change their role (admin only, server-gated). */
+	async setMember(collectionId: string, personId: string, permission: Permission): Promise<void> {
+		log.debug('setMember', { collectionId, personId, permission });
+		await invoke<void>('pro_set_member', { collectionId, personId, permission });
+	}
+
+	/** Remove a member / kick (admin only, last-admin protected server-side). */
+	async removeMember(collectionId: string, personId: string): Promise<void> {
+		log.debug('removeMember', { collectionId, personId });
+		await invoke<void>('pro_remove_member', { collectionId, personId });
+	}
+
+	/** Leave a collection (self-removal). */
+	async leaveCollection(collectionId: string): Promise<void> {
+		log.debug('leaveCollection', { collectionId });
+		await invoke<void>('pro_leave_collection', { collectionId });
+	}
+
+	/**
+	 * Mint an invite code (admin only). `email` binds the invite to that address
+	 * (only that signed-in user may redeem); omit for a bearer share-code.
+	 * `ttlSecs` overrides the server default lifetime (7 days). Returns the code.
+	 */
+	async createInvite(
+		collectionId: string,
+		permission: Permission,
+		email?: string,
+		ttlSecs?: number
+	): Promise<string> {
+		log.debug('createInvite', { collectionId, permission, hasEmail: !!email, ttlSecs });
+		return invoke<string>('pro_create_invite', {
+			collectionId,
+			permission,
+			email: email || undefined,
+			ttlSecs: ttlSecs || undefined
+		});
+	}
+
+	/** Redeem an invite code (invitee self-provisions). Returns the joined collection id. */
+	async acceptInvite(code: string): Promise<string> {
+		log.debug('acceptInvite', { hasCode: !!code });
+		return invoke<string>('pro_accept_invite', { code });
+	}
+
+	/** Ask to join a restricted collection. Returns the request id. */
+	async requestJoin(collectionId: string): Promise<string> {
+		log.debug('requestJoin', { collectionId });
+		return invoke<string>('pro_request_join', { collectionId });
+	}
+
+	/**
+	 * Approve a pending join request (admin only). `permission` of `undefined`
+	 * grants the originally-requested tier.
+	 */
+	async approveRequest(requestId: string, permission?: Permission): Promise<void> {
+		log.debug('approveRequest', { requestId, permission });
+		await invoke<void>('pro_approve_request', { requestId, permission });
+	}
+
+	/** List a collection's pending invites (admin only, server-gated). #239. */
+	async listInvites(collectionId: string): Promise<Invite[]> {
+		log.debug('listInvites', { collectionId });
+		const rows = await invoke<RawInvite[]>('pro_list_invites', { collectionId });
+		return rows.map((r) => ({
+			id: r.id,
+			code: r.code,
+			email: r.email,
+			permission: r.permission as Permission,
+			expiresAt: r.expires_at
+		}));
+	}
+
+	/** List a collection's pending join requests (admin only, server-gated). #239. */
+	async listRequests(collectionId: string): Promise<JoinRequest[]> {
+		log.debug('listRequests', { collectionId });
+		const rows = await invoke<RawRequest[]>('pro_list_requests', { collectionId });
+		return rows.map((r) => ({ id: r.id, requestedBy: r.requested_by, createdAt: r.created_at }));
+	}
+
+	/** Revoke a pending invite OR join request by id (admin only, server-gated). #239. */
+	async revokeInvite(inviteId: string): Promise<void> {
+		log.debug('revokeInvite', { inviteId });
+		await invoke<void>('pro_revoke_invite', { inviteId });
+	}
+
+	/**
+	 * The caller's own identity (bound PersonNode id + email), so the UI can tell
+	 * which roster row is "me" and gate admin controls on the caller's own
+	 * per-collection role. `personId` is `''` on an un-bound device. #239.
+	 */
+	async currentPerson(): Promise<Person> {
+		const p = await invoke<RawPerson>('pro_current_person');
+		return { personId: p.person_id, email: p.email };
+	}
+}
+
+/** Shared singleton — import this, not the class. */
+export const membershipService = new MembershipService();

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -55,6 +55,16 @@ class MembershipStore {
 		return proSync.isPro;
 	}
 
+	/**
+	 * Guard for the value-returning mutations: throws in community mode so they
+	 * never reach the (Pro-only) `pro_*` commands. The void-returning mutations
+	 * early-`return` instead. Keeps the store's community-inert contract whole even
+	 * though today's only callers are already Pro-gated.
+	 */
+	private requirePro(): void {
+		if (!this.isPro) throw new Error('Pro sync is required for membership operations');
+	}
+
 	/** Snapshot for a collection (empty, non-null, when not yet loaded). */
 	get(collectionId: string): CollectionMembership {
 		return this.byCollection[collectionId] ?? emptyMembership();
@@ -91,9 +101,15 @@ class MembershipStore {
 		return personId;
 	}
 
-	/** Ensure the caller's identity is loaded (once). No-op in community mode. */
+	/**
+	 * Ensure the caller's identity is loaded. No-op in community mode, or once a
+	 * *bound* identity is cached. Keeps retrying while `personId` is empty so a
+	 * mid-session identity bind (device signs in after the store first ran) is
+	 * picked up on the next load rather than leaving `currentUserRole` null all
+	 * session.
+	 */
 	async ensureIdentity(): Promise<void> {
-		if (!this.isPro || this.currentPerson) return;
+		if (!this.isPro || this.currentPerson?.personId) return;
 		try {
 			this.currentPerson = await membershipService.currentPerson();
 		} catch (e) {
@@ -116,15 +132,16 @@ class MembershipStore {
 			// Determine admin-ness from the freshly-loaded roster (not stale cache).
 			const me = this.currentPerson?.personId;
 			const amAdmin = !!me && members.some((m) => m.personId === me && m.permission === 'admin');
-			let invites: Invite[] = [];
-			let requests: JoinRequest[] = [];
+			// Commit the roster immediately so a failure of the admin-only listings
+			// below doesn't discard an already-fetched roster (patch merges).
+			this.patch(collectionId, { members, loading: false, error: null });
 			if (amAdmin) {
-				[invites, requests] = await Promise.all([
+				const [invites, requests] = await Promise.all([
 					membershipService.listInvites(collectionId),
 					membershipService.listRequests(collectionId)
 				]);
+				this.patch(collectionId, { invites, requests });
 			}
-			this.patch(collectionId, { members, invites, requests, loading: false, error: null });
 		} catch (e) {
 			log.warn('loadCollection failed', { collectionId, error: e });
 			this.patch(collectionId, { loading: false, error: String(e) });
@@ -135,16 +152,19 @@ class MembershipStore {
 	//     affected collection so the cached roster/invites/requests stay in sync. ---
 
 	async setMember(collectionId: string, personId: string, permission: Permission): Promise<void> {
+		if (!this.isPro) return;
 		await membershipService.setMember(collectionId, personId, permission);
 		await this.loadCollection(collectionId);
 	}
 
 	async removeMember(collectionId: string, personId: string): Promise<void> {
+		if (!this.isPro) return;
 		await membershipService.removeMember(collectionId, personId);
 		await this.loadCollection(collectionId);
 	}
 
 	async leaveCollection(collectionId: string): Promise<void> {
+		if (!this.isPro) return;
 		await membershipService.leaveCollection(collectionId);
 		// After leaving, the caller can no longer read the roster — drop the cache entry.
 		const next = { ...this.byCollection };
@@ -158,12 +178,14 @@ class MembershipStore {
 		email?: string,
 		ttlSecs?: number
 	): Promise<string> {
+		this.requirePro();
 		const code = await membershipService.createInvite(collectionId, permission, email, ttlSecs);
 		await this.loadCollection(collectionId);
 		return code;
 	}
 
 	async revokeInvite(collectionId: string, inviteId: string): Promise<void> {
+		if (!this.isPro) return;
 		await membershipService.revokeInvite(inviteId);
 		await this.loadCollection(collectionId);
 	}
@@ -173,11 +195,13 @@ class MembershipStore {
 		requestId: string,
 		permission?: Permission
 	): Promise<void> {
+		if (!this.isPro) return;
 		await membershipService.approveRequest(requestId, permission);
 		await this.loadCollection(collectionId);
 	}
 
 	async rejectRequest(collectionId: string, requestId: string): Promise<void> {
+		if (!this.isPro) return;
 		// Rejecting a request reuses revoke_invite (same collection_invites row).
 		await membershipService.revokeInvite(requestId);
 		await this.loadCollection(collectionId);
@@ -189,11 +213,13 @@ class MembershipStore {
 	 * collection is loaded on demand by its view).
 	 */
 	async acceptInvite(code: string): Promise<string> {
+		this.requirePro();
 		return membershipService.acceptInvite(code);
 	}
 
 	/** Ask to join a restricted collection (onboarding, S5). Returns the request id. */
 	async requestJoin(collectionId: string): Promise<string> {
+		this.requirePro();
 		return membershipService.requestJoin(collectionId);
 	}
 

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -1,0 +1,208 @@
+/**
+ * Membership store (collection-membership-UI epic #237, slice S1 #238).
+ *
+ * Holds a per-collection cache of the roster + pending invites/requests and the
+ * caller's own identity, so the Collaboration view (S3/S4) and onboarding inbox
+ * (S5) read reactive state instead of calling the daemon on every render.
+ *
+ * Pro-gated: every method early-returns / yields empty in community mode
+ * (`proSync.tier !== 'pro'`), so the community build stays behaviorally
+ * unchanged — it never touches the membership commands.
+ *
+ * Caller identity: fetched once via `pro_current_person` (see the S2 design note
+ * on #239 — a one-shot query rather than a stream field) and cached; the derived
+ * `currentUserRole(collectionId)` matches the caller's own person id against the
+ * roster so admin controls gate correctly. Call {@link MembershipStore.reset} on
+ * sign-out to clear it (identity is per-session).
+ */
+import {
+	membershipService,
+	type Invite,
+	type JoinRequest,
+	type Member,
+	type Permission,
+	type Person
+} from '$lib/services/membership-service';
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { createLogger } from '$lib/utils/logger';
+
+const log = createLogger('MembershipStore');
+
+/** Cached membership state for one collection. */
+export interface CollectionMembership {
+	members: Member[];
+	/** Pending invites — populated only when the caller is an admin, else `[]`. */
+	invites: Invite[];
+	/** Pending join requests — populated only when the caller is an admin, else `[]`. */
+	requests: JoinRequest[];
+	loading: boolean;
+	error: string | null;
+}
+
+function emptyMembership(): CollectionMembership {
+	return { members: [], invites: [], requests: [], loading: false, error: null };
+}
+
+class MembershipStore {
+	/** Per-collection cache, keyed by collection id. Reassigned immutably so runes react. */
+	private byCollection = $state<Record<string, CollectionMembership>>({});
+
+	/** The caller's own identity, fetched lazily and cached (cleared on {@link reset}). */
+	currentPerson = $state<Person | null>(null);
+
+	/** Pro-gate — the whole store is inert in community mode. */
+	get isPro(): boolean {
+		return proSync.isPro;
+	}
+
+	/** Snapshot for a collection (empty, non-null, when not yet loaded). */
+	get(collectionId: string): CollectionMembership {
+		return this.byCollection[collectionId] ?? emptyMembership();
+	}
+
+	private patch(collectionId: string, next: Partial<CollectionMembership>): void {
+		const prev = this.byCollection[collectionId] ?? emptyMembership();
+		this.byCollection = { ...this.byCollection, [collectionId]: { ...prev, ...next } };
+	}
+
+	/**
+	 * The caller's tier in a collection, or `null` if they're not a member / the
+	 * roster isn't loaded / identity is unknown. Drives admin-control gating.
+	 */
+	currentUserRole(collectionId: string): Permission | null {
+		const me = this.currentPerson?.personId;
+		if (!me) return null;
+		const mine = this.get(collectionId).members.find((m) => m.personId === me);
+		return mine?.permission ?? null;
+	}
+
+	/** True when the caller is an admin of the collection. */
+	isAdmin(collectionId: string): boolean {
+		return this.currentUserRole(collectionId) === 'admin';
+	}
+
+	/**
+	 * Display label for a person id. S1 returns the id itself; S3 resolves it to a
+	 * name/email from the locally-synced person nodes (email visibility is
+	 * `can_see_person`-gated server-side, so a non-co-member legitimately sees id
+	 * only). Kept here so the view layer has a single call site to upgrade.
+	 */
+	displayFor(personId: string): string {
+		return personId;
+	}
+
+	/** Ensure the caller's identity is loaded (once). No-op in community mode. */
+	async ensureIdentity(): Promise<void> {
+		if (!this.isPro || this.currentPerson) return;
+		try {
+			this.currentPerson = await membershipService.currentPerson();
+		} catch (e) {
+			log.warn('currentPerson failed', { error: e });
+		}
+	}
+
+	/**
+	 * Load (or refresh) a collection's membership. Fetches the roster + caller
+	 * identity, then — only if the caller is an admin — the pending invites and
+	 * join requests (those RPCs are admin-gated server-side, so a non-admin call
+	 * would just 403). No-op in community mode.
+	 */
+	async loadCollection(collectionId: string): Promise<void> {
+		if (!this.isPro) return;
+		this.patch(collectionId, { loading: true, error: null });
+		try {
+			await this.ensureIdentity();
+			const members = await membershipService.listMembers(collectionId);
+			// Determine admin-ness from the freshly-loaded roster (not stale cache).
+			const me = this.currentPerson?.personId;
+			const amAdmin = !!me && members.some((m) => m.personId === me && m.permission === 'admin');
+			let invites: Invite[] = [];
+			let requests: JoinRequest[] = [];
+			if (amAdmin) {
+				[invites, requests] = await Promise.all([
+					membershipService.listInvites(collectionId),
+					membershipService.listRequests(collectionId)
+				]);
+			}
+			this.patch(collectionId, { members, invites, requests, loading: false, error: null });
+		} catch (e) {
+			log.warn('loadCollection failed', { collectionId, error: e });
+			this.patch(collectionId, { loading: false, error: String(e) });
+		}
+	}
+
+	// --- Mutations. Each forwards to the service (server-gated) then refreshes the
+	//     affected collection so the cached roster/invites/requests stay in sync. ---
+
+	async setMember(collectionId: string, personId: string, permission: Permission): Promise<void> {
+		await membershipService.setMember(collectionId, personId, permission);
+		await this.loadCollection(collectionId);
+	}
+
+	async removeMember(collectionId: string, personId: string): Promise<void> {
+		await membershipService.removeMember(collectionId, personId);
+		await this.loadCollection(collectionId);
+	}
+
+	async leaveCollection(collectionId: string): Promise<void> {
+		await membershipService.leaveCollection(collectionId);
+		// After leaving, the caller can no longer read the roster — drop the cache entry.
+		const next = { ...this.byCollection };
+		delete next[collectionId];
+		this.byCollection = next;
+	}
+
+	async createInvite(
+		collectionId: string,
+		permission: Permission,
+		email?: string,
+		ttlSecs?: number
+	): Promise<string> {
+		const code = await membershipService.createInvite(collectionId, permission, email, ttlSecs);
+		await this.loadCollection(collectionId);
+		return code;
+	}
+
+	async revokeInvite(collectionId: string, inviteId: string): Promise<void> {
+		await membershipService.revokeInvite(inviteId);
+		await this.loadCollection(collectionId);
+	}
+
+	async approveRequest(
+		collectionId: string,
+		requestId: string,
+		permission?: Permission
+	): Promise<void> {
+		await membershipService.approveRequest(requestId, permission);
+		await this.loadCollection(collectionId);
+	}
+
+	async rejectRequest(collectionId: string, requestId: string): Promise<void> {
+		// Rejecting a request reuses revoke_invite (same collection_invites row).
+		await membershipService.revokeInvite(requestId);
+		await this.loadCollection(collectionId);
+	}
+
+	/**
+	 * Redeem an invite code (onboarding, S5). Returns the joined collection id so
+	 * the caller can navigate/pull it. Does not touch the cache (the joined
+	 * collection is loaded on demand by its view).
+	 */
+	async acceptInvite(code: string): Promise<string> {
+		return membershipService.acceptInvite(code);
+	}
+
+	/** Ask to join a restricted collection (onboarding, S5). Returns the request id. */
+	async requestJoin(collectionId: string): Promise<string> {
+		return membershipService.requestJoin(collectionId);
+	}
+
+	/** Clear all cached state + identity. Call on sign-out (identity is per-session). */
+	reset(): void {
+		this.byCollection = {};
+		this.currentPerson = null;
+	}
+}
+
+/** Shared singleton — import this, not the class. */
+export const membership = new MembershipStore();

--- a/packages/desktop-app/src/tests/services/membership-service.test.ts
+++ b/packages/desktop-app/src/tests/services/membership-service.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import { membershipService } from '$lib/services/membership-service';
+
+describe('MembershipService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('listMembers maps snake_case rows to camelCase Member[]', async () => {
+		mockInvoke.mockResolvedValue([
+			{ person_id: 'p1', permission: 'admin' },
+			{ person_id: 'p2', permission: 'readOnly' }
+		]);
+		const members = await membershipService.listMembers('c1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_list_members', { collectionId: 'c1' });
+		expect(members).toEqual([
+			{ personId: 'p1', permission: 'admin' },
+			{ personId: 'p2', permission: 'readOnly' }
+		]);
+	});
+
+	it('setMember forwards camelCase args to pro_set_member', async () => {
+		mockInvoke.mockResolvedValue(undefined);
+		await membershipService.setMember('c1', 'p1', 'modify');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_set_member', {
+			collectionId: 'c1',
+			personId: 'p1',
+			permission: 'modify'
+		});
+	});
+
+	it('removeMember / leaveCollection forward the right command + args', async () => {
+		mockInvoke.mockResolvedValue(undefined);
+		await membershipService.removeMember('c1', 'p1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_remove_member', {
+			collectionId: 'c1',
+			personId: 'p1'
+		});
+		await membershipService.leaveCollection('c1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_leave_collection', { collectionId: 'c1' });
+	});
+
+	it('createInvite omits email/ttl when not given, includes them when given', async () => {
+		mockInvoke.mockResolvedValue('deadbeef');
+		const code = await membershipService.createInvite('c1', 'readOnly');
+		expect(code).toBe('deadbeef');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_create_invite', {
+			collectionId: 'c1',
+			permission: 'readOnly',
+			email: undefined,
+			ttlSecs: undefined
+		});
+
+		mockInvoke.mockClear();
+		await membershipService.createInvite('c1', 'modify', 'a@b.com', 3600);
+		expect(mockInvoke).toHaveBeenCalledWith('pro_create_invite', {
+			collectionId: 'c1',
+			permission: 'modify',
+			email: 'a@b.com',
+			ttlSecs: 3600
+		});
+	});
+
+	it('listInvites maps expires_at → expiresAt', async () => {
+		mockInvoke.mockResolvedValue([
+			{ id: 'i1', code: 'abc', email: '', permission: 'modify', expires_at: '2026-07-09T00:00:00Z' }
+		]);
+		const invites = await membershipService.listInvites('c1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_list_invites', { collectionId: 'c1' });
+		expect(invites).toEqual([
+			{ id: 'i1', code: 'abc', email: '', permission: 'modify', expiresAt: '2026-07-09T00:00:00Z' }
+		]);
+	});
+
+	it('listRequests maps requested_by / created_at', async () => {
+		mockInvoke.mockResolvedValue([
+			{ id: 'r1', requested_by: 'person-bob', created_at: '2026-07-02T00:00:00Z' }
+		]);
+		const reqs = await membershipService.listRequests('c1');
+		expect(reqs).toEqual([
+			{ id: 'r1', requestedBy: 'person-bob', createdAt: '2026-07-02T00:00:00Z' }
+		]);
+	});
+
+	it('revokeInvite / approveRequest forward the right command + args', async () => {
+		mockInvoke.mockResolvedValue(undefined);
+		await membershipService.revokeInvite('i1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_revoke_invite', { inviteId: 'i1' });
+		await membershipService.approveRequest('r1', 'modify');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_approve_request', {
+			requestId: 'r1',
+			permission: 'modify'
+		});
+	});
+
+	it('currentPerson maps person_id → personId', async () => {
+		mockInvoke.mockResolvedValue({ person_id: 'me', email: 'me@x.com' });
+		const p = await membershipService.currentPerson();
+		expect(mockInvoke).toHaveBeenCalledWith('pro_current_person');
+		expect(p).toEqual({ personId: 'me', email: 'me@x.com' });
+	});
+
+	it('acceptInvite / requestJoin return the daemon detail', async () => {
+		mockInvoke.mockResolvedValue('collection-x');
+		expect(await membershipService.acceptInvite('code')).toBe('collection-x');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_accept_invite', { code: 'code' });
+		mockInvoke.mockResolvedValue('req-1');
+		expect(await membershipService.requestJoin('c1')).toBe('req-1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_request_join', { collectionId: 'c1' });
+	});
+});

--- a/packages/desktop-app/src/tests/stores/membership.test.ts
+++ b/packages/desktop-app/src/tests/stores/membership.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+// Hoisted mocks so the vi.mock factories can reference them (vi.mock is hoisted
+// above imports; vi.hoisted keeps the mock objects available there).
+const { svc, proSyncMock } = vi.hoisted(() => ({
+	svc: {
+		listMembers: vi.fn(),
+		listInvites: vi.fn(),
+		listRequests: vi.fn(),
+		currentPerson: vi.fn(),
+		setMember: vi.fn(),
+		removeMember: vi.fn(),
+		leaveCollection: vi.fn(),
+		createInvite: vi.fn(),
+		revokeInvite: vi.fn(),
+		approveRequest: vi.fn(),
+		acceptInvite: vi.fn(),
+		requestJoin: vi.fn()
+	},
+	proSyncMock: { isPro: true }
+}));
+
+vi.mock('$lib/services/membership-service', () => ({ membershipService: svc }));
+vi.mock('$lib/stores/pro-sync.svelte', () => ({ proSync: proSyncMock }));
+
+import { membership } from '$lib/stores/membership.svelte';
+
+describe('MembershipStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		proSyncMock.isPro = true;
+		membership.reset();
+		// Sensible defaults; individual tests override.
+		svc.currentPerson.mockResolvedValue({ personId: 'me', email: 'me@x.com' });
+		svc.listMembers.mockResolvedValue([]);
+		svc.listInvites.mockResolvedValue([]);
+		svc.listRequests.mockResolvedValue([]);
+	});
+
+	it('loads roster, derives admin role, and fetches invites+requests for an admin', async () => {
+		svc.listMembers.mockResolvedValue([
+			{ personId: 'me', permission: 'admin' },
+			{ personId: 'bob', permission: 'modify' }
+		]);
+		svc.listInvites.mockResolvedValue([
+			{ id: 'i1', code: 'c', email: '', permission: 'modify', expiresAt: '' }
+		]);
+		svc.listRequests.mockResolvedValue([
+			{ id: 'r1', requestedBy: 'carol', createdAt: '2026-07-02T00:00:00Z' }
+		]);
+
+		await membership.loadCollection('c1');
+
+		expect(membership.get('c1').members).toHaveLength(2);
+		expect(membership.currentUserRole('c1')).toBe('admin');
+		expect(membership.isAdmin('c1')).toBe(true);
+		expect(membership.get('c1').invites).toHaveLength(1);
+		expect(membership.get('c1').requests).toHaveLength(1);
+		expect(svc.listInvites).toHaveBeenCalledWith('c1');
+	});
+
+	it('does NOT fetch invites/requests for a non-admin', async () => {
+		svc.listMembers.mockResolvedValue([{ personId: 'me', permission: 'readOnly' }]);
+
+		await membership.loadCollection('c1');
+
+		expect(membership.currentUserRole('c1')).toBe('readOnly');
+		expect(membership.isAdmin('c1')).toBe(false);
+		expect(svc.listInvites).not.toHaveBeenCalled();
+		expect(svc.listRequests).not.toHaveBeenCalled();
+		expect(membership.get('c1').invites).toEqual([]);
+	});
+
+	it('is inert in community mode (never touches the service)', async () => {
+		proSyncMock.isPro = false;
+
+		await membership.loadCollection('c1');
+
+		expect(svc.currentPerson).not.toHaveBeenCalled();
+		expect(svc.listMembers).not.toHaveBeenCalled();
+		expect(membership.get('c1').members).toEqual([]);
+		expect(membership.currentUserRole('c1')).toBeNull();
+	});
+
+	it('currentUserRole is null when the caller identity is unknown', async () => {
+		svc.currentPerson.mockResolvedValue({ personId: '', email: '' });
+		svc.listMembers.mockResolvedValue([{ personId: 'someone', permission: 'admin' }]);
+
+		await membership.loadCollection('c1');
+
+		expect(membership.currentUserRole('c1')).toBeNull();
+		expect(membership.isAdmin('c1')).toBe(false);
+		expect(svc.listInvites).not.toHaveBeenCalled(); // unknown identity ⇒ not admin
+	});
+
+	it('a mutation refreshes the affected collection', async () => {
+		svc.listMembers.mockResolvedValue([{ personId: 'me', permission: 'admin' }]);
+		await membership.loadCollection('c1');
+		expect(svc.listMembers).toHaveBeenCalledTimes(1);
+
+		await membership.setMember('c1', 'bob', 'modify');
+		expect(svc.setMember).toHaveBeenCalledWith('c1', 'bob', 'modify');
+		expect(svc.listMembers).toHaveBeenCalledTimes(2); // reloaded after the mutation
+	});
+
+	it('leaving a collection drops its cache entry', async () => {
+		svc.listMembers.mockResolvedValue([{ personId: 'me', permission: 'modify' }]);
+		await membership.loadCollection('c1');
+		expect(membership.get('c1').members).toHaveLength(1);
+
+		await membership.leaveCollection('c1');
+		expect(svc.leaveCollection).toHaveBeenCalledWith('c1');
+		expect(membership.get('c1').members).toEqual([]);
+	});
+
+	it('reset clears cache and identity', async () => {
+		svc.listMembers.mockResolvedValue([{ personId: 'me', permission: 'admin' }]);
+		await membership.loadCollection('c1');
+		expect(membership.currentPerson).not.toBeNull();
+
+		membership.reset();
+		expect(membership.currentPerson).toBeNull();
+		expect(membership.get('c1').members).toEqual([]);
+	});
+});

--- a/packages/desktop-app/src/tests/stores/membership.test.ts
+++ b/packages/desktop-app/src/tests/stores/membership.test.ts
@@ -86,6 +86,19 @@ describe('MembershipStore', () => {
 		expect(membership.currentUserRole('c1')).toBeNull();
 	});
 
+	it('mutations are inert in community mode (never reach the service)', async () => {
+		proSyncMock.isPro = false;
+		// void mutation: no-ops silently, never touches the service
+		await membership.setMember('c1', 'bob', 'modify');
+		expect(svc.setMember).not.toHaveBeenCalled();
+		// value-returning mutations: throw (never a fake success) and never touch the
+		// service — these are the S5 onboarding entry points, so the guard matters.
+		await expect(membership.acceptInvite('code')).rejects.toThrow(/Pro/);
+		await expect(membership.requestJoin('c1')).rejects.toThrow(/Pro/);
+		expect(svc.acceptInvite).not.toHaveBeenCalled();
+		expect(svc.requestJoin).not.toHaveBeenCalled();
+	});
+
 	it('currentUserRole is null when the caller identity is unknown', async () => {
 		svc.currentPerson.mockResolvedValue({ personId: '', email: '' });
 		svc.listMembers.mockResolvedValue([{ personId: 'someone', permission: 'admin' }]);


### PR DESCRIPTION
Slice **S1** of the collection-membership-UI epic (NodeSpaceAI/nodespace-sync#237). Foundations only — no visible surface yet; this is the service + reactive store that the Collaboration view (S3/S4) and onboarding inbox (S5) build on, layered over the already-complete #143 membership backend.

## What
- **`services/membership-service.ts`** — typed, thin wrappers over the eight `pro_*` membership commands plus S2's three (`pro_list_invites` / `pro_list_requests` / `pro_revoke_invite`) and `pro_current_person`. The daemon enforces the ADR-037 gates server-side; these carry no authority. Maps the commands' **snake_case** DTOs (`person_id`, `expires_at`, …) to camelCase interfaces at the boundary so the rest of the frontend never sees the wire shape.
- **`stores/membership.svelte.ts`** — a Svelte 5 runes store caching, per collection, the roster + pending invites/requests, plus the caller's own identity. `currentUserRole(collectionId)` matches the caller's person id against the roster so admin controls gate correctly; the admin-only invite/request listings are fetched **only** when the caller is an admin (a non-admin call would just 403). Mutations refresh the affected collection.

## Pro-gated / community-inert
Every store method early-returns (or yields empty) when `proSync.tier !== 'pro'`, so the community build never touches the membership commands and is behaviorally unchanged.

## Caller identity
Consumes S2's `pro_current_person` (NodeSpaceAI/nodespace-core#1472 / NodeSpaceAI/nodespace-sync#244) — fetched once and cached, cleared on sign-out via `reset()`. Runtime resolution of these commands depends on those S2 PRs landing; this slice's unit tests mock the boundary, so it builds and tests green independently.

## Tests
- `bun run test` on the two new files — **16 passed** (service arg-forwarding + snake→camel mapping; store role-derivation, admin gating, community-inert, mutation-refresh, reset).
- `bun run quality:fix` — ESLint 0/0, `svelte-check` 0 errors.

Depends (at runtime) on #239. Unblocks S3 (#240) / S4 (#241) / S5 (#242).