### PR TITLE
Hide empty collections from the sidebar (core#1487)

### DIFF
--- a/packages/desktop-app/src/lib/stores/collections.ts
+++ b/packages/desktop-app/src/lib/stores/collections.ts
@@ -257,6 +257,26 @@ export const collectionsState = createCollectionsStore();
 // ============================================================================
 
 /**
+ * Recursively prune collections that have no member nodes visible to the
+ * current user. A collection is kept if it has its own members OR any of its
+ * descendants does — so a populated collection nested under an empty parent
+ * still surfaces. Returns a new array of the surviving items (children are
+ * pruned in place on the retained items).
+ *
+ * `memberCount` is sourced from the local per-user store, so it already
+ * reflects RBAC visibility: the local DB only holds member edges the signed-in
+ * user can see. This filter therefore hides collections that are empty *for
+ * this user*, not just globally empty ones.
+ */
+function pruneEmptyCollections(items: CollectionItem[]): CollectionItem[] {
+  return items.filter((item) => {
+    const keptChildren = item.children ? pruneEmptyCollections(item.children) : [];
+    item.children = keptChildren;
+    return item.memberCount > 0 || keptChildren.length > 0;
+  });
+}
+
+/**
  * Transform flat collections into tree structure for UI display
  * Uses parentCollectionIds to build proper hierarchy
  */
@@ -308,7 +328,10 @@ export const collectionsTree = derived(collectionsData, ($data): CollectionItem[
     .map((c) => itemMap.get(c.id)!)
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  return topLevel;
+  // Hide collections with no member nodes visible to the current user. Keep a
+  // collection whenever it — or any descendant — has members, so populated
+  // sub-collections under an empty parent remain reachable.
+  return pruneEmptyCollections(topLevel);
 });
 
 /**

--- a/packages/desktop-app/src/tests/stores/collections.test.ts
+++ b/packages/desktop-app/src/tests/stores/collections.test.ts
@@ -7,6 +7,7 @@ import { get } from 'svelte/store';
 import {
   collectionsState,
   collectionsData,
+  collectionsTree,
   selectedCollection,
   selectedCollectionMembers,
   findCollectionById,
@@ -418,6 +419,76 @@ describe('Collections Store', () => {
 
       const members = get(selectedCollectionMembers);
       expect(members).toEqual([]);
+    });
+  });
+
+  describe('collectionsTree hide-empty filter', () => {
+    it('hides top-level collections with no visible members', () => {
+      // Fixtures include col-3 "Research Papers" with memberCount: 0 (leaf).
+      collectionsData._setTestData(flattenCollections(mockCollections), createTestMembers());
+
+      const tree = get(collectionsTree);
+      const ids = tree.map((c) => c.id);
+
+      expect(ids).not.toContain('col-3');
+      // Populated top-level collections remain.
+      expect(ids).toEqual(expect.arrayContaining(['col-1', 'col-2', 'col-4']));
+    });
+
+    it('keeps an empty parent when a descendant has visible members', () => {
+      const collections: CollectionInfo[] = [
+        {
+          ...createTestCollectionInfo({ id: 'parent', name: 'Empty Parent', memberCount: 0 }),
+          parentCollectionIds: []
+        },
+        {
+          ...createTestCollectionInfo({ id: 'child', name: 'Populated Child', memberCount: 2 }),
+          parentCollectionIds: ['parent']
+        }
+      ];
+      collectionsData._setTestData(collections, new Map());
+
+      const tree = get(collectionsTree);
+      expect(tree.map((c) => c.id)).toEqual(['parent']);
+      expect(tree[0].children?.map((c) => c.id)).toEqual(['child']);
+    });
+
+    it('prunes empty children while keeping populated siblings', () => {
+      const collections: CollectionInfo[] = [
+        {
+          ...createTestCollectionInfo({ id: 'parent', name: 'Parent', memberCount: 1 }),
+          parentCollectionIds: []
+        },
+        {
+          ...createTestCollectionInfo({ id: 'empty-child', name: 'Empty', memberCount: 0 }),
+          parentCollectionIds: ['parent']
+        },
+        {
+          ...createTestCollectionInfo({ id: 'full-child', name: 'Full', memberCount: 3 }),
+          parentCollectionIds: ['parent']
+        }
+      ];
+      collectionsData._setTestData(collections, new Map());
+
+      const tree = get(collectionsTree);
+      expect(tree).toHaveLength(1);
+      expect(tree[0].children?.map((c) => c.id)).toEqual(['full-child']);
+    });
+
+    it('drops an empty parent whose descendants are all empty', () => {
+      const collections: CollectionInfo[] = [
+        {
+          ...createTestCollectionInfo({ id: 'parent', name: 'Parent', memberCount: 0 }),
+          parentCollectionIds: []
+        },
+        {
+          ...createTestCollectionInfo({ id: 'child', name: 'Child', memberCount: 0 }),
+          parentCollectionIds: ['parent']
+        }
+      ];
+      collectionsData._setTestData(collections, new Map());
+
+      expect(get(collectionsTree)).toEqual([]);
     });
   });
 


### PR DESCRIPTION
Resolves NodeSpaceAI/nodespace-core#1487.

## Problem
The Collections sidebar rendered every collection in the tenant, including ones the signed-in user has zero visible member nodes in — on tenant_demo a user sees ~17 empty collections cluttering the tree (each opens to "No nodes in this collection").

## Fix
`pruneEmptyCollections()` applied at the end of the `collectionsTree` derived store. A collection is kept only if `memberCount > 0` **or** a descendant survives pruning (so a populated sub-collection under an empty parent still surfaces). `memberCount` is sourced from the local per-user SQLite store, so it already reflects RBAC visibility — this hides collections empty *for this user*, not just globally empty ones. No backend/daemon change.

## Tests
- `bun run test` → 147 files, **3945 passed** (collections.test.ts 40/40, +4 new for the hide-empty filter)
- `bunx eslint` clean · `bunx svelte-check` 0 errors/0 warnings

## Community-build safety
Additive UX filter on a derived store; users who have members in their collections see no behavioral change.