### PR TITLE
ADR-053 daemon multi-database: registry scaffold + build_services split (#1532)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tray-icon 0.21.3",
+ "ulid",
  "uuid",
 ]
 
@@ -7421,6 +7422,16 @@ dependencies = [
  "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
 ]
 
 [[package]]

--- a/packages/daemon/Cargo.toml
+++ b/packages/daemon/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = "0.8"
+ulid = "1"
 uuid = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -30,7 +30,7 @@ use nodespace_daemon::{
     SettingsServiceImpl,
 };
 use nodespace_nlp_engine::EmbeddingService;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tonic::transport::Server;
 
 #[cfg(unix)]
@@ -173,8 +173,9 @@ async fn serve_headless() -> Result<()> {
     tracing::info!(db_path = %db_path.display(), sock = %sock.display(), "Starting nodespaced (headless)");
 
     let shutdown = install_shutdown_handler().context("Failed to install signal handlers")?;
-    // _bg_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
-    let (bundle, _bg_task) = build_services(&db_path).await?;
+    // _model_task / _embed_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
+    let (shared, _model_task) = build_shared_services().await?;
+    let (bundle, _embed_task) = build_database_services(&db_path, &shared).await?;
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent)
@@ -191,7 +192,7 @@ async fn serve_headless() -> Result<()> {
         node_service: bundle.node_service_grpc,
         agent_session: bundle.agent_session,
         import: bundle.import,
-        settings: bundle.settings,
+        settings: shared.settings,
         local_agent: bundle.local_agent,
         embeddings: bundle.embeddings_service_grpc,
     };
@@ -218,8 +219,9 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
 
     let signal_shutdown =
         install_shutdown_handler().context("Failed to install signal handlers")?;
-    // _bg_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
-    let (bundle, _bg_task) = build_services(&db_path).await?;
+    // _model_task / _embed_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
+    let (shared, _model_task) = build_shared_services().await?;
+    let (bundle, _embed_task) = build_database_services(&db_path, &shared).await?;
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent)
@@ -244,7 +246,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
         node_service: bundle.node_service_grpc,
         agent_session: bundle.agent_session,
         import: bundle.import,
-        settings: bundle.settings,
+        settings: shared.settings,
         local_agent: bundle.local_agent,
         embeddings: bundle.embeddings_service_grpc,
     };
@@ -318,8 +320,9 @@ async fn serve_headless() -> Result<()> {
     tracing::info!(db_path = %db_path.display(), pipe = %name, "Starting nodespaced (headless, Windows)");
 
     let shutdown = install_shutdown_handler().context("Failed to install signal handlers")?;
-    // _bg_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
-    let (bundle, _bg_task) = build_services(&db_path).await?;
+    // _model_task / _embed_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
+    let (shared, _model_task) = build_shared_services().await?;
+    let (bundle, _embed_task) = build_database_services(&db_path, &shared).await?;
 
     tracing::info!(pipe = %name, "gRPC server listening (Named Pipe)");
 
@@ -357,7 +360,7 @@ async fn serve_headless() -> Result<()> {
         node_service: bundle.node_service_grpc,
         agent_session: bundle.agent_session,
         import: bundle.import,
-        settings: bundle.settings,
+        settings: shared.settings,
         local_agent: bundle.local_agent,
         embeddings: bundle.embeddings_service_grpc,
     };
@@ -385,8 +388,9 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
 
     let signal_shutdown =
         install_shutdown_handler().context("Failed to install signal handlers")?;
-    // _bg_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
-    let (bundle, _bg_task) = build_services(&db_path).await?;
+    // _model_task / _embed_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
+    let (shared, _model_task) = build_shared_services().await?;
+    let (bundle, _embed_task) = build_database_services(&db_path, &shared).await?;
 
     let shutdown_controller = controller.clone();
     let combined_shutdown = async move {
@@ -427,7 +431,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
         node_service: bundle.node_service_grpc,
         agent_session: bundle.agent_session,
         import: bundle.import,
-        settings: bundle.settings,
+        settings: shared.settings,
         local_agent: bundle.local_agent,
         embeddings: bundle.embeddings_service_grpc,
     };
@@ -445,31 +449,87 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     Ok(())
 }
 
-/// All initialized service handles for a daemon startup.
-struct ServiceBundle {
+/// Process-global services shared across every database the daemon serves
+/// (ADR-053: one daemon, multiple local databases). Built once by
+/// [`build_shared_services`]; each per-database service set borrows what it
+/// needs from here rather than constructing its own copy.
+struct SharedServices {
+    /// PTY sessions are process-global — one manager backs all databases.
+    pty_manager: Arc<PtySessionManager>,
+    /// Daemon-wide settings (`daemon.toml`); registered once on the router.
+    settings: SettingsServiceImpl,
+    /// The embedding model, loaded once for the whole process and published over
+    /// a watch channel so each database's embedding wiring can await it. Holds
+    /// `None` until the background load completes; a closed channel means the
+    /// load failed or no model file exists.
+    model: watch::Receiver<Option<Arc<EmbeddingService>>>,
+    /// Whether an NLP model file was found at startup. Gates both the
+    /// per-database embedding wiring and the `EmbeddingsService` registration.
+    has_model: bool,
+}
+
+/// The service set backing a single database. One of these is assembled per
+/// open database by [`build_database_services`]; the shared model and PTY
+/// manager come from [`SharedServices`].
+struct DatabaseServices {
     node_service_grpc: NodeServiceImpl,
     agent_session: AgentSessionHandler,
     import: ImportServiceImpl,
-    settings: SettingsServiceImpl,
     local_agent: LocalAgentServiceImpl,
-    /// Always registered — returns `UNAVAILABLE` while the model loads, then
-    /// serves normally. `None` only when no NLP model file exists at all.
+    /// Always registered when a model exists — returns `UNAVAILABLE` while the
+    /// model loads, then serves normally. `None` only when no NLP model file
+    /// exists at all.
     embeddings_service_grpc: Option<EmbeddingsServiceImpl>,
     /// Held so we can drain GPU resources after the server shuts down.
-    /// Populated by the background embedding-load task.
+    /// Populated by the background embedding-wiring task.
     embedding_state: Arc<RwLock<Option<EmbeddingReady>>>,
 }
 
-/// Open the database and assemble the gRPC service implementations.
+/// Build the process-global services shared across every database (ADR-053):
+/// the PTY manager, daemon settings, and the single embedding model. The model
+/// is loaded once in the background and published over a watch channel so each
+/// database's embedding wiring can await it. Returns the shared set plus the
+/// model-load task handle (`None` when no model file exists).
+async fn build_shared_services() -> Result<(SharedServices, Option<tokio::task::JoinHandle<()>>)> {
+    let pty_manager = Arc::new(PtySessionManager::new());
+    let settings = SettingsServiceImpl::with_default_path()
+        .map_err(|e| anyhow::anyhow!("Failed to initialize SettingsService: {}", e))?;
+
+    // One embedding model backs every database. Determine the path now (cheap);
+    // if absent, no task spawns and the channel stays closed so per-database
+    // wiring exits quietly with semantic search disabled.
+    let model_path = resolve_model_path();
+    let has_model = model_path.is_some();
+    let (model_tx, model_rx) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
+    let model_task = model_path.map(|path| {
+        tokio::spawn(async move {
+            load_shared_embedding_model_bg(path, model_tx).await;
+        })
+    });
+
+    Ok((
+        SharedServices {
+            pty_manager,
+            settings,
+            model: model_rx,
+            has_model,
+        },
+        model_task,
+    ))
+}
+
+/// Open one database and assemble its gRPC service implementations, sharing the
+/// process-global services from `shared` (ADR-053).
 ///
-/// Phase 1 (this function): initialize NodeService, seed schemas, build all
-/// gRPC handlers — fast, ~100ms. The embedding model is NOT loaded here.
-///
-/// Phase 2 (background task returned alongside the bundle): load the NLP
-/// model and populate `embedding_state` once ready.
-async fn build_services(
+/// Fast (~100ms): initialize `NodeService`, seed schemas, build all gRPC
+/// handlers. The embedding model is NOT loaded here — a background task (the
+/// returned handle) wires this database's `NodeEmbeddingService` +
+/// `EmbeddingProcessor` and populates `embedding_state` once the shared model is
+/// ready.
+async fn build_database_services(
     db_path: &std::path::Path,
-) -> Result<(ServiceBundle, Option<tokio::task::JoinHandle<()>>)> {
+    shared: &SharedServices,
+) -> Result<(DatabaseServices, Option<tokio::task::JoinHandle<()>>)> {
     if let Some(parent) = db_path.parent() {
         tokio::fs::create_dir_all(parent).await.with_context(|| {
             format!("Failed to create database parent dir: {}", parent.display())
@@ -488,9 +548,6 @@ async fn build_services(
 
     seed_agent_nodes(&mut node_service).await;
 
-    // Determine the model path now (cheap) — if absent, skip background task.
-    let model_path = resolve_model_path();
-
     let embedding_state: Arc<RwLock<Option<EmbeddingReady>>> = Arc::new(RwLock::new(None));
     // Separate handle for consumers that only need Arc<NodeEmbeddingService> (assembler, etc.)
     let embedding_svc_state: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>> =
@@ -500,26 +557,23 @@ async fn build_services(
 
     let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_state.clone());
 
-    // EmbeddingsService is only registered when a model file exists at startup.
-    // If the model appears later (e.g. user downloads it), the endpoint is absent
-    // until daemon restart. This is intentional — not a regression from prior behavior.
-    let embeddings_service_grpc = model_path
-        .as_ref()
-        .map(|_| EmbeddingsServiceImpl::new(node_service.clone(), embedding_state.clone()));
+    // EmbeddingsService is only registered when a model file exists at startup
+    // (the shared model). If the model appears later, the endpoint is absent
+    // until daemon restart — intentional, not a regression from prior behavior.
+    let embeddings_service_grpc = shared
+        .has_model
+        .then(|| EmbeddingsServiceImpl::new(node_service.clone(), embedding_state.clone()));
 
-    let manager = Arc::new(PtySessionManager::new());
     let assembler = Arc::new(GraphContextAssembler::new(
         node_service.clone(),
         embedding_svc_state.clone(),
     ));
-    let settings = SettingsServiceImpl::with_default_path()
-        .map_err(|e| anyhow::anyhow!("Failed to initialize SettingsService: {}", e))?;
     let capture_config_path = {
         let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
         home.join(".nodespace").join("daemon.toml")
     };
     let agent_session = AgentSessionHandler::new(
-        manager,
+        shared.pty_manager.clone(),
         assembler,
         node_service.clone(),
         capture_config_path,
@@ -529,28 +583,30 @@ async fn build_services(
     let local_agent = LocalAgentServiceImpl::new(node_service.clone(), embedding_svc_state.clone());
     local_agent.start_event_watcher();
 
-    // Spawn background model-load task if a model file was found.
-    let bg_task = model_path.map(|path| {
+    // Wire this database's embedding processor from the shared model once it
+    // loads. Spawned only when a model file exists; otherwise embeddings stay
+    // disabled for this database.
+    let embedding_task = shared.has_model.then(|| {
+        let model = shared.model.clone();
+        let store = store.clone();
+        let ns = node_service.clone();
         let state = embedding_state.clone();
         let svc_state = embedding_svc_state.clone();
-        let store_clone = store.clone();
-        let ns_clone = node_service.clone();
         tokio::spawn(async move {
-            load_embedding_model_bg(path, store_clone, ns_clone, state, svc_state).await;
+            wire_database_embeddings_bg(model, store, ns, state, svc_state).await;
         })
     });
 
     Ok((
-        ServiceBundle {
+        DatabaseServices {
             node_service_grpc,
             agent_session,
             import,
-            settings,
             local_agent,
             embeddings_service_grpc,
             embedding_state,
         },
-        bg_task,
+        embedding_task,
     ))
 }
 
@@ -599,17 +655,14 @@ fn resolve_model_path() -> Option<std::path::PathBuf> {
     Some(p)
 }
 
-/// Background task: load the NLP model and populate `state` when done.
-///
-/// Non-fatal: logs errors and leaves `state` as `None` if anything fails.
-async fn load_embedding_model_bg(
+/// Background task: load the NLP embedding model once for the whole process and
+/// publish it over `model_tx`. Non-fatal — on failure the channel simply never
+/// yields a model and embeddings stay disabled everywhere.
+async fn load_shared_embedding_model_bg(
     model_path: std::path::PathBuf,
-    store: Arc<SqliteStore>,
-    node_service: Arc<CoreNodeService>,
-    state: Arc<RwLock<Option<EmbeddingReady>>>,
-    svc_state: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>,
+    model_tx: watch::Sender<Option<Arc<EmbeddingService>>>,
 ) {
-    tracing::info!(path = %model_path.display(), "Loading embedding model in background");
+    tracing::info!(path = %model_path.display(), "Loading shared embedding model in background");
 
     let config = nodespace_nlp_engine::EmbeddingConfig {
         model_path: Some(model_path),
@@ -633,6 +686,34 @@ async fn load_embedding_model_bg(
     {
         Ok(Ok(svc)) => Arc::new(svc),
         Ok(Err(_)) | Err(_) => return,
+    };
+
+    // A send error only means every database's wiring task has already gone away
+    // (daemon shutting down) — nothing left to wire.
+    let _ = model_tx.send(Some(nlp));
+    tracing::info!("Shared embedding model loaded — semantic search now available");
+}
+
+/// Background task: once the shared embedding model is ready, wire this
+/// database's `NodeEmbeddingService` + `EmbeddingProcessor` and publish them to
+/// the per-database state the gRPC handlers read. Awaits the model over the
+/// shared watch channel; a closed channel (no model / load failed) exits quietly
+/// with embeddings disabled for this database. Non-fatal throughout.
+async fn wire_database_embeddings_bg(
+    mut model: watch::Receiver<Option<Arc<EmbeddingService>>>,
+    store: Arc<SqliteStore>,
+    node_service: Arc<CoreNodeService>,
+    state: Arc<RwLock<Option<EmbeddingReady>>>,
+    svc_state: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>,
+) {
+    // Wait for the shared model to be published (or the sender to drop).
+    let nlp = loop {
+        if let Some(nlp) = model.borrow_and_update().clone() {
+            break nlp;
+        }
+        if model.changed().await.is_err() {
+            return; // sender dropped — no model will ever arrive
+        }
     };
 
     let node_accessor: Arc<dyn NodeAccessor> = Arc::new((*node_service).clone());
@@ -663,7 +744,7 @@ async fn load_embedding_model_bg(
         embedding_service,
         processor,
     });
-    tracing::info!("Embedding model loaded — semantic search now available");
+    tracing::info!("Embedding processor wired for database — semantic search now available");
 }
 
 /// GPU drain protocol: drop processor first (shuts down background task),

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -1,0 +1,331 @@
+//! Registry and lifecycle skeleton for the daemon's local databases (ADR-053:
+//! "One Daemon, Multiple Local Databases").
+//!
+//! One daemon process serves N registered databases behind its single socket.
+//! This module owns the persistent registry — the list of known databases plus
+//! which one is the default — and the in-memory map of currently-open
+//! databases. It is deliberately decoupled from the per-database service set
+//! (`SqliteStore`, `NodeService`, ...): assembling and lazily opening those
+//! services is a follow-on stage, so [`DatabaseManager::get_or_open`] returns a
+//! clear "not yet wired" error rather than fabricating a handle.
+//!
+//! The registry persists to a dedicated `~/.nodespace/databases.toml`, kept
+//! separate from the `SettingsService`-owned `daemon.toml` so the two writers
+//! never clobber each other's sections.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use ulid::Ulid;
+
+/// Stable identifier for a registered database.
+///
+/// Backed by a ULID string: lexicographically sortable and monotonic by
+/// creation time, so registry order and creation order agree without a
+/// separate sort key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DatabaseId(String);
+
+impl DatabaseId {
+    /// Generate a fresh identifier for a newly registered database.
+    pub fn generate() -> Self {
+        Self(Ulid::new().to_string())
+    }
+
+    /// Borrow the identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for DatabaseId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for DatabaseId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A single registered database as stored in `databases.toml`.
+///
+/// Serialized as a `[[databases]]` array-of-tables entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseEntry {
+    /// Stable registry identifier (ULID).
+    pub id: DatabaseId,
+    /// Human-facing label; renamable without touching the file.
+    pub name: String,
+    /// Absolute path to the database file.
+    pub path: PathBuf,
+    /// When the entry was registered.
+    pub created_at: DateTime<Utc>,
+    /// Last time the database was opened, if ever.
+    #[serde(default)]
+    pub last_opened_at: Option<DateTime<Utc>>,
+}
+
+/// Runtime status of a registered database, derived at read time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatabaseStatus {
+    /// The database is currently open and serving requests.
+    Open,
+    /// The database file exists on disk but is not currently open.
+    Closed,
+    /// The registry entry points at a path with no database file present.
+    Missing,
+}
+
+/// A registry entry paired with its current runtime status. This is what the
+/// `DatabaseService` handler maps onto the proto `DatabaseInfo` response.
+#[derive(Debug, Clone)]
+pub struct DatabaseListing {
+    pub entry: DatabaseEntry,
+    pub status: DatabaseStatus,
+    pub is_default: bool,
+}
+
+/// An immutable snapshot of the registry plus per-database status.
+#[derive(Debug, Clone, Default)]
+pub struct RegistrySnapshot {
+    pub databases: Vec<DatabaseListing>,
+    pub default_database: Option<DatabaseId>,
+}
+
+/// On-disk representation of `~/.nodespace/databases.toml`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Registry {
+    /// Registered databases, in registration order.
+    #[serde(default)]
+    pub databases: Vec<DatabaseEntry>,
+    /// Identifier of the database that serves routing-header-less requests.
+    #[serde(default)]
+    pub default_database: Option<DatabaseId>,
+}
+
+impl Registry {
+    /// Load the registry from `path`. A missing file yields an empty registry
+    /// rather than an error — first boot has no registry yet.
+    pub async fn load(path: &Path) -> Result<Self> {
+        match tokio::fs::read_to_string(path).await {
+            Ok(contents) => toml::from_str(&contents)
+                .with_context(|| format!("parsing database registry {}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => {
+                Err(e).with_context(|| format!("reading database registry {}", path.display()))
+            }
+        }
+    }
+
+    /// Persist the registry to `path`, creating the parent directory if needed.
+    pub async fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("creating registry directory {}", parent.display()))?;
+        }
+        let contents =
+            toml::to_string_pretty(self).context("serializing database registry to TOML")?;
+        tokio::fs::write(path, contents)
+            .await
+            .with_context(|| format!("writing database registry {}", path.display()))
+    }
+
+    fn find(&self, id: &DatabaseId) -> Option<&DatabaseEntry> {
+        self.databases.iter().find(|e| &e.id == id)
+    }
+}
+
+/// Owns the database registry and the set of currently-open databases.
+///
+/// Method stubs mutate and persist the registry where that is trivial
+/// (create/register/remove/set_default/rename). Lazily opening a database and
+/// returning its service set ([`DatabaseManager::get_or_open`]) depends on the
+/// per-database service split, which is a follow-on stage; until then it
+/// returns a "not yet wired" error rather than panicking.
+pub struct DatabaseManager {
+    /// Path to `~/.nodespace/databases.toml`.
+    registry_path: PathBuf,
+    /// The persistent registry, guarded for concurrent mutation.
+    registry: RwLock<Registry>,
+    /// Databases currently open in this process. The unit value is a
+    /// placeholder for the per-database service set that a follow-on stage
+    /// will store here.
+    open: RwLock<HashMap<DatabaseId, ()>>,
+}
+
+impl DatabaseManager {
+    /// Load the manager, reading any existing registry from `registry_path`.
+    pub async fn load(registry_path: PathBuf) -> Result<Self> {
+        let registry = Registry::load(&registry_path).await?;
+        Ok(Self {
+            registry_path,
+            registry: RwLock::new(registry),
+            open: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Default registry path `~/.nodespace/databases.toml`.
+    pub fn default_registry_path() -> Result<PathBuf> {
+        Ok(Self::nodespace_dir()?.join("databases.toml"))
+    }
+
+    fn nodespace_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir()
+            .context("cannot determine the database registry path: home directory is unknown")?;
+        Ok(home.join(".nodespace"))
+    }
+
+    /// Snapshot every registered database with its current status.
+    pub async fn list(&self) -> RegistrySnapshot {
+        let registry = self.registry.read().await;
+        let open = self.open.read().await;
+        let default_database = registry.default_database.clone();
+        let databases = registry
+            .databases
+            .iter()
+            .map(|entry| {
+                let status = if open.contains_key(&entry.id) {
+                    DatabaseStatus::Open
+                } else if entry.path.exists() {
+                    DatabaseStatus::Closed
+                } else {
+                    DatabaseStatus::Missing
+                };
+                let is_default = default_database.as_ref() == Some(&entry.id);
+                DatabaseListing {
+                    entry: entry.clone(),
+                    status,
+                    is_default,
+                }
+            })
+            .collect();
+        RegistrySnapshot {
+            databases,
+            default_database,
+        }
+    }
+
+    /// Register a brand-new database under `name`. When `path` is `None` the
+    /// daemon derives a path under its managed database directory. The registry
+    /// entry is created and persisted; the database file itself is created
+    /// lazily on first open (a follow-on stage), so a freshly created entry
+    /// reports [`DatabaseStatus::Missing`] until then.
+    pub async fn create(&self, name: String, path: Option<PathBuf>) -> Result<DatabaseEntry> {
+        let id = DatabaseId::generate();
+        let path = match path {
+            Some(path) => path,
+            None => Self::nodespace_dir()?
+                .join("database")
+                .join(format!("{id}.db")),
+        };
+        self.insert_entry(id, name, path).await
+    }
+
+    /// Register an existing database file already present on disk. The name is
+    /// derived from the file stem. Registering never creates or moves files.
+    pub async fn register(&self, path: PathBuf) -> Result<DatabaseEntry> {
+        let name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(str::to_owned)
+            .unwrap_or_else(|| "database".to_owned());
+        let id = DatabaseId::generate();
+        self.insert_entry(id, name, path).await
+    }
+
+    /// Unregister a database. This only removes the registry entry — it never
+    /// deletes the underlying database file. If the removed database was the
+    /// default, the default is cleared.
+    pub async fn remove(&self, id: &DatabaseId) -> Result<()> {
+        {
+            let mut registry = self.registry.write().await;
+            let before = registry.databases.len();
+            registry.databases.retain(|e| &e.id != id);
+            if registry.databases.len() == before {
+                return Err(anyhow!("no database registered with id {id}"));
+            }
+            if registry.default_database.as_ref() == Some(id) {
+                registry.default_database = None;
+            }
+            registry.save(&self.registry_path).await?;
+        }
+        self.open.write().await.remove(id);
+        Ok(())
+    }
+
+    /// Mark a registered database as the default served for header-less
+    /// requests.
+    pub async fn set_default(&self, id: &DatabaseId) -> Result<()> {
+        let mut registry = self.registry.write().await;
+        if registry.find(id).is_none() {
+            return Err(anyhow!("no database registered with id {id}"));
+        }
+        registry.default_database = Some(id.clone());
+        registry.save(&self.registry_path).await
+    }
+
+    /// Rename the human-facing label of a registered database. Does not touch
+    /// the underlying file.
+    pub async fn rename(&self, id: &DatabaseId, name: String) -> Result<()> {
+        let mut registry = self.registry.write().await;
+        let entry = registry
+            .databases
+            .iter_mut()
+            .find(|e| &e.id == id)
+            .ok_or_else(|| anyhow!("no database registered with id {id}"))?;
+        entry.name = name;
+        registry.save(&self.registry_path).await
+    }
+
+    /// Return the per-database service set for `id`, opening it lazily if
+    /// needed.
+    ///
+    /// The per-database service split is a follow-on stage, so there is nothing
+    /// to hand back yet: this validates that the database is registered and
+    /// then returns a "not yet wired" error rather than panicking.
+    pub async fn get_or_open(&self, id: &DatabaseId) -> Result<()> {
+        if self.open.read().await.contains_key(id) {
+            return Err(anyhow!(
+                "database {id} is marked open but per-database service assembly is not yet wired"
+            ));
+        }
+        if self.registry.read().await.find(id).is_none() {
+            return Err(anyhow!("no database registered with id {id}"));
+        }
+        Err(anyhow!(
+            "lazy-opening database {id} is not yet wired: per-database service assembly lands in a later stage"
+        ))
+    }
+
+    /// Push a new entry into the registry and persist it. The first registered
+    /// database becomes the default.
+    async fn insert_entry(
+        &self,
+        id: DatabaseId,
+        name: String,
+        path: PathBuf,
+    ) -> Result<DatabaseEntry> {
+        let entry = DatabaseEntry {
+            id: id.clone(),
+            name,
+            path,
+            created_at: Utc::now(),
+            last_opened_at: None,
+        };
+        let mut registry = self.registry.write().await;
+        registry.databases.push(entry.clone());
+        if registry.default_database.is_none() {
+            registry.default_database = Some(id);
+        }
+        registry.save(&self.registry_path).await?;
+        Ok(entry)
+    }
+}

--- a/packages/daemon/src/services/mod.rs
+++ b/packages/daemon/src/services/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod agent_session_service;
 pub mod capture_service;
+pub mod database_manager;
 pub mod embeddings_service;
 pub mod import_service;
 pub mod local_agent_service;
@@ -12,6 +13,10 @@ pub mod node_service;
 pub mod settings_service;
 
 pub use agent_session_service::AgentSessionHandler;
+pub use database_manager::{
+    DatabaseEntry, DatabaseId, DatabaseListing, DatabaseManager, DatabaseStatus, Registry,
+    RegistrySnapshot,
+};
 pub use embeddings_service::{EmbeddingReady, EmbeddingsServiceImpl};
 pub use import_service::ImportServiceImpl;
 pub use local_agent_service::LocalAgentServiceImpl;

--- a/packages/proto/build.rs
+++ b/packages/proto/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/import_service.proto",
             "proto/settings_service.proto",
             "proto/local_agent_service.proto",
+            "proto/database_service.proto",
         ],
         &["proto"],
     )?;

--- a/packages/proto/proto/database_service.proto
+++ b/packages/proto/proto/database_service.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package nodespace;
+
+// DatabaseService manages the daemon's registry of local databases (ADR-053:
+// "One Daemon, Multiple Local Databases"). A single daemon process serves N
+// registered databases behind its one socket; this service lets clients list,
+// create, register, remove, rename, and choose the default database.
+//
+// Requests to the data-plane services (nodes, agents, import, ...) that omit
+// the per-request routing metadata fall back to the default database chosen
+// via SetDefault, so existing single-database clients keep working unchanged.
+//
+// Remove never deletes the underlying database file — it only detaches the
+// registry entry. Registered-but-missing files are surfaced as a status, never
+// silently pruned.
+service DatabaseService {
+  // List every registered database with its current open/closed/missing status
+  // and identify which one is the default.
+  rpc List(ListDatabasesRequest) returns (ListDatabasesResponse);
+
+  // Create a brand-new database and register it. When `path` is omitted the
+  // daemon places the database file under its managed database directory.
+  rpc Create(CreateDatabaseRequest) returns (DatabaseInfo);
+
+  // Register an existing database file already present on disk.
+  rpc Register(RegisterDatabaseRequest) returns (DatabaseInfo);
+
+  // Unregister a database from the registry. This never deletes the underlying
+  // database file — it only removes the registry entry.
+  rpc Remove(RemoveDatabaseRequest) returns (RemoveDatabaseResponse);
+
+  // Choose which registered database serves requests that omit routing
+  // metadata.
+  rpc SetDefault(SetDefaultDatabaseRequest) returns (DatabaseInfo);
+
+  // Rename the human-facing label of a registered database. Does not move or
+  // rename the underlying file.
+  rpc Rename(RenameDatabaseRequest) returns (DatabaseInfo);
+}
+
+// Runtime status of a registered database.
+enum DatabaseStatus {
+  // The database file exists on disk but is not currently open in the daemon.
+  // This is the resting state for a registered, idle database.
+  DATABASE_STATUS_CLOSED = 0;
+  // The database is open and serving requests.
+  DATABASE_STATUS_OPEN = 1;
+  // The registry entry points at a path with no database file present.
+  DATABASE_STATUS_MISSING = 2;
+}
+
+// A registered database and its current runtime status.
+message DatabaseInfo {
+  // Stable registry identifier (ULID string).
+  string id = 1;
+  // Human-facing label; renamable without touching the file.
+  string name = 2;
+  // Absolute path to the database file.
+  string path = 3;
+  // RFC 3339 timestamp of when the entry was registered.
+  string created_at = 4;
+  // RFC 3339 timestamp of the last time the database was opened, if ever.
+  optional string last_opened_at = 5;
+  // Whether this is the daemon's default (routing-header-less) database.
+  bool is_default = 6;
+  // Current open/closed/missing status.
+  DatabaseStatus status = 7;
+}
+
+message ListDatabasesRequest {}
+
+message ListDatabasesResponse {
+  repeated DatabaseInfo databases = 1;
+  // Identifier of the default database; empty when none is set.
+  string default_database_id = 2;
+}
+
+message CreateDatabaseRequest {
+  // Human-facing label for the new database.
+  string name = 1;
+  // Optional explicit path for the new database file. When omitted the daemon
+  // chooses a path under its managed database directory.
+  optional string path = 2;
+}
+
+message RegisterDatabaseRequest {
+  // Absolute path to an existing database file to register.
+  string path = 1;
+}
+
+message RemoveDatabaseRequest {
+  // Identifier of the database to unregister.
+  string id = 1;
+}
+
+message RemoveDatabaseResponse {
+  // Identifier of the database that was unregistered.
+  string id = 1;
+}
+
+message SetDefaultDatabaseRequest {
+  // Identifier of the database to mark as default.
+  string id = 1;
+}
+
+message RenameDatabaseRequest {
+  // Identifier of the database to rename.
+  string id = 1;
+  // New human-facing label.
+  string name = 2;
+}

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -9,6 +9,8 @@ pub mod nodespace {
 
 pub use nodespace::agent_session_service_client::AgentSessionServiceClient;
 pub use nodespace::agent_session_service_server::AgentSessionServiceServer;
+pub use nodespace::database_service_client::DatabaseServiceClient;
+pub use nodespace::database_service_server::DatabaseServiceServer;
 pub use nodespace::embeddings_service_client::EmbeddingsServiceClient;
 pub use nodespace::embeddings_service_server::EmbeddingsServiceServer;
 pub use nodespace::import_service_client::ImportServiceClient;
@@ -21,8 +23,11 @@ pub use nodespace::settings_service_client::SettingsServiceClient;
 pub use nodespace::settings_service_server::SettingsServiceServer;
 pub use nodespace::{
     AgentAvailability, CaptureContentLevel, CaptureSettingsResponse, CheckAvailabilityRequest,
-    CheckAvailabilityResponse, GetCaptureSettingsRequest, LaunchSessionRequest,
-    LaunchSessionResponse, ListSessionsRequest, ListSessionsResponse, NodeData, ResizeRequest,
-    ResizeResponse, SessionInfo, StreamOutputRequest, TerminateSessionRequest,
-    TerminateSessionResponse, UpdateCaptureSettingsRequest, WriteInputRequest, WriteInputResponse,
+    CheckAvailabilityResponse, CreateDatabaseRequest, DatabaseInfo, DatabaseStatus,
+    GetCaptureSettingsRequest, LaunchSessionRequest, LaunchSessionResponse, ListDatabasesRequest,
+    ListDatabasesResponse, ListSessionsRequest, ListSessionsResponse, NodeData,
+    RegisterDatabaseRequest, RemoveDatabaseRequest, RemoveDatabaseResponse, RenameDatabaseRequest,
+    ResizeRequest, ResizeResponse, SessionInfo, SetDefaultDatabaseRequest, StreamOutputRequest,
+    TerminateSessionRequest, TerminateSessionResponse, UpdateCaptureSettingsRequest,
+    WriteInputRequest, WriteInputResponse,
 };


### PR DESCRIPTION
Foundation for ADR-053 (*One Daemon, Multiple Local Databases*). Two incremental, low-risk stages of #1532; the multi-database routing that consumes them lands next.

## Stage 1–2 — proto + registry (dormant scaffold)
- New `packages/proto/proto/database_service.proto`: `DatabaseService { List, Create(name, path?), Register(path), Remove (unregister-only, never deletes files), SetDefault, Rename }` + a `DatabaseStatus` enum (Open/Closed/Missing). Wired into `build.rs` and re-exported from `packages/proto/src/lib.rs`.
- New `packages/daemon/src/services/database_manager.rs`: `DatabaseId` (ULID) + `DatabaseEntry` + a `Registry` persisted to a dedicated `~/.nodespace/databases.toml` (kept separate from `SettingsService`'s `daemon.toml`), and a `DatabaseManager` holding the registry plus an open-databases map. Registry mutations (create/register/remove/set_default/rename) are implemented and persist; `get_or_open` returns a clear "not yet wired" error (no `todo!()`), since the per-database service set it hands back is assembled in Stage 3+.

The scaffold compiles and is **not yet wired** into service assembly or routing — intentional, to keep the sync lock-step green until Stage 5.

## Stage 3 — split `build_services()` into shared + per-database
The seam the routing needs. `build_services()` becomes:
- **`build_shared_services()`** → process-global (`PtySessionManager`, daemon settings) plus the **embedding model loaded once for the whole process** and published over a `tokio::watch` channel.
- **`build_database_services(db_path, &shared)`** → per-database `SqliteStore`, `NodeService` (+seeding), gRPC handlers, `GraphContextAssembler`, import, local-agent watcher, and per-database embedding state — consuming the shared PTY manager rather than making its own.
- The embedding model is **decoupled from stores** (ADR-053: one model backs all databases): the old per-store load task splits into `load_shared_embedding_model_bg` (loads the raw model once, publishes over `watch`) and `wire_database_embeddings_bg` (each database awaits the shared model, then wires its own `NodeEmbeddingService` + `EmbeddingProcessor` + waker).
- All four serve loops (headless/tray × unix/windows) call `build_shared_services` then `build_database_services`; settings now comes from the shared set.

**Behavior-preserving** for the single default database served today.

## Verification
- `cargo build`/`fmt`/`clippy -p nodespace-daemon --all-targets -- -D warnings` clean.
- `cargo test -p nodespace-daemon` **71/71** — including `grpc_round_trip` and `agent_session` end-to-end suites that exercise the assembled services.
- Rebased on current `main`.

## Not in this PR (follow-on, tracked under #1532)
- Hoist the chat `CompositeModelManager` to shared (it's built inside `LocalAgentServiceImpl::new`, per-database — needs a constructor change; behaviorally identical for one database).
- Stage 4: `x-ns-database-id` interceptor + storing `DatabaseServices` in `DatabaseManager.open`.
- Stage 5: `DatabaseService` handler + `DatabaseServiceServer` on `BaseServices` (needs the nodespace-sync lock-step). Stages 6–7: `database_id` on event envelopes; drop `active_database_path`/`NODESPACED_DB_PATH` + Windows pipe parity.

Part of #1532.