### PR TITLE
Add Invitations inbox + first-run onboarding to the Pro account menu (#242)

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -1,0 +1,224 @@
+<!--
+  InvitationsInbox — onboarding entry point (epic #237, slice S5 #242). A modal
+  opened from the Pro account menu (and once, on first sign-in). Lets a user
+  redeem a share-code invite and ask to join a restricted collection.
+
+  Email-bound invites are auto-redeemed server-side on reconnect
+  (`redeem_my_invites`), so they need no action here — the copy just says so.
+  Listing "my pending invites / my request statuses" and discovering joinable
+  collections have no client-facing backend yet (only admins can list a
+  collection's invites/requests); those are deferred to a follow-up.
+-->
+<script lang="ts">
+	import { focusTrap } from '$lib/actions/focus-trap';
+	import { membership } from '$lib/stores/membership.svelte';
+	import { createLogger } from '$lib/utils/logger';
+
+	const log = createLogger('InvitationsInbox');
+
+	let { open = false, onClose }: { open?: boolean; onClose: () => void } = $props();
+
+	let code = $state('');
+	let redeeming = $state(false);
+	let redeemMsg = $state<string | null>(null);
+	let redeemErr = $state<string | null>(null);
+
+	let joinId = $state('');
+	let requesting = $state(false);
+	let requestMsg = $state<string | null>(null);
+	let requestErr = $state<string | null>(null);
+
+	function friendly(e: unknown): string {
+		return String(e).replace(/^Error:\s*/, '');
+	}
+
+	async function redeem() {
+		const c = code.trim();
+		if (!c) return;
+		redeeming = true;
+		redeemMsg = null;
+		redeemErr = null;
+		try {
+			await membership.acceptInvite(c);
+			redeemMsg = 'You now have access — it will appear in your sidebar as it syncs.';
+			code = '';
+		} catch (e) {
+			log.warn('redeem failed', { error: e });
+			redeemErr = friendly(e);
+		} finally {
+			redeeming = false;
+		}
+	}
+
+	async function requestJoin() {
+		const id = joinId.trim();
+		if (!id) return;
+		requesting = true;
+		requestMsg = null;
+		requestErr = null;
+		try {
+			await membership.requestJoin(id);
+			requestMsg = 'Request sent — an admin will review it.';
+			joinId = '';
+		} catch (e) {
+			log.warn('requestJoin failed', { error: e });
+			requestErr = friendly(e);
+		} finally {
+			requesting = false;
+		}
+	}
+</script>
+
+{#if open}
+	<div class="overlay" role="presentation" tabindex="-1" onclick={onClose}>
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="inv-title"
+			use:focusTrap={{ onEscape: onClose }}
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={(e) => e.stopPropagation()}
+			tabindex="0"
+		>
+			<h2 id="inv-title">Invitations</h2>
+			<p class="lead">
+				Email invites apply automatically when you sign in. To join with a share code, or ask to
+				join a restricted collection, use the options below.
+			</p>
+
+			<section>
+				<h3>Redeem an invite code</h3>
+				<div class="row">
+					<input
+						class="in"
+						type="text"
+						placeholder="paste invite code"
+						bind:value={code}
+						disabled={redeeming}
+					/>
+					<button class="btn btn-primary" disabled={redeeming || !code.trim()} onclick={redeem}>
+						{redeeming ? 'Redeeming…' : 'Redeem'}
+					</button>
+				</div>
+				{#if redeemMsg}<p class="ok" role="status">{redeemMsg}</p>{/if}
+				{#if redeemErr}<p class="err" role="alert">{redeemErr}</p>{/if}
+			</section>
+
+			<section>
+				<h3>Request to join a collection</h3>
+				<div class="row">
+					<input
+						class="in"
+						type="text"
+						placeholder="collection id"
+						bind:value={joinId}
+						disabled={requesting}
+					/>
+					<button
+						class="btn btn-ghost"
+						disabled={requesting || !joinId.trim()}
+						onclick={requestJoin}
+					>
+						{requesting ? 'Sending…' : 'Request'}
+					</button>
+				</div>
+				{#if requestMsg}<p class="ok" role="status">{requestMsg}</p>{/if}
+				{#if requestErr}<p class="err" role="alert">{requestErr}</p>{/if}
+				<!-- Discovering joinable collections (search/browse) is Phase 2; for now
+				     the admin shares the collection id out of band. -->
+			</section>
+
+			<div class="actions">
+				<button class="btn btn-ghost" onclick={onClose}>Close</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+	.modal {
+		background: var(--surface-1, #ffffff);
+		color: var(--text-primary, #1f2937);
+		border-radius: 8px;
+		padding: 24px;
+		width: min(460px, calc(100vw - 48px));
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+	}
+	h2 {
+		margin: 0 0 4px;
+		font-size: 1.1rem;
+		font-weight: 600;
+	}
+	.lead {
+		margin: 0 0 16px;
+		font-size: 0.85rem;
+		color: var(--text-secondary, #6b7280);
+	}
+	section {
+		margin-bottom: 16px;
+	}
+	h3 {
+		margin: 0 0 8px;
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+	.row {
+		display: flex;
+		gap: 8px;
+	}
+	.in {
+		flex: 1;
+		min-width: 0;
+		padding: 8px 10px;
+		font-size: 0.875rem;
+		border: 1px solid var(--border-color, #d1d5db);
+		border-radius: 6px;
+		background: var(--surface-1, #fff);
+		color: var(--text-primary, #1f2937);
+	}
+	.btn {
+		padding: 8px 14px;
+		border: 1px solid transparent;
+		border-radius: 6px;
+		font-size: 0.85rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.btn:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.btn-primary {
+		background: #2563eb;
+		color: #fff;
+	}
+	.btn-ghost {
+		background: var(--surface-2, #e5e7eb);
+		color: var(--text-primary, #1f2937);
+	}
+	.ok {
+		margin: 8px 0 0;
+		font-size: 0.8rem;
+		color: #16a34a;
+	}
+	.err {
+		margin: 8px 0 0;
+		font-size: 0.8rem;
+		color: #dc2626;
+	}
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 8px;
+	}
+</style>

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -20,6 +20,8 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core';
   import { proSync, type SyncState } from '$lib/stores/pro-sync.svelte';
+  import { membership } from '$lib/stores/membership.svelte';
+  import InvitationsInbox from '$lib/components/collaboration/invitations-inbox.svelte';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('ProSyncPill');
@@ -61,6 +63,26 @@
   let menuOpen = $state(false);
   let signingOut = $state(false);
 
+  // Invitations inbox (onboarding, #199 S5). Opened from the account menu and,
+  // once per device, automatically on the first sign-in.
+  let inboxOpen = $state(false);
+
+  const FIRST_RUN_KEY = 'ns:invitations-firstrun-seen';
+  function firstRunSeen(): boolean {
+    try {
+      return typeof localStorage !== 'undefined' && localStorage.getItem(FIRST_RUN_KEY) === '1';
+    } catch {
+      return true; // storage unavailable — don't pester
+    }
+  }
+  function markFirstRunSeen() {
+    try {
+      if (typeof localStorage !== 'undefined') localStorage.setItem(FIRST_RUN_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+  }
+
   // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
   // pill opens the account menu ("signed in as <email>" + Sign out) instead of
   // starting a new sign-in.
@@ -69,6 +91,15 @@
   let pillTitle = $derived(
     signedIn ? `Signed in as ${proSync.userEmail}` : proSync.detail || labels[proSync.state]
   );
+
+  // First-run onboarding: the first time a user signs in on this device, surface
+  // the Invitations inbox once so they can paste a share code or request access.
+  $effect(() => {
+    if (signedIn && !firstRunSeen()) {
+      markFirstRunSeen();
+      inboxOpen = true;
+    }
+  });
 
   async function onClick() {
     if (pending) return;
@@ -103,6 +134,9 @@
     signingOut = true;
     try {
       await proSync.signOut();
+      // Drop cached membership state so the next user doesn't inherit this
+      // session's roster/identity (#199 S5; identity is per-session).
+      membership.reset();
       log.info('signed out');
     } finally {
       signingOut = false;
@@ -141,6 +175,17 @@
           <span class="menu-email">{proSync.userEmail}</span>
         </div>
         <button
+          class="menu-item"
+          type="button"
+          role="menuitem"
+          onclick={() => {
+            inboxOpen = true;
+            menuOpen = false;
+          }}
+        >
+          Invitations
+        </button>
+        <button
           class="menu-signout"
           type="button"
           role="menuitem"
@@ -152,6 +197,8 @@
       </div>
     {/if}
   </div>
+
+  <InvitationsInbox open={inboxOpen} onClose={() => (inboxOpen = false)} />
 {/if}
 
 <style>
@@ -260,6 +307,7 @@
     overflow-wrap: anywhere;
   }
 
+  .menu-item,
   .menu-signout {
     appearance: none;
     text-align: left;
@@ -273,6 +321,7 @@
     cursor: pointer;
   }
 
+  .menu-item:hover:not(:disabled),
   .menu-signout:hover:not(:disabled) {
     background: var(--surface-2, #f3f4f6);
   }

--- a/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
+++ b/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
@@ -1,0 +1,80 @@
+/**
+ * InvitationsInbox component tests (epic #237, slice S5 #242).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const { membershipMock } = vi.hoisted(() => ({
+	membershipMock: {
+		acceptInvite: vi.fn(() => Promise.resolve('collection-x')),
+		requestJoin: vi.fn(() => Promise.resolve('req-1'))
+	}
+}));
+vi.mock('$lib/stores/membership.svelte', () => ({ membership: membershipMock }));
+
+import InvitationsInbox from '$lib/components/collaboration/invitations-inbox.svelte';
+
+describe('InvitationsInbox', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders nothing when closed', () => {
+		const { queryByText } = render(InvitationsInbox, {
+			props: { open: false, onClose: vi.fn() }
+		});
+		expect(queryByText('Invitations')).toBeNull();
+		cleanup();
+	});
+
+	it('redeeming a code calls acceptInvite and shows a success message', async () => {
+		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn() }
+		});
+		await fireEvent.input(getByPlaceholderText('paste invite code'), {
+			target: { value: 'CODE42' }
+		});
+		await fireEvent.click(getByText('Redeem'));
+		expect(membershipMock.acceptInvite).toHaveBeenCalledWith('CODE42');
+		expect(getByText(/You now have access/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('a redeem failure surfaces the error', async () => {
+		membershipMock.acceptInvite.mockRejectedValueOnce('Error: invalid or expired invite code');
+		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn() }
+		});
+		await fireEvent.input(getByPlaceholderText('paste invite code'), {
+			target: { value: 'bad' }
+		});
+		await fireEvent.click(getByText('Redeem'));
+		expect(getByText(/invalid or expired invite code/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('requesting to join calls requestJoin and confirms', async () => {
+		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn() }
+		});
+		await fireEvent.input(getByPlaceholderText('collection id'), {
+			target: { value: 'col-9' }
+		});
+		await fireEvent.click(getByText('Request'));
+		expect(membershipMock.requestJoin).toHaveBeenCalledWith('col-9');
+		expect(getByText(/Request sent/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('Close calls onClose', async () => {
+		const onClose = vi.fn();
+		const { getByText } = render(InvitationsInbox, { props: { open: true, onClose } });
+		await fireEvent.click(getByText('Close'));
+		expect(onClose).toHaveBeenCalled();
+		cleanup();
+	});
+});


### PR DESCRIPTION
Slice **S5** of the collection-membership-UI epic (NodeSpaceAI/nodespace-sync#237) — the onboarding entry point.

> **Stacked on #1473 (S1).** Cross-fork PRs base on `main`; the diff includes the S1 commit until #1473 merges — **review the top commit**. Independent of S3/S4 (touches `pro-sync-pill.svelte`, not the Collaboration view). I'll rebase onto `main` once #1473 lands.

## What
- **`invitations-inbox.svelte`** — a modal (house overlay + `focusTrap`) with:
  - **Redeem an invite code** → `pro_accept_invite`
  - **Request to join a collection** (by id) → `pro_request_join`
  - copy noting **email invites apply automatically** on sign-in (`redeem_my_invites` runs server-side on reconnect).
- **`pro-sync-pill.svelte`** — an **Invitations** item in the account menu opens the inbox; a **first-run** effect opens it once per device on the first sign-in (localStorage-gated). **Sign-out now also clears the membership store** so the next user doesn't inherit the previous session's cached roster/identity.

## Deferred (flagged in code)
Listing one's *own* pending invites / join-request statuses and *discovering* joinable collections have no client-facing backend yet (only admins can list a collection's invites/requests; there's no "my invites" RPC and no collection-discovery). The inbox works from a shared code / known collection id; surfacing auto-redeemed invites ("You were added to X") needs a daemon event or a `my_collection_ids` command — a follow-up.

## Tests
- 5 component tests (redeem success/failure, request-to-join, close, closed-render).
- `bun run quality:fix` — ESLint 0/0, `svelte-check` 0 errors.

Depends on S1 (#238). Part of #242.