### PR TITLE
Add "Continue with Google" sign-in to the Pro sync pill (core half)

### DIFF
--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -80,6 +80,11 @@ message InitiateOAuthRequest {
   // Hint passed to the worker login form so the user knows which
   // account they're signing into (typically the local OS username).
   string user_hint = 2;
+  // Social OAuth provider to sign in with. Empty = the Worker-brokered
+  // email/password flow (default). "google" = sign in directly against
+  // Supabase GoTrue's provider OAuth (PKCE), bypassing the Worker form.
+  // The Worker is still used for the later refresh grant regardless.
+  string provider = 3;
 }
 
 message InitiateOAuthResponse {

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -139,12 +139,15 @@ fn emit_disconnected(app: &AppHandle, reason: String) {
 /// `worker_url` defaults to `http://127.0.0.1:8787` (the
 /// `nodespace-sync/cloud-worker` default). `user_hint` is shown in
 /// the worker's login form so users see which account they're
-/// signing into; empty string is fine.
+/// signing into; empty string is fine. `provider` selects a social
+/// sign-in — empty = the Worker email/password form (default),
+/// `"google"` = direct Supabase GoTrue OAuth.
 #[tauri::command]
 pub async fn pro_initiate_oauth(
     app: AppHandle,
     worker_url: Option<String>,
     user_hint: Option<String>,
+    provider: Option<String>,
 ) -> Result<String, String> {
     let Some(pro) = app.try_state::<ProClient>() else {
         return Err("community tier — Pro sign-in unavailable".into());
@@ -153,8 +156,9 @@ pub async fn pro_initiate_oauth(
     let req = InitiateOAuthRequest {
         worker_url: worker_url.unwrap_or_else(|| DEFAULT_WORKER_URL.to_string()),
         user_hint: user_hint.unwrap_or_default(),
+        provider: provider.unwrap_or_default(),
     };
-    tracing::info!(worker = %req.worker_url, user_hint = %req.user_hint, "Pro: InitiateOAuth");
+    tracing::info!(worker = %req.worker_url, user_hint = %req.user_hint, provider = %req.provider, "Pro: InitiateOAuth");
     let resp = client
         .initiate_o_auth(req)
         .await

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -101,21 +101,35 @@
     }
   });
 
-  async function onClick() {
+  // A pill click opens a menu — the account menu when signed in, the
+  // sign-in options menu when signed out — so a single click never
+  // commits to one sign-in method (email vs Google).
+  function onClick() {
     if (pending) return;
     if (signedIn) {
       menuOpen = !menuOpen;
       return;
     }
     if (!SIGN_IN_STATES.includes(proSync.state)) return;
+    menuOpen = !menuOpen;
+  }
+
+  // Kick off a PKCE sign-in. `provider` empty = the Worker email/password
+  // form; `'google'` = direct Supabase GoTrue OAuth. The daemon opens the
+  // browser; this UI just tracks progress via the `sync:status` stream.
+  async function startSignIn(provider = '') {
+    if (pending) return;
+    if (!SIGN_IN_STATES.includes(proSync.state)) return;
+    menuOpen = false;
     pending = true;
     try {
-      const attemptId = await invoke<string>('pro_initiate_oauth', {
-        // workerUrl + userHint omitted — backend defaults apply.
-      });
-      log.info('PKCE attempt started', { attemptId });
+      const attemptId = await invoke<string>(
+        'pro_initiate_oauth',
+        provider ? { provider } : {}
+      );
+      log.info('PKCE attempt started', { attemptId, provider: provider || 'email' });
     } catch (e) {
-      log.warn('pro_initiate_oauth failed', { error: e });
+      log.warn('pro_initiate_oauth failed', { error: e, provider });
     } finally {
       pending = false;
     }
@@ -156,8 +170,8 @@
       title={pillTitle}
       type="button"
       aria-label="NodeSpace Pro sync status: {labels[proSync.state]}"
-      aria-haspopup={signedIn ? 'menu' : undefined}
-      aria-expanded={signedIn ? menuOpen : undefined}
+      aria-haspopup={clickable ? 'menu' : undefined}
+      aria-expanded={clickable ? menuOpen : undefined}
       disabled={pending || !clickable}
       onclick={onClick}
     >
@@ -165,35 +179,54 @@
       <span class="label">{labels[proSync.state]}</span>
     </button>
 
-    {#if menuOpen && signedIn}
+    {#if menuOpen && clickable}
       <!-- Transparent backdrop so a click anywhere else closes the menu. -->
-      <button class="menu-backdrop" type="button" aria-label="Close account menu" onclick={closeMenu}
+      <button class="menu-backdrop" type="button" aria-label="Close menu" onclick={closeMenu}
       ></button>
       <div class="menu" role="menu">
-        <div class="menu-identity">
-          <span class="menu-identity-label">Signed in as</span>
-          <span class="menu-email">{proSync.userEmail}</span>
-        </div>
-        <button
-          class="menu-item"
-          type="button"
-          role="menuitem"
-          onclick={() => {
-            inboxOpen = true;
-            menuOpen = false;
-          }}
-        >
-          Invitations
-        </button>
-        <button
-          class="menu-signout"
-          type="button"
-          role="menuitem"
-          disabled={signingOut}
-          onclick={onSignOut}
-        >
-          {signingOut ? 'Signing out…' : 'Sign out'}
-        </button>
+        {#if signedIn}
+          <div class="menu-identity">
+            <span class="menu-identity-label">Signed in as</span>
+            <span class="menu-email">{proSync.userEmail}</span>
+          </div>
+          <button
+            class="menu-item"
+            type="button"
+            role="menuitem"
+            onclick={() => {
+              inboxOpen = true;
+              menuOpen = false;
+            }}
+          >
+            Invitations
+          </button>
+          <button
+            class="menu-signout"
+            type="button"
+            role="menuitem"
+            disabled={signingOut}
+            onclick={onSignOut}
+          >
+            {signingOut ? 'Signing out…' : 'Sign out'}
+          </button>
+        {:else}
+          <button
+            class="menu-item"
+            type="button"
+            role="menuitem"
+            onclick={() => startSignIn('google')}
+          >
+            Continue with Google
+          </button>
+          <button
+            class="menu-item"
+            type="button"
+            role="menuitem"
+            onclick={() => startSignIn('')}
+          >
+            Sign in with email
+          </button>
+        {/if}
       </div>
     {/if}
   </div>


### PR DESCRIPTION
Part of **Google OAuth sign-in** (NodeSpaceAI/nodespace-cloud#11). Core half; the daemon half is NodeSpaceAI/nodespace-sync#247.

## What
- **proto:** mirror the daemon's new `InitiateOAuthRequest.provider` field.
- **`pro_initiate_oauth`:** add `provider: Option<String>` and pass it through.
- **`pro-sync-pill.svelte`:** the signed-out pill now opens a small options menu — **"Continue with Google"** / **"Sign in with email"** — instead of committing to one method on a single click. Google passes `provider: "google"`, so the daemon signs in directly against Supabase GoTrue OAuth (PKCE); email is the existing Worker flow, unchanged.

## Behavior / safety
- **Community build unchanged** — everything is inside the existing `{#if proSync.isPro}` pill; empty `provider` preserves the current email/password path exactly.
- Signed-in account menu (identity / Invitations / Sign out) is untouched; the menu markup was generalized to serve both signed-in and signed-out states.

## Tests / checks
- `svelte-check` — **0 errors, 0 warnings** (1714 files). `eslint` — clean.
- `cargo check` (src-tauri) — compiles clean (proto codegen + command change).
- No existing test references the pill or `pro_initiate_oauth`, so nothing regressed.

## Note
Supabase-side config (Google provider enabled + `uri_allow_list` for the loopback callback) is already applied to the shared project and the Google↔Supabase handshake is verified live. Final end-to-end click-through (browser Google login → authenticated) will be validated on a Pro demo build.