### PR TITLE
Add open-collection self-join UI to the invitations modal

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -48,6 +48,7 @@
 
 	let joinId = $state('');
 	let requesting = $state(false);
+	let joining = $state(false);
 	let requestMsg = $state<string | null>(null);
 	let requestErr = $state<string | null>(null);
 
@@ -90,6 +91,24 @@
 			requesting = false;
 		}
 	}
+
+	async function joinCollection() {
+		const id = joinId.trim();
+		if (!id) return;
+		joining = true;
+		requestMsg = null;
+		requestErr = null;
+		try {
+			await membership.joinCollection(id);
+			requestMsg = 'Joined — it will appear in your sidebar as it syncs.';
+			joinId = '';
+		} catch (e) {
+			log.warn('joinCollection failed', { error: e });
+			requestErr = friendly(e);
+		} finally {
+			joining = false;
+		}
+	}
 </script>
 
 {#if open}
@@ -129,18 +148,28 @@
 			</section>
 
 			<section>
-				<h3>Request to join a collection</h3>
+				<h3>Join a collection</h3>
+				<p class="hint">
+					Open collections you can join directly; restricted ones need an admin's approval.
+				</p>
 				<div class="row">
 					<input
 						class="in"
 						type="text"
 						placeholder="collection id"
 						bind:value={joinId}
-						disabled={requesting}
+						disabled={requesting || joining}
 					/>
 					<button
+						class="btn btn-primary"
+						disabled={requesting || joining || !joinId.trim()}
+						onclick={joinCollection}
+					>
+						{joining ? 'Joining…' : 'Join'}
+					</button>
+					<button
 						class="btn btn-ghost"
-						disabled={requesting || !joinId.trim()}
+						disabled={requesting || joining || !joinId.trim()}
 						onclick={requestJoin}
 					>
 						{requesting ? 'Sending…' : 'Request'}
@@ -204,6 +233,11 @@
 		margin: 0 0 8px;
 		font-size: 0.9rem;
 		font-weight: 600;
+	}
+	.hint {
+		margin: -2px 0 8px;
+		font-size: 0.78rem;
+		color: var(--text-secondary, #6b7280);
 	}
 	.row {
 		display: flex;

--- a/packages/desktop-app/src/lib/services/membership-service.ts
+++ b/packages/desktop-app/src/lib/services/membership-service.ts
@@ -145,6 +145,17 @@ export class MembershipService {
 	}
 
 	/**
+	 * Self-join an OPEN collection (the complement to {@link requestJoin}, which is
+	 * for restricted collections). The open-vs-restricted gate is enforced
+	 * server-side — the daemon/cloud reject a restricted collection with a permission
+	 * error, so no client-side check is needed.
+	 */
+	async joinCollection(collectionId: string): Promise<void> {
+		log.debug('joinCollection', { collectionId });
+		await invoke<void>('pro_join_collection', { collectionId });
+	}
+
+	/**
 	 * Approve a pending join request (admin only). `permission` of `undefined`
 	 * grants the originally-requested tier.
 	 */

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -223,6 +223,16 @@ class MembershipStore {
 		return membershipService.requestJoin(collectionId);
 	}
 
+	/**
+	 * Self-join an OPEN collection (the complement to {@link requestJoin}). The
+	 * open-vs-restricted gate is enforced server-side, so a restricted collection
+	 * rejects here rather than joining silently.
+	 */
+	async joinCollection(collectionId: string): Promise<void> {
+		this.requirePro();
+		await membershipService.joinCollection(collectionId);
+	}
+
 	/** Clear all cached state + identity. Call on sign-out (identity is per-session). */
 	reset(): void {
 		this.byCollection = {};

--- a/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
+++ b/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
@@ -11,7 +11,8 @@ vi.mock('$lib/utils/logger', () => ({
 const { membershipMock } = vi.hoisted(() => ({
 	membershipMock: {
 		acceptInvite: vi.fn(() => Promise.resolve('collection-x')),
-		requestJoin: vi.fn(() => Promise.resolve('req-1'))
+		requestJoin: vi.fn(() => Promise.resolve('req-1')),
+		joinCollection: vi.fn(() => Promise.resolve())
 	}
 }));
 vi.mock('$lib/stores/membership.svelte', () => ({ membership: membershipMock }));
@@ -67,6 +68,20 @@ describe('InvitationsInbox', () => {
 		await fireEvent.click(getByText('Request'));
 		expect(membershipMock.requestJoin).toHaveBeenCalledWith('col-9');
 		expect(getByText(/Request sent/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('joining an open collection calls joinCollection and confirms', async () => {
+		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
+			props: { open: true, onClose: vi.fn() }
+		});
+		await fireEvent.input(getByPlaceholderText('collection id'), {
+			target: { value: 'col-open' }
+		});
+		await fireEvent.click(getByText('Join'));
+		expect(membershipMock.joinCollection).toHaveBeenCalledWith('col-open');
+		expect(membershipMock.requestJoin).not.toHaveBeenCalled();
+		expect(getByText(/Joined/)).toBeTruthy();
 		cleanup();
 	});
 

--- a/packages/desktop-app/src/tests/stores/membership.test.ts
+++ b/packages/desktop-app/src/tests/stores/membership.test.ts
@@ -19,7 +19,8 @@ const { svc, proSyncMock } = vi.hoisted(() => ({
 		revokeInvite: vi.fn(),
 		approveRequest: vi.fn(),
 		acceptInvite: vi.fn(),
-		requestJoin: vi.fn()
+		requestJoin: vi.fn(),
+		joinCollection: vi.fn()
 	},
 	proSyncMock: { isPro: true }
 }));
@@ -95,8 +96,16 @@ describe('MembershipStore', () => {
 		// service — these are the S5 onboarding entry points, so the guard matters.
 		await expect(membership.acceptInvite('code')).rejects.toThrow(/Pro/);
 		await expect(membership.requestJoin('c1')).rejects.toThrow(/Pro/);
+		await expect(membership.joinCollection('c1')).rejects.toThrow(/Pro/);
 		expect(svc.acceptInvite).not.toHaveBeenCalled();
 		expect(svc.requestJoin).not.toHaveBeenCalled();
+		expect(svc.joinCollection).not.toHaveBeenCalled();
+	});
+
+	it('joinCollection forwards to the service when Pro (open-collection self-join)', async () => {
+		svc.joinCollection.mockResolvedValue(undefined);
+		await membership.joinCollection('c1');
+		expect(svc.joinCollection).toHaveBeenCalledWith('c1');
 	});
 
 	it('currentUserRole is null when the caller identity is unknown', async () => {


### PR DESCRIPTION
Adds the first UI surface for `pro_join_collection` (merged in #1582): a direct **Join** for open collections, the complement to the existing "request to join" flow for restricted ones. This is the JoinCollection UI follow-up noted when the command landed.

## Changes
- **`membership-service.ts`** — `joinCollection(collectionId)` over the `pro_join_collection` command (void; the daemon returns a static ack).
- **`membership.svelte.ts` store** — `joinCollection()`, Pro-gated via `requirePro()` exactly like `requestJoin` (a no-op path throws in community mode rather than faking success).
- **`invitations-inbox.svelte`** — the "Request to join a collection" section becomes **"Join a collection"**: one collection-id input, a **Join** button (direct self-join, open collections) next to **Request** (restricted). A hint explains the difference. The open-vs-restricted gate stays server-side (the cloud RPC rejects a restricted collection), so a wrong choice surfaces the server's error instead of a client-side guess.

## Community build
Unaffected — the invitations modal is a Pro onboarding surface, and the store method is `requirePro()`-gated (inert without a `ProClient`), covered by the community-mode test.

## Tests
`bun run test` on the two affected suites — **16 pass** (store: `joinCollection` forwards to the service when Pro / throws in community mode; modal: the Join button calls `joinCollection`, not `requestJoin`, and confirms). `bun run quality:fix` clean (eslint/prettier + clippy).

## Scope
Discovering joinable collections (search/browse) remains the documented Phase-2 follow-up — the collection id is still shared out of band. This PR only adds the direct-join action alongside the existing request action.