### PR TITLE
Surface background-sync progress in the Pro sync pill tooltip (core#249)

### DIFF
--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -88,8 +88,16 @@
   // starting a new sign-in.
   let signedIn = $derived(proSync.userEmail !== '');
   let clickable = $derived(SIGN_IN_STATES.includes(proSync.state) || signedIn);
+  // While the daemon catches up in the background (state 'syncing'), the app is
+  // fully usable on the local cache — so the tooltip surfaces that progress even
+  // when signed in, rather than only "Signed in as <email>". Never a blocking gate;
+  // the pill is purely a status indicator (#249).
   let pillTitle = $derived(
-    signedIn ? `Signed in as ${proSync.userEmail}` : proSync.detail || labels[proSync.state]
+    signedIn
+      ? proSync.state === 'syncing'
+        ? `${labels.syncing} — signed in as ${proSync.userEmail}`
+        : `Signed in as ${proSync.userEmail}`
+      : proSync.detail || labels[proSync.state]
   );
 
   // First-run onboarding: the first time a user signs in on this device, surface


### PR DESCRIPTION
Paired core UI half of NodeSpaceAI/nodespace-sync#249 (daemon backgrounding is the sync PR).

## Change (`pro-sync-pill.svelte`, display-only)
The pill already mapped `syncing` → amber "Syncing…" (label + tone). Only change: the tooltip derivation now appends "Syncing…" when signed-in-and-syncing (was masked by "Signed in as <email>"). No state/tone/label/gate change; the #1539/#1488 contrast `<style>` block is untouched.

The full-screen "Loading..." was DB-lock starvation released by the sync-side backgrounding, **not** a core gate — so no core readiness-gate change is made (avoids a false-ready path). `+layout.svelte` already renders AppShell on Tauri injection, not sync completion.

## Tests
`bunx svelte-check` 0 errors/0 warnings; eslint clean. Additive + inside `{#if proSync.isPro}` — community build unaffected.