### PR TITLE
Prime own-echo baseline on node hydration to stop false conflict toasts (#1586)

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -618,6 +618,26 @@ export class SharedNodeStore {
   }
 
   /**
+   * Record a node's server-confirmed content as the own-echo baseline that
+   * `isPlausibleOwnEcho` compares against. Called whenever a node is accepted
+   * from the daemon broadcast or hydrated from the backend — i.e. whenever its
+   * content is known to equal the server state.
+   *
+   * Without this baseline, the FIRST broadcast for a node the user then starts
+   * editing has no `lastPersistedContent` entry, so `isPlausibleOwnEcho`
+   * false-classifies that echo (the daemon streaming a node's current state
+   * after the subscription opens) as a foreign write. The skip-while-editing
+   * guard then fires a spurious "Your edit conflicted with a remote change"
+   * notification even though nothing else touched the node. Priming here — not
+   * only after the first local edit — gives that echo a baseline to match. A
+   * genuinely different foreign write still fails the equality check and
+   * correctly surfaces the conflict.
+   */
+  private primeOwnEchoBaseline(node: Node): void {
+    this.lastPersistedContent.set(node.id, node.content ?? '');
+  }
+
+  /**
    * Decide whether the persistence path should clear a CREATE's
    * `InsertPosition.After` hint as "stale" before talking to the backend.
    *
@@ -1582,6 +1602,9 @@ export class SharedNodeStore {
     // Mark as persisted if explicitly requested or loaded from backend
     if (shouldMarkAsPersisted) {
       this.persistedNodeIds.add(node.id);
+      // This content came from the server (daemon broadcast / backend hydration),
+      // so record it as the own-echo baseline for the skip-while-editing guard.
+      this.primeOwnEchoBaseline(node);
     }
 
     // Phase 2.4: Persist to database
@@ -1894,6 +1917,10 @@ export class SharedNodeStore {
 
       if (shouldMarkAsPersisted) {
         this.persistedNodeIds.add(node.id);
+        // Bulk hydration (initial tree load) flows through here — prime the
+        // own-echo baseline so a subsequently-focused node's first daemon echo
+        // isn't misread as a foreign write (mirrors setNode).
+        this.primeOwnEchoBaseline(node);
       }
     }
 

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -397,5 +397,38 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
 
       expect(versionMismatchFor('dup')).toHaveLength(1);
     });
+
+    // Regression for the "conflict toast on effectively every edit" bug: the
+    // own-echo test above pre-seeds lastPersistedContent through the __test_
+    // backdoor, so it never exercised the real cold path. Here a node is
+    // hydrated from the backend (database source) with NO backdoor — the accept
+    // path must prime the own-echo baseline itself, so the daemon's first echo
+    // after the subscription opens is not misread as a foreign write.
+    it('does NOT notify on a load-echo of a backend-hydrated node (real path, no backdoor)', () => {
+      // Node arrives from the backend/daemon; this alone must prime the baseline.
+      store.setNode(makeNode('hydrated', 'hello world', 5), databaseSource);
+      focusManager.focusNode('hydrated', 'default');
+
+      // The daemon streams the node's current state back after WatchNodes opens.
+      // Before this fix, that echo (no lastPersistedContent entry) fired a
+      // spurious version-mismatch toast even though nothing else changed.
+      store.setNode(makeNode('hydrated', 'hello world', 6), databaseSource);
+
+      expect(versionMismatchFor('hydrated')).toHaveLength(0);
+    });
+
+    it('still notifies on a genuine foreign write after real-path priming (no backdoor)', () => {
+      // Same real hydration priming as above — no __test_ backdoor.
+      store.setNode(makeNode('hydrated2', 'hello world', 5), databaseSource);
+      focusManager.focusNode('hydrated2', 'default');
+
+      // A DIFFERENT writer changes the node. The primed baseline ('hello world')
+      // does not match the incoming content, so the conflict is still surfaced.
+      store.setNode(makeNode('hydrated2', 'a foreign edit', 7), databaseSource);
+
+      expect(versionMismatchFor('hydrated2')).toHaveLength(1);
+      // The local content is still protected (the clobber was skipped).
+      expect(store.getNode('hydrated2')?.content).toBe('hello world');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Editing a freshly-loaded node in a single-writer session reliably fired a **"Your edit conflicted with a remote change"** toast even with no other writer. This fixes the false positive at its root.

## Root cause
`setNode`'s skip-while-editing guard raises a `version-mismatch` conflict notification whenever a `database`-source broadcast for an actively-edited node is **not** recognised as this client's own echo. Recognition (`isPlausibleOwnEcho`) compares the incoming content against `lastPersistedContent`, which was only populated **after the first local edit**. So a node's *first* daemon echo after the `WatchNodes` subscription opens — the daemon streaming the node's current (unchanged) state — had **no baseline**, was misclassified as a foreign write, and fired a spurious toast. The function's own doc comment already flagged this "no last-sent record ⇒ reports false for all broadcasts, including legitimate own-echoes after load" trade-off; in practice it fired on effectively every edit of a loaded node.

## Fix
Prime `lastPersistedContent` with the server-confirmed content whenever a node is accepted from the daemon broadcast or hydrated from the backend — the `setNode` **and** `batchSetNodes` accept paths (initial tree load goes through `batchSetNodes`), gated on `shouldMarkAsPersisted` (true iff the content equals the backend's). Factored into a single `primeOwnEchoBaseline()` helper so the rationale lives in one place.

- The first echo of unchanged content now **matches** → silent.
- A **genuinely different** foreign write still fails the equality check → conflict still surfaces.
- The guarded, actively-edited early-return path is deliberately left **un-primed** so it can never adopt a foreign write as the baseline (that would defeat foreign-write detection).

## On the hypothesised broadcast-vs-persistence race
Investigated and dismissed for a node's own edits: `lastPersistedContent.set()` on the persistence path runs **synchronously right before** the `UpdateNode` RPC, which strictly precedes the daemon's echo — so a node's own `C1` echo always finds `lastPersistedContent = C1`. The false positives came from **unprimed** (never-locally-edited) nodes, which this change addresses.

## Tests
Added two regression tests that drive the **real** hydration path (no `__test_setLastPersistedContent` backdoor):
- `does NOT notify on a load-echo of a backend-hydrated node (real path, no backdoor)`
- `still notifies on a genuine foreign write after real-path priming (no backdoor)`

Verification:
- `shared-node-store-skip-while-editing`: 20/20 pass (18 existing + 2 new; existing foreign-write/own-echo/dedup tests unchanged).
- All `shared-node-store` suites: 251/251.
- Full frontend unit suite: **3952/3952**, 150 files.
- `bun run --cwd packages/desktop-app quality:fix`: eslint 0 errors, svelte-check 0 errors/0 warnings.

## Acceptance criteria
- [x] Editing a node's content in a single-writer session does not produce the false conflict toast
- [x] Regression test exercises the real (non-backdoor) hydration path and asserts no false notification
- [x] Genuine foreign-write conflicts still raise the notification (existing + new test)
- [x] Broadcast-vs-persistence race investigated and dismissed with rationale
- [x] `quality:fix` clean; no new frontend test failures

Closes #1586