### PR TITLE
Fix slash/type-conversion state_unsafe_mutation that wedges the flush (closes #1578)

### DIFF
--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -1057,6 +1057,9 @@
     } else {
       // Defer the focus + content/type writes to next tick: run synchronously they
       // mutate $state during the keystroke's render flush and throw state_unsafe_mutation.
+      // No explicit hasNode guard needed here (unlike the slash handler): these route
+      // through nodeManager.updateNodeContent/updateNodeType, which internally
+      // `if (!node) return` when node.id was promoted/removed since the event fired.
       tick().then(() => {
         focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
 
@@ -1202,13 +1205,13 @@
       }
       // Defer the focus + store writes to next tick: run synchronously they mutate
       // $state during the keystroke's render flush and throw state_unsafe_mutation.
-      // Guard updateNode with hasNode — if node.id was promoted/removed since the
-      // event fired, updateNode would log "Cannot update non-existent node".
+      // Guard the whole operation with hasNode — if node.id was promoted/removed since
+      // the event fired, there is nothing left to convert: skip focus, the update
+      // (which would log "Cannot update non-existent node"), and the custom-entity flow.
       tick().then(() => {
+        if (!sharedNodeStore.hasNode(node.id)) return;
         focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
-        if (sharedNodeStore.hasNode(node.id)) {
-          sharedNodeStore.updateNode(node.id, updatePayload, { type: 'viewer', viewerId });
-        }
+        sharedNodeStore.updateNode(node.id, updatePayload, { type: 'viewer', viewerId });
         if (isCustomSchemaType(newNodeType)) {
           handleCustomEntitySlashCommand(node.id, !!cmdDef?.hasTitleTemplate).catch((err) =>
             log.error('Custom entity slash command failed (real-node path):', err)

--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -1003,10 +1003,6 @@
       await nodeLoader.load(newNodeType);
     }
 
-    // CRITICAL: Set editing state BEFORE updating node type
-    // This ensures focus manager state is ready when the new component mounts
-    focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
-
     // Normalize content for code-block conversion
     if (newNodeType === 'code-block') {
       cleanedContent = normalizeCodeBlockContent(cleanedContent);
@@ -1039,6 +1035,10 @@
       // state_unsafe_mutation during template render (matches contentChanged path).
       const promotionParentId = nodeId;
       tick().then(() => {
+        // Set editing state so the promoted component sees focus on mount (deferred:
+        // a synchronous focus write runs during the render flush and also throws).
+        focusManager.focusNodeFromTypeConversion(promotedNode.id, cursorPosition, paneId);
+
         // Add to store and trigger persistence
         sharedNodeStore.setNode(promotedNode, { type: 'viewer', viewerId }, false);
 
@@ -1055,13 +1055,19 @@
         isPromoting = false;
       });
     } else {
-      // Update content if cleanedContent is provided (e.g., from contentTemplate)
-      if (cleanedContent !== undefined) {
-        nodeManager.updateNodeContent(node.id, cleanedContent);
-      }
+      // Defer the focus + content/type writes to next tick: run synchronously they
+      // mutate $state during the keystroke's render flush and throw state_unsafe_mutation.
+      tick().then(() => {
+        focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
 
-      // Update node type through proper API (triggers component re-render)
-      nodeManager.updateNodeType(node.id, newNodeType);
+        // Update content if cleanedContent is provided (e.g., from contentTemplate)
+        if (cleanedContent !== undefined) {
+          nodeManager.updateNodeContent(node.id, cleanedContent);
+        }
+
+        // Update node type through proper API (triggers component re-render)
+        nodeManager.updateNodeType(node.id, newNodeType);
+      });
     }
   }
 
@@ -1115,10 +1121,6 @@
       await nodeLoader.load(newNodeType);
     }
 
-    // CRITICAL: Set editing state BEFORE updating node type
-    // This ensures focus manager state is ready when the new component mounts
-    focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
-
     log.debug('slashCommandSelected:', {
       nodeId: node.id,
       newType: detail.nodeType,
@@ -1160,6 +1162,11 @@
       // Svelte throws "state_unsafe_mutation". tick() ensures we're outside render.
       const promotionParentId = nodeId;
       tick().then(() => {
+        // Set editing state so the promoted component sees focus on mount.
+        // Deferred with the store writes — a synchronous focus write here runs during
+        // the keystroke's render flush and also throws state_unsafe_mutation.
+        focusManager.focusNodeFromTypeConversion(promotedNode.id, cursorPosition, paneId);
+
         // Add to store and trigger persistence
         // Note: domain events handles parent-child relationship via edge:created events
         sharedNodeStore.setNode(promotedNode, { type: 'viewer', viewerId }, false);
@@ -1193,12 +1200,21 @@
       if (contentTemplate !== undefined) {
         updatePayload.content = contentTemplate;
       }
-      sharedNodeStore.updateNode(node.id, updatePayload, { type: 'viewer', viewerId });
-      if (isCustomSchemaType(newNodeType)) {
-        handleCustomEntitySlashCommand(node.id, !!cmdDef?.hasTitleTemplate).catch((err) =>
-          log.error('Custom entity slash command failed (real-node path):', err)
-        );
-      }
+      // Defer the focus + store writes to next tick: run synchronously they mutate
+      // $state during the keystroke's render flush and throw state_unsafe_mutation.
+      // Guard updateNode with hasNode — if node.id was promoted/removed since the
+      // event fired, updateNode would log "Cannot update non-existent node".
+      tick().then(() => {
+        focusManager.focusNodeFromTypeConversion(node.id, cursorPosition, paneId);
+        if (sharedNodeStore.hasNode(node.id)) {
+          sharedNodeStore.updateNode(node.id, updatePayload, { type: 'viewer', viewerId });
+        }
+        if (isCustomSchemaType(newNodeType)) {
+          handleCustomEntitySlashCommand(node.id, !!cmdDef?.hasTitleTemplate).catch((err) =>
+            log.error('Custom entity slash command failed (real-node path):', err)
+          );
+        }
+      });
     }
   }
 

--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -78,15 +78,16 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     return 1 + computeDepth(parents[0].id, visited);
   }
 
-  // Lazily initialize UI state for nodes not yet seen by this viewer (e.g. promoted
-  // placeholders, or nodes synced in from another window/cloud).
-  function ensureUIState(nodeId: string): NodeUIState {
-    let uiState = _uiState[nodeId];
-    if (!uiState) {
-      uiState = createDefaultUIState(nodeId, { depth: computeDepth(nodeId) });
-      _uiState[nodeId] = uiState;
-    }
-    return uiState;
+  // Pure read of a node's UI state for the render/derived path. Returns the persisted
+  // entry if present, otherwise a freshly-computed default WITHOUT writing $state.
+  //
+  // UI state is seeded for real by the genuine mutation/lifecycle paths (node load,
+  // create, expand/collapse, structure changes). A lazy write during a read is an
+  // ADR-049 violation: getVisibleNodes/getUIState run inside the visibleNodesFromStores
+  // $derived (via flattenNodes), so persisting here throws state_unsafe_mutation and
+  // wedges the flush — which stalls slash/type-conversion and Task creation in the UI.
+  function peekUIState(nodeId: string): NodeUIState {
+    return _uiState[nodeId] ?? createDefaultUIState(nodeId, { depth: computeDepth(nodeId) });
   }
 
   // NOTE: Backend now returns children pre-sorted via fractional ordering (ORDER BY order ASC)
@@ -111,7 +112,9 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
 
     for (const nodeId of nodeIds) {
       const node = sharedNodeStore.getNode(nodeId);
-      const uiState = node ? ensureUIState(nodeId) : _uiState[nodeId];
+      // Pure read: getVisibleNodesRecursive feeds $derived render paths, so it must not
+      // persist UI state (would throw state_unsafe_mutation). See peekUIState.
+      const uiState = node ? peekUIState(nodeId) : _uiState[nodeId];
       if (node) {
         // Get children from SharedNodeStore (already sorted by backend via fractional ordering)
         const children = sharedNodeStore.getNodesForParent(nodeId).map((n) => n.id);
@@ -1430,9 +1433,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       return getVisibleNodesForParent(parentId);
     },
     // Direct access to UI state for computed properties. Lazily initializes state
-    // for nodes not yet seen by this viewer (see ensureUIState).
+    // for nodes not yet seen by this viewer (see peekUIState). PURE read — safe to call
+    // from $derived/template render paths; returns a computed default without persisting.
     getUIState(nodeId: string) {
-      return sharedNodeStore.getNode(nodeId) ? ensureUIState(nodeId) : _uiState[nodeId];
+      return sharedNodeStore.getNode(nodeId) ? peekUIState(nodeId) : _uiState[nodeId];
     },
 
     // Lifecycle management

--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -1432,9 +1432,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     })[] {
       return getVisibleNodesForParent(parentId);
     },
-    // Direct access to UI state for computed properties. Lazily initializes state
-    // for nodes not yet seen by this viewer (see peekUIState). PURE read — safe to call
-    // from $derived/template render paths; returns a computed default without persisting.
+    // Direct pure read of a node's UI state for computed properties — safe to call from
+    // $derived/template render paths. For a node not yet seen by this viewer it returns a
+    // computed default WITHOUT persisting it (see peekUIState); undefined only when the
+    // node isn't in the store.
     getUIState(nodeId: string) {
       return sharedNodeStore.getNode(nodeId) ? peekUIState(nodeId) : _uiState[nodeId];
     },


### PR DESCRIPTION
## Summary

Fixes #1578 — typing `/` (or converting/creating a node type, e.g. **Task**) threw `state_unsafe_mutation`, wedged the Svelte flush, made the edited node disappear, and left node-type creation failing in the UI with the app going sluggish.

Two distinct reactive-safety violations on the date-viewer render path had to be fixed; the second is the one the issue's proposed fix didn't catch and was the actual flush-wedger.

## Root cause & fix

**1. Slash/type-conversion handlers wrote `$state` during the render flush** (`base-node-viewer.svelte`)

`handleSlashCommandSelected` and `handleNodeTypeChanged` called `focusManager.focusNodeFromTypeConversion()` (and, on the non-placeholder path, `sharedNodeStore.updateNode()`) **synchronously** at the top of the handler — during the render flush a keystroke triggers. Svelte throws `state_unsafe_mutation`.

Fix: move these writes into the `tick().then(...)` blocks the placeholder-promotion paths already use (focus first, so the new component sees it on mount). The non-placeholder `updateNode` is now guarded with `hasNode()`, eliminating the `Cannot update non-existent node` warning when the id was promoted/removed since the event fired.

**2. UI-state lazy-init wrote `$state` from inside a `$derived`** (`reactive-node-service.svelte.ts`)

The `visibleNodesFromStores` `$derived` flattens nodes and reads each node's UI state via `getUIState → ensureUIState`, which **lazily persisted a default into the `_uiState` `$state` map**. Writing reactive state from inside a `$derived` throws `state_unsafe_mutation` **at date-viewer render time — before any keystroke** — and wedges the flush, so even with fix #1 the deferred writes never landed and Task creation silently did nothing.

Fix: replace the render-path read with a pure `peekUIState()` that computes a default **without** persisting. Genuine UI-state seeding still happens on the mutation/lifecycle paths (node load, create, expand/collapse, structure changes). Deleted the now-unused `ensureUIState`.

Both align with ADR-049: reactive state is written from event handlers / store methods, never inside a render/derived path.

## Verification

Verified end-to-end in `dev:browser` driving the real app (not just tests):

- **On load:** 0 console errors (was throwing `state_unsafe_mutation` at date-viewer render before fix #2).
- **Type `/`:** slash palette opens (14 commands), node does **not** disappear, focus retained, 0 new errors.
- **`/task` → Enter:** node converts to a **Task**, keeps cursor/focus, and **persists to the daemon** (`nodeType: "task"`). No `Cannot update non-existent node` warning.
- **Reload:** the persisted Task renders cleanly with 0 errors.
- The `/` → Task path also confirmed working in `dev:tauri`.

Before/after comparison against unmodified `main` (via stash) confirmed the exact issue symptoms (`Cannot update non-existent node` + multiple `state_unsafe_mutation`) are eliminated.

`bun run test` → 150 files / 3940 tests pass. eslint + svelte-check clean. Pre-push gate (`test:all` + `cargo build` + `test:e2e`) passed.

## Acceptance criteria

- [x] Typing `/` no longer makes the node disappear; slash palette opens normally.
- [x] Creating/converting to Task via `/` works in the UI and keeps cursor/focus.
- [x] No `state_unsafe_mutation` on the slash / node-type-conversion path.
- [x] No `Cannot update non-existent node` warning during slash-command node creation.
- [x] App remains responsive after these interactions (no flush wedge).
- [x] Verified in `dev:browser`; slash→Task path verified in `dev:tauri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
