### PR TITLE
Edit persistence amplifies writes and self-conflicts during fast typing — serialize per-node writes

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -147,6 +147,8 @@ class SimplePersistenceCoordinator {
       // than sitting on a debounce timer. `operation()` here does NOT force
       // early execution — it just resolves once the coordinator's own
       // finally-chain runs the queued write after confirmation lands.
+      // resolve/reject below are dead no-ops: real settlement flows through
+      // `promise` (== queuedPromise), settled via queued.resolve/reject.
       this.pendingOperations.set(nodeId, {
         nodeId,
         operation: () => queuedPromise,
@@ -220,6 +222,9 @@ class SimplePersistenceCoordinator {
           // queue time) so waitForPersistence()/flush callers awaiting
           // `pending.promise` block on the actual queued write, not resolve
           // prematurely.
+          // resolve/reject below are dead no-ops: real settlement flows
+          // through `promise` (== queued.promise), settled via runOperation's
+          // onDone/onError, which are queued.resolve/reject.
           this.pendingOperations.set(nodeId, {
             nodeId,
             operation: () => runOperation(queued.operation, queued.options.dependencies, queued.resolve, queued.reject),
@@ -298,11 +303,23 @@ class SimplePersistenceCoordinator {
 
   /**
    * Clear any queued operation for a node (e.g., after OCC conflict to prevent stale retries)
+   *
+   * CRITICAL: Must settle the queued op's promise and drop its pendingOperations
+   * placeholder here. Both were registered at queue time (see `persist()`), and
+   * without this, discarding the queue entry mid-flight leaves that promise
+   * unsettled forever and hasPending(nodeId) stuck `true` — silently blocking
+   * database broadcasts for this node and hanging any flush/wait call on it.
    */
   clearQueued(nodeId: string): void {
-    if (this.queuedOperations.has(nodeId)) {
+    const queued = this.queuedOperations.get(nodeId);
+    if (queued) {
       coordLog.debug(`Cleared queued operation for ${nodeId.substring(0, 8)} (OCC conflict)`);
       this.queuedOperations.delete(nodeId);
+      queued.reject(new OperationCancelledError('Queued write cancelled: prior write hit an OCC conflict'));
+      const pending = this.pendingOperations.get(nodeId);
+      if (pending && pending.promise === queued.promise) {
+        this.pendingOperations.delete(nodeId);
+      }
     }
   }
 

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -73,6 +73,10 @@ const coordLog = createLogger('PersistenceCoordinator');
 interface QueuedOperation {
   operation: () => Promise<void>;
   options: { mode: 'immediate' | 'debounce'; dependencies?: Array<string | (() => Promise<void>)> };
+  resolve: () => void;
+  reject: (error: Error) => void;
+  /** The queued write's own completion promise, settled by resolve/reject above. */
+  promise: Promise<void>;
 }
 
 class SimplePersistenceCoordinator {
@@ -113,23 +117,48 @@ class SimplePersistenceCoordinator {
       `hasPending=${hasPending}, isExecuting=${isExecuting}`
     );
 
-    // If an operation is already executing for this node, queue the new operation
-    // This prevents multiple concurrent database operations and OCC conflicts
-    // CRITICAL: We store the NEW operation so DELETE isn't lost when UPDATE is executing
+    // If an operation is already executing for this node, collapse the new
+    // operation into a single latest-wins pending write. It runs immediately
+    // after the in-flight write's version confirmation lands (see the
+    // `finally` block below) — never re-debounced, never re-fired per RPC
+    // round-trip. This makes a conflict-with-self structurally impossible:
+    // the queued closure always re-reads the version only after the prior
+    // write's `localNode.version` write-back has happened.
     if (isExecuting) {
-      // Queue the new operation - it will supersede any previously queued operation
-      this.queuedOperations.set(nodeId, { operation, options });
+      // Queue the new operation - it supersedes any previously queued operation
+      // (single-slot Map so DELETE isn't lost behind a re-run UPDATE, and a
+      // burst of keystrokes collapses to the single latest edit).
+      let queuedResolve: () => void = () => {};
+      let queuedReject: (error: Error) => void = () => {};
+      const queuedPromise = new Promise<void>((res, rej) => {
+        queuedResolve = res;
+        queuedReject = rej;
+      });
+      this.queuedOperations.set(nodeId, {
+        operation,
+        options,
+        resolve: queuedResolve,
+        reject: queuedReject,
+        promise: queuedPromise
+      });
+      // Also register a pendingOperations placeholder so flush/wait helpers
+      // (which only look at pendingOperations) see this node as outstanding
+      // even though its write is collapsed behind an in-flight RPC rather
+      // than sitting on a debounce timer. `operation()` here does NOT force
+      // early execution — it just resolves once the coordinator's own
+      // finally-chain runs the queued write after confirmation lands.
+      this.pendingOperations.set(nodeId, {
+        nodeId,
+        operation: () => queuedPromise,
+        resolve: () => {},
+        reject: () => {},
+        promise: queuedPromise,
+        timeoutId: setTimeout(() => {}, 0)
+      });
       coordLog.debug(
-        `[op#${opId}] operation already executing for ${shortNodeId}, queued new operation (mode=${options.mode})`
+        `[op#${opId}] operation already executing for ${shortNodeId}, collapsed into latest-wins pending write (mode=${options.mode})`
       );
-      // Return a promise that resolves when the current operation completes
-      // The queued operation will run automatically after completion
-      const existingPending = this.pendingOperations.get(nodeId);
-      if (existingPending) {
-        return { promise: existingPending.promise };
-      }
-      // Fallback: return immediately resolved promise
-      return { promise: Promise.resolve() };
+      return { promise: queuedPromise };
     }
 
     // Cancel existing pending operation for this node (only if not executing)
@@ -142,15 +171,20 @@ class SimplePersistenceCoordinator {
       reject = rej;
     });
 
-    const executeOperation = async () => {
+    const runOperation = async (
+      op: () => Promise<void>,
+      deps: Array<string | (() => Promise<void>)> | undefined,
+      onDone: () => void,
+      onError: (error: Error) => void
+    ) => {
       // Mark as executing
       this.executingOperations.add(nodeId);
       coordLog.debug(`[op#${opId}] executeOperation() starting for ${shortNodeId}`);
 
       try {
         // Wait for dependencies if any
-        if (options.dependencies) {
-          for (const dep of options.dependencies) {
+        if (deps) {
+          for (const dep of deps) {
             if (typeof dep === 'function') {
               await dep();
             } else {
@@ -163,49 +197,57 @@ class SimplePersistenceCoordinator {
           }
         }
 
-        await operation();
+        await op();
         coordLog.debug(`[op#${opId}] executeOperation() completed for ${shortNodeId}`);
-        resolve();
+        onDone();
       } catch (error) {
-        coordLog.debug(`[op#${opId}] executeOperation() failed for ${shortNodeId}: ${error}`);
-        reject(error instanceof Error ? error : new Error(String(error)));
+        const err = error instanceof Error ? error : new Error(String(error));
+        coordLog.debug(`[op#${opId}] executeOperation() failed for ${shortNodeId}: ${err}`);
+        onError(err);
       } finally {
         this.pendingOperations.delete(nodeId);
 
         // Check for a queued operation BEFORE clearing executingOperations so
         // that hasPending() returns true with no gap. A WatchNodes setNode
-        // arriving between "execution done" and "queued op re-scheduled" would
+        // arriving between "execution done" and "queued op taking over" would
         // otherwise see hasPending=false and clobber the optimistic store.
         const queued = this.queuedOperations.get(nodeId);
         if (queued) {
           this.queuedOperations.delete(nodeId);
           // Re-register in pendingOperations immediately so hasPending() stays
-          // true until persist() takes over when the setTimeout fires.
-          const placeholderPromise = Promise.resolve();
+          // true until the queued write actually starts below. `promise` is
+          // the queued write's OWN completion promise (already registered at
+          // queue time) so waitForPersistence()/flush callers awaiting
+          // `pending.promise` block on the actual queued write, not resolve
+          // prematurely.
           this.pendingOperations.set(nodeId, {
             nodeId,
-            operation: queued.operation,
+            operation: () => runOperation(queued.operation, queued.options.dependencies, queued.resolve, queued.reject),
             resolve: () => {},
             reject: () => {},
-            promise: placeholderPromise,
+            promise: queued.promise,
             timeoutId: setTimeout(() => {}, 0),
           });
           coordLog.debug(
-            `[op#${opId}] queued operation re-registered as pending for ${shortNodeId} (mode=${queued.options.mode})`
+            `[op#${opId}] queued operation taking over for ${shortNodeId} (mode=${queued.options.mode})`
           );
         }
 
         this.executingOperations.delete(nodeId);
 
         if (queued) {
-          // Execute the queued operation - use setTimeout to avoid stack overflow
-          // CRITICAL: Use the QUEUED operation, not the original one
-          setTimeout(() => {
-            this.persist(nodeId, queued.operation, queued.options);
-          }, 0);
+          // Run the queued write now that this write's version confirmation
+          // has landed — deferred via microtask (not setTimeout/debounce) to
+          // avoid unbounded stack growth while still running as soon as
+          // possible after confirmation, never re-debounced.
+          void Promise.resolve().then(() => {
+            void runOperation(queued.operation, queued.options.dependencies, queued.resolve, queued.reject);
+          });
         }
       }
     };
+
+    const executeOperation = () => runOperation(operation, options.dependencies, resolve, reject);
 
     if (options.mode === 'immediate') {
       coordLog.debug(`[op#${opId}] scheduling IMMEDIATE for ${shortNodeId}`);
@@ -412,11 +454,21 @@ class SimplePersistenceCoordinator {
    * @returns Set of node IDs that failed to persist
    */
   async flushAll(timeoutMs = 5000): Promise<Set<string>> {
-    const allNodeIds = Array.from(this.pendingOperations.keys());
-    if (allNodeIds.length === 0) {
+    // Include nodes that are mid-RPC (executingOperations) or that have a
+    // collapsed latest-wins write waiting behind one (queuedOperations), not
+    // just nodes with a debounce timer still pending. Otherwise a node whose
+    // write is in flight — with a serial-writer follow-up queued behind it —
+    // is invisible to this snapshot and flushAll() returns before either
+    // write actually lands.
+    const allNodeIds = new Set<string>([
+      ...this.pendingOperations.keys(),
+      ...this.executingOperations,
+      ...this.queuedOperations.keys()
+    ]);
+    if (allNodeIds.size === 0) {
       return new Set();
     }
-    return this.flushAndWaitForNodes(allNodeIds, timeoutMs);
+    return this.flushAndWaitForNodes(Array.from(allNodeIds), timeoutMs);
   }
 }
 

--- a/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for issue #1492: edit persistence amplifies writes and
+ * self-conflicts during fast typing.
+ *
+ * Covers the SimplePersistenceCoordinator's per-node serial writer: a
+ * keystroke arriving while an UpdateNode RPC is in flight must collapse into
+ * a single latest-wins write that runs only after the in-flight write's
+ * version confirmation lands, never re-fired per RPC round-trip and never
+ * OCC-conflicting against the same client's own prior write.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
+import { backendAdapter } from '../../lib/services/backend-adapter';
+import { conflictNotifications } from '../../lib/stores/conflict-notifications.svelte';
+import type { Node } from '../../lib/types';
+
+const makeNode = (id: string, content: string, version = 1): Node => ({
+  id,
+  nodeType: 'text',
+  content,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  modifiedAt: '2024-01-01T00:00:00.000Z',
+  version,
+  properties: {},
+  mentions: []
+});
+
+const dbSource = { type: 'database' as const, reason: 'initial-load' };
+const viewerSource = { type: 'viewer' as const, viewerId: 'pane-1' };
+
+describe('Persistence serial writer regression (#1492)', () => {
+  let store: SharedNodeStore;
+
+  beforeEach(() => {
+    SharedNodeStore.resetInstance();
+    store = SharedNodeStore.getInstance();
+    conflictNotifications.dismissAll();
+  });
+
+  afterEach(() => {
+    store.clearAll();
+    SharedNodeStore.resetInstance();
+    conflictNotifications.dismissAll();
+    vi.restoreAllMocks();
+  });
+
+  it('a keystroke arriving mid-RPC collapses into a single follow-up write, not a re-fire per round-trip', async () => {
+    const nodeId = 'serial-writer-1';
+    const initialNode = makeNode(nodeId, 'a', 1);
+
+    let callCount = 0;
+    // Each RPC takes a tick to resolve, simulating an in-flight round-trip.
+    const updateSpy = vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, version, node) => {
+      callCount++;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return {
+        id: nodeId,
+        nodeType: 'text',
+        content: String(node.content ?? ''),
+        createdAt: '2024-01-01T00:00:00.000Z',
+        modifiedAt: new Date().toISOString(),
+        version: version + 1,
+        properties: {},
+        mentions: []
+      };
+    });
+
+    store.setNode(initialNode, dbSource);
+
+    // First edit: debounce fires immediately in test env or after 500ms; force
+    // it into flight by using immediate-mode structural updates is not
+    // representative, so instead simulate the debounce firing and then queue
+    // a second edit while the RPC for the first is in flight.
+    store.updateNode(nodeId, { content: 'ab' }, viewerSource);
+
+    // Wait past the 500ms debounce so the first RPC starts (but not past the
+    // 20ms RPC latency, so it's still in flight).
+    await new Promise((resolve) => setTimeout(resolve, 520));
+    expect(store.isNodePersistenceExecuting(nodeId)).toBe(true);
+
+    // A burst of further keystrokes arrives while the RPC is in flight.
+    store.updateNode(nodeId, { content: 'abc' }, viewerSource);
+    store.updateNode(nodeId, { content: 'abcd' }, viewerSource);
+    store.updateNode(nodeId, { content: 'abcde' }, viewerSource);
+
+    await store.flushAllPendingSaves(3000);
+
+    // The in-flight write plus the collapsed latest-wins follow-up write is
+    // exactly two RPCs — not one per queued keystroke.
+    expect(callCount).toBe(2);
+    const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
+    expect(lastCall[2].content).toBe('abcde');
+
+    const stored = store.getNode(nodeId);
+    expect(stored?.content).toBe('abcde');
+    expect(stored?.version).toBe(3);
+  }, 10000);
+
+  it('the follow-up write always reads the version confirmed by the prior write — no self-conflict', async () => {
+    const nodeId = 'serial-writer-2';
+    const initialNode = makeNode(nodeId, 'x', 5);
+
+    const versionsSeen: number[] = [];
+    vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, version, node) => {
+      versionsSeen.push(version);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return {
+        id: nodeId,
+        nodeType: 'text',
+        content: String(node.content ?? ''),
+        createdAt: '2024-01-01T00:00:00.000Z',
+        modifiedAt: new Date().toISOString(),
+        version: version + 1,
+        properties: {},
+        mentions: []
+      };
+    });
+
+    store.setNode(initialNode, dbSource);
+
+    store.updateNode(nodeId, { content: 'xy' }, viewerSource);
+    await new Promise((resolve) => setTimeout(resolve, 520));
+
+    // Second edit queued while first RPC (version 5) is in flight.
+    store.updateNode(nodeId, { content: 'xyz' }, viewerSource);
+
+    await store.flushAllPendingSaves(3000);
+
+    // The second RPC must carry the version the first RPC's response
+    // confirmed (6), not the stale version read before confirmation (5).
+    expect(versionsSeen).toEqual([5, 6]);
+
+    // No OCC conflict notification should have been raised.
+    const versionMismatches = conflictNotifications.notifications.filter(
+      (n) => n.conflictType === 'version-mismatch'
+    );
+    expect(versionMismatches).toHaveLength(0);
+  }, 10000);
+});

--- a/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
@@ -51,9 +51,10 @@ describe('Persistence serial writer regression (#1492)', () => {
 
     let callCount = 0;
     // Each RPC takes a tick to resolve, simulating an in-flight round-trip.
+    // 300ms gives ample margin over the 200ms post-debounce wait below.
     const updateSpy = vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, version, node) => {
       callCount++;
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       return {
         id: nodeId,
         nodeType: 'text',
@@ -74,9 +75,9 @@ describe('Persistence serial writer regression (#1492)', () => {
     // a second edit while the RPC for the first is in flight.
     store.updateNode(nodeId, { content: 'ab' }, viewerSource);
 
-    // Wait past the 500ms debounce so the first RPC starts (but not past the
-    // 20ms RPC latency, so it's still in flight).
-    await new Promise((resolve) => setTimeout(resolve, 520));
+    // Wait past the 500ms debounce so the first RPC starts (but well short of
+    // the 300ms RPC latency, so it's still in flight).
+    await new Promise((resolve) => setTimeout(resolve, 700));
     expect(store.isNodePersistenceExecuting(nodeId)).toBe(true);
 
     // A burst of further keystrokes arrives while the RPC is in flight.
@@ -104,7 +105,7 @@ describe('Persistence serial writer regression (#1492)', () => {
     const versionsSeen: number[] = [];
     vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, version, node) => {
       versionsSeen.push(version);
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       return {
         id: nodeId,
         nodeType: 'text',
@@ -120,7 +121,7 @@ describe('Persistence serial writer regression (#1492)', () => {
     store.setNode(initialNode, dbSource);
 
     store.updateNode(nodeId, { content: 'xy' }, viewerSource);
-    await new Promise((resolve) => setTimeout(resolve, 520));
+    await new Promise((resolve) => setTimeout(resolve, 700));
 
     // Second edit queued while first RPC (version 5) is in flight.
     store.updateNode(nodeId, { content: 'xyz' }, viewerSource);
@@ -136,5 +137,68 @@ describe('Persistence serial writer regression (#1492)', () => {
       (n) => n.conflictType === 'version-mismatch'
     );
     expect(versionMismatches).toHaveLength(0);
+  }, 10000);
+
+  it('an OCC conflict on the in-flight write settles the collapsed follow-up write instead of hanging it', async () => {
+    const nodeId = 'serial-writer-3';
+    const initialNode = makeNode(nodeId, 'a', 1);
+
+    // The in-flight RPC takes far longer than the debounce window, so the
+    // second edit below is guaranteed to land while it is still in flight.
+    vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, _version, node) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      const occError = new Error('VERSION_CONFLICT: optimistic concurrency failure') as Error & {
+        code: string;
+        conflictData: {
+          node_id: string;
+          expected: number;
+          actual: number;
+          current_node: Node | null;
+        };
+      };
+      occError.code = 'VERSION_CONFLICT';
+      occError.conflictData = {
+        node_id: nodeId,
+        expected: 1,
+        actual: 2,
+        current_node: { ...initialNode, content: String(node.content ?? ''), version: 2 }
+      };
+      throw occError;
+    });
+
+    store.setNode(initialNode, dbSource);
+
+    // First edit starts the in-flight write that will hit an OCC conflict.
+    store.updateNode(nodeId, { content: 'ab' }, viewerSource);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(store.isNodePersistenceExecuting(nodeId)).toBe(true);
+
+    // A second edit arrives and collapses into the latest-wins queued write
+    // behind the doomed in-flight write, well BEFORE its OCC rejection lands.
+    store.updateNode(nodeId, { content: 'abc' }, viewerSource);
+    expect(store.hasPendingSave(nodeId)).toBe(true);
+
+    // Must not hang: flushAllPendingSaves(5000) races each node's promise
+    // against its OWN 5s internal timeout. Without the fix, the collapsed
+    // queued write's promise never settles, so this call only "succeeds"
+    // by burning the full internal timeout — asserting on elapsed time
+    // catches that even though the call eventually resolves either way.
+    const flushStart = performance.now();
+    const failed = await store.flushAllPendingSaves(5000);
+    const flushDuration = performance.now() - flushStart;
+
+    // The RPC takes 2000ms and the write started ~600ms before this flush
+    // call; a correctly-settled promise resolves within ~1.5s of that,
+    // nowhere near the 5s internal timeout.
+    expect(flushDuration).toBeLessThan(3000);
+
+    // The queued write must be reported as settled (rejected, since it was
+    // cancelled), not silently forgotten.
+    expect(failed.has(nodeId)).toBe(true);
+
+    // hasPendingSave must clear once the OCC conflict is handled — a stuck
+    // `true` here would mean database broadcasts are permanently skipped for
+    // this node (see setNode's skip-while-editing guard).
+    expect(store.hasPendingSave(nodeId)).toBe(false);
   }, 10000);
 });


### PR DESCRIPTION
Closes #1492