### PR TITLE
ADR-053 Stage 5 (part 2): route import, embeddings, and agent-session requests

### DIFF
--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -24,6 +24,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
+use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     agent_session_service_server::AgentSessionService, AgentAvailability, CheckAvailabilityRequest,
     CheckAvailabilityResponse, LaunchSessionRequest, LaunchSessionResponse, ListSessionsRequest,
@@ -32,6 +33,7 @@ use crate::nodespace::{
     WriteInputResponse,
 };
 use crate::services::capture_service::{finalize_capture, CompletedSession};
+use crate::services::database_manager::DatabaseManager;
 use crate::services::settings_service::{read_capture_settings, CaptureConfig};
 
 /// gRPC adapter that owns shared handles to the PTY engine.
@@ -57,6 +59,39 @@ impl AgentSessionHandler {
             config_path,
         }
     }
+
+    /// Resolve which database this request targets (ADR-053) and return that
+    /// database's handler. See [`crate::services::NodeServiceImpl::route`] for
+    /// the shared contract: no manager injected (Pro daemon, unit tests) →
+    /// `self`; an `x-ns-database-id` header selects a registered database
+    /// (unregistered → rejected).
+    ///
+    /// Only [`launch_session`](Self::launch_session) routes: the `PtySessionManager`
+    /// is process-global (the same `Arc` backs every database), so PTY
+    /// operations (stream/write/resize/terminate/list) act on the shared session
+    /// set regardless of database. Launch is the sole handler that reads the
+    /// per-database context assembler and node service (for context + capture),
+    /// so it follows the targeted database.
+    async fn route<T>(&self, request: &Request<T>) -> Result<AgentSessionHandler, Status> {
+        let Some(db_manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
+            return Ok(self.clone());
+        };
+        let header = request
+            .metadata()
+            .get(DATABASE_ID_HEADER)
+            .map(|v| v.to_str())
+            .transpose()
+            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
+        let id = db_manager
+            .resolve_database_id(header)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        let services = db_manager
+            .get_or_open(&id)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(services.agent_session.clone())
+    }
 }
 
 #[tonic::async_trait]
@@ -65,6 +100,7 @@ impl AgentSessionService for AgentSessionHandler {
         &self,
         request: Request<LaunchSessionRequest>,
     ) -> Result<Response<LaunchSessionResponse>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
 
         let agent_type = parse_agent_type(&req.agent_type).map_err(Status::invalid_argument)?;
@@ -110,9 +146,9 @@ impl AgentSessionService for AgentSessionHandler {
             }
         }
 
-        let id = self
+        let id = this
             .manager
-            .launch(agent_type, req.prompt, &self.assembler)
+            .launch(agent_type, req.prompt, &this.assembler)
             .await
             .map_err(|e| Status::internal(format!("launch session failed: {e}")))?;
 
@@ -123,7 +159,7 @@ impl AgentSessionService for AgentSessionHandler {
         // `unwrap_or` fallback covers the vanishingly unlikely case where the
         // spawned child has already exited and the auto-prune watcher has
         // already removed the entry.
-        let session = self.manager.get(&id).await;
+        let session = this.manager.get(&id).await;
         let created_at = session
             .as_ref()
             .map(|s| s.started_at.timestamp())
@@ -163,10 +199,10 @@ impl AgentSessionService for AgentSessionHandler {
         // Capture config is read once here (at launch time) so finalize_capture
         // doesn't re-hit the filesystem on every session end. Sessions started
         // before the handler initializes are not covered (no manager.get hit).
-        if let Some(ref session) = self.manager.get(&id).await {
+        if let Some(ref session) = this.manager.get(&id).await {
             let session = session.clone();
-            let node_service = self.node_service.clone();
-            let config_path = self.config_path.clone();
+            let node_service = this.node_service.clone();
+            let config_path = this.config_path.clone();
             let started_at = session.started_at;
             let node_id = req.node_id.clone();
 

--- a/packages/daemon/src/services/embeddings_service.rs
+++ b/packages/daemon/src/services/embeddings_service.rs
@@ -15,6 +15,7 @@ use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService, NodeSer
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
+use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     embeddings_service_server::EmbeddingsService as GrpcEmbeddingsService, BatchEmbeddingFailure,
     BatchQueueEmbeddingsRequest, BatchQueueEmbeddingsResponse, EmbeddingStatusResponse,
@@ -23,6 +24,7 @@ use crate::nodespace::{
     SearchSemanticRequest, SearchSemanticResponse, TriggerBatchEmbedRequest,
     TriggerBatchEmbedResponse,
 };
+use crate::services::database_manager::DatabaseManager;
 use crate::services::node_service::node_to_proto;
 
 /// Live embedding state once the model has finished loading.
@@ -50,6 +52,38 @@ impl EmbeddingsServiceImpl {
         Status::unavailable("embedding model loading, please retry")
     }
 
+    /// Resolve which database this request targets (ADR-053) and return that
+    /// database's embeddings service. See
+    /// [`crate::services::NodeServiceImpl::route`] for the shared contract: no
+    /// manager injected (Pro daemon, unit tests) → `self`; an `x-ns-database-id`
+    /// header selects a registered database (unregistered → rejected). If the
+    /// target database has no embeddings service (no model — which, since the
+    /// model is process-global, cannot happen while this service is registered)
+    /// fall back to `self`.
+    async fn route<T>(&self, request: &Request<T>) -> Result<EmbeddingsServiceImpl, Status> {
+        let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
+            return Ok(self.clone());
+        };
+        let header = request
+            .metadata()
+            .get(DATABASE_ID_HEADER)
+            .map(|v| v.to_str())
+            .transpose()
+            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
+        let id = manager
+            .resolve_database_id(header)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        let services = manager
+            .get_or_open(&id)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(services
+            .embeddings_service_grpc
+            .clone()
+            .unwrap_or_else(|| self.clone()))
+    }
+
     /// Shared implementation for stale-count queries used by both
     /// `get_embedding_status` and `get_stale_count` to avoid duplication.
     async fn stale_count_inner(&self) -> Result<i32, Status> {
@@ -67,11 +101,12 @@ impl EmbeddingsServiceImpl {
 impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
     async fn get_embedding_status(
         &self,
-        _request: Request<GetEmbeddingStatusRequest>,
+        request: Request<GetEmbeddingStatusRequest>,
     ) -> Result<Response<EmbeddingStatusResponse>, Status> {
-        let available = self.state.read().await.is_some();
+        let this = self.route(&request).await?;
+        let available = this.state.read().await.is_some();
         let stale_count = if available {
-            self.stale_count_inner().await?
+            this.stale_count_inner().await?
         } else {
             0
         };
@@ -85,13 +120,14 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         request: Request<SearchSemanticRequest>,
     ) -> Result<Response<SearchSemanticResponse>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
 
         if req.query.trim().is_empty() {
             return Err(Status::invalid_argument("query cannot be empty"));
         }
 
-        let guard = self.state.read().await;
+        let guard = this.state.read().await;
         let state = guard.as_ref().ok_or_else(Self::unavailable)?;
 
         let threshold = if req.threshold == 0.0 {
@@ -111,7 +147,7 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
             .generate_embedding(&req.query)
             .map_err(|e| Status::internal(format!("Failed to generate query embedding: {}", e)))?;
 
-        let store = self.node_service.store();
+        let store = this.node_service.store();
         let search_results = store
             .search_embeddings(&query_embedding, limit, threshold)
             .await
@@ -131,12 +167,13 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         request: Request<RegenerateEmbeddingRequest>,
     ) -> Result<Response<RegenerateEmbeddingResponse>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
 
-        let guard = self.state.read().await;
+        let guard = this.state.read().await;
         let state = guard.as_ref().ok_or_else(Self::unavailable)?;
 
-        let node = self
+        let node = this
             .node_service
             .get_node(&req.node_id)
             .await
@@ -156,12 +193,13 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         request: Request<QueueEmbeddingRequest>,
     ) -> Result<Response<QueueEmbeddingResponse>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
 
-        let guard = self.state.read().await;
+        let guard = this.state.read().await;
         let state = guard.as_ref().ok_or_else(Self::unavailable)?;
 
-        let node = self
+        let node = this
             .node_service
             .get_node(&req.node_id)
             .await
@@ -179,9 +217,10 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
 
     async fn trigger_batch_embed(
         &self,
-        _request: Request<TriggerBatchEmbedRequest>,
+        request: Request<TriggerBatchEmbedRequest>,
     ) -> Result<Response<TriggerBatchEmbedResponse>, Status> {
-        let guard = self.state.read().await;
+        let this = self.route(&request).await?;
+        let guard = this.state.read().await;
         let state = guard.as_ref().ok_or_else(Self::unavailable)?;
 
         state
@@ -194,10 +233,11 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
 
     async fn get_stale_count(
         &self,
-        _request: Request<GetStaleCountRequest>,
+        request: Request<GetStaleCountRequest>,
     ) -> Result<Response<GetStaleCountResponse>, Status> {
+        let this = self.route(&request).await?;
         // No model required — queries the DB stale-embedding table directly.
-        let count = self.stale_count_inner().await?;
+        let count = this.stale_count_inner().await?;
         Ok(Response::new(GetStaleCountResponse { count }))
     }
 
@@ -205,16 +245,17 @@ impl GrpcEmbeddingsService for EmbeddingsServiceImpl {
         &self,
         request: Request<BatchQueueEmbeddingsRequest>,
     ) -> Result<Response<BatchQueueEmbeddingsResponse>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
 
-        let guard = self.state.read().await;
+        let guard = this.state.read().await;
         let state = guard.as_ref().ok_or_else(Self::unavailable)?;
 
         let mut success_count = 0i32;
         let mut failures = Vec::new();
 
         for node_id in req.node_ids {
-            match self.node_service.get_node(&node_id).await {
+            match this.node_service.get_node(&node_id).await {
                 Ok(Some(node)) => {
                     match state.embedding_service.queue_for_embedding(&node.id).await {
                         Ok(_) => success_count += 1,

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -19,10 +19,12 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
+use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     import_service_server::ImportService as GrpcImportService, FileImportResult,
     ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions, ImportProgressEvent,
 };
+use crate::services::database_manager::DatabaseManager;
 
 const CHANNEL_BUFFER: usize = 64;
 
@@ -34,6 +36,33 @@ pub struct ImportServiceImpl {
 impl ImportServiceImpl {
     pub fn new(node_service: Arc<CoreNodeService>) -> Self {
         Self { node_service }
+    }
+
+    /// Resolve which database this request targets (ADR-053) and return that
+    /// database's import service. See [`crate::services::NodeServiceImpl::route`]
+    /// for the shared routing contract: with no manager injected (Pro daemon,
+    /// unit tests) this returns `self`, so behavior is unchanged; an
+    /// `x-ns-database-id` header selects a registered database (unregistered →
+    /// rejected).
+    async fn route<T>(&self, request: &Request<T>) -> Result<ImportServiceImpl, Status> {
+        let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
+            return Ok(self.clone());
+        };
+        let header = request
+            .metadata()
+            .get(DATABASE_ID_HEADER)
+            .map(|v| v.to_str())
+            .transpose()
+            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
+        let id = manager
+            .resolve_database_id(header)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        let services = manager
+            .get_or_open(&id)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(services.import.clone())
     }
 }
 
@@ -50,9 +79,10 @@ impl GrpcImportService for ImportServiceImpl {
         &self,
         request: Request<ImportMarkdownRequest>,
     ) -> Result<Response<Self::ImportMarkdownStream>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
         let opts = req.options.unwrap_or_default();
-        let node_service = Arc::clone(&self.node_service);
+        let node_service = Arc::clone(&this.node_service);
 
         let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
 
@@ -67,9 +97,10 @@ impl GrpcImportService for ImportServiceImpl {
         &self,
         request: Request<ImportMarkdownFilesRequest>,
     ) -> Result<Response<Self::ImportMarkdownFilesStream>, Status> {
+        let this = self.route(&request).await?;
         let req = request.into_inner();
         let opts = req.options.unwrap_or_default();
-        let node_service = Arc::clone(&self.node_service);
+        let node_service = Arc::clone(&this.node_service);
 
         let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
 
@@ -997,4 +1028,56 @@ async fn import_markdown_content(
     }
 
     Ok((root_id, nodes_created))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::SharedContext;
+    use nodespace_agent::pty::PtySessionManager;
+    use nodespace_nlp_engine::EmbeddingService;
+    use tokio::sync::watch;
+
+    fn test_context() -> SharedContext {
+        let (_tx, model) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
+        SharedContext {
+            pty_manager: Arc::new(PtySessionManager::new()),
+            model,
+            has_model: false,
+        }
+    }
+
+    /// A request naming an unregistered database is rejected at the routing
+    /// boundary (ADR-053), never silently served from the default.
+    #[tokio::test]
+    async fn import_rejects_unregistered_database_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = Arc::new(
+            DatabaseManager::load(dir.path().join("databases.toml"), test_context())
+                .await
+                .unwrap(),
+        );
+        let default_id = manager
+            .ensure_default_registered("Default".into(), dir.path().join("db.db"))
+            .await
+            .unwrap();
+        let svc = manager
+            .get_or_open(&default_id)
+            .await
+            .unwrap()
+            .import
+            .clone();
+
+        let mut req = Request::new(ImportMarkdownRequest {
+            file_path: "/nonexistent.md".into(),
+            options: None,
+        });
+        req.extensions_mut().insert(manager.clone());
+        req.metadata_mut()
+            .insert(DATABASE_ID_HEADER, "ZZZ-UNREGISTERED".parse().unwrap());
+        assert_eq!(
+            svc.import_markdown(req).await.unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+    }
 }


### PR DESCRIPTION
## ADR-053 Stage 5 (part 2) — route import, embeddings, and agent-session requests

Part of the ADR-053 epic ("One Daemon, Multiple Local Databases", #1532). Follows part 1 (#1590), which added the `DbManagerLayer` routing middleware and routed `NodeService`. This applies the same, now-reviewed pattern to the remaining cleanly per-database services.

### What changed

Each service gains a `route(&request)` helper — identical in shape to `NodeServiceImpl::route` — that reads the `DatabaseManager` injected by `DbManagerLayer`, resolves `x-ns-database-id` (absent → default; **unregistered → rejected**, never silently served from the default), and returns the target database's service. With no manager present (the Pro daemon installs no layer; unit tests construct impls directly) it returns `self`, so behavior is unchanged.

- **ImportService** — both handlers route, so an import writes to the targeted database. New test `import_rejects_unregistered_database_header`.
- **EmbeddingsService** — all seven handlers route (search / queue / regenerate / stale-count operate on the targeted database's vectors). The `stale_count_inner` helper deliberately stays on `self`: it runs on the already-routed impl.
- **AgentSessionService** — only `launch_session` routes. The `PtySessionManager` is process-global (one `Arc` backs every database), so stream / write / resize / terminate / list act on the shared session set regardless of database. `launch_session` is the sole handler that reads the per-database context assembler and node service (for context + capture), so it follows the targeted database.

### Cross-repo

No impl constructor, `BaseServices` field, or `build_base_router` signature is touched — no cross-repo change; `nodespaced-pro` is unaffected (it inherits the extension-aware handler bodies via its pinned core rev and, installing no layer, behaves identically).

### Verification

The routing wiring is enforced by the type-checker: a missed `self`→`this` swap surfaces as an unused-`this` error under `clippy -D warnings`, and returning the wrong service field is a type error. On top of that, `import_rejects_unregistered_database_header` exercises the fail-closed path end-to-end for a non-`NodeService` service (part 1's `routes_requests_by_database_header` already proves data isolation for the routing mechanism itself).

`cargo test -p nodespace-daemon` green (lib **48**); `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

### Deferred

**LocalAgentService** routing. Its model manager is process-global (with a pending hoist-to-shared refactor) while only its chat-turn processing is per-database; routing it now would prematurely couple to that unresolved global/per-database split. It will be handled together with the model-manager-to-shared work.
