### PR TITLE
Remove vestigial active_database_path daemon setting (ADR-053)

### DIFF
--- a/packages/daemon/src/services/settings_service.rs
+++ b/packages/daemon/src/services/settings_service.rs
@@ -25,7 +25,6 @@ fn default_socket_path() -> String {
 /// On-disk representation of `~/.nodespace/daemon.toml`.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct DaemonConfig {
-    active_database_path: Option<String>,
     grpc_address: Option<String>,
     #[serde(default)]
     capture: CaptureConfig,
@@ -145,7 +144,6 @@ impl SettingsServiceImpl {
 
     fn config_to_response(config: &DaemonConfig) -> DaemonConfigResponse {
         DaemonConfigResponse {
-            active_database_path: config.active_database_path.clone().unwrap_or_default(),
             grpc_address: config
                 .grpc_address
                 .clone()
@@ -181,9 +179,6 @@ impl GrpcSettingsService for SettingsServiceImpl {
 
         let mut config = self.read_config().await?;
 
-        if !req.active_database_path.is_empty() {
-            config.active_database_path = Some(req.active_database_path);
-        }
         if !req.grpc_address.is_empty() {
             config.grpc_address = Some(req.grpc_address);
         }

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -1,15 +1,18 @@
 //! Settings commands for reading and updating app preferences.
 //!
-//! Daemon config (database path, gRPC address) is owned by `nodespaced` and
-//! fetched/updated via the `SettingsService` gRPC RPC.
+//! Daemon config (gRPC address) is owned by `nodespaced` and fetched/updated
+//! via the `SettingsService` gRPC RPC.
+//!
+//! The active database path is not daemon config — it is read from the
+//! `DatabaseService` registry (ADR-053: one daemon, multiple local
+//! databases), which is the source of truth for which database is default.
 //!
 //! Display preferences (theme, render_markdown) are UI-only state that remain
 //! in Tauri local storage and are never sent to the daemon.
 
 use crate::services::GrpcClient;
 use nodespace_proto::nodespace::{
-    GetCaptureSettingsRequest, GetDaemonConfigRequest, UpdateCaptureSettingsRequest,
-    UpdateDaemonConfigRequest,
+    GetCaptureSettingsRequest, ListDatabasesRequest, UpdateCaptureSettingsRequest,
 };
 use tauri::{AppHandle, Manager};
 
@@ -17,7 +20,8 @@ use tauri::{AppHandle, Manager};
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SettingsResponse {
-    /// Currently active database path (from daemon config via gRPC).
+    /// Path of the default registered database (from the DatabaseService
+    /// registry). Empty string if no default is set.
     pub active_database_path: String,
     /// Display preferences.
     pub display: DisplaySettingsResponse,
@@ -30,20 +34,10 @@ pub struct DisplaySettingsResponse {
     pub theme: String,
 }
 
-/// Result of a database path update.
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DatabaseUpdateResult {
-    pub new_path: String,
-    pub success: bool,
-    /// Whether the app needs a restart for the change to take effect.
-    pub restart_required: bool,
-}
-
 /// Get current app settings for the Settings UI.
 ///
-/// Daemon config (database path) is fetched via gRPC; display preferences
-/// are read from local Tauri storage.
+/// The default database path is fetched from the `DatabaseService` registry;
+/// display preferences are read from local Tauri storage.
 #[tauri::command]
 pub async fn get_settings(
     app: AppHandle,
@@ -51,15 +45,22 @@ pub async fn get_settings(
 ) -> Result<SettingsResponse, String> {
     let prefs = crate::preferences::load_preferences(&app).await?;
 
-    let mut client = grpc_client.settings_client().await;
-    let daemon_config = client
-        .get_daemon_config(GetDaemonConfigRequest {})
+    let mut client = grpc_client.database_service_client().await;
+    let listing = client
+        .list(ListDatabasesRequest {})
         .await
-        .map_err(|e| format!("Failed to fetch daemon config: {}", e))?
+        .map_err(|e| format!("Failed to list databases: {}", e))?
         .into_inner();
 
+    let active_database_path = listing
+        .databases
+        .iter()
+        .find(|db| db.is_default)
+        .map(|db| db.path.clone())
+        .unwrap_or_default();
+
     Ok(SettingsResponse {
-        active_database_path: daemon_config.active_database_path,
+        active_database_path,
         display: DisplaySettingsResponse {
             render_markdown: prefs.display.render_markdown,
             theme: prefs.display.theme,
@@ -107,46 +108,6 @@ pub async fn update_display_settings(
     }
 
     Ok(())
-}
-
-/// Open native folder picker and save the chosen database path to daemon config.
-///
-/// The change is persisted to `~/.nodespace/daemon.toml` via gRPC. The daemon
-/// must be restarted for the new path to take effect.
-#[tauri::command]
-pub async fn select_new_database(
-    app: tauri::AppHandle,
-    grpc_client: tauri::State<'_, GrpcClient>,
-) -> Result<DatabaseUpdateResult, String> {
-    use tauri_plugin_dialog::{DialogExt, FilePath};
-
-    let folder = app
-        .dialog()
-        .file()
-        .blocking_pick_folder()
-        .ok_or_else(|| "No folder selected".to_string())?;
-
-    let folder_path = match folder {
-        FilePath::Path(path) => path,
-        FilePath::Url(url) => std::path::PathBuf::from(url.path()),
-    };
-
-    let path_str = folder_path.to_string_lossy().to_string();
-
-    let mut client = grpc_client.settings_client().await;
-    client
-        .update_daemon_config(UpdateDaemonConfigRequest {
-            active_database_path: path_str.clone(),
-            grpc_address: String::new(),
-        })
-        .await
-        .map_err(|e| format!("Failed to update daemon config: {}", e))?;
-
-    Ok(DatabaseUpdateResult {
-        new_path: path_str,
-        success: true,
-        restart_required: true,
-    })
 }
 
 /// Restart the application with graceful GPU/background task shutdown.
@@ -242,26 +203,4 @@ fn str_to_content_level(s: &str) -> Result<i32, String> {
             other
         )),
     }
-}
-
-/// Reset database path to default by updating daemon config.
-///
-/// The daemon must be restarted for the change to take effect.
-#[tauri::command]
-pub async fn reset_database_to_default(
-    grpc_client: tauri::State<'_, GrpcClient>,
-) -> Result<String, String> {
-    let default_path = crate::preferences::get_default_database_path()?;
-    let path_str = default_path.to_string_lossy().to_string();
-
-    let mut client = grpc_client.settings_client().await;
-    client
-        .update_daemon_config(UpdateDaemonConfigRequest {
-            active_database_path: path_str.clone(),
-            grpc_address: String::new(),
-        })
-        .await
-        .map_err(|e| format!("Failed to reset daemon config: {}", e))?;
-
-    Ok(path_str)
 }

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -168,14 +168,6 @@ pub fn run() {
                 .accelerator("CmdOrCtrl+Shift+I")
                 .build(app)?;
 
-            let new_database = MenuItemBuilder::new("New Database...")
-                .id("new_database")
-                .build(app)?;
-
-            let open_database = MenuItemBuilder::new("Open Database...")
-                .id("open_database")
-                .build(app)?;
-
             let open_settings = MenuItemBuilder::new("Settings...")
                 .id("open_settings")
                 .accelerator("CmdOrCtrl+,")
@@ -185,7 +177,6 @@ pub fn run() {
                 .id("open_integrations")
                 .build(app)?;
 
-            let db_separator = PredefinedMenuItem::separator(app)?;
             let settings_separator = PredefinedMenuItem::separator(app)?;
             let integrations_separator = PredefinedMenuItem::separator(app)?;
 
@@ -210,9 +201,6 @@ pub fn run() {
 
             let file_menu = SubmenuBuilder::new(app, "File")
                 .items(&[
-                    &new_database,
-                    &open_database,
-                    &db_separator,
                     &import_submenu,
                     &settings_separator,
                     &open_settings,
@@ -399,8 +387,6 @@ pub fn run() {
             let toggle_status_bar_id = MenuId::new("toggle_status_bar");
             let quit_id = MenuId::new("quit");
             let import_folder_id = MenuId::new("import_folder");
-            let new_database_id = MenuId::new("new_database");
-            let open_database_id = MenuId::new("open_database");
             let open_settings_id = MenuId::new("open_settings");
             let open_integrations_id = MenuId::new("open_integrations");
 
@@ -421,10 +407,6 @@ pub fn run() {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.emit("menu-import-folder", ());
                     println!("Import folder requested from menu");
-                }
-            } else if *event.id() == new_database_id || *event.id() == open_database_id {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.emit("menu-select-database", ());
                 }
             } else if *event.id() == open_settings_id {
                 if let Some(window) = app.get_webview_window("main") {
@@ -520,9 +502,7 @@ pub fn run() {
             // Settings commands
             commands::settings::get_settings,
             commands::settings::update_display_settings,
-            commands::settings::select_new_database,
             commands::settings::restart_app,
-            commands::settings::reset_database_to_default,
             commands::settings::get_capture_settings,
             commands::settings::update_capture_settings,
             // Local agent commands

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use nodespace_proto::{
-    AgentSessionServiceClient, EmbeddingsServiceClient, ImportServiceClient,
+    AgentSessionServiceClient, DatabaseServiceClient, EmbeddingsServiceClient, ImportServiceClient,
     LocalAgentServiceClient, NodeServiceClient, SettingsServiceClient,
 };
 use tokio::sync::RwLock;
@@ -24,6 +24,7 @@ struct GrpcClientInner {
     embeddings: EmbeddingsServiceClient<Channel>,
     agent_session: AgentSessionServiceClient<Channel>,
     local_agent: LocalAgentServiceClient<Channel>,
+    database_service: DatabaseServiceClient<Channel>,
     /// Underlying transport channel — held so Pro-tier services can
     /// ride the same h2 connection via `GrpcClient::channel()`. One
     /// channel, multiple service surfaces. Opening a parallel channel
@@ -84,6 +85,7 @@ impl GrpcClient {
             embeddings: EmbeddingsServiceClient::new(channel.clone()),
             agent_session: AgentSessionServiceClient::new(channel.clone()),
             local_agent: LocalAgentServiceClient::new(channel.clone()),
+            database_service: DatabaseServiceClient::new(channel.clone()),
             channel,
         };
         Self {
@@ -146,6 +148,11 @@ impl GrpcClient {
     /// Borrow a clone of the `LocalAgentServiceClient`.
     pub async fn local_agent_client(&self) -> LocalAgentServiceClient<Channel> {
         self.inner.read().await.local_agent.clone()
+    }
+
+    /// Borrow a clone of the `DatabaseServiceClient`.
+    pub async fn database_service_client(&self) -> DatabaseServiceClient<Channel> {
+        self.inner.read().await.database_service.clone()
     }
 
     /// Clone of the underlying `tonic::transport::Channel`. Used by

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -233,7 +233,6 @@
     let unlistenMenu: Promise<() => void> | null = null;
     let unlistenStatusBar: Promise<() => void> | null = null;
     let unlistenImport: Promise<() => void> | null = null;
-    let unlistenDatabase: Promise<() => void> | null = null;
     let unlistenSettings: Promise<() => void> | null = null;
     let unlistenIntegrations: Promise<() => void> | null = null;
     let unlistenSkillCliMissing: Promise<() => void> | null = null;
@@ -404,24 +403,6 @@
         }
       });
 
-      // Listen for database selection from menu — saves new path to daemon config,
-      // restart required for the change to take effect.
-      unlistenDatabase = listen('menu-select-database', async () => {
-        try {
-          const result = await invoke<{ newPath: string; success: boolean; restartRequired: boolean }>(
-            'select_new_database'
-          );
-          if (result.success) {
-            log.info('Database path saved:', result.newPath);
-            statusBar.success(`Database path saved — restart to apply: ${result.newPath}`);
-          }
-        } catch (err) {
-          if (err !== 'No folder selected') {
-            log.error('Database selection failed:', err);
-          }
-        }
-      });
-
       // Listen for settings menu — open or focus settings tab
       unlistenSettings = listen('menu-open-settings', () => {
         const state = navigationStore.state;
@@ -586,9 +567,6 @@
       }
       if (unlistenImport) {
         (await unlistenImport)();
-      }
-      if (unlistenDatabase) {
-        (await unlistenDatabase)();
       }
       if (unlistenSettings) {
         (await unlistenSettings)();

--- a/packages/desktop-app/src/lib/components/settings/sections/database-settings.svelte
+++ b/packages/desktop-app/src/lib/components/settings/sections/database-settings.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-    import { settingsStore, loadSettings } from '$lib/stores/settings.svelte';
-    import { invoke } from '@tauri-apps/api/core';
-    import { createLogger } from '$lib/utils/logger';
-    import { Button } from '$lib/components/ui/button';
-
-    const log = createLogger('DatabaseSettings');
-
-    let restartPending = $state(false);
+    import { settingsStore } from '$lib/stores/settings.svelte';
 </script>
 
 <div class="max-w-[600px]">
@@ -17,43 +10,5 @@
         <div class="text-foreground bg-muted rounded-[var(--radius)] break-all px-3 py-2 font-mono text-sm">
             {settingsStore.appSettings?.activeDatabasePath ?? 'Loading...'}
         </div>
-    </div>
-
-    {#if restartPending}
-        <div class="border-amber-500/30 bg-amber-500/10 text-amber-700 rounded-[var(--radius)] mb-4 border px-3 py-2 text-sm">
-            Restart required for the new database path to take effect.
-        </div>
-    {/if}
-
-    <div class="mt-4 flex gap-3">
-        <Button variant="secondary" onclick={async () => {
-            try {
-                const result = await invoke<{ newPath: string; success: boolean; restartRequired: boolean }>('select_new_database');
-                if (result.success) {
-                    await loadSettings();
-                    if (result.restartRequired) {
-                        restartPending = true;
-                    }
-                }
-            } catch (err) {
-                if (err !== 'No folder selected') {
-                    log.error('Database selection failed:', err);
-                }
-            }
-        }}>
-            Change Location...
-        </Button>
-
-        <Button variant="outline" onclick={async () => {
-            try {
-                await invoke<string>('reset_database_to_default');
-                await loadSettings();
-                restartPending = true;
-            } catch (err) {
-                log.error('Failed to reset database:', err);
-            }
-        }}>
-            Reset to Default
-        </Button>
     </div>
 </div>

--- a/packages/proto/proto/settings_service.proto
+++ b/packages/proto/proto/settings_service.proto
@@ -2,9 +2,12 @@ syntax = "proto3";
 
 package nodespace;
 
-// SettingsService exposes daemon-owned configuration (database path, gRPC
-// address, session capture) over gRPC so Tauri and CLI clients can read and
-// update config without direct file access.
+// SettingsService exposes daemon-owned configuration (gRPC address, session
+// capture) over gRPC so Tauri and CLI clients can read and update config
+// without direct file access.
+//
+// The active database path is owned by DatabaseService (ADR-053), not this
+// service — clients read it from the registry, not daemon.toml.
 //
 // Display preferences (theme, render_markdown) stay in Tauri local storage
 // and are NOT part of this service.
@@ -12,8 +15,8 @@ service SettingsService {
   // Read current daemon configuration.
   rpc GetDaemonConfig(GetDaemonConfigRequest) returns (DaemonConfigResponse);
 
-  // Persist updated daemon configuration. Changes take effect on the next
-  // daemon restart (database path) or immediately (gRPC address, next start).
+  // Persist updated daemon configuration. Takes effect on the next daemon
+  // start.
   rpc UpdateDaemonConfig(UpdateDaemonConfigRequest) returns (DaemonConfigResponse);
 
   // Read session capture settings.
@@ -27,15 +30,11 @@ service SettingsService {
 message GetDaemonConfigRequest {}
 
 message UpdateDaemonConfigRequest {
-  // New database path. Empty string means "no change".
-  string active_database_path = 1;
   // New gRPC bind address. Empty string means "no change".
   string grpc_address = 2;
 }
 
 message DaemonConfigResponse {
-  // Absolute path to the SurrealDB / RocksDB database directory.
-  string active_database_path = 1;
   // gRPC bind address the daemon is currently configured to use.
   string grpc_address = 2;
 }


### PR DESCRIPTION
## Summary

Final cleanup for the ADR-053 multi-database epic (#1532). The daemon never read `active_database_path` from `daemon.toml` — it resolves its database via the `DatabaseService` registry — so this field was vestigial and the Tauri commands that wrote it were no-ops. With the prior change that stopped injecting `NODESPACED_DB_PATH` from the service definitions (#1594), those commands became fully inert.

This removes the dead field and the dead command/UI surface while preserving the read-only database-path display, now sourced from the registry (the actual source of truth).

## Changes

- **Daemon** — remove `active_database_path` from `DaemonConfig`, `DaemonConfigResponse`, and the `UpdateDaemonConfig` handler (`settings_service.rs`) and from the `SettingsService` proto messages. `SettingsService` now owns only `grpc_address` + capture settings.
- **Tauri** — delete the no-op `select_new_database` / `reset_database_to_default` commands, their `invoke_handler` registrations, and the File-menu items/handler that only ever called them. `get_settings` now sources `SettingsResponse.active_database_path` from `DatabaseService.List`'s default entry via a new `GrpcClient::database_service_client()` accessor — the response field name is unchanged, so the Settings and Diagnostics path displays render exactly as before.
- **Frontend** — remove the "Change Location…" / "Reset to Default" buttons from the Database settings section and the `menu-select-database` event listener that invoked them. The read-only "Active Database Path" display is kept.

## Validation

- `cargo fmt --check` clean; `cargo clippy` clean on `nodespace-daemon` and `nodespace-app`.
- `cargo test -p nodespace-daemon` — all pass, including the DatabaseService gRPC e2e (`create_second_database_then_route_a_write_to_it`, `watch_events_are_stamped_with_the_serving_database_id`) and the `settings_service` unit tests.
- `cargo check` on the Tauri crate (`nodespace-app`) compiles with sidecars built.
- Frontend `bun run test`: 3952/3952 pass (incl. `settings.test.ts`).
- Pre-push gate (`test:all` + `cargo build --bin nodespaced` + `test:e2e`) green.

Community build is behaviorally unchanged: the path display still works (registry-sourced); the only visible difference is the removal of the already-broken select/reset affordances.

This completes the final acceptance criterion of the ADR-053 epic.
