### PR TITLE
ADR-053: DatabaseService gRPC server (local-database registry)

### DIFF
--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -40,18 +40,19 @@ pub use nodespace_proto::nodespace;
 pub use nodespace_proto::{
     AgentAvailability, AgentSessionServiceClient, AgentSessionServiceServer, CaptureContentLevel,
     CaptureSettingsResponse, CheckAvailabilityRequest, CheckAvailabilityResponse,
-    EmbeddingsServiceClient, EmbeddingsServiceServer, GetCaptureSettingsRequest,
-    ImportServiceClient, ImportServiceServer, LaunchSessionRequest, LaunchSessionResponse,
-    ListSessionsRequest, ListSessionsResponse, LocalAgentServiceClient, LocalAgentServiceServer,
-    NodeData, NodeServiceClient, NodeServiceServer, ResizeRequest, ResizeResponse, SessionInfo,
-    SettingsServiceClient, SettingsServiceServer, StreamOutputRequest, TerminateSessionRequest,
-    TerminateSessionResponse, UpdateCaptureSettingsRequest, WriteInputRequest, WriteInputResponse,
+    DatabaseServiceClient, DatabaseServiceServer, EmbeddingsServiceClient, EmbeddingsServiceServer,
+    GetCaptureSettingsRequest, ImportServiceClient, ImportServiceServer, LaunchSessionRequest,
+    LaunchSessionResponse, ListSessionsRequest, ListSessionsResponse, LocalAgentServiceClient,
+    LocalAgentServiceServer, NodeData, NodeServiceClient, NodeServiceServer, ResizeRequest,
+    ResizeResponse, SessionInfo, SettingsServiceClient, SettingsServiceServer, StreamOutputRequest,
+    TerminateSessionRequest, TerminateSessionResponse, UpdateCaptureSettingsRequest,
+    WriteInputRequest, WriteInputResponse,
 };
 
 pub use db_routing::{DbManagerLayer, DATABASE_ID_HEADER};
 pub use router::{build_base_router, BaseServices};
 pub use services::{
     build_database_services, build_shared_services, AgentSessionHandler, DatabaseManager,
-    DatabaseServices, EmbeddingsServiceImpl, ImportServiceImpl, LocalAgentServiceImpl,
-    NodeServiceImpl, SettingsServiceImpl, SharedContext, SharedServices,
+    DatabaseServiceImpl, DatabaseServices, EmbeddingsServiceImpl, ImportServiceImpl,
+    LocalAgentServiceImpl, NodeServiceImpl, SettingsServiceImpl, SharedContext, SharedServices,
 };

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -19,7 +19,7 @@ use nodespace_daemon::services::embeddings_service::EmbeddingReady;
 use nodespace_daemon::tray::layer::TrayMetricsLayer;
 use nodespace_daemon::{
     build_base_router, build_shared_services, resolve_db_path, tray, BaseServices, DatabaseManager,
-    DatabaseServices, DbManagerLayer, SharedContext,
+    DatabaseServiceImpl, DatabaseServices, DbManagerLayer, SharedContext,
 };
 use tokio::sync::RwLock;
 use tonic::transport::Server;
@@ -210,6 +210,7 @@ async fn serve_headless() -> Result<()> {
         settings: shared.settings,
         local_agent: bundle.local_agent.clone(),
         embeddings: bundle.embeddings_service_grpc.clone(),
+        database: DatabaseServiceImpl::new(manager.clone()),
     };
     build_base_router(
         Server::builder().layer(DbManagerLayer::new(manager)),
@@ -267,6 +268,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
         settings: shared.settings,
         local_agent: bundle.local_agent.clone(),
         embeddings: bundle.embeddings_service_grpc.clone(),
+        database: DatabaseServiceImpl::new(manager.clone()),
     };
     build_base_router(
         Server::builder()
@@ -383,6 +385,7 @@ async fn serve_headless() -> Result<()> {
         settings: shared.settings,
         local_agent: bundle.local_agent.clone(),
         embeddings: bundle.embeddings_service_grpc.clone(),
+        database: DatabaseServiceImpl::new(manager.clone()),
     };
     build_base_router(
         Server::builder().layer(DbManagerLayer::new(manager)),
@@ -457,6 +460,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
         settings: shared.settings,
         local_agent: bundle.local_agent.clone(),
         embeddings: bundle.embeddings_service_grpc.clone(),
+        database: DatabaseServiceImpl::new(manager.clone()),
     };
     build_base_router(
         Server::builder()

--- a/packages/daemon/src/router.rs
+++ b/packages/daemon/src/router.rs
@@ -11,9 +11,10 @@ use tonic::transport::Server;
 use tower::Layer;
 
 use crate::{
-    AgentSessionHandler, AgentSessionServiceServer, EmbeddingsServiceImpl, EmbeddingsServiceServer,
-    ImportServiceImpl, ImportServiceServer, LocalAgentServiceImpl, LocalAgentServiceServer,
-    NodeServiceImpl, NodeServiceServer, SettingsServiceImpl, SettingsServiceServer,
+    AgentSessionHandler, AgentSessionServiceServer, DatabaseServiceImpl, DatabaseServiceServer,
+    EmbeddingsServiceImpl, EmbeddingsServiceServer, ImportServiceImpl, ImportServiceServer,
+    LocalAgentServiceImpl, LocalAgentServiceServer, NodeServiceImpl, NodeServiceServer,
+    SettingsServiceImpl, SettingsServiceServer,
 };
 
 /// All base service implementations required by a NodeSpace daemon.
@@ -29,6 +30,9 @@ pub struct BaseServices {
     pub local_agent: LocalAgentServiceImpl,
     /// `None` only when no NLP model file exists at daemon startup.
     pub embeddings: Option<EmbeddingsServiceImpl>,
+    /// Registry manager for the daemon's local databases (ADR-053). Process-global
+    /// (not routed): it operates on the registry itself, not a single database.
+    pub database: DatabaseServiceImpl,
 }
 
 /// Build the base tonic router with all community services registered.
@@ -63,7 +67,8 @@ where
         .add_service(AgentSessionServiceServer::new(services.agent_session))
         .add_service(ImportServiceServer::new(services.import))
         .add_service(SettingsServiceServer::new(services.settings))
-        .add_service(LocalAgentServiceServer::new(services.local_agent));
+        .add_service(LocalAgentServiceServer::new(services.local_agent))
+        .add_service(DatabaseServiceServer::new(services.database));
 
     match services.embeddings {
         Some(emb) => router.add_service(EmbeddingsServiceServer::new(emb)),

--- a/packages/daemon/src/services/database_service.rs
+++ b/packages/daemon/src/services/database_service.rs
@@ -1,0 +1,314 @@
+//! tonic `DatabaseService` implementation — the client-facing registry manager
+//! for the daemon's local databases (ADR-053: "One Daemon, Multiple Local
+//! Databases").
+//!
+//! Unlike the per-database services (nodes, agents, import, ...), this service
+//! is process-global: it operates on the [`DatabaseManager`] registry itself
+//! rather than on any one open database, so it is not routed by the
+//! `x-ns-database-id` header. It is the reachable path clients use to list,
+//! create, register, remove, rename, and choose the default database that
+//! header-less requests fall back to.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use crate::nodespace::database_service_server::DatabaseService as GrpcDatabaseService;
+use crate::nodespace::{
+    CreateDatabaseRequest, DatabaseInfo, DatabaseStatus as ProtoDatabaseStatus,
+    ListDatabasesRequest, ListDatabasesResponse, RegisterDatabaseRequest, RemoveDatabaseRequest,
+    RemoveDatabaseResponse, RenameDatabaseRequest, SetDefaultDatabaseRequest,
+};
+use crate::services::database_manager::{
+    DatabaseId, DatabaseListing, DatabaseManager, DatabaseStatus,
+};
+
+/// gRPC `DatabaseService` backed by the shared [`DatabaseManager`].
+#[derive(Clone)]
+pub struct DatabaseServiceImpl {
+    manager: Arc<DatabaseManager>,
+}
+
+impl DatabaseServiceImpl {
+    pub fn new(manager: Arc<DatabaseManager>) -> Self {
+        Self { manager }
+    }
+
+    /// Build the proto `DatabaseInfo` for `id` from a fresh registry snapshot.
+    ///
+    /// Every mutating RPC re-reads the snapshot through this so the returned
+    /// `status` and `is_default` reflect the write just applied (the manager's
+    /// mutators return the bare entry, not its derived runtime status).
+    async fn info_for(&self, id: &DatabaseId) -> Result<DatabaseInfo, Status> {
+        let snapshot = self.manager.list().await;
+        snapshot
+            .databases
+            .iter()
+            .find(|listing| &listing.entry.id == id)
+            .map(listing_to_info)
+            .ok_or_else(|| {
+                Status::internal(format!("database {id} missing from registry after write"))
+            })
+    }
+}
+
+/// Map a registry listing (entry + derived status + default flag) onto the proto
+/// `DatabaseInfo` response.
+fn listing_to_info(listing: &DatabaseListing) -> DatabaseInfo {
+    let entry = &listing.entry;
+    DatabaseInfo {
+        id: entry.id.to_string(),
+        name: entry.name.clone(),
+        path: entry.path.display().to_string(),
+        created_at: entry.created_at.to_rfc3339(),
+        last_opened_at: entry.last_opened_at.map(|t| t.to_rfc3339()),
+        is_default: listing.is_default,
+        status: proto_status(listing.status) as i32,
+    }
+}
+
+/// Translate the manager's runtime status enum into the generated proto enum.
+fn proto_status(status: DatabaseStatus) -> ProtoDatabaseStatus {
+    match status {
+        DatabaseStatus::Open => ProtoDatabaseStatus::Open,
+        DatabaseStatus::Closed => ProtoDatabaseStatus::Closed,
+        DatabaseStatus::Missing => ProtoDatabaseStatus::Missing,
+    }
+}
+
+#[tonic::async_trait]
+impl GrpcDatabaseService for DatabaseServiceImpl {
+    async fn list(
+        &self,
+        _request: Request<ListDatabasesRequest>,
+    ) -> Result<Response<ListDatabasesResponse>, Status> {
+        let snapshot = self.manager.list().await;
+        let databases = snapshot.databases.iter().map(listing_to_info).collect();
+        let default_database_id = snapshot
+            .default_database
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        Ok(Response::new(ListDatabasesResponse {
+            databases,
+            default_database_id,
+        }))
+    }
+
+    async fn create(
+        &self,
+        request: Request<CreateDatabaseRequest>,
+    ) -> Result<Response<DatabaseInfo>, Status> {
+        let req = request.into_inner();
+        let entry = self
+            .manager
+            .create(req.name, req.path.map(PathBuf::from))
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(self.info_for(&entry.id).await?))
+    }
+
+    async fn register(
+        &self,
+        request: Request<RegisterDatabaseRequest>,
+    ) -> Result<Response<DatabaseInfo>, Status> {
+        let req = request.into_inner();
+        let entry = self
+            .manager
+            .register(PathBuf::from(req.path))
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(self.info_for(&entry.id).await?))
+    }
+
+    async fn remove(
+        &self,
+        request: Request<RemoveDatabaseRequest>,
+    ) -> Result<Response<RemoveDatabaseResponse>, Status> {
+        let id = DatabaseId::from(request.into_inner().id);
+        self.manager
+            .remove(&id)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        Ok(Response::new(RemoveDatabaseResponse { id: id.to_string() }))
+    }
+
+    async fn set_default(
+        &self,
+        request: Request<SetDefaultDatabaseRequest>,
+    ) -> Result<Response<DatabaseInfo>, Status> {
+        let id = DatabaseId::from(request.into_inner().id);
+        self.manager
+            .set_default(&id)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        Ok(Response::new(self.info_for(&id).await?))
+    }
+
+    async fn rename(
+        &self,
+        request: Request<RenameDatabaseRequest>,
+    ) -> Result<Response<DatabaseInfo>, Status> {
+        let req = request.into_inner();
+        let id = DatabaseId::from(req.id);
+        self.manager
+            .rename(&id, req.name)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+        Ok(Response::new(self.info_for(&id).await?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::assembly::SharedContext;
+    use nodespace_agent::pty::PtySessionManager;
+    use nodespace_nlp_engine::EmbeddingService;
+    use tokio::sync::watch;
+
+    /// A model-less build context (mirrors `database_manager::tests`): with
+    /// `has_model = false` no embedding wiring runs, so the dropped watch sender
+    /// is harmless.
+    fn test_context() -> SharedContext {
+        let (_tx, model) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
+        SharedContext {
+            pty_manager: Arc::new(PtySessionManager::new()),
+            model,
+            has_model: false,
+        }
+    }
+
+    async fn service() -> (DatabaseServiceImpl, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = dir.path().join("databases.toml");
+        let manager = DatabaseManager::load(registry, test_context())
+            .await
+            .unwrap();
+        (DatabaseServiceImpl::new(Arc::new(manager)), dir)
+    }
+
+    #[tokio::test]
+    async fn create_list_set_default_rename_remove_round_trip() {
+        let (svc, dir) = service().await;
+
+        // Create two databases; the first becomes the default automatically.
+        let first = svc
+            .create(Request::new(CreateDatabaseRequest {
+                name: "First".into(),
+                path: Some(dir.path().join("first.db").display().to_string()),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(first.name, "First");
+        assert!(first.is_default);
+        // File not created until first open, so a freshly created entry is Missing.
+        assert_eq!(first.status, ProtoDatabaseStatus::Missing as i32);
+
+        let second = svc
+            .create(Request::new(CreateDatabaseRequest {
+                name: "Second".into(),
+                path: Some(dir.path().join("second.db").display().to_string()),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!second.is_default);
+
+        // List reports both, with the first as default.
+        let listed = svc
+            .list(Request::new(ListDatabasesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(listed.databases.len(), 2);
+        assert_eq!(listed.default_database_id, first.id);
+
+        // Switch the default to the second.
+        let now_default = svc
+            .set_default(Request::new(SetDefaultDatabaseRequest {
+                id: second.id.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(now_default.is_default);
+        let listed = svc
+            .list(Request::new(ListDatabasesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(listed.default_database_id, second.id);
+
+        // Rename the first; the label changes, the id does not.
+        let renamed = svc
+            .rename(Request::new(RenameDatabaseRequest {
+                id: first.id.clone(),
+                name: "Renamed".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(renamed.id, first.id);
+        assert_eq!(renamed.name, "Renamed");
+
+        // Remove the first; it drops out of the listing, second stays default.
+        let removed = svc
+            .remove(Request::new(RemoveDatabaseRequest {
+                id: first.id.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(removed.id, first.id);
+        let listed = svc
+            .list(Request::new(ListDatabasesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(listed.databases.len(), 1);
+        assert_eq!(listed.databases[0].id, second.id);
+    }
+
+    #[tokio::test]
+    async fn register_reports_missing_for_absent_file() {
+        let (svc, dir) = service().await;
+        let info = svc
+            .register(Request::new(RegisterDatabaseRequest {
+                path: dir.path().join("not-here.db").display().to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        // Registering never creates the file, so an absent target reports Missing.
+        assert_eq!(info.status, ProtoDatabaseStatus::Missing as i32);
+        assert!(info.is_default); // first registered → default
+    }
+
+    #[tokio::test]
+    async fn mutations_on_unknown_id_are_not_found() {
+        let (svc, _dir) = service().await;
+        let unknown = || "ZZZ-NOT-REGISTERED".to_string();
+
+        for status in [
+            svc.remove(Request::new(RemoveDatabaseRequest { id: unknown() }))
+                .await
+                .map(|_| ())
+                .unwrap_err(),
+            svc.set_default(Request::new(SetDefaultDatabaseRequest { id: unknown() }))
+                .await
+                .map(|_| ())
+                .unwrap_err(),
+            svc.rename(Request::new(RenameDatabaseRequest {
+                id: unknown(),
+                name: "x".into(),
+            }))
+            .await
+            .map(|_| ())
+            .unwrap_err(),
+        ] {
+            assert_eq!(status.code(), tonic::Code::NotFound);
+        }
+    }
+}

--- a/packages/daemon/src/services/mod.rs
+++ b/packages/daemon/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod agent_session_service;
 pub mod assembly;
 pub mod capture_service;
 pub mod database_manager;
+pub mod database_service;
 pub mod embeddings_service;
 pub mod import_service;
 pub mod local_agent_service;
@@ -21,6 +22,7 @@ pub use database_manager::{
     DatabaseEntry, DatabaseId, DatabaseListing, DatabaseManager, DatabaseStatus, Registry,
     RegistrySnapshot,
 };
+pub use database_service::DatabaseServiceImpl;
 pub use embeddings_service::{EmbeddingReady, EmbeddingsServiceImpl};
 pub use import_service::ImportServiceImpl;
 pub use local_agent_service::LocalAgentServiceImpl;

--- a/packages/daemon/tests/database_service_e2e.rs
+++ b/packages/daemon/tests/database_service_e2e.rs
@@ -1,0 +1,206 @@
+//! End-to-end gRPC test for the `DatabaseService` registry manager and
+//! per-request database routing (ADR-053: "One Daemon, Multiple Local
+//! Databases").
+//!
+//! Unlike the unit tests (which call handlers directly with a manager injected
+//! into request extensions), this drives the *real* tonic transport: the
+//! `DbManagerLayer` must inject the `DatabaseManager` into each request over the
+//! wire, `DatabaseService.Create` must register a second database, and a
+//! subsequent `NodeService` write carrying the `x-ns-database-id` header must
+//! land in that second database — invisible to the default. This is the
+//! user-visible path that makes multi-database routing reachable.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nodespace_agent::pty::PtySessionManager;
+use nodespace_daemon::nodespace::DatabaseStatus as ProtoDatabaseStatus;
+use nodespace_daemon::nodespace::{
+    CreateDatabaseRequest, CreateNodeRequest, GetNodeRequest, ListDatabasesRequest,
+};
+use nodespace_daemon::{
+    DatabaseManager, DatabaseServiceClient, DatabaseServiceImpl, DatabaseServiceServer,
+    DbManagerLayer, NodeServiceClient, NodeServiceServer, SharedContext, DATABASE_ID_HEADER,
+};
+use nodespace_nlp_engine::EmbeddingService;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, watch};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Channel;
+use tonic::{Code, Request};
+
+/// A model-less build context — with `has_model = false` no embedding wiring
+/// runs, so the dropped watch sender is harmless (it is never read).
+fn test_context() -> SharedContext {
+    let (_tx, model) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
+    SharedContext {
+        pty_manager: Arc::new(PtySessionManager::new()),
+        model,
+        has_model: false,
+    }
+}
+
+/// Attach the `x-ns-database-id` routing header to a request.
+fn with_db_header<T>(msg: T, id: &str) -> Request<T> {
+    let mut req = Request::new(msg);
+    req.metadata_mut()
+        .insert(DATABASE_ID_HEADER, MetadataValue::try_from(id).unwrap());
+    req
+}
+
+/// Spin up an in-process daemon serving `DatabaseService` + `NodeService` behind
+/// the `DbManagerLayer`, backed by a tempdir registry with one default database.
+async fn spawn() -> (
+    DatabaseServiceClient<Channel>,
+    NodeServiceClient<Channel>,
+    oneshot::Sender<()>,
+    TempDir,
+) {
+    let tempdir = TempDir::new().unwrap();
+    let registry_path = tempdir.path().join("databases.toml");
+    let default_db = tempdir.path().join("default.db");
+
+    let manager = Arc::new(
+        DatabaseManager::load(registry_path, test_context())
+            .await
+            .unwrap(),
+    );
+    let default_id = manager
+        .ensure_default_registered("Default".into(), default_db)
+        .await
+        .unwrap();
+    // Open the default through the manager and register that bundle's NodeService
+    // (exactly as the daemon boot path does) so the manager's cache is the served
+    // handle — no double-open.
+    let default_bundle = manager.get_or_open(&default_id).await.unwrap();
+    let node_default = default_bundle.node_service_grpc.clone();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let mgr = manager.clone();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .layer(DbManagerLayer::new(mgr.clone()))
+            .add_service(DatabaseServiceServer::new(DatabaseServiceImpl::new(mgr)))
+            .add_service(NodeServiceServer::new(node_default))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("server crashed");
+    });
+
+    let endpoint = format!("http://{addr}");
+    for _ in 0..50 {
+        if let Ok(db) = DatabaseServiceClient::connect(endpoint.clone()).await {
+            let node = NodeServiceClient::connect(endpoint.clone()).await.unwrap();
+            return (db, node, shutdown_tx, tempdir);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("failed to connect to in-process daemon");
+}
+
+#[tokio::test]
+async fn create_second_database_then_route_a_write_to_it() {
+    let (mut db, mut node, shutdown, tempdir) = spawn().await;
+
+    // The layer injects the manager over the wire → List is reachable and reports
+    // just the default database.
+    let listed = db.list(ListDatabasesRequest {}).await.unwrap().into_inner();
+    assert_eq!(listed.databases.len(), 1);
+    let default_id = listed.default_database_id.clone();
+    assert!(!default_id.is_empty());
+
+    // Register a second database via the service.
+    let second = db
+        .create(CreateDatabaseRequest {
+            name: "Second".into(),
+            path: Some(tempdir.path().join("second.db").display().to_string()),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!second.is_default);
+    let second_id = second.id.clone();
+
+    // Write a node addressed to the second database via the routing header.
+    let created = node
+        .create_node(with_db_header(
+            CreateNodeRequest {
+                node_type: "text".into(),
+                content: "only in the second database".into(),
+                parent_id: None,
+                properties: String::new(),
+                collection: None,
+                lifecycle_status: None,
+                id: None,
+                position: None,
+            },
+            &second_id,
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    let node_id = created.node_id.clone();
+    assert!(!node_id.is_empty());
+
+    // Visible from the second database...
+    let from_second = node
+        .get_node(with_db_header(
+            GetNodeRequest {
+                node_id: node_id.clone(),
+            },
+            &second_id,
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        from_second.node_data.unwrap().content,
+        "only in the second database"
+    );
+
+    // ...and invisible from the default database (header-less) — real isolation
+    // over the transport, not just at the routing layer.
+    let miss = node
+        .get_node(GetNodeRequest {
+            node_id: node_id.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(miss.code(), Code::NotFound);
+
+    // The routed write opened the second database: it now reports Open where it
+    // was Missing before, proving the write hit db2 and not the default.
+    let listed = db.list(ListDatabasesRequest {}).await.unwrap().into_inner();
+    assert_eq!(listed.databases.len(), 2);
+    let second_listed = listed.databases.iter().find(|d| d.id == second_id).unwrap();
+    assert_eq!(second_listed.status, ProtoDatabaseStatus::Open as i32);
+
+    // A header naming an unregistered database is rejected over the wire, never
+    // silently served from the default.
+    let rejected = node
+        .create_node(with_db_header(
+            CreateNodeRequest {
+                node_type: "text".into(),
+                content: "nowhere".into(),
+                parent_id: None,
+                properties: String::new(),
+                collection: None,
+                lifecycle_status: None,
+                id: None,
+                position: None,
+            },
+            "ZZZ-NOT-REGISTERED",
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(rejected.code(), Code::NotFound);
+
+    let _ = shutdown.send(());
+}


### PR DESCRIPTION
Part of the ADR-053 epic ("One Daemon, Multiple Local Databases", #1532). This adds the **client-facing `DatabaseService`** — the reachable path that makes the per-request database routing built in Stages 1–5 user-visible. Until now a client had no way to register a second database, so routing was exercised only in tests; production always resolved to the single default.

## What changed

- **`DatabaseServiceImpl`** (`services/database_service.rs`) wraps the existing `DatabaseManager` and implements the already-generated proto: `List` / `Create` / `Register` / `Remove` / `SetDefault` / `Rename`. The manager already had every method these need — this is the gRPC adapter over it.
- **Process-global, not routed.** Unlike the per-database services (nodes, import, embeddings, agent-session), this service operates on the registry itself, so it deliberately does *not* consult the `x-ns-database-id` header. Mutating RPCs re-read the registry snapshot to build the `DatabaseInfo` response, so `status`/`is_default` reflect the write just applied. Unknown-id mutations map to `NotFound`; create/register IO failures map to `Internal`.
- **Wired into `BaseServices` + `build_base_router` + all four serve loops**, cloning the `Arc<DatabaseManager>` already opened for the default database (no double-open).

## Cross-repo (ADR-043)

Adding `database` to `BaseServices` is the intended compile-time contract: `nodespaced-pro` must provide the impl when it bumps its core pin. That is a coordinated follow-up on the `nodespace-sync` side (bump pin + seed a manager with the active database); the Pro daemon installs no routing layer, so its data/sync path is unchanged and multi-database-under-one-cloud-session stays an explicit deferral.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p nodespace-daemon` — **51 lib** (+3 new `DatabaseService` unit tests) + all integration suites green.
- **New e2e** (`tests/database_service_e2e.rs`) drives the *real* tonic transport: the `DbManagerLayer` injects the manager over the wire → `Create` registers a second database → a header-routed `NodeService` write lands in it (visible **with** the header, `NotFound` **without** it — real isolation), the second database flips to `Open`, and an unregistered header is rejected.