### PR TITLE
Log out button on the invitations popup for a signed-in user without a workspace (core#248)

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -16,7 +16,30 @@
 
 	const log = createLogger('InvitationsInbox');
 
-	let { open = false, onClose }: { open?: boolean; onClose: () => void } = $props();
+	let {
+		open = false,
+		onClose,
+		onLogout
+	}: {
+		open?: boolean;
+		onClose: () => void;
+		// When provided, a signed-in user with no code/membership can log out from
+		// here — reverting to the free/signed-out state (#248). Omitted callers get
+		// the plain Close-only footer.
+		onLogout?: () => void | Promise<void>;
+	} = $props();
+
+	let loggingOut = $state(false);
+
+	async function logout() {
+		if (!onLogout || loggingOut) return;
+		loggingOut = true;
+		try {
+			await onLogout();
+		} finally {
+			loggingOut = false;
+		}
+	}
 
 	let code = $state('');
 	let redeeming = $state(false);
@@ -130,6 +153,16 @@
 			</section>
 
 			<div class="actions">
+				{#if onLogout}
+					<button
+						class="btn btn-logout"
+						type="button"
+						disabled={loggingOut}
+						onclick={logout}
+					>
+						{loggingOut ? 'Logging out…' : 'Log out'}
+					</button>
+				{/if}
 				<button class="btn btn-ghost" onclick={onClose}>Close</button>
 			</div>
 		</div>
@@ -206,6 +239,11 @@
 		background: var(--surface-2, #e5e7eb);
 		color: var(--text-primary, #1f2937);
 	}
+	.btn-logout {
+		background: transparent;
+		border-color: var(--border-color, #d1d5db);
+		color: #dc2626;
+	}
 	.ok {
 		margin: 8px 0 0;
 		font-size: 0.8rem;
@@ -218,7 +256,8 @@
 	}
 	.actions {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: space-between;
+		gap: 8px;
 		margin-top: 8px;
 	}
 </style>

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -231,7 +231,14 @@
     {/if}
   </div>
 
-  <InvitationsInbox open={inboxOpen} onClose={() => (inboxOpen = false)} />
+  <InvitationsInbox
+    open={inboxOpen}
+    onClose={() => (inboxOpen = false)}
+    onLogout={async () => {
+      await onSignOut();
+      inboxOpen = false;
+    }}
+  />
 {/if}
 
 <style>

--- a/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
+++ b/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
@@ -77,4 +77,23 @@ describe('InvitationsInbox', () => {
 		expect(onClose).toHaveBeenCalled();
 		cleanup();
 	});
+
+	it('shows a Log out button only when onLogout is provided, and invokes it (#248)', async () => {
+		// No onLogout → no logout affordance (existing callers unaffected).
+		const { queryByText, unmount } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn() }
+		});
+		expect(queryByText('Log out')).toBeNull();
+		unmount();
+
+		// With onLogout → a signed-in user with no code/membership can revert to
+		// the free/signed-out state from here.
+		const onLogout = vi.fn(() => Promise.resolve());
+		const { getByText } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn(), onLogout }
+		});
+		await fireEvent.click(getByText('Log out'));
+		expect(onLogout).toHaveBeenCalled();
+		cleanup();
+	});
 });


### PR DESCRIPTION
Paired core UI half of NodeSpaceAI/nodespace-sync#248 (daemon provisioning is the sync PR).

## Change (UI-only — `pro_signout`/`proSync.signOut()` already existed)
- `invitations-inbox.svelte`: optional `onLogout` prop → renders a **Log out** button in the footer (guarded by `{#if onLogout}`, so existing callers are unchanged).
- `pro-sync-pill.svelte`: passes `onLogout` that runs the existing sign-out flow (`proSync.signOut()` + `membership.reset()`) then closes the popup → reverts to the free/signed-out state.
- Component test added.

So a signed-in user with no redeem code / no membership can leave the invitations screen instead of being stuck.

## Tests
`bunx svelte-check` 0 errors/0 warnings (1714 files); eslint clean; affected component tests 9/9. Additive + Pro-gated (`onLogout` optional) — community build unaffected.