### PR TITLE
Implement DatabaseSettingsNode (database-settings schema + behavior)

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -2082,6 +2082,74 @@ impl NodeBehavior for PersonNodeBehavior {
     }
 }
 
+/// Built-in behavior for the database-settings singleton node
+///
+/// DatabaseSettingsNode is the single container for database-level configuration:
+/// `sync_enabled` (user intent to sync) and `auth_status` (system-managed cloud
+/// bind state). Tenant roles are NOT stored here — they live on the `has_role`
+/// edge (PersonNode → DatabaseSettingsNode). Per ADR-037, both `role` and
+/// `auth_status` were moved off PersonNode as part of that revision.
+pub struct DatabaseSettingsNodeBehavior;
+
+impl NodeBehavior for DatabaseSettingsNodeBehavior {
+    fn type_name(&self) -> &'static str {
+        "database-settings"
+    }
+
+    fn validate(&self, node: &Node) -> Result<(), NodeValidationError> {
+        // Validate auth_status if present
+        if let Some(auth_status) = node.properties.get("auth_status") {
+            if let Some(auth_status_str) = auth_status.as_str() {
+                match auth_status_str {
+                    "local" | "connected" => {}
+                    _ => {
+                        return Err(NodeValidationError::InvalidProperties(format!(
+                            "Invalid auth_status '{}': must be one of local, connected",
+                            auth_status_str
+                        )));
+                    }
+                }
+            }
+        }
+
+        // Validate sync_enabled is a boolean if present
+        if let Some(sync_enabled) = node.properties.get("sync_enabled") {
+            if !sync_enabled.is_boolean() && !sync_enabled.is_null() {
+                return Err(NodeValidationError::InvalidProperties(
+                    "sync_enabled must be a boolean".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn can_have_children(&self) -> bool {
+        false // Configuration container; it holds no child content
+    }
+
+    fn supports_markdown(&self) -> bool {
+        false // Settings are not markdown-rendered content
+    }
+
+    fn default_metadata(&self) -> serde_json::Value {
+        serde_json::json!({
+            "sync_enabled": false,
+            "auth_status": "local"
+        })
+    }
+
+    /// Settings carry no semantic content; they are not embedded for search.
+    fn get_embeddable_content(&self, _node: &Node) -> Option<String> {
+        None
+    }
+
+    /// Settings do not contribute to parent embeddings.
+    fn get_parent_contribution(&self, _node: &Node) -> Option<String> {
+        None
+    }
+}
+
 /// Registry for managing node behaviors
 ///
 /// The registry provides thread-safe storage and retrieval of node behaviors.
@@ -2183,6 +2251,7 @@ impl NodeBehaviorRegistry {
         registry.register(Arc::new(SkillNodeBehavior));
         registry.register(Arc::new(ToolNodeBehavior));
         registry.register(Arc::new(PersonNodeBehavior));
+        registry.register(Arc::new(DatabaseSettingsNodeBehavior));
 
         registry
     }
@@ -2882,7 +2951,8 @@ mod tests {
         assert!(types.contains(&"skill".to_string()));
         assert!(types.contains(&"tool".to_string()));
         assert!(types.contains(&"person".to_string()));
-        assert_eq!(types.len(), 17);
+        assert!(types.contains(&"database-settings".to_string()));
+        assert_eq!(types.len(), 18);
     }
 
     #[test]
@@ -4854,5 +4924,113 @@ mod tests {
         let behavior = PersonNodeBehavior;
         let node = person_node(json!({}));
         assert!(behavior.get_embeddable_content(&node).is_none());
+    }
+
+    // --- DatabaseSettingsNodeBehavior tests ---
+
+    fn database_settings_node(props: serde_json::Value) -> Node {
+        Node::new("database-settings".to_string(), String::new(), props)
+    }
+
+    #[test]
+    fn database_settings_schema_is_present_in_core_schemas() {
+        use crate::models::core_schemas::get_core_schemas;
+        let schemas = get_core_schemas();
+        assert!(schemas.iter().any(|s| s.id == "database-settings"));
+    }
+
+    #[test]
+    fn database_settings_behavior_is_registered() {
+        let registry = NodeBehaviorRegistry::new();
+        let types = registry.get_all_types();
+        assert!(types.contains(&"database-settings".to_string()));
+        assert_eq!(
+            registry.get("database-settings").unwrap().type_name(),
+            "database-settings"
+        );
+    }
+
+    #[test]
+    fn database_settings_valid_defaults_pass() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let node = database_settings_node(json!({
+            "sync_enabled": false,
+            "auth_status": "local"
+        }));
+        assert!(behavior.validate(&node).is_ok());
+    }
+
+    #[test]
+    fn database_settings_minimal_node_is_valid() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let node = database_settings_node(json!({}));
+        assert!(behavior.validate(&node).is_ok());
+    }
+
+    #[test]
+    fn database_settings_valid_auth_status_values_pass() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        for auth_status in &["local", "connected"] {
+            let node = database_settings_node(json!({ "auth_status": auth_status }));
+            assert!(
+                behavior.validate(&node).is_ok(),
+                "auth_status '{}' should be valid",
+                auth_status
+            );
+        }
+    }
+
+    #[test]
+    fn database_settings_invalid_auth_status_fails() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let node = database_settings_node(json!({ "auth_status": "disconnected" }));
+        let err = behavior.validate(&node).unwrap_err();
+        match err {
+            NodeValidationError::InvalidProperties(msg) => {
+                assert!(msg.contains("Invalid auth_status"));
+                assert!(msg.contains("disconnected"));
+            }
+            _ => panic!("Expected InvalidProperties error"),
+        }
+    }
+
+    #[test]
+    fn database_settings_non_bool_sync_enabled_fails() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let node = database_settings_node(json!({ "sync_enabled": "yes" }));
+        let err = behavior.validate(&node).unwrap_err();
+        match err {
+            NodeValidationError::InvalidProperties(msg) => {
+                assert!(msg.contains("sync_enabled must be a boolean"));
+            }
+            _ => panic!("Expected InvalidProperties error"),
+        }
+    }
+
+    #[test]
+    fn database_settings_capabilities() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        assert_eq!(behavior.type_name(), "database-settings");
+        assert!(!behavior.can_have_children());
+        assert!(!behavior.supports_markdown());
+    }
+
+    #[test]
+    fn database_settings_default_metadata() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let meta = behavior.default_metadata();
+        assert_eq!(meta["sync_enabled"], false);
+        assert_eq!(meta["auth_status"], "local");
+    }
+
+    #[test]
+    fn database_settings_is_not_embeddable() {
+        let behavior = DatabaseSettingsNodeBehavior;
+        let node = database_settings_node(json!({
+            "sync_enabled": false,
+            "auth_status": "local"
+        }));
+        assert!(behavior.get_embeddable_content(&node).is_none());
+        assert!(behavior.get_parent_contribution(&node).is_none());
     }
 }

--- a/packages/core/src/db/sqlite_store.rs
+++ b/packages/core/src/db/sqlite_store.rs
@@ -3868,6 +3868,28 @@ impl SqliteStore {
         }
     }
 
+    /// Fetch a single relationship edge (with its properties) by endpoints and type.
+    ///
+    /// Complements `get_relationship_id` when the caller needs the edge's stored
+    /// properties (e.g. the `role`/`status` carried on a `has_role` edge), not just
+    /// its id. Returns `None` when no such edge exists.
+    pub async fn get_relationship_record(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        rel_type: &str,
+    ) -> Result<Option<RelationshipRecord>> {
+        let mut rows = self.db.query(
+            "SELECT id, in_node, out_node, relationship_type, properties FROM relationship WHERE in_node = ?1 AND out_node = ?2 AND relationship_type = ?3 LIMIT 1",
+            libsql::params![source_id.to_string(), target_id.to_string(), rel_type.to_string()],
+        ).await.context("Failed to get relationship record")?;
+        if let Some(row) = rows.next().await? {
+            Ok(Some(Self::row_to_relationship(&row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub async fn delete_generic_relationship(
         &self,
         source_id: &str,

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -18,6 +18,7 @@
 //! - **horizontal-line** - Horizontal rule / thematic break
 //! - **table** - GFM markdown table
 //! - **person** - Identity primitive (name, email)
+//! - **database-settings** - Singleton container for database-level config (sync state, roles)
 //!
 //! ## Usage
 //!
@@ -938,6 +939,72 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             title_template: None,
             properties_header_summary_template: None,
         },
+        // Database Settings schema — a singleton container for database-level
+        // configuration. `sync_enabled` is user intent; `auth_status` is
+        // system-managed cloud bind state. ADR-037 moved role and auth_status off
+        // PersonNode: role now lives on the has_role edge (person → this node) and
+        // auth_status lives here.
+        SchemaNode {
+            id: "database-settings".to_string(),
+            content: "Database Settings".to_string(),
+            version: 1,
+            created_at: now,
+            modified_at: now,
+            is_core: true,
+            schema_version: 1,
+            fields: vec![
+                SchemaField {
+                    name: "sync_enabled".to_string(),
+                    field_type: "boolean".to_string(),
+                    protection: SchemaProtectionLevel::Core,
+                    core_values: None,
+                    user_values: None,
+                    indexed: false,
+                    required: Some(false),
+                    extensible: None,
+                    default: Some(serde_json::json!(false)),
+                    description: Some(
+                        "User intent to sync this database to the cloud. Inert on the \
+                         free/community tier; the Pro sync daemon reads it to gate sync."
+                            .to_string(),
+                    ),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+                SchemaField {
+                    name: "auth_status".to_string(),
+                    field_type: "enum".to_string(),
+                    protection: SchemaProtectionLevel::Core,
+                    core_values: Some(vec![
+                        EnumValue {
+                            value: "local".to_string(),
+                            label: "Local".to_string(),
+                        },
+                        EnumValue {
+                            value: "connected".to_string(),
+                            label: "Connected".to_string(),
+                        },
+                    ]),
+                    user_values: Some(vec![]),
+                    indexed: true,
+                    required: Some(true),
+                    extensible: Some(false),
+                    default: Some(serde_json::json!("local")),
+                    description: Some(
+                        "System-managed cloud bind state. Default local; the Pro sync \
+                         daemon sets connected after a Supabase identity bind."
+                            .to_string(),
+                    ),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+            ],
+            relationships: vec![],
+            title_template: None,
+            properties_header_summary_template: None,
+        },
     ]
 }
 
@@ -948,7 +1015,7 @@ mod tests {
     #[test]
     fn test_get_core_schemas_returns_all() {
         let schemas = get_core_schemas();
-        assert_eq!(schemas.len(), 16);
+        assert_eq!(schemas.len(), 17);
     }
 
     #[test]
@@ -1073,6 +1140,41 @@ mod tests {
         let whitelist = skill.get_field("tool_whitelist").unwrap();
         assert_eq!(whitelist.field_type, "array");
         assert_eq!(whitelist.item_type.as_deref(), Some("string"));
+    }
+
+    #[test]
+    fn test_database_settings_schema_has_fields() {
+        // ADR-037: database-settings is a Core singleton carrying sync_enabled
+        // (boolean) and auth_status (Core-protected enum: local/connected).
+        let schemas = get_core_schemas();
+        let settings = schemas
+            .iter()
+            .find(|s| s.id == "database-settings")
+            .unwrap();
+
+        assert_eq!(settings.fields.len(), 2);
+
+        let sync_enabled = settings
+            .get_field("sync_enabled")
+            .expect("database-settings has sync_enabled");
+        assert_eq!(sync_enabled.field_type, "boolean");
+        assert_eq!(sync_enabled.protection, SchemaProtectionLevel::Core);
+        assert_eq!(sync_enabled.default, Some(serde_json::json!(false)));
+
+        let auth_status = settings
+            .get_field("auth_status")
+            .expect("database-settings has auth_status");
+        assert_eq!(auth_status.field_type, "enum");
+        assert_eq!(auth_status.protection, SchemaProtectionLevel::Core);
+        assert_eq!(auth_status.default, Some(serde_json::json!("local")));
+        let values: Vec<&str> = auth_status
+            .core_values
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|ev| ev.value.as_str())
+            .collect();
+        assert_eq!(values, vec!["local", "connected"]);
     }
 
     #[test]

--- a/packages/core/src/services/node_service/crud.rs
+++ b/packages/core/src/services/node_service/crud.rs
@@ -59,6 +59,25 @@ impl NodeService {
             // Content is preserved - date nodes can have custom content like "Custom Date Content"
         }
 
+        // DatabaseSettingsNode is a singleton (ADR-037). The fixed reserved ID makes
+        // creation idempotent: if one already exists, treat a second create as a no-op
+        // and return the existing id rather than erroring. Mirrors the collection-name
+        // uniqueness guard in SqliteStore::create_node, but non-fatal.
+        if node.node_type == "database-settings" {
+            if let Some(existing) = self
+                .query_nodes_by_type("database-settings", None)
+                .await?
+                .into_iter()
+                .next()
+            {
+                tracing::debug!(
+                    node_id = %existing.id,
+                    "create_node: database-settings singleton already exists, no-op"
+                );
+                return Ok(existing.id);
+            }
+        }
+
         // Step 1: Core behavior validation (PROTECTED)
         // Validates basic data integrity (non-empty content, correct types, etc.)
         self.behaviors.validate_node(&node)?;

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -41,6 +41,14 @@ pub(crate) mod query;
 pub(crate) mod relationship;
 pub(crate) mod schema;
 
+/// Reserved ID for the DatabaseSettingsNode singleton instance.
+///
+/// The `database-settings` schema node stores its own id as the slug
+/// `"database-settings"`, so the instance must use a distinct reserved id to
+/// avoid colliding with it. Seeding and the singleton idempotency guard both
+/// key off this constant so the node is deterministic and created at most once.
+pub(crate) const DATABASE_SETTINGS_NODE_ID: &str = "database-settings-singleton";
+
 /// Compute property changes between pre-mutation and post-mutation node properties (Issue #995)
 ///
 /// Diffs the top-level keys within each namespace. For namespaced properties
@@ -919,6 +927,10 @@ impl NodeService {
         // ADR-037 (#133): every install has exactly one local PersonNode (the user).
         service.seed_local_person_if_needed().await?;
 
+        // ADR-037: seed the DatabaseSettingsNode singleton and its owner has_role
+        // edge. Must run AFTER the local person seed — the owner edge attaches to it.
+        service.seed_database_settings_if_needed().await?;
+
         Ok(service)
     }
 
@@ -937,6 +949,64 @@ impl NodeService {
         let person = Node::new("person".to_string(), String::new(), serde_json::json!({}));
         let id = self.create_node(person).await?;
         tracing::info!(node_id = %id, "🌱 Seeded local PersonNode (ADR-037)");
+        Ok(())
+    }
+
+    /// ADR-037: seed the DatabaseSettingsNode singleton — the container for
+    /// database-level configuration (sync state; tenant roles via `has_role`
+    /// edges). Idempotent: skips when a database-settings node already exists, so
+    /// an existing database is backfilled on next open too. Seeds `sync_enabled:
+    /// false`, `auth_status: local`, and one `has_role` owner edge from the local
+    /// PersonNode to this node (role `owner`, status `active`). Must run after the
+    /// local person seed so the owner edge always has a person to attach to.
+    async fn seed_database_settings_if_needed(&self) -> Result<(), NodeServiceError> {
+        if !self
+            .query_nodes_by_type("database-settings", None)
+            .await?
+            .is_empty()
+        {
+            return Ok(());
+        }
+
+        let settings = Node::new_with_id(
+            DATABASE_SETTINGS_NODE_ID.to_string(),
+            "database-settings".to_string(),
+            String::new(),
+            serde_json::json!({
+                "database-settings": {
+                    "sync_enabled": false,
+                    "auth_status": "local"
+                }
+            }),
+        );
+        let settings_id = self.create_node(settings).await?;
+
+        // Attach the owner role edge from the local PersonNode. Seeding order
+        // guarantees exactly one local person exists at this point.
+        let local_person_id = self
+            .query_nodes_by_type("person", None)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                NodeServiceError::InitializationError(
+                    "cannot seed DatabaseSettingsNode owner edge: no local PersonNode".to_string(),
+                )
+            })?
+            .id;
+        self.create_relationship(
+            &local_person_id,
+            "has_role",
+            &settings_id,
+            serde_json::json!({"role": "owner", "status": "active"}),
+        )
+        .await?;
+
+        tracing::info!(
+            node_id = %settings_id,
+            owner = %local_person_id,
+            "🌱 Seeded DatabaseSettingsNode singleton with owner has_role edge (ADR-037)"
+        );
         Ok(())
     }
 
@@ -3903,6 +3973,123 @@ mod tests {
         assert!(
             rx.try_recv().is_ok(),
             "single create after bulk import must emit immediately"
+        );
+    }
+
+    // --- DatabaseSettingsNode seeding tests (ADR-037) ---
+
+    #[tokio::test]
+    async fn test_seed_database_settings_singleton_with_owner_edge() {
+        let (service, _temp) = create_test_service().await;
+
+        // Exactly one database-settings node, with the reserved id and defaults.
+        let settings = service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            settings.len(),
+            1,
+            "a fresh install must seed exactly one DatabaseSettingsNode"
+        );
+        let node = &settings[0];
+        assert_eq!(node.id, DATABASE_SETTINGS_NODE_ID);
+        assert_eq!(node.properties["database-settings"]["sync_enabled"], false);
+        assert_eq!(node.properties["database-settings"]["auth_status"], "local");
+
+        // Exactly one local person, and exactly one has_role owner edge to the singleton.
+        let people = service.query_nodes_by_type("person", None).await.unwrap();
+        assert_eq!(people.len(), 1);
+        let person_id = people[0].id.clone();
+
+        let targets = service
+            .get_related_nodes(&person_id, "has_role", "out")
+            .await
+            .unwrap();
+        assert_eq!(targets.len(), 1, "exactly one has_role edge must be seeded");
+        assert_eq!(targets[0].id, DATABASE_SETTINGS_NODE_ID);
+
+        let edge = service
+            .store()
+            .get_relationship_record(&person_id, DATABASE_SETTINGS_NODE_ID, "has_role")
+            .await
+            .unwrap()
+            .expect("owner has_role edge exists");
+        assert_eq!(edge.properties["role"], "owner");
+        assert_eq!(edge.properties["status"], "active");
+    }
+
+    #[tokio::test]
+    async fn test_create_second_database_settings_is_noop() {
+        let (service, _temp) = create_test_service().await;
+
+        // A second database-settings create is idempotent: returns the existing
+        // singleton id and does not create a duplicate.
+        let duplicate = Node::new(
+            "database-settings".to_string(),
+            String::new(),
+            json!({"sync_enabled": true, "auth_status": "connected"}),
+        );
+        let returned_id = service.create_node(duplicate).await.unwrap();
+        assert_eq!(returned_id, DATABASE_SETTINGS_NODE_ID);
+
+        let settings = service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            settings.len(),
+            1,
+            "second database-settings create must be a no-op"
+        );
+        // The original singleton is untouched (still holds seeded defaults).
+        assert_eq!(
+            settings[0].properties["database-settings"]["auth_status"],
+            "local"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reopening_database_does_not_reseed_database_settings() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        // First open seeds the singleton + owner edge.
+        {
+            let mut store = Arc::new(SqliteStore::new(db_path.clone()).await.unwrap());
+            let service = NodeService::new(&mut store).await.unwrap();
+            assert_eq!(
+                service
+                    .query_nodes_by_type("database-settings", None)
+                    .await
+                    .unwrap()
+                    .len(),
+                1
+            );
+        }
+
+        // Re-opening the same database must be idempotent — still exactly one.
+        let mut store = Arc::new(SqliteStore::new(db_path).await.unwrap());
+        let service = NodeService::new(&mut store).await.unwrap();
+        assert_eq!(
+            service
+                .query_nodes_by_type("database-settings", None)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "re-opening an existing database must not seed a second DatabaseSettingsNode"
+        );
+
+        let people = service.query_nodes_by_type("person", None).await.unwrap();
+        let edges = service
+            .get_related_nodes(&people[0].id, "has_role", "out")
+            .await
+            .unwrap();
+        assert_eq!(
+            edges.len(),
+            1,
+            "owner edge must not be duplicated on reopen"
         );
     }
 }

--- a/packages/core/src/services/node_service/relationship.rs
+++ b/packages/core/src/services/node_service/relationship.rs
@@ -484,7 +484,10 @@ impl NodeService {
         // The relationship_type field distinguishes between different relationship types
 
         // Built-in type validation
-        let is_builtin = matches!(relationship_name, "member_of" | "has_child" | "mentions");
+        let is_builtin = matches!(
+            relationship_name,
+            "member_of" | "has_child" | "mentions" | "has_role"
+        );
 
         if is_builtin {
             // Built-in type-specific validation
@@ -539,7 +542,7 @@ impl NodeService {
                 .find(|r| r.name == relationship_name)
                 .ok_or_else(|| {
                     NodeServiceError::invalid_update(format!(
-                        "Relationship '{}' not defined in schema '{}'. Built-in relationships (member_of, has_child, mentions) are universal.",
+                        "Relationship '{}' not defined in schema '{}'. Built-in relationships (member_of, has_child, mentions, has_role) are universal.",
                         relationship_name, schema_id
                     ))
                 })?;


### PR DESCRIPTION
## Summary

Implements `DatabaseSettingsNode` as a core node type: the `database-settings` schema entry, `DatabaseSettingsNodeBehavior`, first-launch seeding of the singleton plus its owner `has_role` edge, and registration of `has_role` as a universal built-in relationship.

Per ADR-037, database-level state is separated from identity: `sync_enabled` (user intent) and `auth_status` (system-managed cloud bind state) move onto this singleton, and tenant authority moves onto a `has_role` edge (PersonNode -> DatabaseSettingsNode) instead of living on PersonNode.

### Fixed-ID collision (the key implementation detail)

Schema nodes store their id as the slug, so the `database-settings` schema node already occupies id `"database-settings"`. To keep the instance deterministic without colliding, the singleton **instance** uses a distinct reserved id `"database-settings-singleton"`. Determinism/idempotency (the intent behind the issue's "fixed ID" criterion) is preserved: `create_node` treats a second `database-settings` create as a no-op that returns the existing id.

## Acceptance criteria

- **`database-settings` schema entry with `sync_enabled` and Core-protected `auth_status`** — `packages/core/src/models/core_schemas.rs`: Core `SchemaNode` with `sync_enabled` (boolean, default `false`, Core-protected) and `auth_status` (enum `local`/`connected`, default `local`, Core-protected).
- **`DatabaseSettingsNodeBehavior` implements all `NodeBehavior` methods and is registered** — `packages/core/src/behaviors/mod.rs`: `type_name`, `validate`, `can_have_children` (`false`), `supports_markdown` (`false`), `default_metadata` (`{sync_enabled:false, auth_status:"local"}`), `get_embeddable_content`/`get_parent_contribution` (`None`); registered in `NodeBehaviorRegistry::new()`.
- **`validate` enforces `auth_status` enum and boolean `sync_enabled`** — rejects `auth_status` outside `{local, connected}` and non-boolean `sync_enabled` with `InvalidProperties` (same shape as `AiChatNodeBehavior`).
- **`can_have_children()` -> `false`** — implemented.
- **Fixed ID; second creation is a no-op, not an error** — reserved instance id `database-settings-singleton`; `create_node` returns the existing id on a duplicate `database-settings` create (`packages/core/src/services/node_service/crud.rs`).
- **Seeded at first launch with `sync_enabled:false`, `auth_status:local`, and owner `has_role` edge to local PersonNode** — `seed_database_settings_if_needed` in `packages/core/src/services/node_service/mod.rs`, invoked from `NodeService::new()` after the local person seed; owner edge carries `{role:"owner", status:"active"}`. Idempotent across reopen.
- **`has_role` relationship type registered** — added to the built-in `matches!` set in `create_relationship` and to the built-in-relationships error string (`packages/core/src/services/node_service/relationship.rs`).
- **Unit tests cover singleton, seeding, and validation** — schema-shape test, behavior tests (registration, valid/invalid `auth_status`, non-bool `sync_enabled`, capabilities, defaults, embeddable), and async NodeService tests (seed yields exactly one node with correct defaults + exactly one owner `has_role` edge; second create is a no-op; reopen does not reseed).
- **Passes `cargo clippy`; no lint suppression** — clippy clean with `-D warnings`; no `#[allow]` / suppression added.

## Out of scope (not implemented)

Pro sync writes (`auth_status=connected`, `sync_enabled=true`), RLS enforcement, `auth_identities` bind, sync-toggle UI, and last-admin invariant enforcement.

## Checks

- `cargo test -p nodespace-core -- --test-threads=2` — 985 lib + all integration + 125 doctests pass, 0 failed
- `cargo clippy -p nodespace-core --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Note: ADR-037 documents the data-model revision this implements; a docs update lives in the nodespace-docs repo (out of scope for this code PR).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
