### PR TITLE
Add pro_join_collection Tauri command (open-collection self-join)

### DIFF
--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -50,6 +50,10 @@ service CloudSyncService {
   rpc CreateInvite (CreateInviteRequest) returns (CreateInviteResponse);
   rpc AcceptInvite (AcceptInviteRequest) returns (MembershipAck);
   rpc RequestJoin (RequestJoinRequest) returns (RequestJoinResponse);
+  // Open-collection self-join — the complement to RequestJoin (which is for
+  // restricted collections). The cloud RPC rejects a restricted collection with
+  // 42501, so the open-vs-restricted gate is enforced server-side.
+  rpc JoinCollection (JoinCollectionRequest) returns (MembershipAck);
   rpc ApproveRequest (ApproveRequestRequest) returns (MembershipAck);
 
   // --- Invite / request listings + revocation (S2, #239). These three cloud
@@ -188,6 +192,9 @@ message RequestJoinRequest {
 }
 message RequestJoinResponse {
   string request_id = 1;
+}
+message JoinCollectionRequest {
+  string collection_id = 1;
 }
 message ApproveRequestRequest {
   string request_id = 1;

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -13,9 +13,9 @@ use crate::services::pro_client::pb::cloud_sync_service_client::CloudSyncService
 use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{
     AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, GetIdentityRequest,
-    InitiateOAuthRequest, LeaveCollectionRequest, ListInvitesRequest, ListMembersRequest,
-    ListRequestsRequest, RemoveMemberRequest, RequestJoinRequest, RevokeInviteRequest,
-    SetMemberRequest, SignOutRequest, WatchSyncStatusRequest,
+    InitiateOAuthRequest, JoinCollectionRequest, LeaveCollectionRequest, ListInvitesRequest,
+    ListMembersRequest, ListRequestsRequest, RemoveMemberRequest, RequestJoinRequest,
+    RevokeInviteRequest, SetMemberRequest, SignOutRequest, WatchSyncStatusRequest,
 };
 use crate::services::{ProClient, ProTier};
 use tonic::transport::Channel;
@@ -367,6 +367,19 @@ pub async fn pro_request_join(app: AppHandle, collection_id: String) -> Result<S
         .map_err(|e| format!("RequestJoin failed: {e}"))?
         .into_inner();
     Ok(resp.request_id)
+}
+
+/// Self-join an OPEN collection (the complement to `pro_request_join`, which is for
+/// restricted collections). The cloud RPC rejects a restricted collection, so the
+/// open-vs-restricted gate is enforced server-side.
+#[tauri::command]
+pub async fn pro_join_collection(app: AppHandle, collection_id: String) -> Result<(), String> {
+    let mut client = membership_client(&app).await?;
+    client
+        .join_collection(JoinCollectionRequest { collection_id })
+        .await
+        .map_err(|e| format!("JoinCollection failed: {e}"))?;
+    Ok(())
 }
 
 /// Approve a pending join request (admin only). `permission` of `None`/empty

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -459,6 +459,7 @@ pub fn run() {
             commands::pro_sync::pro_create_invite,
             commands::pro_sync::pro_accept_invite,
             commands::pro_sync::pro_request_join,
+            commands::pro_sync::pro_join_collection,
             commands::pro_sync::pro_approve_request,
             commands::pro_sync::pro_list_invites,
             commands::pro_sync::pro_list_requests,


### PR DESCRIPTION
Completes the desktop half of the membership command surface: wires the daemon's `JoinCollection` gRPC — the open-collection complement to `RequestJoin` — through to a Tauri command. The daemon half shipped in nodespace-sync#287 (`JoinCollection` rpc on `CloudSyncService`); this adds the matching client binding + command in core.

## Changes
- **`proto/nodespace_pro.proto`** (vendored Pro contract): add `rpc JoinCollection (JoinCollectionRequest) returns (MembershipAck)` + `message JoinCollectionRequest { string collection_id = 1; }`, mirroring the daemon proto.
- **`commands/pro_sync.rs`**: `pro_join_collection(app, collection_id)` → forwards to `client.join_collection(...)`. Mirrors `pro_request_join` (returns `()` since the ack is just `"ok"`). The open-vs-restricted gate is enforced server-side (the cloud RPC rejects a restricted collection with 42501), so no client-side check.
- **`lib.rs`**: register the command in the invoke handler.

## Notes
- No UI yet — this parallels the other `pro_*` membership commands (`pro_request_join`, `pro_set_member`, …), which exist for tests and a future UI.
- Community build unaffected: this is a Pro-only command on `nodespace-app`; the `pb` bindings regenerate from the vendored proto at build time.

## Verification
`cargo check -p nodespace-app` clean (regenerates the `pb` bindings from the updated proto — `join_collection` method + `JoinCollectionRequest` type resolve). Backend-only change; no frontend surface touched.