### PR TITLE
ADR-053: stamp WatchNodes events with the serving database id

### DIFF
--- a/packages/daemon/src/services/assembly.rs
+++ b/packages/daemon/src/services/assembly.rs
@@ -119,6 +119,7 @@ pub async fn build_shared_services() -> Result<(SharedServices, Option<tokio::ta
 pub async fn build_database_services(
     db_path: &std::path::Path,
     shared: &SharedContext,
+    database_id: &str,
 ) -> Result<(DatabaseServices, Option<tokio::task::JoinHandle<()>>)> {
     if let Some(parent) = db_path.parent() {
         tokio::fs::create_dir_all(parent).await.with_context(|| {
@@ -145,7 +146,8 @@ pub async fn build_database_services(
 
     let node_service = Arc::new(node_service);
 
-    let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_state.clone());
+    let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_state.clone())
+        .with_database_id(database_id.to_string());
 
     // EmbeddingsService is only registered when a model file exists at startup
     // (the shared model). If the model appears later, the endpoint is absent

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -389,7 +389,7 @@ impl DatabaseManager {
         // Assemble the service set (opens SQLite, seeds schema) without holding
         // the `open` lock. The per-database embedding-wiring task is detached,
         // matching the boot path. `last_opened_at` bookkeeping is deferred.
-        let (services, _embed_task) = build_database_services(&path, &self.context)
+        let (services, _embed_task) = build_database_services(&path, &self.context, id.as_str())
             .await
             .with_context(|| format!("opening database {id}"))?;
         let services = Arc::new(services);

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -70,6 +70,10 @@ pub struct NodeServiceImpl {
     node_service: Arc<CoreNodeService>,
     /// Shared with EmbeddingsServiceImpl; populated by the background load task.
     embedding_state: Arc<RwLock<Option<EmbeddingReady>>>,
+    /// Registry id of the database this impl serves (ADR-053), stamped onto
+    /// `WatchNodes` events. Empty when the daemon serves a single unregistered
+    /// database (Pro daemon) or when the impl is constructed directly in tests.
+    database_id: String,
 }
 
 impl NodeServiceImpl {
@@ -80,7 +84,16 @@ impl NodeServiceImpl {
         Self {
             node_service,
             embedding_state,
+            database_id: String::new(),
         }
+    }
+
+    /// Tag this database's `WatchNodes` events with its registry id (ADR-053).
+    /// Set by [`crate::build_database_services`] when a database is opened
+    /// through the registry; left empty for the single-database Pro daemon.
+    pub fn with_database_id(mut self, database_id: String) -> Self {
+        self.database_id = database_id;
+        self
     }
 
     /// Resolve which database a request targets (ADR-053) and return that
@@ -1260,6 +1273,8 @@ impl GrpcNodeService for NodeServiceImpl {
         // outlives `&self` (it is returned to tonic and polled independently),
         // so it cannot borrow from the handler scope.
         let node_service = this.node_service.clone();
+        // The database this stream serves (ADR-053) — stamped onto every event.
+        let database_id = this.database_id.clone();
 
         let stream = async_stream::stream! {
             loop {
@@ -1272,7 +1287,10 @@ impl GrpcNodeService for NodeServiceImpl {
                         // future workload makes this hot, parallelize by
                         // dispatching translations to a bounded mpsc.
                         if let Some(event) = convert_domain_event(&envelope.event, &node_service).await {
-                            yield Ok(event);
+                            yield Ok(NodeEvent {
+                                event: Some(event),
+                                database_id: database_id.clone(),
+                            });
                         }
                     }
                     Err(RecvError::Lagged(skipped)) => {
@@ -1354,12 +1372,10 @@ pub(crate) fn node_to_proto(node: Node) -> NodeData {
 async fn convert_domain_event(
     event: &DomainEvent,
     node_service: &Arc<CoreNodeService>,
-) -> Option<NodeEvent> {
+) -> Option<NodeEventKind> {
     match event {
         DomainEvent::NodeCreated { node_id, .. } => match node_service.get_node(node_id).await {
-            Ok(Some(node)) => Some(NodeEvent {
-                event: Some(NodeEventKind::Created(node_to_proto(node))),
-            }),
+            Ok(Some(node)) => Some(NodeEventKind::Created(node_to_proto(node))),
             Ok(None) => {
                 tracing::debug!(node_id = %node_id, "NodeCreated event skipped: node already gone");
                 None
@@ -1369,40 +1385,32 @@ async fn convert_domain_event(
                 None
             }
         },
-        DomainEvent::NodeUpdated { node, .. } => Some(NodeEvent {
-            event: Some(NodeEventKind::Updated(node_to_proto(node.clone()))),
-        }),
-        DomainEvent::NodeDeleted { id, node_type } => Some(NodeEvent {
-            event: Some(NodeEventKind::Deleted(NodeDeleted {
-                node_id: id.clone(),
-                node_type: node_type.clone(),
-            })),
-        }),
-        DomainEvent::RelationshipCreated { relationship } => Some(NodeEvent {
-            event: Some(NodeEventKind::RelationshipCreated(relationship_to_proto(
-                relationship,
-            ))),
-        }),
-        DomainEvent::RelationshipUpdated { relationship } => Some(NodeEvent {
-            event: Some(NodeEventKind::RelationshipUpdated(relationship_to_proto(
-                relationship,
-            ))),
-        }),
+        DomainEvent::NodeUpdated { node, .. } => {
+            Some(NodeEventKind::Updated(node_to_proto(node.clone())))
+        }
+        DomainEvent::NodeDeleted { id, node_type } => Some(NodeEventKind::Deleted(NodeDeleted {
+            node_id: id.clone(),
+            node_type: node_type.clone(),
+        })),
+        DomainEvent::RelationshipCreated { relationship } => Some(
+            NodeEventKind::RelationshipCreated(relationship_to_proto(relationship)),
+        ),
+        DomainEvent::RelationshipUpdated { relationship } => Some(
+            NodeEventKind::RelationshipUpdated(relationship_to_proto(relationship)),
+        ),
         DomainEvent::RelationshipDeleted {
             id,
             from_id,
             to_id,
             relationship_type,
-        } => Some(NodeEvent {
-            event: Some(NodeEventKind::RelationshipDeleted(
-                RelationshipDeletedPayload {
-                    id: id.clone(),
-                    from_id: from_id.clone(),
-                    to_id: to_id.clone(),
-                    relationship_type: relationship_type.clone(),
-                },
-            )),
-        }),
+        } => Some(NodeEventKind::RelationshipDeleted(
+            RelationshipDeletedPayload {
+                id: id.clone(),
+                from_id: from_id.clone(),
+                to_id: to_id.clone(),
+                relationship_type: relationship_type.clone(),
+            },
+        )),
     }
 }
 

--- a/packages/daemon/tests/database_service_e2e.rs
+++ b/packages/daemon/tests/database_service_e2e.rs
@@ -16,7 +16,8 @@ use std::time::Duration;
 use nodespace_agent::pty::PtySessionManager;
 use nodespace_daemon::nodespace::DatabaseStatus as ProtoDatabaseStatus;
 use nodespace_daemon::nodespace::{
-    CreateDatabaseRequest, CreateNodeRequest, GetNodeRequest, ListDatabasesRequest,
+    node_event::Event as NodeEventKind, CreateDatabaseRequest, CreateNodeRequest, GetNodeRequest,
+    ListDatabasesRequest, WatchRequest,
 };
 use nodespace_daemon::{
     DatabaseManager, DatabaseServiceClient, DatabaseServiceImpl, DatabaseServiceServer,
@@ -28,7 +29,28 @@ use tokio::net::TcpListener;
 use tokio::sync::{oneshot, watch};
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
-use tonic::{Code, Request};
+use tonic::{Code, Request, Streaming};
+
+/// Read from a `WatchNodes` stream until a `Created` event for `node_id`
+/// arrives (skipping any unrelated events), returning the whole envelope so the
+/// caller can assert its `database_id`. Bounded by a per-message timeout.
+async fn await_created(
+    stream: &mut Streaming<nodespace_daemon::nodespace::NodeEvent>,
+    node_id: &str,
+) -> String {
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), stream.message())
+            .await
+            .expect("timed out waiting for a watch event")
+            .expect("watch stream error")
+            .expect("watch stream closed");
+        if let Some(NodeEventKind::Created(ref data)) = event.event {
+            if data.id == node_id {
+                return event.database_id;
+            }
+        }
+    }
+}
 
 /// A model-less build context — with `has_model = false` no embedding wiring
 /// runs, so the dropped watch sender is harmless (it is never read).
@@ -201,6 +223,102 @@ async fn create_second_database_then_route_a_write_to_it() {
         .await
         .unwrap_err();
     assert_eq!(rejected.code(), Code::NotFound);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn watch_events_are_stamped_with_the_serving_database_id() {
+    let (mut db, node, shutdown, tempdir) = spawn().await;
+
+    let default_id = db
+        .list(ListDatabasesRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .default_database_id;
+
+    let second_id = db
+        .create(CreateDatabaseRequest {
+            name: "Second".into(),
+            path: Some(tempdir.path().join("second.db").display().to_string()),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .id;
+
+    // Open the watch streams BEFORE mutating so the events are observed. Each
+    // stream is routed to its database by the header (the default stream omits
+    // it). Separate client handles keep the streaming responses independent.
+    let mut watch_default = node.clone();
+    let mut default_stream = watch_default
+        .watch_nodes(Request::new(WatchRequest {
+            node_type: String::new(),
+            root_id: String::new(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let mut watch_second = node.clone();
+    let mut second_stream = watch_second
+        .watch_nodes(with_db_header(
+            WatchRequest {
+                node_type: String::new(),
+                root_id: String::new(),
+            },
+            &second_id,
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // A write routed to the second database → its watch event carries the second
+    // database's id, not the default's.
+    let mut writer = node.clone();
+    let in_second = writer
+        .create_node(with_db_header(
+            CreateNodeRequest {
+                node_type: "text".into(),
+                content: "second-db node".into(),
+                parent_id: None,
+                properties: String::new(),
+                collection: None,
+                lifecycle_status: None,
+                id: None,
+                position: None,
+            },
+            &second_id,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .node_id;
+    assert_eq!(
+        await_created(&mut second_stream, &in_second).await,
+        second_id
+    );
+
+    // A header-less write → the default stream stamps the default database's id.
+    let in_default = writer
+        .create_node(Request::new(CreateNodeRequest {
+            node_type: "text".into(),
+            content: "default-db node".into(),
+            parent_id: None,
+            properties: String::new(),
+            collection: None,
+            lifecycle_status: None,
+            id: None,
+            position: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .node_id;
+    assert_eq!(
+        await_created(&mut default_stream, &in_default).await,
+        default_id
+    );
 
     let _ = shutdown.send(());
 }

--- a/packages/proto/proto/node_service.proto
+++ b/packages/proto/proto/node_service.proto
@@ -267,6 +267,11 @@ message NodeEvent {
     RelationshipPayload relationship_updated = 5;
     RelationshipDeletedPayload relationship_deleted = 6;
   }
+  // ADR-053: the registered database this event came from, so a client watching
+  // a specific database can attribute events when the daemon serves several.
+  // Empty when the daemon serves a single unregistered database (Pro daemon) or
+  // in tests that construct the service directly.
+  string database_id = 7;
 }
 
 message NodeDeleted {


### PR DESCRIPTION
Part of the ADR-053 epic ("One Daemon, Multiple Local Databases", #1532). One of the two remaining acceptance criteria: **event streams carry `database_id`** so a client watching a specific database can attribute the events it receives when the daemon serves several.

## What changed
- **Proto:** `NodeEvent` gains an additive `string database_id = 7;` (sibling of the event oneof). Backward-compatible — existing consumers (the tauri watcher, the frontend) ignore it, so the community app is behaviorally unchanged.
- **`NodeServiceImpl`** gains a `database_id`, set via a **`with_database_id` builder**. `build_database_services` calls it with the registry id when a database is opened through the manager. **`NodeServiceImpl::new` is unchanged**, so the single-database Pro daemon (`nodespaced-pro` constructs it directly) and direct-construction unit tests keep an empty id and carry no cross-repo break.
- **Watch handler** stamps `this.database_id` (the routed database, resolved by the existing `route()`) onto every emitted event. `convert_domain_event` now returns the inner `NodeEventKind` so the id is applied at a single construction site.

Header-less/default watch streams carry the default database's id; a stream routed by `x-ns-database-id` carries that database's id.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p nodespace-daemon` — **51 lib + all integration suites** green.
- **e2e** (`database_service_e2e.rs`): opens watch streams on the default and a second database over the real transport, then routes a write to each and asserts each stream's `Created` event carries **its own** database id (default id for the header-less stream, the second id for the routed stream).

## Cross-repo
No constructor or `BaseServices` change — `nodespaced-pro` is unaffected and inherits the additive proto field transparently on its next pin bump.