### PR TITLE
Add Collaboration view: roster + member management (#240)

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
@@ -1,0 +1,337 @@
+<!--
+  CollaborationView — per-collection membership management (epic #237, slice S3
+  #240). Shows the roster (people + role) and, for admins, controls to change a
+  member's role, remove them (last-admin protected server-side), and add someone
+  already in the workspace. Self-service "Leave" for the caller. Non-admins see a
+  read-only roster.
+
+  Pro-only: rendered only when proSync.tier === 'pro' (the host tab is gated too),
+  so the community build never mounts this. Invites & join requests (the primary
+  onboarding paths) live in the sibling InvitesPanel (S4).
+-->
+<script lang="ts">
+	import { membership } from '$lib/stores/membership.svelte';
+	import type { Permission } from '$lib/services/membership-service';
+	import { proSync } from '$lib/stores/pro-sync.svelte';
+	import { createLogger } from '$lib/utils/logger';
+
+	const log = createLogger('CollaborationView');
+
+	let { collectionId }: { collectionId: string } = $props();
+
+	// readOnly → modify → admin, in ascending-privilege order for the role select.
+	const PERMISSIONS: Permission[] = ['readOnly', 'modify', 'admin'];
+	const ROLE_LABEL: Record<Permission, string> = {
+		readOnly: 'Viewer',
+		modify: 'Editor',
+		admin: 'Admin'
+	};
+
+	let actionError = $state<string | null>(null);
+	let busyPerson = $state<string | null>(null);
+	let pendingRemove = $state<string | null>(null);
+	// Add-existing-person form. A raw person-id input for now — a proper
+	// autocomplete picker over locally-synced person nodes is a follow-up once a
+	// "list persons" source exists; invites (S4) are the primary way to bring in
+	// people who aren't already in the workspace.
+	let addId = $state('');
+	let addRole = $state<Permission>('readOnly');
+	let adding = $state(false);
+
+	$effect(() => {
+		if (proSync.isPro && collectionId) {
+			membership.loadCollection(collectionId);
+		}
+	});
+
+	let view = $derived(membership.get(collectionId));
+	let myRole = $derived(membership.currentUserRole(collectionId));
+	let amAdmin = $derived(myRole === 'admin');
+	let myId = $derived(membership.currentPerson?.personId ?? '');
+
+	function friendly(e: unknown): string {
+		const s = String(e);
+		// Surface the last-admin protection clearly (daemon FAILED_PRECONDITION).
+		if (/last[ _]?admin|only admin|last remaining admin/i.test(s)) {
+			return 'You can’t remove or demote the last admin of this collection.';
+		}
+		return s.replace(/^Error:\s*/, '');
+	}
+
+	async function changeRole(personId: string, permission: Permission) {
+		actionError = null;
+		busyPerson = personId;
+		try {
+			await membership.setMember(collectionId, personId, permission);
+		} catch (e) {
+			log.warn('changeRole failed', { personId, error: e });
+			actionError = friendly(e);
+		} finally {
+			busyPerson = null;
+		}
+	}
+
+	async function confirmRemove(personId: string) {
+		actionError = null;
+		busyPerson = personId;
+		try {
+			await membership.removeMember(collectionId, personId);
+			pendingRemove = null;
+		} catch (e) {
+			log.warn('removeMember failed', { personId, error: e });
+			actionError = friendly(e);
+		} finally {
+			busyPerson = null;
+		}
+	}
+
+	async function leave() {
+		actionError = null;
+		busyPerson = myId;
+		try {
+			await membership.leaveCollection(collectionId);
+		} catch (e) {
+			log.warn('leaveCollection failed', { error: e });
+			actionError = friendly(e);
+		} finally {
+			busyPerson = null;
+		}
+	}
+
+	async function addExisting() {
+		const id = addId.trim();
+		if (!id) return;
+		actionError = null;
+		adding = true;
+		try {
+			await membership.setMember(collectionId, id, addRole);
+			addId = '';
+		} catch (e) {
+			log.warn('addExisting failed', { error: e });
+			actionError = friendly(e);
+		} finally {
+			adding = false;
+		}
+	}
+</script>
+
+{#if proSync.isPro}
+	<div class="collaboration">
+		{#if view.loading && view.members.length === 0}
+			<div class="state-row">Loading members…</div>
+		{:else if view.error && view.members.length === 0}
+			<div class="state-row error">{friendly(view.error)}</div>
+		{:else}
+			<div class="section-head">
+				<h2>Members</h2>
+				<span class="count">{view.members.length}</span>
+			</div>
+
+			{#if actionError}
+				<div class="state-row error" role="alert">{actionError}</div>
+			{/if}
+
+			<ul class="roster">
+				{#each view.members as m (m.personId)}
+					{@const isSelf = m.personId === myId}
+					<li class="member">
+						<span class="member-name" title={m.personId}>
+							{membership.displayFor(m.personId)}{#if isSelf}<span class="you"> (you)</span>{/if}
+						</span>
+
+						{#if amAdmin && !isSelf}
+							<select
+								class="role-select"
+								value={m.permission}
+								disabled={busyPerson === m.personId}
+								onchange={(e) => changeRole(m.personId, e.currentTarget.value as Permission)}
+								aria-label="Role for {m.personId}"
+							>
+								{#each PERMISSIONS as p}
+									<option value={p}>{ROLE_LABEL[p]}</option>
+								{/each}
+							</select>
+
+							{#if pendingRemove === m.personId}
+								<button
+									class="btn btn-danger"
+									disabled={busyPerson === m.personId}
+									onclick={() => confirmRemove(m.personId)}>Confirm remove</button
+								>
+								<button class="btn btn-ghost" onclick={() => (pendingRemove = null)}>Cancel</button>
+							{:else}
+								<button class="btn btn-ghost" onclick={() => (pendingRemove = m.personId)}
+									>Remove</button
+								>
+							{/if}
+						{:else}
+							<span class="role-badge" data-role={m.permission}>{ROLE_LABEL[m.permission]}</span>
+							{#if isSelf}
+								<button class="btn btn-ghost" disabled={busyPerson === myId} onclick={leave}
+									>Leave</button
+								>
+							{/if}
+						{/if}
+					</li>
+				{/each}
+			</ul>
+
+			{#if amAdmin}
+				<div class="add-existing">
+					<h3>Add someone already in the workspace</h3>
+					<div class="add-row">
+						<input
+							class="add-input"
+							type="text"
+							placeholder="person node id"
+							bind:value={addId}
+							disabled={adding}
+						/>
+						<select class="role-select" bind:value={addRole} disabled={adding} aria-label="Role">
+							{#each PERMISSIONS as p}
+								<option value={p}>{ROLE_LABEL[p]}</option>
+							{/each}
+						</select>
+						<button class="btn btn-primary" disabled={adding || !addId.trim()} onclick={addExisting}>
+							{adding ? 'Adding…' : 'Add'}
+						</button>
+					</div>
+					<p class="hint">To bring in someone new, use <strong>Invites</strong> instead.</p>
+				</div>
+			{/if}
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.collaboration {
+		padding: 1.25rem 2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.section-head {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.section-head h2 {
+		font-size: 1rem;
+		font-weight: 600;
+		margin: 0;
+		color: hsl(var(--foreground));
+	}
+	.count {
+		font-size: 0.8rem;
+		color: hsl(var(--muted-foreground));
+		padding: 0.1rem 0.5rem;
+		background: hsl(var(--muted));
+		border-radius: 9999px;
+	}
+	.state-row {
+		font-size: 0.875rem;
+		color: hsl(var(--muted-foreground));
+	}
+	.state-row.error {
+		color: hsl(var(--destructive));
+	}
+	.roster {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.member {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.5rem;
+		border-radius: 6px;
+	}
+	.member:hover {
+		background: hsl(var(--muted) / 0.5);
+	}
+	.member-name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: hsl(var(--foreground));
+		font-size: 0.9rem;
+	}
+	.you {
+		color: hsl(var(--muted-foreground));
+	}
+	.role-badge {
+		font-size: 0.75rem;
+		padding: 0.1rem 0.5rem;
+		border-radius: 9999px;
+		background: hsl(var(--muted));
+		color: hsl(var(--muted-foreground));
+	}
+	.role-badge[data-role='admin'] {
+		background: hsl(var(--primary) / 0.15);
+		color: hsl(var(--primary));
+	}
+	.role-select,
+	.add-input {
+		font-size: 0.85rem;
+		padding: 0.25rem 0.4rem;
+		border: 1px solid hsl(var(--border));
+		border-radius: 6px;
+		background: hsl(var(--background));
+		color: hsl(var(--foreground));
+	}
+	.add-input {
+		flex: 1;
+		min-width: 0;
+	}
+	.btn {
+		font-size: 0.8rem;
+		padding: 0.25rem 0.6rem;
+		border-radius: 6px;
+		border: 1px solid transparent;
+		cursor: pointer;
+	}
+	.btn:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.btn-ghost {
+		background: transparent;
+		border-color: hsl(var(--border));
+		color: hsl(var(--foreground));
+	}
+	.btn-danger {
+		background: hsl(var(--destructive));
+		color: #fff;
+	}
+	.btn-primary {
+		background: hsl(var(--primary));
+		color: hsl(var(--primary-foreground));
+	}
+	.add-existing {
+		margin-top: 0.75rem;
+		border-top: 1px solid hsl(var(--border));
+		padding-top: 0.75rem;
+	}
+	.add-existing h3 {
+		font-size: 0.85rem;
+		font-weight: 600;
+		margin: 0 0 0.5rem;
+		color: hsl(var(--foreground));
+	}
+	.add-row {
+		display: flex;
+		gap: 0.4rem;
+		align-items: center;
+	}
+	.hint {
+		font-size: 0.78rem;
+		color: hsl(var(--muted-foreground));
+		margin: 0.4rem 0 0;
+	}
+</style>

--- a/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
@@ -21,6 +21,12 @@
   import { tabState, addTab, setActiveTab } from '$lib/stores/navigation';
   import { createLogger } from '$lib/utils/logger';
   import { v4 as uuidv4 } from 'uuid';
+  import CollaborationView from '$lib/components/collaboration/collaboration-view.svelte';
+  import { proSync } from '$lib/stores/pro-sync.svelte';
+
+  // Collection sub-view: "contents" (member nodes, the default/community view) or
+  // "collaboration" (people & roles, Pro only — the tab strip only appears for Pro).
+  let activeView = $state<'contents' | 'collaboration'>('contents');
 
   const log = createLogger('CollectionNodeViewer');
 
@@ -175,8 +181,31 @@
     {#if collection?.properties?.description}
       <p class="collection-description">{collection.properties.description}</p>
     {/if}
+
+    {#if proSync.isPro}
+      <!-- Pro-only: switch between the collection's content nodes and its people. -->
+      <div class="collection-tabs" role="tablist">
+        <button
+          class="tab"
+          class:active={activeView === 'contents'}
+          role="tab"
+          aria-selected={activeView === 'contents'}
+          onclick={() => (activeView = 'contents')}>Contents</button
+        >
+        <button
+          class="tab"
+          class:active={activeView === 'collaboration'}
+          role="tab"
+          aria-selected={activeView === 'collaboration'}
+          onclick={() => (activeView = 'collaboration')}>Collaboration</button
+        >
+      </div>
+    {/if}
   </div>
 
+  {#if proSync.isPro && activeView === 'collaboration'}
+    <CollaborationView collectionId={nodeId} />
+  {:else}
   <!-- Content -->
   <div class="collection-content">
     {#if loading}
@@ -225,6 +254,7 @@
       </ul>
     {/if}
   </div>
+  {/if}
 </div>
 
 <style>
@@ -233,6 +263,25 @@
     flex-direction: column;
     height: 100%;
     background: hsl(var(--background));
+  }
+
+  .collection-tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin-top: 1rem;
+  }
+  .collection-tabs .tab {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+  }
+  .collection-tabs .tab.active {
+    color: hsl(var(--foreground));
+    border-bottom-color: hsl(var(--primary));
   }
 
   .collection-header {

--- a/packages/desktop-app/src/tests/components/collaboration-view.test.ts
+++ b/packages/desktop-app/src/tests/components/collaboration-view.test.ts
@@ -1,0 +1,110 @@
+/**
+ * CollaborationView component tests (epic #237, slice S3 #240).
+ * Verifies admin controls gate on the caller's own role and that the community
+ * build renders nothing.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const { membershipMock, proSyncMock } = vi.hoisted(() => ({
+	membershipMock: {
+		get: vi.fn(),
+		currentUserRole: vi.fn(),
+		currentPerson: { personId: 'me' } as { personId: string } | null,
+		displayFor: (id: string) => id,
+		loadCollection: vi.fn(() => Promise.resolve()),
+		setMember: vi.fn(() => Promise.resolve()),
+		removeMember: vi.fn(() => Promise.resolve()),
+		leaveCollection: vi.fn(() => Promise.resolve())
+	},
+	proSyncMock: { isPro: true }
+}));
+
+vi.mock('$lib/stores/membership.svelte', () => ({ membership: membershipMock }));
+vi.mock('$lib/stores/pro-sync.svelte', () => ({ proSync: proSyncMock }));
+
+import CollaborationView from '$lib/components/collaboration/collaboration-view.svelte';
+
+function roster(members: Array<{ personId: string; permission: string }>) {
+	membershipMock.get.mockReturnValue({
+		members,
+		invites: [],
+		requests: [],
+		loading: false,
+		error: null
+	});
+}
+
+describe('CollaborationView', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		proSyncMock.isPro = true;
+		membershipMock.currentPerson = { personId: 'me' };
+	});
+
+	it('renders nothing in community mode', () => {
+		proSyncMock.isPro = false;
+		roster([{ personId: 'me', permission: 'admin' }]);
+		const { queryByText } = render(CollaborationView, { props: { collectionId: 'c1' } });
+		expect(queryByText('Members')).toBeNull();
+		cleanup();
+	});
+
+	it('an admin sees role selects, remove, and the add form; self can leave', () => {
+		membershipMock.currentUserRole.mockReturnValue('admin');
+		roster([
+			{ personId: 'me', permission: 'admin' },
+			{ personId: 'bob', permission: 'modify' }
+		]);
+		const { getByLabelText, getByText, queryByLabelText } = render(CollaborationView, {
+			props: { collectionId: 'c1' }
+		});
+		// admin controls on the OTHER member
+		expect(getByLabelText('Role for bob')).toBeTruthy();
+		expect(getByText('Remove')).toBeTruthy();
+		// self row: no role select, a Leave button
+		expect(queryByLabelText('Role for me')).toBeNull();
+		expect(getByText('Leave')).toBeTruthy();
+		// add-existing admin form
+		expect(getByText('Add someone already in the workspace')).toBeTruthy();
+		cleanup();
+	});
+
+	it('a non-admin sees a read-only roster (no selects, no add form)', () => {
+		membershipMock.currentUserRole.mockReturnValue('readOnly');
+		roster([
+			{ personId: 'me', permission: 'readOnly' },
+			{ personId: 'bob', permission: 'admin' }
+		]);
+		const { queryByLabelText, queryByText } = render(CollaborationView, {
+			props: { collectionId: 'c1' }
+		});
+		expect(queryByLabelText('Role for bob')).toBeNull();
+		expect(queryByText('Add someone already in the workspace')).toBeNull();
+		cleanup();
+	});
+
+	it('changing a member role calls setMember', async () => {
+		membershipMock.currentUserRole.mockReturnValue('admin');
+		roster([
+			{ personId: 'me', permission: 'admin' },
+			{ personId: 'bob', permission: 'readOnly' }
+		]);
+		const { getByLabelText } = render(CollaborationView, { props: { collectionId: 'c1' } });
+		await fireEvent.change(getByLabelText('Role for bob'), { target: { value: 'modify' } });
+		expect(membershipMock.setMember).toHaveBeenCalledWith('c1', 'bob', 'modify');
+		cleanup();
+	});
+
+	it('loads the collection on mount', () => {
+		membershipMock.currentUserRole.mockReturnValue('admin');
+		roster([{ personId: 'me', permission: 'admin' }]);
+		render(CollaborationView, { props: { collectionId: 'c9' } });
+		expect(membershipMock.loadCollection).toHaveBeenCalledWith('c9');
+		cleanup();
+	});
+});


### PR DESCRIPTION
Slice **S3** of the collection-membership-UI epic (NodeSpaceAI/nodespace-sync#237) — the first membership UI surface.

> **Stacked on #1473 (S1).** Cross-fork PRs must base on `main`, so this PR's diff includes the S1 commit until #1473 merges — **review the top commit** (`Add Collaboration view…`). I'll rebase onto `main` once #1473 lands.

## What
Adds a Pro-only **Collaboration** tab to `collection-node-viewer.svelte`. The community build is unchanged — the tab strip only appears when `proSync.tier === 'pro'`; otherwise the existing Contents view renders exactly as before.

The Collaboration tab renders the people roster (via S1's membership store):
- Each member's **role badge**; the caller's own row is marked "(you)".
- **Admin controls** (gated on the caller's *own* role === 'admin'):
  - change a member's role — Viewer / Editor / Admin select → `pro_set_member`
  - remove a member — inline confirm → `pro_remove_member`, with the **last-admin protection** surfaced as a friendly message
  - add someone already in the workspace by person id → `pro_set_member`
- **Leave** (self) → `pro_leave_collection`.
- **Non-admins** see a read-only roster (no selects, no add form).

## Notes
- The "add existing person" input takes a raw person id for now; a proper autocomplete over locally-synced person nodes is a follow-up once a persons-listing source exists — **invites** (S4, #241) are the primary path for bringing in new people.
- Role display currently shows the person id (`membership.displayFor`); resolving to a name/email from local person nodes is wired in a follow-up (email visibility is `can_see_person`-gated server-side).

## Tests
- 5 component tests (`@testing-library/svelte`): admin vs non-admin gating, community-inert render, role-change wiring, load-on-mount. Full membership suite (S1 + S3) green — 21 tests.
- `bun run quality:fix` — ESLint 0/0, `svelte-check` 0 errors.

Depends on S1 (#238 / #1473). Part of #240.