### PR TITLE
Fix unreadable contrast in Google sign-in popup / Pro re-login modal (core#1488)

### DIFF
--- a/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
+++ b/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
@@ -81,8 +81,8 @@
   }
 
   .relogin-content {
-    background: var(--surface-1, #ffffff);
-    color: var(--text-primary, #1f2937);
+    background: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
     border-radius: 8px;
     padding: 24px;
     width: min(440px, calc(100vw - 48px));
@@ -98,16 +98,16 @@
     margin: 0;
     font-size: 14px;
     line-height: 1.5;
-    color: var(--text-secondary, #4b5563);
+    color: hsl(var(--muted-foreground));
   }
 
   .relogin-detail {
     margin: 12px 0 0 0;
     padding: 8px 10px;
-    background: var(--surface-2, #f3f4f6);
+    background: hsl(var(--muted));
     border-radius: 4px;
     font-size: 12px;
-    color: var(--text-secondary, #6b7280);
+    color: hsl(var(--muted-foreground));
     word-break: break-word;
   }
 
@@ -142,25 +142,11 @@
   }
 
   .btn-secondary {
-    background-color: var(--surface-2, #e5e7eb);
-    color: var(--text-primary, #1f2937);
+    background-color: hsl(var(--muted));
+    color: hsl(var(--foreground));
   }
 
   .btn-secondary:hover:not(:disabled) {
-    background-color: var(--surface-3, #d1d5db);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .relogin-content {
-      background: var(--surface-1, #1f2937);
-      color: var(--text-primary, #e5e7eb);
-    }
-    .btn-secondary {
-      background-color: var(--surface-2, #374151);
-      color: var(--text-primary, #e5e7eb);
-    }
-    .btn-secondary:hover:not(:disabled) {
-      background-color: var(--surface-3, #4b5563);
-    }
+    background-color: hsl(var(--muted) / 0.7);
   }
 </style>

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -246,9 +246,9 @@
     gap: 6px;
     padding: 4px 10px;
     border-radius: 999px;
-    border: 1px solid var(--border-color, #d1d5db);
-    background: var(--surface-1, #f9fafb);
-    color: var(--text-primary, #1f2937);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
     font-size: 12px;
     font-weight: 500;
     line-height: 1;
@@ -256,7 +256,7 @@
   }
 
   .pro-sync-pill:hover:not(:disabled) {
-    background: var(--surface-2, #f3f4f6);
+    background: hsl(var(--muted));
   }
 
   .pro-sync-pill:disabled {
@@ -315,8 +315,8 @@
     gap: 6px;
     padding: 8px;
     border-radius: 8px;
-    border: 1px solid var(--border-color, #d1d5db);
-    background: var(--surface-1, #ffffff);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--popover));
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
   }
 
@@ -325,18 +325,18 @@
     flex-direction: column;
     gap: 2px;
     padding: 2px 4px 6px;
-    border-bottom: 1px solid var(--border-color, #e5e7eb);
+    border-bottom: 1px solid hsl(var(--border));
   }
 
   .menu-identity-label {
     font-size: 11px;
-    color: var(--text-secondary, #6b7280);
+    color: hsl(var(--muted-foreground));
   }
 
   .menu-email {
     font-size: 12px;
     font-weight: 600;
-    color: var(--text-primary, #1f2937);
+    color: hsl(var(--popover-foreground));
     overflow-wrap: anywhere;
   }
 
@@ -348,7 +348,7 @@
     border-radius: 6px;
     border: none;
     background: transparent;
-    color: var(--text-primary, #1f2937);
+    color: hsl(var(--popover-foreground));
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
@@ -356,38 +356,11 @@
 
   .menu-item:hover:not(:disabled),
   .menu-signout:hover:not(:disabled) {
-    background: var(--surface-2, #f3f4f6);
+    background: hsl(var(--muted));
   }
 
   .menu-signout:disabled {
     cursor: default;
     opacity: 0.7;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .pro-sync-pill {
-      background: var(--surface-1, #1f2937);
-      border-color: var(--border-color, #374151);
-      color: var(--text-primary, #e5e7eb);
-    }
-    .pro-sync-pill:hover {
-      background: var(--surface-2, #374151);
-    }
-    .menu {
-      background: var(--surface-1, #1f2937);
-      border-color: var(--border-color, #374151);
-    }
-    .menu-identity {
-      border-bottom-color: var(--border-color, #374151);
-    }
-    .menu-email {
-      color: var(--text-primary, #e5e7eb);
-    }
-    .menu-signout {
-      color: var(--text-primary, #e5e7eb);
-    }
-    .menu-signout:hover:not(:disabled) {
-      background: var(--surface-2, #374151);
-    }
   }
 </style>


### PR DESCRIPTION
Resolves NodeSpaceAI/nodespace-core#1488.

## Problem
The pill sign-in menu and Pro re-login modal referenced CSS vars (`--surface-*`, `--text-primary/secondary`, `--border-color`) that **are not defined anywhere in the codebase**, so every rule fell back to hardcoded light values; their dark variants were gated on `@media (prefers-color-scheme: dark)` (OS scheme), not the app's own theme → light text on white surface = invisible.

## Fix
Re-keyed both components onto the app's real design tokens (defined per-theme in `app.css` under `:root` / `.dark`, selected app-side via `data-theme`): surface → `hsl(var(--popover))`, text → `hsl(var(--popover-foreground))`, pill → `hsl(var(--card))`/`--foreground`, borders → `hsl(var(--border))`, secondary → `hsl(var(--muted-foreground))`, hover → `hsl(var(--muted))`. Removed both `@media (prefers-color-scheme: dark)` blocks. Matches the existing dropdown/popover convention.

Dark theme after fix: near-black surface `hsl(240 4% 10%)` with near-white text `hsl(0 0% 98%)` (~17:1). Light theme also self-consistent.

## Tests
`bunx eslint` clean · `bunx svelte-check` → 1714 files, 0 errors/0 warnings. CSS-only (+19/−60), both components render only when Pro.