### PR TITLE
Finish the ADR-049 $effect conversion — 19 residual violations across four clusters

### DIFF
--- a/packages/design-system/src/examples/SchemaPropertyFormDemo.svelte
+++ b/packages/design-system/src/examples/SchemaPropertyFormDemo.svelte
@@ -29,10 +29,6 @@
     { value: "charlie", label: "@charlie" }
   ];
 
-  $effect(() => {
-    assigneeSearch;
-  });
-
   // Example task node data
   const taskData = {
     title: "Implement Schema-Driven Property UI",

--- a/packages/desktop-app/src/lib/components/chat/node-card-inline.svelte
+++ b/packages/desktop-app/src/lib/components/chat/node-card-inline.svelte
@@ -7,6 +7,7 @@
 -->
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { createLogger } from '$lib/utils/logger';
   import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
   import { backendAdapter } from '$lib/services/backend-adapter';
@@ -28,20 +29,24 @@
   };
 
   let node = $derived(sharedNodeStore.getNode(nodeId));
+  // True once the on-mount fetch has settled; drives the "unknown" fallback below when
+  // the node still isn't present. Written from the fetch callback, never from an effect.
   let fetchAttempted = $state(false);
 
-  // Fetch from backend if not in store
-  $effect(() => {
-    if (!node && !fetchAttempted) {
+  // Fetch from the backend on mount if the node isn't already in the store. Each card is
+  // mounted imperatively with a fixed nodeId, so this is a one-shot per-card load - not a
+  // reactive watch (ADR-049). Once fetched, `node` updates via the store read above.
+  onMount(() => {
+    if (sharedNodeStore.getNode(nodeId)) return;
+    backendAdapter.getNode(nodeId).then((fetched) => {
+      if (fetched) {
+        sharedNodeStore.setNode(fetched, { type: 'database', reason: 'node-card-fetch' }, true);
+      }
+    }).catch((e) => {
+      log.warn(`Failed to fetch node ${nodeId}:`, e);
+    }).finally(() => {
       fetchAttempted = true;
-      backendAdapter.getNode(nodeId).then((fetched) => {
-        if (fetched) {
-          sharedNodeStore.setNode(fetched, { type: 'database', reason: 'node-card-fetch' }, true);
-        }
-      }).catch((e) => {
-        log.warn(`Failed to fetch node ${nodeId}:`, e);
-      });
-    }
+    });
   });
 
   let title = $derived(node?.content?.split('\n')[0]?.slice(0, 120) || displayText || nodeId.slice(0, 8));

--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
@@ -10,6 +10,7 @@
   onboarding paths) live in the sibling InvitesPanel (S4).
 -->
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { membership } from '$lib/stores/membership.svelte';
 	import type { Permission } from '$lib/services/membership-service';
 	import { proSync } from '$lib/stores/pro-sync.svelte';
@@ -53,10 +54,16 @@
 	let approveRole = $state<Record<string, Permission>>({});
 	let busyRequest = $state<string | null>(null);
 
-	$effect(() => {
-		if (proSync.isPro && collectionId) {
+	// Load the roster on mount if Pro is already confirmed (the host tab is Pro-gated, so
+	// this is the common path). If tier confirms after mount, load then - via the store's
+	// transition hook, not a reactive $effect that watches isPro (ADR-049).
+	onMount(() => {
+		if (!collectionId) return;
+		if (proSync.isPro) {
 			membership.loadCollection(collectionId);
+			return;
 		}
+		return proSync.onProConfirmed(() => membership.loadCollection(collectionId));
 	});
 
 	let view = $derived(membership.get(collectionId));

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -46,15 +46,10 @@
   // covers the brief window before the first daemon-status event arrives (or
   // a short grace period elapses); `unreachable` reflects a terminal
   // `not_running` event.
-  let daemonConnecting = $state(true);
-  let daemonUnreachable = $state(false);
-  $effect(() => {
-    const unsubscribe = daemonStatus.subscribe((s) => {
-      daemonConnecting = s.connecting;
-      daemonUnreachable = s.unreachable;
-    });
-    return unsubscribe;
-  });
+  // Read directly from the store via $-auto-subscription — no effect mirroring the
+  // store into local $state (ADR-049).
+  const daemonConnecting = $derived($daemonStatus.connecting);
+  const daemonUnreachable = $derived($daemonStatus.unreachable);
 
   // First-launch onboarding wizard (Issue #1180).
   let showOnboarding = $state(false);
@@ -78,14 +73,11 @@
   // show a one-time snackbar on first open; the inline badge handles per-node
   // review/restore. Guarded one-shot so it loads exactly once per session; fully
   // inert in community (proSync.isPro is false → load() returns empty → no toast).
-  let recoveredLoadStarted = false;
-  let recoveredNotified = false;
-  $effect(() => {
-    if (!proSync.isPro || recoveredLoadStarted) return;
-    recoveredLoadStarted = true;
+  // Fired from proSync.onProConfirmed (the tier state-transition site) rather than a
+  // guarded $effect (ADR-049); fully inert in community since the callback never fires.
+  function loadRecoveredItems(): void {
     recoveredItems.load().then(() => {
-      if (recoveredNotified || recoveredItems.items.length === 0) return;
-      recoveredNotified = true;
+      if (recoveredItems.items.length === 0) return;
       const n = recoveredItems.items.length;
       conflictNotifications.add({
         nodeId: recoveredItems.items[0].node_id,
@@ -93,7 +85,7 @@
         conflictType: 'recovered-items'
       });
     });
-  });
+  }
 
   async function handleReloginSignIn() {
     if (reloginPending) return;
@@ -249,6 +241,7 @@
     let cleanupMCP: (() => Promise<void>) | null = null;
     let staleNodesInterval: ReturnType<typeof setInterval> | null = null;
     let cleanupProSync: (() => void) | null = null;
+    let unregisterProConfirmed: (() => void) | null = null;
     let unlistenTier: Promise<() => void> | null = null;
 
     if (
@@ -263,6 +256,10 @@
         .start()
         .then((stop) => (cleanupProSync = stop))
         .catch((e) => log.warn('proSync.start failed', { error: e }));
+
+      // Load the recovered-items log once the daemon confirms Pro tier. Registering
+      // here (a listener, not an effect) keeps the sequencing at the transition site.
+      unregisterProConfirmed = proSync.onProConfirmed(loadRecoveredItems);
 
       // Sync theme from backend preferences (overrides localStorage if different)
       invoke<{ activeDatabasePath: string; display: { renderMarkdown: boolean; theme: string } }>('get_settings')
@@ -607,6 +604,7 @@
         (await unlistenTier)();
       }
       cleanupProSync?.();
+      unregisterProConfirmed?.();
       if (cleanupMCP) {
         await cleanupMCP();
       }

--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -31,10 +31,6 @@
   let viewerLoadErrors = $state<Map<string, string>>(new Map());
   let viewerLoading = $state<Set<string>>(new Set());
 
-  // Track node hydration state per nodeId. A node is hydrated once ensureNode()
-  // has confirmed it is present in sharedNodeStore (or closed the tab if not found).
-  let hydratedNodeIds = $state<Set<string>>(new Set());
-
   // Load viewer when needed - moved to function called from onMount to avoid derived context issues
   async function loadViewerForNodeType(nodeType: string) {
     if (viewerComponents.has(nodeType) || viewerLoadErrors.has(nodeType) || viewerLoading.has(nodeType)) {
@@ -68,15 +64,15 @@
     }
   }
 
-  // Tracks the nodeId each pane's hydration effect most recently requested, so that when
-  // an in-flight ensureNode() resolves after a newer navigation has already superseded it,
-  // the stale response is discarded instead of racing its state write against the new one.
-  let latestRequestedNodeId: string | undefined;
-
+  // Ensure the node backing a tab is present in the store. This only pushes a fetch into
+  // sharedNodeStore (a non-reactive external system) — it writes no local reactive state,
+  // so there is nothing to race: hydration status is read back off the store's per-node
+  // cell via isNodeHydrated below. No staleness guard is needed. If the node genuinely
+  // doesn't exist, close the tab — but only if that tab still points at this nodeId, so a
+  // superseded navigation can't close the newly-active tab (checked against live tab state,
+  // the single source of truth, not a tracked "latest requested" variable).
   async function hydrateNode(nodeId: string, tabId: string) {
-    if (hydratedNodeIds.has(nodeId)) return;
-
-    latestRequestedNodeId = nodeId;
+    if (sharedNodeStore.getNode(nodeId)) return;
 
     let node;
     try {
@@ -86,17 +82,13 @@
       return;
     }
 
-    // A newer navigation superseded this request while we were awaiting — discard the
-    // stale result instead of mutating state for a nodeId that's no longer current.
-    if (latestRequestedNodeId !== nodeId) return;
-
     if (!node) {
-      log.warn(`Node ${nodeId} not found — closing stale tab`);
-      closeTab(tabId);
-      return;
+      const tab = untrack(() => $tabState.tabs.find((t) => t.id === tabId));
+      if (tab?.content?.nodeId === nodeId) {
+        log.warn(`Node ${nodeId} not found — closing stale tab`);
+        closeTab(tabId);
+      }
     }
-
-    hydratedNodeIds = new Set(hydratedNodeIds).add(nodeId);
   }
 
   // Derive viewer component for active tab.
@@ -121,14 +113,16 @@
   const isNodeHydrated = $derived.by(() => {
     const nodeId = activeTab?.content?.nodeId;
     if (!nodeId) return true; // settings tabs and placeholder tabs need no hydration
-    return hydratedNodeIds.has(nodeId);
+    // Read the store's per-node cell directly: a node is hydrated once it is present.
+    return sharedNodeStore.getNode(nodeId) != null;
   });
 
-  // Load viewer and hydrate parent node when active tab changes.
-  // Both run in parallel — viewer module load and node fetch are independent.
-  // tabId is captured synchronously before untrack() so that if the user switches
-  // tabs during the async fetch, closeTab targets the tab that triggered the fetch,
-  // not the newly-active one.
+  // When the active tab changes, push the two side effects it requires into their
+  // subsystems: lazy-load the viewer module for the node type, and ensure the node is
+  // present in sharedNodeStore. The effect body writes no reactive state of its own
+  // (ADR-049) — viewer results land in the module cache, hydration lands in the store,
+  // and both are read back via the $derived values above. tabId is captured here so a
+  // not-found close targets the tab that triggered the fetch.
   $effect(() => {
     const nodeType = activeTab?.content?.nodeType;
     const nodeId = activeTab?.content?.nodeId;

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -89,6 +89,23 @@
     }
   }
 
+  // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
+  // pill opens the account menu ("signed in as <email>" + Sign out) instead of
+  // starting a new sign-in.
+  let signedIn = $derived(proSync.userEmail !== '');
+  let clickable = $derived(SIGN_IN_STATES.includes(proSync.state) || signedIn);
+  // While the daemon catches up in the background (state 'syncing'), the app is
+  // fully usable on the local cache — so the tooltip surfaces that progress even
+  // when signed in, rather than only "Signed in as <email>". Never a blocking gate;
+  // the pill is purely a status indicator (#249).
+  let pillTitle = $derived(
+    signedIn
+      ? proSync.state === 'syncing'
+        ? `${labels.syncing} — signed in as ${proSync.userEmail}`
+        : `Signed in as ${proSync.userEmail}`
+      : proSync.detail || labels[proSync.state]
+  );
+
   // The inbox is open when explicitly opened, or auto-opened for a fresh, undismissed
   // first sign-in on a device that hasn't seen onboarding yet.
   const firstRunAutoOpen = $derived(
@@ -106,23 +123,6 @@
     dismissedSignInEpisode = proSync.signedInEpisode;
     markFirstRunSeen();
   }
-
-  // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
-  // pill opens the account menu ("signed in as <email>" + Sign out) instead of
-  // starting a new sign-in.
-  let signedIn = $derived(proSync.userEmail !== '');
-  let clickable = $derived(SIGN_IN_STATES.includes(proSync.state) || signedIn);
-  // While the daemon catches up in the background (state 'syncing'), the app is
-  // fully usable on the local cache — so the tooltip surfaces that progress even
-  // when signed in, rather than only "Signed in as <email>". Never a blocking gate;
-  // the pill is purely a status indicator (#249).
-  let pillTitle = $derived(
-    signedIn
-      ? proSync.state === 'syncing'
-        ? `${labels.syncing} — signed in as ${proSync.userEmail}`
-        : `Signed in as ${proSync.userEmail}`
-      : proSync.detail || labels[proSync.state]
-  );
 
   // A pill click opens a menu — the account menu when signed in, the
   // sign-in options menu when signed out — so a single click never

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -65,7 +65,13 @@
 
   // Invitations inbox (onboarding, #199 S5). Opened from the account menu and,
   // once per device, automatically on the first sign-in.
-  let inboxOpen = $state(false);
+  //
+  // `inboxOpenedManually` tracks explicit opens (account menu). The first-run
+  // auto-open is derived from proSync.signedInEpisode instead of pushed by an effect:
+  // when a fresh sign-in episode arrives on a device that hasn't seen the onboarding,
+  // the inbox shows until dismissed — no $effect reading/writing its own seen flag.
+  let inboxOpenedManually = $state(false);
+  let dismissedSignInEpisode = $state(0);
 
   const FIRST_RUN_KEY = 'ns:invitations-firstrun-seen';
   function firstRunSeen(): boolean {
@@ -81,6 +87,24 @@
     } catch {
       /* ignore */
     }
+  }
+
+  // The inbox is open when explicitly opened, or auto-opened for a fresh, undismissed
+  // first sign-in on a device that hasn't seen onboarding yet.
+  const firstRunAutoOpen = $derived(
+    signedIn &&
+      !firstRunSeen() &&
+      proSync.signedInEpisode > 0 &&
+      proSync.signedInEpisode !== dismissedSignInEpisode
+  );
+  const inboxOpen = $derived(inboxOpenedManually || firstRunAutoOpen);
+
+  function closeInbox() {
+    inboxOpenedManually = false;
+    // Dismiss the current first-run episode and remember it device-wide so it
+    // doesn't reopen for this sign-in or on future launches.
+    dismissedSignInEpisode = proSync.signedInEpisode;
+    markFirstRunSeen();
   }
 
   // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
@@ -99,15 +123,6 @@
         : `Signed in as ${proSync.userEmail}`
       : proSync.detail || labels[proSync.state]
   );
-
-  // First-run onboarding: the first time a user signs in on this device, surface
-  // the Invitations inbox once so they can paste a share code or request access.
-  $effect(() => {
-    if (signedIn && !firstRunSeen()) {
-      markFirstRunSeen();
-      inboxOpen = true;
-    }
-  });
 
   // A pill click opens a menu — the account menu when signed in, the
   // sign-in options menu when signed out — so a single click never
@@ -202,7 +217,7 @@
             type="button"
             role="menuitem"
             onclick={() => {
-              inboxOpen = true;
+              inboxOpenedManually = true;
               menuOpen = false;
             }}
           >
@@ -241,10 +256,10 @@
 
   <InvitationsInbox
     open={inboxOpen}
-    onClose={() => (inboxOpen = false)}
+    onClose={closeInbox}
     onLogout={async () => {
       await onSignOut();
-      inboxOpen = false;
+      closeInbox();
     }}
   />
 {/if}

--- a/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
@@ -18,6 +18,7 @@
 -->
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { Collapsible } from 'bits-ui';
   import * as Select from '$lib/components/ui/select';
   import * as Popover from '$lib/components/ui/popover';
@@ -67,8 +68,9 @@
    */
   const assigneeOptions: Array<{ value: string; label: string }> = [];
 
-  // Load schema when nodeType changes
-  $effect(() => {
+  // Load schema on mount. base-node-viewer wraps this form in {#key node.id-nodeType},
+  // so a nodeType change remounts it — a discrete per-type load, not a reactive watch (ADR-049).
+  onMount(() => {
     async function loadSchema() {
       if (!nodeType) return;
 

--- a/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
@@ -10,6 +10,7 @@
 -->
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { Collapsible } from 'bits-ui';
   import * as Select from '$lib/components/ui/select';
   import * as Popover from '$lib/components/ui/popover';
@@ -45,8 +46,9 @@
     return rawNode?.nodeType === 'task' ? nodeToTaskNode(rawNode) : null;
   });
 
-  // Load schema for user-defined extensions
-  $effect(() => {
+  // Load the task schema once on mount (constant type — never re-fetches). ADR-049:
+  // a mount-time load, not a reactive-state watch.
+  onMount(() => {
     async function loadSchema() {
       try {
         const schemaNode = await backendAdapter.getSchema('task');

--- a/packages/desktop-app/src/lib/components/query/query-editor.svelte
+++ b/packages/desktop-app/src/lib/components/query/query-editor.svelte
@@ -27,22 +27,13 @@
     onPreview?: (_query: QueryDefinition) => Promise<number>;
   } = $props();
 
-  // We intentionally capture the prop value once at mount rather than reactively
-  // tracking it, so that parent re-derivations don't overwrite in-progress edits.
-  let initialized = false;
-  let jsonText = $state('');
+  // Capture the prop value once at component init rather than tracking it reactively,
+  // so parent re-derivations don't overwrite in-progress edits. The $state initializer
+  // runs once with the initial `query` prop — no $effect syncing prop→state (ADR-049).
+  let jsonText = $state(JSON.stringify(query ?? DEFAULT_QUERY, null, 2));
   let errorMessage = $state<string | null>(null);
   let previewCount = $state<number | null>(null);
   let previewLoading = $state(false);
-
-  $effect(() => {
-    // Read `query` reactively but only apply it on the first run.
-    const q = query;
-    if (!initialized) {
-      jsonText = JSON.stringify(q ?? DEFAULT_QUERY, null, 2);
-      initialized = true;
-    }
-  });
 
   function validateAndSave(): void {
     errorMessage = null;

--- a/packages/desktop-app/src/lib/components/query/query-editor.svelte
+++ b/packages/desktop-app/src/lib/components/query/query-editor.svelte
@@ -10,6 +10,7 @@
 <script lang="ts">
   import type { QueryDefinition } from '$lib/types/query';
   import { DEFAULT_QUERY, QUERY_TEMPLATE_EXAMPLES } from '$lib/types/query';
+  import { untrack } from 'svelte';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('QueryEditor');
@@ -30,7 +31,7 @@
   // Capture the prop value once at component init rather than tracking it reactively,
   // so parent re-derivations don't overwrite in-progress edits. The $state initializer
   // runs once with the initial `query` prop — no $effect syncing prop→state (ADR-049).
-  let jsonText = $state(JSON.stringify(query ?? DEFAULT_QUERY, null, 2));
+  let jsonText = $state(untrack(() => JSON.stringify(query ?? DEFAULT_QUERY, null, 2)));
   let errorMessage = $state<string | null>(null);
   let previewCount = $state<number | null>(null);
   let previewLoading = $state(false);

--- a/packages/desktop-app/src/lib/components/query/table-view.svelte
+++ b/packages/desktop-app/src/lib/components/query/table-view.svelte
@@ -27,13 +27,10 @@
   } = $props();
 
   const PAGE_SIZE = 25;
+  // Raw user pagination intent. The effective page is derived and clamped into the
+  // valid range for the current nodeIds, so a shrinking/changing result set corrects an
+  // out-of-range page on read — no $effect syncing state to the nodeIds prop (ADR-049).
   let currentPage = $state(0);
-
-  // Reset to page 0 when nodeIds change
-  $effect(() => {
-    nodeIds;
-    currentPage = 0;
-  });
 
   // Derive columns from schema fields — capitalize name and replace underscores with spaces
   const columns = $derived.by(() => {
@@ -58,9 +55,10 @@
 
   const totalPages = $derived(Math.ceil(nodeIds.length / PAGE_SIZE));
 
-  const pageIds = $derived(
-    nodeIds.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE)
-  );
+  // Effective page, clamped so it never points past the current result set.
+  const page = $derived(Math.min(currentPage, Math.max(0, totalPages - 1)));
+
+  const pageIds = $derived(nodeIds.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE));
 
 </script>
 
@@ -84,17 +82,17 @@
     <Button
       variant="outline"
       size="sm"
-      onclick={() => currentPage--}
-      disabled={currentPage === 0}
+      onclick={() => (currentPage = page - 1)}
+      disabled={page === 0}
     >
       ‹
     </Button>
-    <span class="text-muted-foreground text-sm">{currentPage + 1} / {totalPages}</span>
+    <span class="text-muted-foreground text-sm">{page + 1} / {totalPages}</span>
     <Button
       variant="outline"
       size="sm"
-      onclick={() => currentPage++}
-      disabled={currentPage >= totalPages - 1}
+      onclick={() => (currentPage = page + 1)}
+      disabled={page >= totalPages - 1}
     >
       ›
     </Button>

--- a/packages/desktop-app/src/lib/components/ui/calendar/calendar.svelte
+++ b/packages/desktop-app/src/lib/components/ui/calendar/calendar.svelte
@@ -16,35 +16,15 @@
   }: WithoutChildrenOrChild<CalendarPrimitive.RootProps> = $props();
 
   /**
-   * Value Binding Workaround Pattern
+   * The primitive binds directly to the `$bindable` `value` prop — bits-ui v1 propagates
+   * bindable changes in both directions, so no intermediate mirror state is needed.
+   * handleValueChange only forwards to the optional onValueChange callback; `bind:value`
+   * already keeps the prop in sync.
    *
-   * PROBLEM: bits-ui CalendarPrimitive.Root doesn't properly propagate bindable value
-   * changes in Svelte 5. Direct bind:value={value} doesn't trigger parent updates.
-   *
-   * SOLUTION: Bridge pattern with intermediate state
-   * - internalValue: Local reactive state that bits-ui can bind to
-   * - $effect: Syncs external value changes to internal (one-way: parent → child)
-   * - handleValueChange: Syncs internal changes to external (one-way: child → parent)
-   *
-   * This pattern ensures proper two-way binding despite the library limitation.
    * The 'as never' casts are necessary due to discriminated union type conflicts
    * between CalendarPrimitive's type parameter and our generic value binding.
-   *
-   * TODO: Revisit when bits-ui has full Svelte 5 support or consider upstream PR
-   * Related: https://github.com/huntabyte/bits-ui/issues (Svelte 5 compatibility)
    */
-  let internalValue = $state<DateValue | DateValue[] | undefined>(value);
-
-  // Sync external value changes to internal
-  $effect(() => {
-    internalValue = value;
-  });
-
-  // Handle internal changes and propagate them
   function handleValueChange(v: DateValue | DateValue[] | undefined) {
-    // Update the bindable prop
-    value = v;
-    // Call the user's callback if provided
     if (onValueChange) {
       onValueChange(v as never);
     }
@@ -56,7 +36,7 @@ Discriminated Unions + Destructing (required for bindable) do not
 get along, so we shut typescript up by casting `value` to `never`.
 -->
 <CalendarPrimitive.Root
-  bind:value={internalValue as never}
+  bind:value={value as never}
   bind:ref
   bind:placeholder
   onValueChange={handleValueChange}

--- a/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
@@ -14,6 +14,7 @@
 -->
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import Icon from '$lib/design/icons/icon.svelte';
   import { collectionService } from '$lib/services/collection-service';
   import { collectionsData } from '$lib/stores/collections';
@@ -44,8 +45,10 @@
   let loading = $state(true);
   let error: string | null = $state(null);
 
-  // Load collection and members when nodeId changes
-  $effect(() => {
+  // Load collection and members on mount. pane-content remounts this viewer via
+  // {#key ...nodeId} when the tab's nodeId changes, so this is a discrete per-node
+  // lifecycle load — not a reactive-state watch (ADR-049).
+  onMount(() => {
     loadCollectionData(nodeId);
   });
 

--- a/packages/desktop-app/src/lib/components/viewers/query-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/query-node-viewer.svelte
@@ -13,7 +13,7 @@
 -->
 
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { backendAdapter } from '$lib/services/backend-adapter';
   import { getNavigationService } from '$lib/services/navigation-service';
   import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
@@ -63,10 +63,11 @@
 
   const hasResults = $derived(loadedNodeIds.length > 0);
 
-  // Load schema and execute query when nodeId changes
-  $effect(() => {
-    const id = nodeId;
-    untrack(() => loadAndQuery(id));
+  // Load schema and execute the query on mount. pane-content remounts this viewer via
+  // {#key ...nodeId} when the tab's nodeId changes, so this is a discrete per-node
+  // lifecycle load — not a reactive-state watch (ADR-049).
+  onMount(() => {
+    loadAndQuery(nodeId);
   });
 
   async function loadAndQuery(schemaId: string) {

--- a/packages/desktop-app/src/lib/design/components/code-block-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/code-block-node.svelte
@@ -19,13 +19,12 @@
 -->
 
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import BaseNode from './base-node.svelte';
   import { focusManager } from '$lib/services/focus-manager.svelte';
 
   import ViewModeRenderer from './view-mode-renderer.svelte';
-  import { highlightCode, type HighlightLine } from '$lib/services/syntax-highlight';
-  import { renderMermaid } from '$lib/services/mermaid-render';
+  import { CodeBlockRenderer } from './code-block-renderer.svelte';
   import { currentTheme } from '$lib/design/theme';
 
   // Supported languages for code blocks
@@ -97,107 +96,51 @@
   let typingTimer: ReturnType<typeof setTimeout> | undefined;
 
   // Syntax highlighting and Mermaid state
-  let highlightedLines = $state<HighlightLine[] | null>(null);
-  let mermaidSvg = $state<string | null>(null);
-  let mermaidError = $state<string | null>(null);
+  // Render results live on the renderer store (ADR-049); the component reads them
+  // directly and pushes them into the DOM via the innerHTML-injection effects below.
+  const renderer = new CodeBlockRenderer();
   let mermaidContainer = $state<HTMLDivElement | null>(null);
 
   // Split-panel live preview state (mermaid edit mode only)
-  let previewSvg = $state<string | null>(null);
-  let previewError = $state<string | null>(null);
   let previewContainer = $state<HTMLDivElement | null>(null);
-  let previewRenderSeq = 0;
-  let previewDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
   // Inject sanitized SVG into the container via DOM — avoids {@html} and its lint warning.
   // sanitizeSvg() strips all scripts and event handlers before this runs.
   $effect(() => {
     if (mermaidContainer) {
-      mermaidContainer.innerHTML = mermaidSvg ?? '';
+      mermaidContainer.innerHTML = renderer.mermaidSvg ?? '';
     }
   });
 
   $effect(() => {
     if (previewContainer) {
-      previewContainer.innerHTML = previewSvg ?? '';
+      previewContainer.innerHTML = renderer.previewSvg ?? '';
     }
   });
-
-  // Monotonic counter to discard stale async results when language/content changes rapidly
-  let renderSeq = 0;
 
   // Track dark mode from the app's theme store (not OS media query)
   // so syntax highlighting matches the actual UI theme, not the OS preference
   let isDark = $derived($currentTheme === 'dark');
 
-  // Re-highlight whenever language, content, or dark mode changes (skip during editing).
-  // Uses a sequence counter to discard stale results from in-flight async renders.
+  // Trigger a re-render whenever language, content, or dark mode changes (skip during
+  // editing). The effect body only pushes into the renderer subsystem — it writes no
+  // reactive state itself; the results land on the renderer store (ADR-049).
   $effect(() => {
     if (isEditing) return;
-    const code = displayContent.trim();
-    const lang = language;
-    const dark = isDark;
-    const seq = ++renderSeq;
-
-    if (lang === 'mermaid') {
-      highlightedLines = null;
-      mermaidError = null; // Reset stale error so it doesn't flash while new render is pending
-      renderMermaid(code, nodeId, dark).then((svg) => {
-        if (seq !== renderSeq) return; // stale — a newer render is already in-flight; preserve existing diagram
-        if (svg !== null) {
-          mermaidSvg = svg;
-        } else {
-          // Definitive failure: render returned null, so there is no diagram to preserve
-          mermaidSvg = null;
-          mermaidError = 'Diagram rendering failed. Check your Mermaid syntax.';
-        }
-      });
-    } else if (lang !== 'plaintext') {
-      mermaidSvg = null;
-      mermaidError = null;
-      highlightCode(code, lang, dark).then((lines) => {
-        if (seq !== renderSeq) return; // stale — discard
-        highlightedLines = lines;
-      });
-    } else {
-      highlightedLines = null;
-      mermaidSvg = null;
-      mermaidError = null;
-    }
+    renderer.render(displayContent.trim(), language, nodeId, isDark);
   });
 
-  // Debounced live preview for mermaid split-panel (fires only when editing a mermaid block)
+  // Debounced live preview for the mermaid split-panel (only while editing a mermaid
+  // block). Pushes into the renderer subsystem; the debounced SVG lands on the store.
   $effect(() => {
     if (!isEditing || language !== 'mermaid') {
-      // Clear preview state when leaving edit mode or switching away from mermaid
-      previewSvg = null;
-      previewError = null;
+      renderer.clearPreview();
       return;
     }
-    const code = displayContent.trim();
-    const dark = isDark;
-
-    if (previewDebounceTimer) clearTimeout(previewDebounceTimer);
-    previewDebounceTimer = setTimeout(async () => {
-      const seq = ++previewRenderSeq;
-      const svg = await renderMermaid(code, `${nodeId}-preview`, dark);
-      if (seq !== previewRenderSeq) return; // stale — discard
-      if (svg !== null) {
-        previewSvg = svg;
-        previewError = null;
-      } else {
-        previewSvg = null;
-        previewError = 'Syntax error — check your Mermaid definition.';
-      }
-    }, 300);
-
-    return () => {
-      if (previewDebounceTimer) {
-        clearTimeout(previewDebounceTimer);
-        previewDebounceTimer = undefined;
-      }
-    };
+    renderer.renderPreview(displayContent.trim(), nodeId, isDark);
   });
+
+  onDestroy(() => renderer.destroy());
 
   function handleTypingStart() {
     isTyping = true;
@@ -388,16 +331,16 @@
 <!-- Custom view content snippet for syntax highlighting and Mermaid diagrams -->
 {#snippet codeViewContent()}
   {#if language === 'mermaid'}
-    {#if mermaidSvg}
+    {#if renderer.mermaidSvg}
       <div class="mermaid-output" bind:this={mermaidContainer}></div>
-    {:else if mermaidError}
-      <div class="mermaid-error">{mermaidError}</div>
+    {:else if renderer.mermaidError}
+      <div class="mermaid-error">{renderer.mermaidError}</div>
     {:else}
       <div class="code-loading">Rendering diagram...</div>
     {/if}
-  {:else if highlightedLines}
+  {:else if renderer.highlightedLines}
     <div class="highlighted-code">
-      {#each highlightedLines as line}
+      {#each renderer.highlightedLines as line}
         <div class="code-line">
           {#each line as token}
             <span
@@ -451,10 +394,10 @@
   <!-- Mermaid split-panel live preview (edit mode only) -->
   {#if isEditing && language === 'mermaid'}
     <div class="mermaid-split-preview">
-      {#if previewSvg}
+      {#if renderer.previewSvg}
         <div class="mermaid-output mermaid-preview-output" bind:this={previewContainer}></div>
-      {:else if previewError}
-        <div class="mermaid-error mermaid-preview-error">{previewError}</div>
+      {:else if renderer.previewError}
+        <div class="mermaid-error mermaid-preview-error">{renderer.previewError}</div>
       {:else}
         <div class="code-loading">Rendering…</div>
       {/if}

--- a/packages/desktop-app/src/lib/design/components/code-block-renderer.svelte.ts
+++ b/packages/desktop-app/src/lib/design/components/code-block-renderer.svelte.ts
@@ -1,0 +1,105 @@
+/**
+ * CodeBlockRenderer — reactive render pipeline for a single code-block node.
+ *
+ * ADR-049: the syntax-highlight / mermaid render results live here as `$state` on a
+ * store class; the component reads them directly and re-renders when they change. The
+ * component triggers a render by calling `render()` / `renderPreview()` (an imperative
+ * push into this async subsystem) rather than an `$effect` that writes reactive state.
+ *
+ * Staleness is handled by monotonic sequence counters so an out-of-order async result
+ * from a superseded input is discarded instead of clobbering the current output.
+ */
+
+import { highlightCode, type HighlightLine } from '$lib/services/syntax-highlight';
+import { renderMermaid } from '$lib/services/mermaid-render';
+
+const PREVIEW_DEBOUNCE_MS = 300;
+
+export class CodeBlockRenderer {
+  /** Highlighted lines for non-mermaid, non-plaintext code. */
+  highlightedLines = $state<HighlightLine[] | null>(null);
+  /** Rendered mermaid diagram SVG (injected into the DOM by the component). */
+  mermaidSvg = $state<string | null>(null);
+  /** User-facing mermaid render error, if the diagram failed. */
+  mermaidError = $state<string | null>(null);
+
+  /** Split-panel live-preview SVG (mermaid edit mode). */
+  previewSvg = $state<string | null>(null);
+  /** Split-panel live-preview error. */
+  previewError = $state<string | null>(null);
+
+  // Monotonic counters to discard stale async results when inputs change rapidly.
+  #renderSeq = 0;
+  #previewSeq = 0;
+  #previewTimer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Render the display view for the given code/language/theme. Skips highlighting for
+   * plaintext. `nodeId` scopes the mermaid render so concurrent blocks don't collide.
+   */
+  render(code: string, language: string, nodeId: string, isDark: boolean): void {
+    const seq = ++this.#renderSeq;
+
+    if (language === 'mermaid') {
+      this.highlightedLines = null;
+      this.mermaidError = null; // reset stale error so it doesn't flash while pending
+      renderMermaid(code, nodeId, isDark).then((svg) => {
+        if (seq !== this.#renderSeq) return; // superseded — preserve existing diagram
+        if (svg !== null) {
+          this.mermaidSvg = svg;
+        } else {
+          // Definitive failure: no diagram to preserve.
+          this.mermaidSvg = null;
+          this.mermaidError = 'Diagram rendering failed. Check your Mermaid syntax.';
+        }
+      });
+    } else if (language !== 'plaintext') {
+      this.mermaidSvg = null;
+      this.mermaidError = null;
+      highlightCode(code, language, isDark).then((lines) => {
+        if (seq !== this.#renderSeq) return; // superseded — discard
+        this.highlightedLines = lines;
+      });
+    } else {
+      this.highlightedLines = null;
+      this.mermaidSvg = null;
+      this.mermaidError = null;
+    }
+  }
+
+  /** Debounced mermaid live preview for the split-panel editor. */
+  renderPreview(code: string, nodeId: string, isDark: boolean): void {
+    if (this.#previewTimer) clearTimeout(this.#previewTimer);
+    this.#previewTimer = setTimeout(() => {
+      const seq = ++this.#previewSeq;
+      renderMermaid(code, `${nodeId}-preview`, isDark).then((svg) => {
+        if (seq !== this.#previewSeq) return; // superseded — discard
+        if (svg !== null) {
+          this.previewSvg = svg;
+          this.previewError = null;
+        } else {
+          this.previewSvg = null;
+          this.previewError = 'Syntax error — check your Mermaid definition.';
+        }
+      });
+    }, PREVIEW_DEBOUNCE_MS);
+  }
+
+  /** Clear the split-panel preview (leaving edit mode or switching away from mermaid). */
+  clearPreview(): void {
+    if (this.#previewTimer) {
+      clearTimeout(this.#previewTimer);
+      this.#previewTimer = undefined;
+    }
+    this.previewSvg = null;
+    this.previewError = null;
+  }
+
+  /** Cancel any pending debounce timer (component teardown). */
+  destroy(): void {
+    if (this.#previewTimer) {
+      clearTimeout(this.#previewTimer);
+      this.#previewTimer = undefined;
+    }
+  }
+}

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -83,13 +83,58 @@ class ProSyncStore {
    */
   authRequiredEpisode = $state(0);
 
+  /**
+   * Bumped each time `userEmail` transitions from empty to non-empty — i.e. a fresh
+   * sign-in. Lets consumers (the sync pill's first-run onboarding) react to the
+   * transition via a derived comparison instead of an effect that reads and writes
+   * its own "seen" flag. Same pattern as authRequiredEpisode.
+   */
+  signedInEpisode = $state(0);
+
   isPro = $derived(this.tier === 'pro');
+
+  /**
+   * Callbacks fired once when `tier` first resolves to 'pro'. Lets consumers run a
+   * Pro-confirmed one-shot (e.g. loading the recovered-items log) from this state
+   * transition rather than an $effect that guards on isPro (ADR-049). A callback
+   * registered after tier is already 'pro' fires immediately.
+   */
+  private proConfirmedCallbacks = new Set<() => void>();
+  private proConfirmed = false;
+
+  /** Register a one-shot callback for Pro-tier confirmation. Returns an unregister fn. */
+  onProConfirmed(callback: () => void): () => void {
+    if (this.proConfirmed) {
+      callback();
+      return () => {};
+    }
+    this.proConfirmedCallbacks.add(callback);
+    return () => this.proConfirmedCallbacks.delete(callback);
+  }
 
   private setState(next: SyncState) {
     if (next === 'auth-required' && this.state !== 'auth-required') {
       this.authRequiredEpisode++;
     }
     this.state = next;
+  }
+
+  /** Set tier, firing proConfirmed callbacks once on the first transition to 'pro'. */
+  private setTier(next: ProTier) {
+    this.tier = next;
+    if (next === 'pro' && !this.proConfirmed) {
+      this.proConfirmed = true;
+      for (const cb of this.proConfirmedCallbacks) cb();
+      this.proConfirmedCallbacks.clear();
+    }
+  }
+
+  /** Set userEmail, bumping signedInEpisode on an empty→non-empty (fresh sign-in) edge. */
+  private setUserEmail(next: string) {
+    if (next !== '' && this.userEmail === '') {
+      this.signedInEpisode++;
+    }
+    this.userEmail = next;
   }
 
   private unlistenTier: UnlistenFn | null = null;
@@ -112,7 +157,7 @@ class ProSyncStore {
     // fired before we subscribed (Tauri events are not buffered).
     try {
       const t = await invoke<ProTier>('pro_tier');
-      this.tier = t;
+      this.setTier(t);
     } catch (e) {
       log.warn('pro_tier invoke failed', { error: e });
     }
@@ -123,11 +168,11 @@ class ProSyncStore {
     }>('pro:tier-detected', async (event) => {
       const p = event.payload;
       log.info('tier detected', { tier: p.tier });
-      this.tier = p.tier;
+      this.setTier(p.tier);
       if (p.initial_status) {
         this.setState(decodeState(p.initial_status.state));
         this.detail = p.initial_status.detail;
-        this.userEmail = p.initial_status.user_email ?? '';
+        this.setUserEmail(p.initial_status.user_email ?? '');
       }
       // The first pro_subscribe_sync_status invoke below races the
       // backend's async init (Tauri setup spawns the connect on the
@@ -148,7 +193,7 @@ class ProSyncStore {
       (event) => {
         this.setState(decodeState(event.payload.state));
         this.detail = event.payload.detail;
-        this.userEmail = event.payload.user_email ?? '';
+        this.setUserEmail(event.payload.user_email ?? '');
       }
     );
 
@@ -176,7 +221,7 @@ class ProSyncStore {
       log.warn('pro_signout invoke failed', { error: e });
     }
     this.setState('auth-required');
-    this.userEmail = '';
+    this.setUserEmail('');
   }
 
   stop() {

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -98,6 +98,13 @@ class ProSyncStore {
    * Pro-confirmed one-shot (e.g. loading the recovered-items log) from this state
    * transition rather than an $effect that guards on isPro (ADR-049). A callback
    * registered after tier is already 'pro' fires immediately.
+   *
+   * `proConfirmed` is a deliberate one-way latch: Pro tier is a per-process capability
+   * probe result, not a session-lifetime flag, so it never resets on sign-out (unlike
+   * `signedInEpisode`, which tracks the per-session sign-in edge and re-bumps). A
+   * consumer needing to re-run on a genuine tier downgrade→upgrade would need a
+   * different, episode-style signal — none exists today because tier does not change
+   * within a running app.
    */
   private proConfirmedCallbacks = new Set<() => void>();
   private proConfirmed = false;

--- a/packages/desktop-app/src/tests/components/collaboration-view.test.ts
+++ b/packages/desktop-app/src/tests/components/collaboration-view.test.ts
@@ -25,7 +25,7 @@ const { membershipMock, proSyncMock } = vi.hoisted(() => ({
 		approveRequest: vi.fn(() => Promise.resolve()),
 		rejectRequest: vi.fn(() => Promise.resolve())
 	},
-	proSyncMock: { isPro: true }
+	proSyncMock: { isPro: true, onProConfirmed: vi.fn(() => () => {}) }
 }));
 
 vi.mock('$lib/stores/membership.svelte', () => ({ membership: membershipMock }));

--- a/packages/desktop-app/src/tests/components/node-card-inline.test.ts
+++ b/packages/desktop-app/src/tests/components/node-card-inline.test.ts
@@ -1,0 +1,83 @@
+/**
+ * NodeCardInline — on-mount fetch (ADR-049 / #1566).
+ *
+ * The card previously fetched a missing node from inside a $effect that watched the
+ * derived `node` value. After the ADR-049 conversion it fetches once on mount (the card
+ * is mounted imperatively with a fixed nodeId), skipping the fetch entirely when the node
+ * is already present in the store. These tests pin that single-call-site behaviour.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const getNode = vi.fn();
+const setNode = vi.fn();
+const fetchNode = vi.fn();
+
+vi.mock('$lib/services/shared-node-store.svelte', () => ({
+  sharedNodeStore: {
+    getNode: (...a: unknown[]) => getNode(...a),
+    setNode: (...a: unknown[]) => setNode(...a)
+  }
+}));
+
+vi.mock('$lib/services/backend-adapter', () => ({
+  backendAdapter: {
+    getNode: (...a: unknown[]) => fetchNode(...a)
+  }
+}));
+
+import NodeCardInline from '$lib/components/chat/node-card-inline.svelte';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('NodeCardInline on-mount fetch (#1566)', () => {
+  it('fetches a missing node exactly once on mount and stores the result', async () => {
+    const fetched = { id: 'abc-123', nodeType: 'text', content: 'Hello', properties: {} };
+    getNode.mockReturnValue(undefined); // not in store
+    fetchNode.mockResolvedValue(fetched);
+
+    render(NodeCardInline, { nodeId: 'abc-123' });
+    await tick();
+    await tick();
+
+    expect(fetchNode).toHaveBeenCalledTimes(1);
+    expect(fetchNode).toHaveBeenCalledWith('abc-123');
+    expect(setNode).toHaveBeenCalledWith(
+      fetched,
+      { type: 'database', reason: 'node-card-fetch' },
+      true
+    );
+  });
+
+  it('does not fetch when the node is already in the store', async () => {
+    getNode.mockReturnValue({ id: 'abc-123', nodeType: 'text', content: 'Cached', properties: {} });
+
+    render(NodeCardInline, { nodeId: 'abc-123' });
+    await tick();
+    await tick();
+
+    expect(fetchNode).not.toHaveBeenCalled();
+    expect(setNode).not.toHaveBeenCalled();
+  });
+
+  it('does not store anything when the backend has no such node', async () => {
+    getNode.mockReturnValue(undefined);
+    fetchNode.mockResolvedValue(undefined);
+
+    render(NodeCardInline, { nodeId: 'missing' });
+    await tick();
+    await tick();
+
+    expect(fetchNode).toHaveBeenCalledTimes(1);
+    expect(setNode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
+++ b/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
@@ -1,15 +1,17 @@
 /**
- * Regression tests for the pane-content.svelte hydration race (issue #1564).
+ * Regression tests for the pane-content.svelte hydration behaviour (issue #1564, #1566).
  *
- * Full-component-mount tests for BaseNodeViewer-adjacent components require complex
- * setup (NodeServiceContext, plugin registry, database mocking - see the note in
- * merge-prevention.test.ts). Instead these tests exercise the exact hydration/race-guard
- * logic extracted from pane-content.svelte's hydrateNode(), driven with real async
- * timing via a controllable mock ensureNode(), to verify:
+ * Full-component-mount tests for BaseNodeViewer-adjacent components require complex setup
+ * (NodeServiceContext, plugin registry, database mocking - see merge-prevention.test.ts).
+ * Instead these tests exercise the hydration logic extracted from pane-content.svelte's
+ * hydrateNode(), driven with real async timing via a controllable mock store, to verify the
+ * event-driven conversion (ADR-049): hydration writes only into the store (one cell per
+ * nodeId), reads its status back off the store, and closes a not-found tab only if that tab
+ * still points at the fetched nodeId.
  *
- * 1. A slow/failed ensureNode() no longer throws an unhandled rejection.
- * 2. Rapid/repeated navigation before an earlier ensureNode() resolves does not let the
- *    stale response overwrite state for a nodeId that is no longer current.
+ * The earlier `latestRequestedNodeId` staleness guard is gone: because hydration state lives
+ * on the store keyed by nodeId — not a single shared local mirror — a stale in-flight fetch
+ * simply populates its own cell and can no longer overwrite the current node's state.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,18 +20,22 @@ interface Node {
   id: string;
 }
 
-// Mirrors hydrateNode() in pane-content.svelte: tracks the most recently requested
-// nodeId so a stale in-flight response can be detected and discarded after await.
-function createHydrationHarness(ensureNode: (nodeId: string) => Promise<Node | undefined>) {
-  let hydratedNodeIds = new Set<string>();
-  let latestRequestedNodeId: string | undefined;
+/**
+ * Mirrors hydrateNode() in pane-content.svelte after the ADR-049 conversion:
+ * fetch-if-missing into the store; on not-found, close the tab only if it still
+ * points at this nodeId. `getNode` reads the store's per-node cell — the single
+ * source of truth the component's isNodeHydrated $derived reads too.
+ */
+function createHydrationHarness(
+  ensureNode: (nodeId: string) => Promise<Node | undefined>,
+  tabNodeId: (tabId: string) => string | undefined
+) {
+  const store = new Map<string, Node>();
   const closedTabs: string[] = [];
   const errors: unknown[] = [];
 
   async function hydrateNode(nodeId: string, tabId: string) {
-    if (hydratedNodeIds.has(nodeId)) return;
-
-    latestRequestedNodeId = nodeId;
+    if (store.has(nodeId)) return;
 
     let node: Node | undefined;
     try {
@@ -39,40 +45,40 @@ function createHydrationHarness(ensureNode: (nodeId: string) => Promise<Node | u
       return;
     }
 
-    if (latestRequestedNodeId !== nodeId) return;
-
-    if (!node) {
-      closedTabs.push(tabId);
+    if (node) {
+      store.set(node.id, node);
       return;
     }
 
-    hydratedNodeIds = new Set(hydratedNodeIds).add(nodeId);
+    // Not found — close the tab only if it still points at this nodeId.
+    if (tabNodeId(tabId) === nodeId) {
+      closedTabs.push(tabId);
+    }
   }
 
   return {
     hydrateNode,
-    isHydrated: (nodeId: string) => hydratedNodeIds.has(nodeId),
+    isHydrated: (nodeId: string) => store.has(nodeId),
     closedTabs,
     errors
   };
 }
 
-describe('pane-content hydration race guard (#1564)', () => {
+describe('pane-content hydration (event-driven, #1564/#1566)', () => {
   beforeEach(() => {
     vi.useRealTimers();
   });
 
   it('does not throw or leave an unhandled rejection when ensureNode fails', async () => {
     const ensureNode = vi.fn().mockRejectedValue(new TypeError('Load failed'));
-    const harness = createHydrationHarness(ensureNode);
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-07');
 
     await expect(harness.hydrateNode('2026-07-07', 'tab-1')).resolves.toBeUndefined();
     expect(harness.errors).toHaveLength(1);
     expect(harness.isHydrated('2026-07-07')).toBe(false);
   });
 
-  it('discards a stale response when a newer navigation supersedes it before resolving', async () => {
-    // First request is slow; second (newer) request resolves first.
+  it('a stale fetch resolving late populates only its own store cell — it cannot overwrite the current node', async () => {
     const resolvers = new Map<string, (node: Node | undefined) => void>();
     const ensureNode = vi.fn(
       (nodeId: string) =>
@@ -80,28 +86,27 @@ describe('pane-content hydration race guard (#1564)', () => {
           resolvers.set(nodeId, resolve);
         })
     );
-    const harness = createHydrationHarness(ensureNode);
+    // Tab currently shows the later-requested date.
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-07');
 
-    // Simulate rapid prev/next clicks: navigate to "2026-07-08" then immediately to "2026-07-07"
-    // before the first ensureNode() call has resolved (the #1564 repro: navigation keeps
-    // landing on the wrong date because the stale request wins the race).
+    // Rapid prev/next: request 07-08 (slow) then 07-07 (newer).
     const firstCall = harness.hydrateNode('2026-07-08', 'tab-1');
     const secondCall = harness.hydrateNode('2026-07-07', 'tab-1');
 
-    // Resolve the newer request first, then the stale one - mirrors an out-of-order
-    // network response for a slow/failed dev-proxy fetch.
+    // Resolve newer first, then the stale one — out-of-order, the #1564 repro.
     resolvers.get('2026-07-07')?.({ id: '2026-07-07' });
     await secondCall;
     resolvers.get('2026-07-08')?.({ id: '2026-07-08' });
     await firstCall;
 
-    // Only the current (later-requested) date should be marked hydrated - the stale
-    // '2026-07-08' response must not win even though its promise resolves after.
+    // Both cells populate, but they are independent — the current node (07-07) is hydrated
+    // and its state was never clobbered by the late 07-08 resolution. The component reads
+    // getNode(currentNodeId), so it always sees the right node regardless of resolve order.
     expect(harness.isHydrated('2026-07-07')).toBe(true);
-    expect(harness.isHydrated('2026-07-08')).toBe(false);
+    expect(harness.isHydrated('2026-07-08')).toBe(true);
   });
 
-  it('closes the tab only if the not-found response is still the latest request', async () => {
+  it('closes the tab only if the not-found response is still the tab\'s current nodeId', async () => {
     const resolvers = new Map<string, (node: Node | undefined) => void>();
     const ensureNode = vi.fn(
       (nodeId: string) =>
@@ -109,14 +114,15 @@ describe('pane-content hydration race guard (#1564)', () => {
           resolvers.set(nodeId, resolve);
         })
     );
-    const harness = createHydrationHarness(ensureNode);
+    // The tab has navigated on to 2026-07-07 by the time the stale fetch settles.
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-07');
 
     const staleCall = harness.hydrateNode('deleted-node', 'tab-1');
     const freshCall = harness.hydrateNode('2026-07-07', 'tab-1');
 
     resolvers.get('2026-07-07')?.({ id: '2026-07-07' });
     await freshCall;
-    // The stale request resolves as "not found" after being superseded - should not close the tab.
+    // Stale "not found" resolves after the tab moved on — must NOT close the tab.
     resolvers.get('deleted-node')?.(undefined);
     await staleCall;
 
@@ -124,7 +130,17 @@ describe('pane-content hydration race guard (#1564)', () => {
     expect(harness.isHydrated('2026-07-07')).toBe(true);
   });
 
-  it('repeated rapid navigation across many dates converges on the last requested date', async () => {
+  it('closes the tab when the current node is genuinely not found', async () => {
+    const ensureNode = vi.fn().mockResolvedValue(undefined);
+    // Tab still points at the missing node.
+    const harness = createHydrationHarness(ensureNode, () => 'missing-node');
+
+    await harness.hydrateNode('missing-node', 'tab-1');
+
+    expect(harness.closedTabs).toEqual(['tab-1']);
+  });
+
+  it('repeated rapid navigation across many dates hydrates every visited node independently', async () => {
     const resolvers = new Map<string, (node: Node | undefined) => void>();
     const ensureNode = vi.fn(
       (nodeId: string) =>
@@ -132,7 +148,7 @@ describe('pane-content hydration race guard (#1564)', () => {
           resolvers.set(nodeId, resolve);
         })
     );
-    const harness = createHydrationHarness(ensureNode);
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-09');
 
     const dates = ['2026-07-05', '2026-07-06', '2026-07-07', '2026-07-08', '2026-07-09'];
     const calls = dates.map((date) => harness.hydrateNode(date, 'tab-1'));
@@ -143,7 +159,18 @@ describe('pane-content hydration race guard (#1564)', () => {
     }
     await Promise.all(calls);
 
-    const hydratedDates = dates.filter((date) => harness.isHydrated(date));
-    expect(hydratedDates).toEqual(['2026-07-09']);
+    // Every visited date hydrates its own cell; the component displays getNode(currentNodeId),
+    // so the last-navigated date (07-09) is what renders — no stale winner.
+    expect(dates.every((date) => harness.isHydrated(date))).toBe(true);
+  });
+
+  it('skips the fetch entirely when the node is already in the store', async () => {
+    const ensureNode = vi.fn().mockResolvedValue({ id: '2026-07-07' });
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-07');
+
+    await harness.hydrateNode('2026-07-07', 'tab-1'); // populates the cell
+    await harness.hydrateNode('2026-07-07', 'tab-1'); // second call is a no-op
+
+    expect(ensureNode).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/desktop-app/src/tests/stores/pro-sync.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync.test.ts
@@ -130,3 +130,80 @@ describe('ProSync store — authRequiredEpisode transition counter', () => {
     expect(proSync.authRequiredEpisode).toBe(before + 1);
   });
 });
+
+
+describe('ProSync store — signedInEpisode transition counter (#1566)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue('pro');
+    await proSync.start();
+    // Reset to a signed-out baseline so the empty→non-empty edge fires freshly.
+    emit('sync:status', { state: 4, detail: '', user_email: '' });
+    expect(proSync.userEmail).toBe('');
+  });
+
+  it('bumps the episode when userEmail transitions from empty to non-empty', () => {
+    const before = proSync.signedInEpisode;
+
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+
+    expect(proSync.userEmail).toBe('mayank@nodespace.dev');
+    expect(proSync.signedInEpisode).toBe(before + 1);
+  });
+
+  it('does not bump while already signed in (non-empty → non-empty)', () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    const afterSignIn = proSync.signedInEpisode;
+
+    // A subsequent status update for the same signed-in user must not re-bump.
+    emit('sync:status', { state: 5, detail: 'syncing', user_email: 'mayank@nodespace.dev' });
+
+    expect(proSync.signedInEpisode).toBe(afterSignIn);
+  });
+
+  it('bumps again on a fresh sign-in after signing out', () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    const firstEpisode = proSync.signedInEpisode;
+
+    emit('sync:status', { state: 4, detail: '', user_email: '' }); // sign out
+    emit('sync:status', { state: 6, detail: '', user_email: 'other@nodespace.dev' }); // sign back in
+
+    expect(proSync.signedInEpisode).toBe(firstEpisode + 1);
+  });
+});
+
+describe('ProSync store — onProConfirmed (#1566)', () => {
+  // proSync is a module-level singleton and proConfirmed is a one-way latch, so once
+  // any prior test has confirmed Pro tier it stays confirmed. These assertions are
+  // therefore written to be order-independent: they exercise the "already pro" path,
+  // which is the steady state after tier detection.
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue('pro');
+    await proSync.start();
+    emit('pro:tier-detected', { tier: 'pro', initial_status: null });
+  });
+
+  it('fires a callback registered after tier is already pro immediately', () => {
+    const cb = vi.fn();
+    proSync.onProConfirmed(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires each registered callback exactly once, not again on re-confirmation', () => {
+    const cb = vi.fn();
+    proSync.onProConfirmed(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // A subsequent pro re-confirmation must not re-fire it.
+    emit('pro:tier-detected', { tier: 'pro', initial_status: null });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an unregister function', () => {
+    const cb = vi.fn();
+    const unregister = proSync.onProConfirmed(cb);
+    expect(typeof unregister).toBe('function');
+    expect(() => unregister()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Finishes the ADR-049 `$effect` conversion. Every remaining `$effect` that wrote reactive state is either converted to the ADR-conformant primitive or shown to be a legitimate DOM/listener push.

Rebased on #1565, which had already resolved **Cluster 2** (titles are now computed via `computeTabTitle` + plugin `getTitle`, never pushed). The remaining clusters:

### Cluster 1 — data-fetch effects → `onMount` / store methods
- `query-node-viewer`, `collection-node-viewer`, `schema-property-form`, `task-schema-form`: fetch moved to `onMount` (parents remount them via `{#key ...nodeId}` / `{#key node.id-nodeType}`, so the fetch is a discrete per-instance lifecycle load).
- `node-card-inline`: fetch-if-missing moved to `onMount` (cards mount imperatively per nodeId). `fetchAttempted` kept purely as a fetch-settled flag for the "unknown" fallback, written from the fetch callback.
- `collaboration-view`: loads on mount when Pro, else via `proSync.onProConfirmed` (the tier-transition hook) instead of an `isPro`-watching effect.
- **`pane-content`**: hydration no longer keeps a local `hydratedNodeIds` mirror or the `latestRequestedNodeId` staleness guard. `hydrateNode()` only pushes `ensureNode()` into the store; `isNodeHydrated` derives directly from `sharedNodeStore.getNode(nodeId)`. Because state lives per-nodeId on the store — not one shared local mirror — a stale in-flight fetch can only populate its own cell and can never overwrite the current node, so **the guard is deleted**. A not-found response closes the tab only if that tab still points at the fetched nodeId (checked against live tab state). `pane-content-hydration.test.ts` rewritten to assert this event-driven contract.

### Cluster 3 — mirrors, subscribe-in-effect, sequencing
- `calendar`: bind the primitive directly to the `$bindable` `value`; drop the `internalValue` mirror + its prop→state effect.
- `table-view`: clamp the effective page via `$derived` instead of a reset-on-`nodeIds` effect.
- `query-editor`: initialise `jsonText` in the `$state` initializer (`untrack`ed one-shot capture).
- `app-shell`: read `daemonStatus` via `$`-auto-subscription (`$derived`) instead of subscribe-in-effect; load recovered-items from `proSync.onProConfirmed` instead of an `isPro`-guarded effect.
- `pro-sync` store: adds `signedInEpisode` (empty→non-empty `userEmail` edge) and `onProConfirmed` (fires once on tier→pro); tier/userEmail writes routed through `setTier`/`setUserEmail`.
- `pro-sync-pill`: derive first-run inbox-open from `proSync.signedInEpisode` + a dismissed marker instead of a first-run effect.
- `code-block-node`: extract the syntax-highlight / mermaid render pipeline to a new `CodeBlockRenderer` store class (state lives on the store, component reads it). The component triggers renders by calling `renderer.render()`/`renderPreview()`; the two innerHTML-injection effects stay (legitimate DOM push) and now read `renderer.*`.

### Cluster 4 — dead effect
- `SchemaPropertyFormDemo`: deleted the read-state/empty-body effect.

## Testing
- `bun run test:all` green: **150 unit files / 3944 tests**, **17 browser tests**, **971 Rust tests**, plus the pre-push `test:e2e` gate.
- `bun run quality:fix` clean.
- New tests: `pane-content-hydration.test.ts` (rewritten, event-driven contract), `pro-sync.test.ts` (`signedInEpisode` + `onProConfirmed`), `node-card-inline.test.ts` (single-call-site on-mount fetch).

## Note
Hit a **pre-existing timing flake** in `text-node.test.ts:103` on the first push (`modifiedAt === createdAt` when two `new Date()` calls land 1 ms apart). Not touched by this branch; passes on retry. Same class as #1567 — worth a follow-up to seed a fixed timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
