### PR TITLE
Collection discovery (browse & join) in the invitations modal

### DIFF
--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -65,6 +65,13 @@ service CloudSyncService {
   rpc ListRequests (ListRequestsRequest) returns (ListRequestsResponse);
   rpc RevokeInvite (RevokeInviteRequest) returns (MembershipAck);
 
+  // Collection discovery (browse & join). Lists the collections the signed-in user
+  // could join but isn't a member of yet (open + restricted), so the client can
+  // offer Join / Request without the collection id being shared out of band. Thin
+  // adapter over the cloud `list_joinable_collections` RPC (JWT-forwarded; the RPC
+  // filters to what the caller can see and excludes their memberships server-side).
+  rpc ListJoinableCollections (ListJoinableCollectionsRequest) returns (ListJoinableCollectionsResponse);
+
   // Caller identity (#238/#239). Returns THIS device's bound PersonNode id (+
   // the signed-in email) so the UI can tell which roster row is "me" and gate
   // admin controls on the caller's own per-collection role. A dedicated one-shot
@@ -238,6 +245,18 @@ message ListRequestsResponse {
 }
 message RevokeInviteRequest {
   string invite_id = 1;  // uuid of the pending invite OR join request to cancel
+}
+
+// --- Collection discovery (browse & join) ------------------------
+message ListJoinableCollectionsRequest {}
+// A collection the caller could join but isn't a member of yet.
+message JoinableCollection {
+  string id = 1;          // collection node id
+  string name = 2;        // display name (the collection node's content)
+  bool restricted = 3;    // true => needs a request (admin approval); false => open self-join
+}
+message ListJoinableCollectionsResponse {
+  repeated JoinableCollection collections = 1;
 }
 
 // --- Caller identity (S1/S2, #238/#239) --------------------------

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -14,8 +14,9 @@ use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{
     AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, GetIdentityRequest,
     InitiateOAuthRequest, JoinCollectionRequest, LeaveCollectionRequest, ListInvitesRequest,
-    ListMembersRequest, ListRequestsRequest, RemoveMemberRequest, RequestJoinRequest,
-    RevokeInviteRequest, SetMemberRequest, SignOutRequest, WatchSyncStatusRequest,
+    ListJoinableCollectionsRequest, ListMembersRequest, ListRequestsRequest, RemoveMemberRequest,
+    RequestJoinRequest, RevokeInviteRequest, SetMemberRequest, SignOutRequest,
+    WatchSyncStatusRequest,
 };
 use crate::services::{ProClient, ProTier};
 use tonic::transport::Channel;
@@ -229,6 +230,18 @@ pub struct RequestDto {
     pub created_at: String,
 }
 
+/// One joinable collection returned by [`pro_list_joinable_collections`] —
+/// collection discovery (browse & join).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct JoinableCollectionDto {
+    /// Collection node id.
+    pub id: String,
+    /// Display name (the collection node's content).
+    pub name: String,
+    /// `true` => needs a request (admin approval); `false` => open self-join.
+    pub restricted: bool,
+}
+
 /// The caller's own identity, returned by [`pro_current_person`] (#238/#239).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PersonDto {
@@ -380,6 +393,31 @@ pub async fn pro_join_collection(app: AppHandle, collection_id: String) -> Resul
         .await
         .map_err(|e| format!("JoinCollection failed: {e}"))?;
     Ok(())
+}
+
+/// List the collections the signed-in user could join but isn't a member of yet
+/// (open + restricted) — collection discovery (browse & join). The daemon
+/// forwards the caller's JWT, so the cloud RPC filters to what the caller can see
+/// and excludes their own memberships server-side.
+#[tauri::command]
+pub async fn pro_list_joinable_collections(
+    app: AppHandle,
+) -> Result<Vec<JoinableCollectionDto>, String> {
+    let mut client = membership_client(&app).await?;
+    let resp = client
+        .list_joinable_collections(ListJoinableCollectionsRequest {})
+        .await
+        .map_err(|e| format!("ListJoinableCollections failed: {e}"))?
+        .into_inner();
+    Ok(resp
+        .collections
+        .into_iter()
+        .map(|c| JoinableCollectionDto {
+            id: c.id,
+            name: c.name,
+            restricted: c.restricted,
+        })
+        .collect())
 }
 
 /// Approve a pending join request (admin only). `permission` of `None`/empty

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -460,6 +460,7 @@ pub fn run() {
             commands::pro_sync::pro_accept_invite,
             commands::pro_sync::pro_request_join,
             commands::pro_sync::pro_join_collection,
+            commands::pro_sync::pro_list_joinable_collections,
             commands::pro_sync::pro_approve_request,
             commands::pro_sync::pro_list_invites,
             commands::pro_sync::pro_list_requests,

--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -1,13 +1,15 @@
 <!--
   InvitationsInbox — onboarding entry point (epic #237, slice S5 #242). A modal
   opened from the Pro account menu (and once, on first sign-in). Lets a user
-  redeem a share-code invite and ask to join a restricted collection.
+  redeem a share-code invite, browse the collections they can join, and join an
+  open one directly / request a restricted one.
 
   Email-bound invites are auto-redeemed server-side on reconnect
   (`redeem_my_invites`), so they need no action here — the copy just says so.
-  Listing "my pending invites / my request statuses" and discovering joinable
-  collections have no client-facing backend yet (only admins can list a
-  collection's invites/requests); those are deferred to a follow-up.
+  The discovery list comes from `list_joinable_collections` (memberships excluded
+  and visibility filtered server-side). Listing "my pending invites / my request
+  statuses" still has no client-facing backend (only admins can list a
+  collection's invites/requests); that remains deferred to a follow-up.
 -->
 <script lang="ts">
 	import { focusTrap } from '$lib/actions/focus-trap';
@@ -46,11 +48,23 @@
 	let redeemMsg = $state<string | null>(null);
 	let redeemErr = $state<string | null>(null);
 
-	let joinId = $state('');
-	let requesting = $state(false);
-	let joining = $state(false);
-	let requestMsg = $state<string | null>(null);
-	let requestErr = $state<string | null>(null);
+	// Collection discovery (browse & join). The joinable list lives in the store
+	// (loaded server-side, memberships excluded). `actingId` is the collection a
+	// per-row Join/Request is in flight for, so only that row's buttons disable.
+	let actingId = $state<string | null>(null);
+	let browseMsg = $state<string | null>(null);
+	let browseErr = $state<string | null>(null);
+
+	// Load the joinable list the first time the modal is opened (Pro only). Reopening
+	// after a join reflects the store's already-updated list without a refetch; the
+	// explicit Refresh button re-queries on demand.
+	let loadedOnce = false;
+	$effect(() => {
+		if (open && membership.isPro && !loadedOnce) {
+			loadedOnce = true;
+			void membership.loadJoinable();
+		}
+	});
 
 	function friendly(e: unknown): string {
 		return String(e).replace(/^Error:\s*/, '');
@@ -74,39 +88,35 @@
 		}
 	}
 
-	async function requestJoin() {
-		const id = joinId.trim();
-		if (!id) return;
-		requesting = true;
-		requestMsg = null;
-		requestErr = null;
+	async function join(id: string, name: string) {
+		if (actingId) return;
+		actingId = id;
+		browseMsg = null;
+		browseErr = null;
 		try {
-			await membership.requestJoin(id);
-			requestMsg = 'Request sent — an admin will review it.';
-			joinId = '';
+			await membership.joinCollection(id);
+			browseMsg = `Joined ${name} — it will appear in your sidebar as it syncs.`;
 		} catch (e) {
-			log.warn('requestJoin failed', { error: e });
-			requestErr = friendly(e);
+			log.warn('joinCollection failed', { id, error: e });
+			browseErr = friendly(e);
 		} finally {
-			requesting = false;
+			actingId = null;
 		}
 	}
 
-	async function joinCollection() {
-		const id = joinId.trim();
-		if (!id) return;
-		joining = true;
-		requestMsg = null;
-		requestErr = null;
+	async function request(id: string, name: string) {
+		if (actingId) return;
+		actingId = id;
+		browseMsg = null;
+		browseErr = null;
 		try {
-			await membership.joinCollection(id);
-			requestMsg = 'Joined — it will appear in your sidebar as it syncs.';
-			joinId = '';
+			await membership.requestJoin(id);
+			browseMsg = `Request sent for ${name} — an admin will review it.`;
 		} catch (e) {
-			log.warn('joinCollection failed', { error: e });
-			requestErr = friendly(e);
+			log.warn('requestJoin failed', { id, error: e });
+			browseErr = friendly(e);
 		} finally {
-			joining = false;
+			actingId = null;
 		}
 	}
 </script>
@@ -148,37 +158,57 @@
 			</section>
 
 			<section>
-				<h3>Join a collection</h3>
+				<div class="head">
+					<h3>Discover collections</h3>
+					<button
+						class="link"
+						type="button"
+						disabled={membership.joinableLoading || actingId !== null}
+						onclick={() => membership.loadJoinable()}
+					>
+						{membership.joinableLoading ? 'Refreshing…' : 'Refresh'}
+					</button>
+				</div>
 				<p class="hint">
 					Open collections you can join directly; restricted ones need an admin's approval.
 				</p>
-				<div class="row">
-					<input
-						class="in"
-						type="text"
-						placeholder="collection id"
-						bind:value={joinId}
-						disabled={requesting || joining}
-					/>
-					<button
-						class="btn btn-primary"
-						disabled={requesting || joining || !joinId.trim()}
-						onclick={joinCollection}
-					>
-						{joining ? 'Joining…' : 'Join'}
-					</button>
-					<button
-						class="btn btn-ghost"
-						disabled={requesting || joining || !joinId.trim()}
-						onclick={requestJoin}
-					>
-						{requesting ? 'Sending…' : 'Request'}
-					</button>
-				</div>
-				{#if requestMsg}<p class="ok" role="status">{requestMsg}</p>{/if}
-				{#if requestErr}<p class="err" role="alert">{requestErr}</p>{/if}
-				<!-- Discovering joinable collections (search/browse) is Phase 2; for now
-				     the admin shares the collection id out of band. -->
+
+				{#if membership.joinableLoading && membership.joinable.length === 0}
+					<p class="muted">Loading…</p>
+				{:else if membership.joinableError}
+					<p class="err" role="alert">{friendly(membership.joinableError)}</p>
+				{:else if membership.joinable.length === 0}
+					<p class="muted">No collections available to join right now.</p>
+				{:else}
+					<ul class="list">
+						{#each membership.joinable as c (c.id)}
+							<li class="item">
+								<span class="name" title={c.id}>{c.name || c.id}</span>
+								{#if c.restricted}
+									<span class="tag tag-restricted">Restricted</span>
+									<button
+										class="btn btn-ghost"
+										disabled={actingId !== null}
+										onclick={() => request(c.id, c.name || c.id)}
+									>
+										{actingId === c.id ? 'Sending…' : 'Request'}
+									</button>
+								{:else}
+									<span class="tag tag-open">Open</span>
+									<button
+										class="btn btn-primary"
+										disabled={actingId !== null}
+										onclick={() => join(c.id, c.name || c.id)}
+									>
+										{actingId === c.id ? 'Joining…' : 'Join'}
+									</button>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+				{#if browseMsg}<p class="ok" role="status">{browseMsg}</p>{/if}
+				{#if browseErr}<p class="err" role="alert">{browseErr}</p>{/if}
 			</section>
 
 			<div class="actions">
@@ -238,6 +268,70 @@
 		margin: -2px 0 8px;
 		font-size: 0.78rem;
 		color: var(--text-secondary, #6b7280);
+	}
+	.head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+	}
+	.link {
+		background: none;
+		border: none;
+		padding: 0;
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: #2563eb;
+		cursor: pointer;
+	}
+	.link:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.muted {
+		margin: 4px 0 0;
+		font-size: 0.82rem;
+		color: var(--text-secondary, #6b7280);
+	}
+	.list {
+		list-style: none;
+		margin: 4px 0 0;
+		padding: 0;
+		max-height: 220px;
+		overflow-y: auto;
+	}
+	.item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 0;
+		border-bottom: 1px solid var(--border-color, #eceef1);
+	}
+	.item:last-child {
+		border-bottom: none;
+	}
+	.name {
+		flex: 1;
+		min-width: 0;
+		font-size: 0.875rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.tag {
+		flex: none;
+		font-size: 0.7rem;
+		font-weight: 600;
+		padding: 2px 6px;
+		border-radius: 4px;
+	}
+	.tag-restricted {
+		background: #fef3c7;
+		color: #92400e;
+	}
+	.tag-open {
+		background: #dcfce7;
+		color: #166534;
 	}
 	.row {
 		display: flex;

--- a/packages/desktop-app/src/lib/services/membership-service.ts
+++ b/packages/desktop-app/src/lib/services/membership-service.ts
@@ -59,6 +59,16 @@ export interface Person {
 	email: string;
 }
 
+/** A collection the caller could join but isn't a member of yet (browse & join). */
+export interface JoinableCollection {
+	/** Collection node id. */
+	id: string;
+	/** Display name (the collection node's content). */
+	name: string;
+	/** `true` => needs a request (admin approval); `false` => open self-join. */
+	restricted: boolean;
+}
+
 // Raw wire shapes (snake_case, as serialized by the Rust command DTOs).
 interface RawMember {
 	person_id: string;
@@ -79,6 +89,11 @@ interface RawRequest {
 interface RawPerson {
 	person_id: string;
 	email: string;
+}
+interface RawJoinableCollection {
+	id: string;
+	name: string;
+	restricted: boolean;
 }
 
 /**
@@ -153,6 +168,18 @@ export class MembershipService {
 	async joinCollection(collectionId: string): Promise<void> {
 		log.debug('joinCollection', { collectionId });
 		await invoke<void>('pro_join_collection', { collectionId });
+	}
+
+	/**
+	 * List the collections the signed-in user could join but isn't a member of yet
+	 * (open + restricted) — collection discovery (browse & join). The daemon forwards
+	 * the caller's JWT, so the cloud RPC filters to what the caller can see and
+	 * excludes their own memberships server-side.
+	 */
+	async listJoinable(): Promise<JoinableCollection[]> {
+		log.debug('listJoinable');
+		const rows = await invoke<RawJoinableCollection[]>('pro_list_joinable_collections');
+		return rows.map((r) => ({ id: r.id, name: r.name, restricted: r.restricted }));
 	}
 
 	/**

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -18,6 +18,7 @@
 import {
 	membershipService,
 	type Invite,
+	type JoinableCollection,
 	type JoinRequest,
 	type Member,
 	type Permission,
@@ -49,6 +50,17 @@ class MembershipStore {
 
 	/** The caller's own identity, fetched lazily and cached (cleared on {@link reset}). */
 	currentPerson = $state<Person | null>(null);
+
+	/**
+	 * Collection discovery (browse & join): the collections the caller could join
+	 * but isn't a member of yet. Loaded on demand by {@link loadJoinable}; cleared
+	 * on {@link reset}. `joinableLoaded` distinguishes "not fetched" from "fetched,
+	 * empty" so a refresh after a join only fires once discovery has been opened.
+	 */
+	joinable = $state<JoinableCollection[]>([]);
+	joinableLoading = $state(false);
+	joinableError = $state<string | null>(null);
+	private joinableLoaded = false;
 
 	/** Pro-gate — the whole store is inert in community mode. */
 	get isPro(): boolean {
@@ -148,6 +160,26 @@ class MembershipStore {
 		}
 	}
 
+	/**
+	 * Load (or refresh) the joinable-collection list (browse & join). No-op in
+	 * community mode. Server-side the RPC excludes the caller's memberships and
+	 * filters to what they can see, so this is safe to call for any signed-in user.
+	 */
+	async loadJoinable(): Promise<void> {
+		if (!this.isPro) return;
+		this.joinableLoading = true;
+		this.joinableError = null;
+		try {
+			this.joinable = await membershipService.listJoinable();
+			this.joinableLoaded = true;
+		} catch (e) {
+			log.warn('loadJoinable failed', { error: e });
+			this.joinableError = String(e);
+		} finally {
+			this.joinableLoading = false;
+		}
+	}
+
 	// --- Mutations. Each forwards to the service (server-gated) then refreshes the
 	//     affected collection so the cached roster/invites/requests stay in sync. ---
 
@@ -217,7 +249,11 @@ class MembershipStore {
 		return membershipService.acceptInvite(code);
 	}
 
-	/** Ask to join a restricted collection (onboarding, S5). Returns the request id. */
+	/**
+	 * Ask to join a restricted collection (onboarding, S5). Returns the request id.
+	 * A pending request doesn't grant membership, so the collection stays in the
+	 * discovery list — the list isn't refreshed here.
+	 */
 	async requestJoin(collectionId: string): Promise<string> {
 		this.requirePro();
 		return membershipService.requestJoin(collectionId);
@@ -226,17 +262,24 @@ class MembershipStore {
 	/**
 	 * Self-join an OPEN collection (the complement to {@link requestJoin}). The
 	 * open-vs-restricted gate is enforced server-side, so a restricted collection
-	 * rejects here rather than joining silently.
+	 * rejects here rather than joining silently. On success the collection is now a
+	 * membership, so it's dropped from any loaded discovery list.
 	 */
 	async joinCollection(collectionId: string): Promise<void> {
 		this.requirePro();
 		await membershipService.joinCollection(collectionId);
+		if (this.joinableLoaded) {
+			this.joinable = this.joinable.filter((c) => c.id !== collectionId);
+		}
 	}
 
 	/** Clear all cached state + identity. Call on sign-out (identity is per-session). */
 	reset(): void {
 		this.byCollection = {};
 		this.currentPerson = null;
+		this.joinable = [];
+		this.joinableError = null;
+		this.joinableLoaded = false;
 	}
 }
 

--- a/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
+++ b/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
@@ -10,6 +10,11 @@ vi.mock('$lib/utils/logger', () => ({
 
 const { membershipMock } = vi.hoisted(() => ({
 	membershipMock: {
+		isPro: true,
+		joinable: [] as Array<{ id: string; name: string; restricted: boolean }>,
+		joinableLoading: false,
+		joinableError: null as string | null,
+		loadJoinable: vi.fn(() => Promise.resolve()),
 		acceptInvite: vi.fn(() => Promise.resolve('collection-x')),
 		requestJoin: vi.fn(() => Promise.resolve('req-1')),
 		joinCollection: vi.fn(() => Promise.resolve())
@@ -22,6 +27,10 @@ import InvitationsInbox from '$lib/components/collaboration/invitations-inbox.sv
 describe('InvitationsInbox', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		membershipMock.isPro = true;
+		membershipMock.joinable = [];
+		membershipMock.joinableLoading = false;
+		membershipMock.joinableError = null;
 	});
 
 	it('renders nothing when closed', () => {
@@ -58,30 +67,39 @@ describe('InvitationsInbox', () => {
 		cleanup();
 	});
 
-	it('requesting to join calls requestJoin and confirms', async () => {
-		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
-			props: { open: true, onClose: vi.fn() }
-		});
-		await fireEvent.input(getByPlaceholderText('collection id'), {
-			target: { value: 'col-9' }
-		});
-		await fireEvent.click(getByText('Request'));
-		expect(membershipMock.requestJoin).toHaveBeenCalledWith('col-9');
-		expect(getByText(/Request sent/)).toBeTruthy();
+	it('loads the discovery list on open (Pro)', () => {
+		render(InvitationsInbox, { props: { open: true, onClose: vi.fn() } });
+		expect(membershipMock.loadJoinable).toHaveBeenCalled();
 		cleanup();
 	});
 
-	it('joining an open collection calls joinCollection and confirms', async () => {
-		const { getByPlaceholderText, getByText } = render(InvitationsInbox, {
-			props: { open: true, onClose: vi.fn() }
-		});
-		await fireEvent.input(getByPlaceholderText('collection id'), {
-			target: { value: 'col-open' }
-		});
+	it('shows an empty state when there is nothing to join', () => {
+		const { getByText } = render(InvitationsInbox, { props: { open: true, onClose: vi.fn() } });
+		expect(getByText(/No collections available to join/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('requesting a restricted collection from the list calls requestJoin and confirms', async () => {
+		membershipMock.joinable = [{ id: 'col-9', name: 'Legal', restricted: true }];
+		const { getByText } = render(InvitationsInbox, { props: { open: true, onClose: vi.fn() } });
+		expect(getByText('Legal')).toBeTruthy();
+		expect(getByText('Restricted')).toBeTruthy();
+		await fireEvent.click(getByText('Request'));
+		expect(membershipMock.requestJoin).toHaveBeenCalledWith('col-9');
+		expect(membershipMock.joinCollection).not.toHaveBeenCalled();
+		expect(getByText(/Request sent for Legal/)).toBeTruthy();
+		cleanup();
+	});
+
+	it('joining an open collection from the list calls joinCollection and confirms', async () => {
+		membershipMock.joinable = [{ id: 'col-open', name: 'Marketing', restricted: false }];
+		const { getByText } = render(InvitationsInbox, { props: { open: true, onClose: vi.fn() } });
+		expect(getByText('Marketing')).toBeTruthy();
+		expect(getByText('Open')).toBeTruthy();
 		await fireEvent.click(getByText('Join'));
 		expect(membershipMock.joinCollection).toHaveBeenCalledWith('col-open');
 		expect(membershipMock.requestJoin).not.toHaveBeenCalled();
-		expect(getByText(/Joined/)).toBeTruthy();
+		expect(getByText(/Joined Marketing/)).toBeTruthy();
 		cleanup();
 	});
 

--- a/packages/desktop-app/src/tests/services/membership-service.test.ts
+++ b/packages/desktop-app/src/tests/services/membership-service.test.ts
@@ -118,4 +118,23 @@ describe('MembershipService', () => {
 		expect(await membershipService.requestJoin('c1')).toBe('req-1');
 		expect(mockInvoke).toHaveBeenCalledWith('pro_request_join', { collectionId: 'c1' });
 	});
+
+	it('joinCollection forwards to pro_join_collection', async () => {
+		mockInvoke.mockResolvedValue(undefined);
+		await membershipService.joinCollection('c1');
+		expect(mockInvoke).toHaveBeenCalledWith('pro_join_collection', { collectionId: 'c1' });
+	});
+
+	it('listJoinable maps rows to JoinableCollection[] (no args)', async () => {
+		mockInvoke.mockResolvedValue([
+			{ id: 'c-open', name: 'Marketing', restricted: false },
+			{ id: 'c-r', name: 'Legal', restricted: true }
+		]);
+		const rows = await membershipService.listJoinable();
+		expect(mockInvoke).toHaveBeenCalledWith('pro_list_joinable_collections');
+		expect(rows).toEqual([
+			{ id: 'c-open', name: 'Marketing', restricted: false },
+			{ id: 'c-r', name: 'Legal', restricted: true }
+		]);
+	});
 });

--- a/packages/desktop-app/src/tests/stores/membership.test.ts
+++ b/packages/desktop-app/src/tests/stores/membership.test.ts
@@ -20,7 +20,8 @@ const { svc, proSyncMock } = vi.hoisted(() => ({
 		approveRequest: vi.fn(),
 		acceptInvite: vi.fn(),
 		requestJoin: vi.fn(),
-		joinCollection: vi.fn()
+		joinCollection: vi.fn(),
+		listJoinable: vi.fn()
 	},
 	proSyncMock: { isPro: true }
 }));
@@ -106,6 +107,50 @@ describe('MembershipStore', () => {
 		svc.joinCollection.mockResolvedValue(undefined);
 		await membership.joinCollection('c1');
 		expect(svc.joinCollection).toHaveBeenCalledWith('c1');
+	});
+
+	it('loadJoinable caches the discovery list (Pro)', async () => {
+		svc.listJoinable.mockResolvedValue([
+			{ id: 'c-open', name: 'Marketing', restricted: false },
+			{ id: 'c-r', name: 'Legal', restricted: true }
+		]);
+		await membership.loadJoinable();
+		expect(membership.joinable).toHaveLength(2);
+		expect(membership.joinableError).toBeNull();
+		expect(membership.joinableLoading).toBe(false);
+	});
+
+	it('loadJoinable records an error and is inert in community mode', async () => {
+		svc.listJoinable.mockRejectedValue(new Error('boom'));
+		await membership.loadJoinable();
+		expect(membership.joinableError).toContain('boom');
+		expect(membership.joinable).toEqual([]);
+
+		proSyncMock.isPro = false;
+		svc.listJoinable.mockClear();
+		await membership.loadJoinable();
+		expect(svc.listJoinable).not.toHaveBeenCalled();
+	});
+
+	it('joining an open collection drops it from a loaded discovery list', async () => {
+		svc.listJoinable.mockResolvedValue([
+			{ id: 'c-open', name: 'Marketing', restricted: false },
+			{ id: 'c-r', name: 'Legal', restricted: true }
+		]);
+		await membership.loadJoinable();
+		svc.joinCollection.mockResolvedValue(undefined);
+
+		await membership.joinCollection('c-open');
+		expect(membership.joinable.map((c) => c.id)).toEqual(['c-r']);
+	});
+
+	it('requesting a restricted collection leaves it in the discovery list', async () => {
+		svc.listJoinable.mockResolvedValue([{ id: 'c-r', name: 'Legal', restricted: true }]);
+		await membership.loadJoinable();
+		svc.requestJoin.mockResolvedValue('req-1');
+
+		await membership.requestJoin('c-r');
+		expect(membership.joinable.map((c) => c.id)).toEqual(['c-r']);
 	});
 
 	it('currentUserRole is null when the caller identity is unknown', async () => {


### PR DESCRIPTION
## Summary

Phase 2, Slice 3 (core) of **collection discovery (browse & join)**. Wires the discovery RPC end-to-end into the onboarding modal.

Before this, the invitations modal could only redeem a share code or join a collection whose **id was pasted in by hand** — there was no way to see which collections you could actually join. This adds a real discovery list: the collections you're *not* a member of yet, each with a per-row **Join** (open) / **Request** (restricted).

## Changes

- **proto**: `ListJoinableCollections` rpc + `JoinableCollection { id, name, restricted }` (mirrors the sync daemon proto).
- **pro_sync.rs**: `pro_list_joinable_collections` Tauri command (registered in `lib.rs`).
- **membership-service.ts**: `listJoinable()` + `JoinableCollection` type.
- **membership store**: `joinable` list + `loadJoinable()`; joining an open collection drops it from the loaded list; `reset()` clears discovery state.
- **invitations-inbox.svelte**: replaces the manual collection-id entry with a browse list (loaded on open), per-row Join/Request with in-flight + status states, a Refresh control, and loading / empty / error states. Open vs. restricted shown as a tag.

## Testing

- `cargo check -p nodespace-app` — clean
- `bun run quality:fix` (eslint + svelte-check) — **0 errors / 0 warnings / 0 problems** across 1729 files
- `bun run test` (service + store + component): **33 passed** (11 service, 13 store, 9 component), incl. new discovery tests: row mapping, load/error/inert, drop-on-join, request-keeps, and per-row Join/Request UI + empty state.

## Notes

- The daemon forwards the caller's JWT, so the cloud RPC filters to what the caller can see and excludes their own memberships **server-side**; the open-vs-restricted gate is enforced server-side too (restricted → request → admin approval).
- Pairs with the sync daemon RPC (nodespace-sync #293) and the cloud `list_joinable_collections` RPC (nodespace-cloud #72).
- **Community build unchanged** — the Pro-gated store is inert without a Pro client, so the modal shows no discovery list in community mode.