### PR TITLE
Scope browser-mode tests to engine-agnostic DOM and add a tauri-driver smoke suite

### DIFF
--- a/.github/workflows/nightly-webkit.yml
+++ b/.github/workflows/nightly-webkit.yml
@@ -1,0 +1,51 @@
+name: Nightly WebKit smoke
+
+# Non-blocking, nightly smoke coverage of the shipping WebKit engine.
+#
+# The desktop app renders in WKWebView (WebKit / JavaScriptCore), but the
+# browser-mode test tier (`test:browser`) runs in Chromium (Blink). Anything
+# WebKit-specific can pass in Chromium yet break in the real app. This job runs
+# the SAME engine-agnostic browser suite (src/tests/browser/**) against
+# Playwright's bundled WebKit build — the shipping engine's family — so a
+# WebKit-only regression surfaces here.
+#
+# This workflow is deliberately NOT a required status check and is NOT wired into
+# the blocking `ci.yml` gate: it is a nightly signal, not a merge gate. Chromium
+# stays the fast, blocking browser tier (via `test:integration:full` / local
+# runs); WebKit is the nightly delta check.
+
+on:
+  schedule:
+    # 07:00 UTC ≈ midnight PT — nightly.
+    - cron: "0 7 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-webkit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  webkit:
+    name: test:webkit (Playwright WebKit)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate SvelteKit types
+        run: bun run --cwd packages/desktop-app sync
+
+      - name: Install Playwright WebKit browser
+        run: bunx --bun playwright install webkit --with-deps
+        working-directory: packages/desktop-app
+
+      - name: Run WebKit smoke suite
+        run: bun run test:webkit

--- a/.github/workflows/nightly-webkit.yml
+++ b/.github/workflows/nightly-webkit.yml
@@ -44,7 +44,13 @@ jobs:
         run: bun run --cwd packages/desktop-app sync
 
       - name: Install Playwright WebKit browser
-        run: bunx --bun playwright install webkit --with-deps
+        # The WebKit revision is pinned transitively by the lockfile's Playwright
+        # version; log it so a nightly red is easy to triage as an engine-version
+        # delta vs. an app regression. (No --with-deps: that installer is
+        # Linux-only and a no-op on macos-latest.)
+        run: |
+          bunx --bun playwright --version
+          bunx --bun playwright install webkit
         working-directory: packages/desktop-app
 
       - name: Run WebKit smoke suite

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "bun run --cwd packages/desktop-app test:coverage",
     "test:skill": "bun run --cwd packages/skill test",
     "test:e2e": "bun run --cwd packages/desktop-app test:e2e",
+    "test:webkit": "bun run --cwd packages/desktop-app test:webkit",
     "test:all": "bun run test && bun run test:skill && bun run rust:test",
     "test:all:db": "bun run test:db && bun run test:skill && bun run rust:test",
     "check": "bun run --cwd packages/desktop-app check",

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -24,6 +24,8 @@
     "test:watch": "bunx vitest",
     "test:browser": "bunx vitest run --config vitest.browser.config.ts",
     "test:browser:watch": "bunx vitest --config vitest.browser.config.ts",
+    "test:webkit": "bunx vitest run --config vitest.webkit.config.ts",
+    "test:webkit:watch": "bunx vitest --config vitest.webkit.config.ts",
     "test:coverage": "bunx vitest run --coverage",
     "test:perf": "TEST_FULL_PERFORMANCE=1 bunx vitest run src/tests/performance/",
     "test:db": "TEST_USE_DATABASE=true bunx vitest run",

--- a/packages/desktop-app/vitest.browser.config.ts
+++ b/packages/desktop-app/vitest.browser.config.ts
@@ -20,6 +20,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Chromium-only APIs, or behavior that differs between Blink and WebKit). Such a
  * test would pass under Chromium and fail the WebKit smoke tier — or, worse,
  * silently validate the wrong engine for the app users actually run.
+ *
+ * LOCKSTEP TWIN: `vitest.webkit.config.ts` must stay identical to this file
+ * except for `browser.name`. The engine-agnostic contract depends on both
+ * running the same suite the same way — change one (timeouts, setup files,
+ * pool, include glob), change the other.
  */
 export default defineConfig({
   plugins: [sveltekit()],

--- a/packages/desktop-app/vitest.webkit.config.ts
+++ b/packages/desktop-app/vitest.webkit.config.ts
@@ -25,6 +25,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *
  * Run with: bun run test:webkit
  * Requires one-time setup: bunx playwright install webkit
+ *
+ * LOCKSTEP TWIN: this file must stay identical to `vitest.browser.config.ts`
+ * except for `browser.name` (webkit vs chromium). If you change a timeout,
+ * setup file, pool option, or include glob in one, change it in the other —
+ * the engine-agnostic contract depends on both running the same suite the
+ * same way.
  */
 export default defineConfig({
   plugins: [sveltekit()],

--- a/packages/desktop-app/vitest.webkit.config.ts
+++ b/packages/desktop-app/vitest.webkit.config.ts
@@ -7,19 +7,24 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Browser-mode tier (Chromium / Blink via Playwright).
+ * WebKit (JavaScriptCore) smoke tier — the engine family of the shipping
+ * WKWebView desktop app.
  *
- * ENGINE-AGNOSTIC CONTRACT: the tests under `src/tests/browser/**` must exercise
- * only standard DOM behavior that any modern engine implements the same way —
- * focus/blur, `document.activeElement`, textarea selection, keyboard events,
- * non-zero `getBoundingClientRect`, viewport-based positioning math. The exact
- * same suite is run against WebKit (the shipping WKWebView engine) by
- * `vitest.webkit.config.ts`, and both must pass.
+ * This runs the SAME engine-agnostic browser suite (`src/tests/browser/**`) as
+ * `vitest.browser.config.ts`, but against Playwright's bundled WebKit build
+ * instead of Chromium. Chromium (Blink) and WebKit (JavaScriptCore) are
+ * different engines; the desktop app ships WebKit, so a suite that only ever
+ * runs under Chromium can pass here yet break in the real app.
  *
- * Do NOT add engine-specific assertions here (e.g. pixel-exact layout values,
- * Chromium-only APIs, or behavior that differs between Blink and WebKit). Such a
- * test would pass under Chromium and fail the WebKit smoke tier — or, worse,
- * silently validate the wrong engine for the app users actually run.
+ * The value is the delta: any browser test that passes under Chromium but fails
+ * under WebKit is a real, WebKit-specific finding. Passing under both engines is
+ * the proof that the browser tier is genuinely engine-agnostic.
+ *
+ * This tier is NIGHTLY and NON-BLOCKING — it is deliberately kept out of
+ * `test:all` and the pre-push gate (see `.github/workflows/nightly-webkit.yml`).
+ *
+ * Run with: bun run test:webkit
+ * Requires one-time setup: bunx playwright install webkit
  */
 export default defineConfig({
   plugins: [sveltekit()],
@@ -33,17 +38,17 @@ export default defineConfig({
   },
 
   test: {
-    // Enable Vitest Browser Mode
+    // Enable Vitest Browser Mode against WebKit (the shipping WKWebView engine).
     browser: {
       enabled: true,
-      name: 'chromium',
+      name: 'webkit',
       provider: 'playwright',
       headless: true,
       // Enable screenshotting for debugging failures (helps identify issues quickly)
       screenshotFailures: true
     },
 
-    // Only run browser integration tests
+    // Run the same engine-agnostic browser suite as vitest.browser.config.ts.
     include: ['src/tests/browser/**/*.{test,spec}.{js,ts}'],
 
     // Setup files for browser tests


### PR DESCRIPTION
Closes #1527