### PR TITLE
ADR-053: stop injecting NODESPACED_DB_PATH from the daemon service definitions

### DIFF
--- a/packages/desktop-app/src-tauri/src/daemon_setup.rs
+++ b/packages/desktop-app/src-tauri/src/daemon_setup.rs
@@ -610,7 +610,6 @@ fn write_plist(home: &Path, plist_path: &Path, daemon_bin: &Path) -> Result<()> 
     let home_str = home.to_string_lossy();
     let bin_str = daemon_bin.to_string_lossy();
     let socket_path = xml_escape(&format!("{}/{}", home_str, daemon_socket_relative()));
-    let db_path = xml_escape(&format!("{}/{}/nodespace.db", home_str, DAEMON_DB_DIR));
     let log_out = xml_escape(&format!("{}/{}/nodespaced.log", home_str, DAEMON_LOG_DIR));
     let log_err = xml_escape(&format!(
         "{}/{}/nodespaced-error.log",
@@ -663,8 +662,6 @@ fn write_plist(home: &Path, plist_path: &Path, daemon_bin: &Path) -> Result<()> 
     <dict>
         <key>NODESPACED_SOCKET</key>
         <string>{socket}</string>
-        <key>NODESPACED_DB_PATH</key>
-        <string>{db}</string>
         <key>NODESPACE_UI_BINARY</key>
         <string>{ui_binary}</string>
 {pro_env}    </dict>
@@ -682,7 +679,6 @@ fn write_plist(home: &Path, plist_path: &Path, daemon_bin: &Path) -> Result<()> 
         label = label_escaped,
         bin = bin_escaped,
         socket = socket_path,
-        db = db_path,
         ui_binary = ui_binary,
         pro_env = pro_env,
         log_out = log_out,
@@ -798,7 +794,6 @@ fn write_systemd_service(home: &Path, service_path: &Path, daemon_bin: &Path) ->
     let home_str = home.to_string_lossy();
     let bin_str = daemon_bin.to_string_lossy();
     let socket_path = format!("{}/{}", home_str, daemon_socket_relative());
-    let db_path = format!("{}/{}/nodespace.db", home_str, DAEMON_DB_DIR);
     let log_out = format!("{}/{}/nodespaced.log", home_str, DAEMON_LOG_DIR);
     let log_err = format!("{}/{}/nodespaced-error.log", home_str, DAEMON_LOG_DIR);
 
@@ -825,7 +820,6 @@ fn write_systemd_service(home: &Path, service_path: &Path, daemon_bin: &Path) ->
          Type=simple\n\
          ExecStart={bin}\n\
          Environment=NODESPACED_SOCKET='{socket}'\n\
-         Environment=NODESPACED_DB_PATH='{db}'\n\
          Environment=NODESPACE_UI_BINARY='{ui_binary}'\n\
          StandardOutput=append:{log_out}\n\
          StandardError=append:{log_err}\n\
@@ -835,7 +829,6 @@ fn write_systemd_service(home: &Path, service_path: &Path, daemon_bin: &Path) ->
          WantedBy=default.target\n",
         bin = bin_str,
         socket = sq_escape(&socket_path),
-        db = sq_escape(&db_path),
         ui_binary = sq_escape(&ui_binary),
         log_out = log_out,
         log_err = log_err,


### PR DESCRIPTION
Part of the ADR-053 epic (#1532) — the first half of the final acceptance criterion ("remove `active_database_path` + plist `NODESPACED_DB_PATH` injection").

## What changed
The macOS launchd plist and the Linux systemd unit (`daemon_setup.rs`) injected `NODESPACED_DB_PATH` = `$HOME/.nodespace/database/nodespace.db` — the **exact path the daemon already derives in `resolve_db_path()` when the variable is unset**. Under ADR-053 the database registry is the source of truth for which database the daemon opens, so hard-coding the path in the service definition is redundant. This removes the injection from both service definitions.

## Safety
Verified the daemon's default (`resolve_db_path()` → `$HOME/.nodespace/database/nodespace.db`) is identical to the removed injected value, so **the database location does not change**. `NODESPACED_DB_PATH` remains honored when set (integration tests / alternate deployments still redirect storage via `test-support`), it is simply no longer injected by the packaged service definition.

## Scope note
The other half of the criterion — removing the vestigial `active_database_path` setting (the daemon never reads it for DB selection; its `select/reset-database` commands are effectively no-ops) and re-sourcing the Settings DB-path display from `DatabaseService.List` — is a separate focused change tracked on #1532, since it touches the settings proto + the tauri command layer + the frontend.