### PR TITLE
Desktop: live database switcher + client-side routing (ADR-053)

### DIFF
--- a/packages/daemon/src/db_routing.rs
+++ b/packages/daemon/src/db_routing.rs
@@ -22,10 +22,10 @@ use tower::{Layer, Service};
 use crate::services::database_manager::DatabaseManager;
 
 /// The metadata/header key a client sets to target a specific registered
-/// database. Absent → the default database (single-database clients are
-/// unchanged); present but unregistered → the handler rejects the request
-/// rather than silently serving the default (no cross-database leak).
-pub const DATABASE_ID_HEADER: &str = "x-ns-database-id";
+/// database. Re-exported from the wire-contract crate so the daemon and every
+/// client share one canonical key; see [`nodespace_proto::DATABASE_ID_HEADER`]
+/// for the full semantics.
+pub use nodespace_proto::DATABASE_ID_HEADER;
 
 /// `tower::Layer` that inserts the shared [`Arc<DatabaseManager>`] into each
 /// request's extensions. See the module docs for why this is core-only and

--- a/packages/desktop-app/src-tauri/src/commands/database.rs
+++ b/packages/desktop-app/src-tauri/src/commands/database.rs
@@ -1,0 +1,172 @@
+//! Tauri commands for the daemon's registry of local databases (ADR-053:
+//! "One Daemon, Multiple Local Databases").
+//!
+//! Thin wrappers over `DatabaseService` plus the desktop-local "which database
+//! am I viewing" selection. The registry operations (list/create/register/
+//! rename/remove/set-default) are global to the daemon and never routed;
+//! `set_active_database` is a purely local selection that stamps the routing
+//! header on the data-plane clients without touching the daemon-wide default.
+
+use crate::services::GrpcClient;
+use nodespace_proto::nodespace::{
+    CreateDatabaseRequest, DatabaseInfo, DatabaseStatus, ListDatabasesRequest,
+    RegisterDatabaseRequest, RemoveDatabaseRequest, RenameDatabaseRequest,
+    SetDefaultDatabaseRequest,
+};
+
+/// A registered database as surfaced to the frontend (camelCase).
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseEntry {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub is_default: bool,
+    /// "closed" | "open" | "missing" | "unknown".
+    pub status: String,
+    pub created_at: String,
+    pub last_opened_at: Option<String>,
+}
+
+/// The full registry listing plus the daemon-wide default id.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseListing {
+    pub databases: Vec<DatabaseEntry>,
+    /// Identifier of the daemon-wide default database; empty when none is set.
+    pub default_database_id: String,
+}
+
+/// Human-readable name for a `DatabaseStatus` enum value.
+fn status_str(status: i32) -> String {
+    match DatabaseStatus::try_from(status) {
+        Ok(DatabaseStatus::Closed) => "closed",
+        Ok(DatabaseStatus::Open) => "open",
+        Ok(DatabaseStatus::Missing) => "missing",
+        Err(_) => "unknown",
+    }
+    .to_string()
+}
+
+fn to_entry(info: DatabaseInfo) -> DatabaseEntry {
+    DatabaseEntry {
+        id: info.id,
+        name: info.name,
+        path: info.path,
+        is_default: info.is_default,
+        status: status_str(info.status),
+        created_at: info.created_at,
+        last_opened_at: info.last_opened_at,
+    }
+}
+
+/// List every registered database and identify the daemon-wide default.
+#[tauri::command]
+pub async fn list_databases(
+    grpc_client: tauri::State<'_, GrpcClient>,
+) -> Result<DatabaseListing, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let listing = client
+        .list(ListDatabasesRequest {})
+        .await
+        .map_err(|e| format!("Failed to list databases: {}", e))?
+        .into_inner();
+
+    Ok(DatabaseListing {
+        databases: listing.databases.into_iter().map(to_entry).collect(),
+        default_database_id: listing.default_database_id,
+    })
+}
+
+/// Create a brand-new database and register it. When `path` is omitted the
+/// daemon places the file under its managed database directory.
+#[tauri::command]
+pub async fn create_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    name: String,
+    path: Option<String>,
+) -> Result<DatabaseEntry, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let info = client
+        .create(CreateDatabaseRequest { name, path })
+        .await
+        .map_err(|e| format!("Failed to create database: {}", e))?
+        .into_inner();
+    Ok(to_entry(info))
+}
+
+/// Register an existing database file already present on disk.
+#[tauri::command]
+pub async fn register_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    path: String,
+) -> Result<DatabaseEntry, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let info = client
+        .register(RegisterDatabaseRequest { path })
+        .await
+        .map_err(|e| format!("Failed to register database: {}", e))?
+        .into_inner();
+    Ok(to_entry(info))
+}
+
+/// Set the daemon-wide default database (used when no database is selected).
+#[tauri::command]
+pub async fn set_default_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    id: String,
+) -> Result<DatabaseEntry, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let info = client
+        .set_default(SetDefaultDatabaseRequest { id })
+        .await
+        .map_err(|e| format!("Failed to set default database: {}", e))?
+        .into_inner();
+    Ok(to_entry(info))
+}
+
+/// Rename a registered database's human-facing label (does not move the file).
+#[tauri::command]
+pub async fn rename_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    id: String,
+    name: String,
+) -> Result<DatabaseEntry, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let info = client
+        .rename(RenameDatabaseRequest { id, name })
+        .await
+        .map_err(|e| format!("Failed to rename database: {}", e))?
+        .into_inner();
+    Ok(to_entry(info))
+}
+
+/// Unregister a database from the registry. This never deletes the underlying
+/// database file — it only removes the registry entry.
+#[tauri::command]
+pub async fn remove_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    id: String,
+) -> Result<String, String> {
+    let mut client = grpc_client.database_service_client().await;
+    let response = client
+        .remove(RemoveDatabaseRequest { id })
+        .await
+        .map_err(|e| format!("Failed to remove database: {}", e))?
+        .into_inner();
+    Ok(response.id)
+}
+
+/// Select which database the desktop app is viewing. Rebuilds the routed
+/// data-plane clients so subsequent node/import/embeddings/agent-session
+/// requests target `id` (or the daemon default when `id` is `None`), and
+/// signals the node-event watcher to re-subscribe. This is a desktop-local
+/// selection only — it does NOT change the daemon-wide default.
+#[tauri::command]
+pub async fn set_active_database(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    id: Option<String>,
+) -> Result<(), String> {
+    grpc_client.set_active_database(id).await;
+    Ok(())
+}

--- a/packages/desktop-app/src-tauri/src/commands/mod.rs
+++ b/packages/desktop-app/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@
 pub mod agent_session;
 pub mod chat_models;
 pub mod collections;
+pub mod database;
 pub mod embeddings;
 pub mod import;
 pub mod local_agent;

--- a/packages/desktop-app/src-tauri/src/commands/nodes.rs
+++ b/packages/desktop-app/src-tauri/src/commands/nodes.rs
@@ -16,11 +16,9 @@ use nodespace_proto::nodespace::{
     NodeData, NodeResponse, OptionalStringClear, OptionalTimestampClear, QueryNodesSimpleRequest,
     ReorderNodeRequest, UpdateNodeRequest, UpdateTaskNodeRequest, UpsertNodeWithParentRequest,
 };
-use nodespace_proto::NodeServiceClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::State;
-use tonic::transport::Channel;
 use tonic::Request;
 
 use crate::services::GrpcClient;
@@ -197,7 +195,7 @@ fn proto_node_response_to_node(resp: NodeResponse) -> Result<Node, CommandError>
 /// Validate that node type has a schema via gRPC GetSchemaDefinition RPC
 async fn validate_node_type(
     node_type: &str,
-    client: &mut NodeServiceClient<Channel>,
+    client: &mut crate::services::NodeClient,
 ) -> Result<(), CommandError> {
     match client
         .get_schema_definition(Request::new(GetSchemaDefinitionRequest {

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -110,20 +110,6 @@ pub async fn update_display_settings(
     Ok(())
 }
 
-/// Restart the application with graceful GPU/background task shutdown.
-///
-/// Without explicit cleanup, `app.restart()` calls `std::process::exit()` which
-/// triggers C++ destructors via `__cxa_finalize_ranges`. The Metal residency sets
-/// for the embedding model are still active, causing a SIGABRT assertion failure
-/// in `ggml_metal_rsets_free`.
-#[tauri::command]
-pub fn restart_app(app: tauri::AppHandle) {
-    tracing::info!("Restart requested, performing graceful shutdown...");
-    crate::graceful_shutdown(&app);
-    tracing::info!("Graceful shutdown complete, restarting app...");
-    app.restart();
-}
-
 // ---------------------------------------------------------------------------
 // Capture settings
 // ---------------------------------------------------------------------------

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -320,7 +320,9 @@ pub fn run() {
                     use tauri::Manager;
                     let grpc_client = (*app_handle.state::<crate::services::GrpcClient>()).clone();
                     let channel = grpc_client.channel().await;
-                    watcher::spawn(app_handle.clone(), session_token);
+                    // The watcher rides the shared client so its WatchNodes stream
+                    // targets the active database and re-subscribes on switch (ADR-053).
+                    watcher::spawn(app_handle.clone(), grpc_client.clone(), session_token);
                     // Subscribe to token stream for ai-chat node inference events.
                     commands::local_agent::start_token_stream_subscription(
                         app_handle.clone(),
@@ -502,9 +504,16 @@ pub fn run() {
             // Settings commands
             commands::settings::get_settings,
             commands::settings::update_display_settings,
-            commands::settings::restart_app,
             commands::settings::get_capture_settings,
             commands::settings::update_capture_settings,
+            // Local database registry commands (ADR-053)
+            commands::database::list_databases,
+            commands::database::create_database,
+            commands::database::register_database,
+            commands::database::set_default_database,
+            commands::database::rename_database,
+            commands::database::remove_database,
+            commands::database::set_active_database,
             // Local agent commands
             commands::local_agent::local_agent_status,
             commands::local_agent::local_agent_cancel_turn,

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -12,19 +12,97 @@ use std::sync::Arc;
 
 use nodespace_proto::{
     AgentSessionServiceClient, DatabaseServiceClient, EmbeddingsServiceClient, ImportServiceClient,
-    LocalAgentServiceClient, NodeServiceClient, SettingsServiceClient,
+    LocalAgentServiceClient, NodeServiceClient, SettingsServiceClient, DATABASE_ID_HEADER,
 };
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
+use tonic::metadata::{Ascii, MetadataValue};
+use tonic::service::interceptor::InterceptedService;
+use tonic::service::Interceptor;
 use tonic::transport::Channel;
 
+/// Stamps the ADR-053 `x-ns-database-id` routing header on every outgoing
+/// request so the daemon routes it to a specific local database.
+///
+/// Concrete (not a closure) so the intercepted client types stay nameable and
+/// aliasable — see [`NodeClient`] and friends. `database_id: None` stamps
+/// nothing, letting the daemon fall back to its default database; the variant
+/// is applied uniformly so a routed client's type is the same whether or not a
+/// database is currently selected. Mirrors the CLI's interceptor of the same
+/// name.
+#[derive(Clone)]
+pub struct DatabaseIdInterceptor {
+    // Some(id) → stamp header on every request; None → stamp nothing (daemon
+    // uses its default database).
+    database_id: Option<MetadataValue<Ascii>>,
+}
+
+impl DatabaseIdInterceptor {
+    /// No routing header — the daemon serves its default database.
+    pub fn none() -> Self {
+        Self { database_id: None }
+    }
+
+    /// Stamp `x-ns-database-id: <id>` on every request when `id` is `Some`.
+    /// `id` must be an already resolved registry identifier (ULID); the daemon
+    /// resolves the header as an id only, never a name. An id that is not a
+    /// valid gRPC header value falls back to no routing (default database)
+    /// rather than poisoning every subsequent request.
+    pub fn for_id(id: Option<&str>) -> Self {
+        let database_id = id.and_then(|id| match MetadataValue::try_from(id) {
+            Ok(value) => Some(value),
+            Err(_) => {
+                // A resolved ULID is always valid ASCII, so this should be
+                // unreachable — but log it rather than silently serving the
+                // default database, which would be a hard-to-spot wrong-database
+                // fallback.
+                tracing::warn!(
+                    "database id {id:?} is not a valid routing header; \
+                     falling back to the default database"
+                );
+                None
+            }
+        });
+        Self { database_id }
+    }
+}
+
+impl Interceptor for DatabaseIdInterceptor {
+    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        if let Some(id) = &self.database_id {
+            req.metadata_mut().insert(DATABASE_ID_HEADER, id.clone());
+        }
+        Ok(req)
+    }
+}
+
+/// A channel wrapped so every request carries the database routing header.
+pub type Intercepted = InterceptedService<Channel, DatabaseIdInterceptor>;
+/// `NodeService` client bound to the active database (ADR-053).
+pub type NodeClient = NodeServiceClient<Intercepted>;
+/// `ImportService` client bound to the active database.
+pub type ImportClient = ImportServiceClient<Intercepted>;
+/// `EmbeddingsService` client bound to the active database.
+pub type EmbeddingsClient = EmbeddingsServiceClient<Intercepted>;
+/// `AgentSessionService` client bound to the active database.
+pub type AgentSessionClient = AgentSessionServiceClient<Intercepted>;
+
 struct GrpcClientInner {
-    node: NodeServiceClient<Channel>,
-    import: ImportServiceClient<Channel>,
+    // Routed data-plane clients — rebuilt with a fresh interceptor whenever the
+    // active database changes so their requests carry the routing header. The
+    // daemon routes node/import/embeddings/agent_session by `x-ns-database-id`.
+    node: NodeClient,
+    import: ImportClient,
+    embeddings: EmbeddingsClient,
+    agent_session: AgentSessionClient,
+    // Unrouted clients — registry-global (database_service) or daemon-global
+    // (settings, local_agent); they never carry the routing header.
     settings: SettingsServiceClient<Channel>,
-    embeddings: EmbeddingsServiceClient<Channel>,
-    agent_session: AgentSessionServiceClient<Channel>,
     local_agent: LocalAgentServiceClient<Channel>,
     database_service: DatabaseServiceClient<Channel>,
+    /// The desktop-local "which database am I viewing" selection. `None` = the
+    /// daemon's default database. Distinct from the daemon-wide default set via
+    /// `DatabaseService::SetDefault`.
+    active_database_id: Option<String>,
     /// Underlying transport channel — held so Pro-tier services can
     /// ride the same h2 connection via `GrpcClient::channel()`. One
     /// channel, multiple service surfaces. Opening a parallel channel
@@ -41,6 +119,10 @@ struct GrpcClientInner {
 #[derive(Clone)]
 pub struct GrpcClient {
     inner: Arc<RwLock<GrpcClientInner>>,
+    /// Bumped by [`set_active_database`] on every switch so the node-event
+    /// watcher can re-open its `WatchNodes` stream against the newly-active
+    /// database. `watch::Sender` is not `Clone`, hence the `Arc`.
+    db_generation: Arc<watch::Sender<u64>>,
 }
 
 impl GrpcClient {
@@ -78,18 +160,31 @@ impl GrpcClient {
     /// Shared by [`connect`] and [`connect_lazy`] so the set of service clients
     /// stays in sync as new services are added. `Channel` is platform-agnostic.
     fn from_channel(channel: Channel) -> Self {
+        // No database selected initially → the routed clients carry an empty
+        // interceptor and requests fall back to the daemon's default database,
+        // exactly as before ADR-053 client routing existed.
+        let interceptor = DatabaseIdInterceptor::none();
         let inner = GrpcClientInner {
-            node: NodeServiceClient::new(channel.clone()),
-            import: ImportServiceClient::new(channel.clone()),
+            node: NodeServiceClient::with_interceptor(channel.clone(), interceptor.clone()),
+            import: ImportServiceClient::with_interceptor(channel.clone(), interceptor.clone()),
+            embeddings: EmbeddingsServiceClient::with_interceptor(
+                channel.clone(),
+                interceptor.clone(),
+            ),
+            agent_session: AgentSessionServiceClient::with_interceptor(
+                channel.clone(),
+                interceptor,
+            ),
             settings: SettingsServiceClient::new(channel.clone()),
-            embeddings: EmbeddingsServiceClient::new(channel.clone()),
-            agent_session: AgentSessionServiceClient::new(channel.clone()),
             local_agent: LocalAgentServiceClient::new(channel.clone()),
             database_service: DatabaseServiceClient::new(channel.clone()),
+            active_database_id: None,
             channel,
         };
+        let (db_generation, _) = watch::channel(0u64);
         Self {
             inner: Arc::new(RwLock::new(inner)),
+            db_generation: Arc::new(db_generation),
         }
     }
 
@@ -117,42 +212,84 @@ impl GrpcClient {
         Self::from_channel(channel)
     }
 
-    /// Borrow a clone of the `NodeServiceClient`.
-    pub async fn client(&self) -> NodeServiceClient<Channel> {
+    /// Borrow a clone of the routed `NodeService` client (carries the active
+    /// database's `x-ns-database-id` header).
+    pub async fn client(&self) -> NodeClient {
         self.inner.read().await.node.clone()
     }
 
-    /// Borrow a clone of the `ImportServiceClient`.
-    pub async fn import_client(&self) -> ImportServiceClient<Channel> {
+    /// Borrow a clone of the routed `ImportService` client.
+    pub async fn import_client(&self) -> ImportClient {
         self.inner.read().await.import.clone()
     }
 
-    /// Borrow a clone of the `SettingsServiceClient`.
+    /// Borrow a clone of the `SettingsServiceClient`. Settings are daemon-global
+    /// and never routed by database.
     pub async fn settings_client(&self) -> SettingsServiceClient<Channel> {
         self.inner.read().await.settings.clone()
     }
 
-    /// Borrow a clone of the `EmbeddingsServiceClient`.
+    /// Borrow a clone of the routed `EmbeddingsService` client.
     ///
     /// Embeddings are always available in the daemon (unlike the old in-process
     /// optional configuration), so this returns the client directly.
-    pub async fn embeddings_client(&self) -> EmbeddingsServiceClient<Channel> {
+    pub async fn embeddings_client(&self) -> EmbeddingsClient {
         self.inner.read().await.embeddings.clone()
     }
 
-    /// Borrow a clone of the `AgentSessionServiceClient`.
-    pub async fn agent_session_client(&self) -> AgentSessionServiceClient<Channel> {
+    /// Borrow a clone of the routed `AgentSessionService` client.
+    pub async fn agent_session_client(&self) -> AgentSessionClient {
         self.inner.read().await.agent_session.clone()
     }
 
-    /// Borrow a clone of the `LocalAgentServiceClient`.
+    /// Borrow a clone of the `LocalAgentServiceClient`. The local inference
+    /// model is a daemon-global resource and is never routed by database.
     pub async fn local_agent_client(&self) -> LocalAgentServiceClient<Channel> {
         self.inner.read().await.local_agent.clone()
     }
 
-    /// Borrow a clone of the `DatabaseServiceClient`.
+    /// Borrow a clone of the `DatabaseServiceClient`. The registry is global to
+    /// the daemon and is never routed by database.
     pub async fn database_service_client(&self) -> DatabaseServiceClient<Channel> {
         self.inner.read().await.database_service.clone()
+    }
+
+    /// Select which local database the routed data-plane clients target
+    /// (ADR-053). `Some(id)` stamps `x-ns-database-id: <id>` on every
+    /// node/import/embeddings/agent_session request; `None` clears the header
+    /// so requests route to the daemon's default database.
+    ///
+    /// Only the routed clients are rebuilt — over the SAME channel, so no
+    /// reconnection happens. `settings`/`local_agent`/`database_service` stay
+    /// unrouted. Bumps a generation counter so the node-event watcher re-opens
+    /// its `WatchNodes` stream against the newly-active database.
+    pub async fn set_active_database(&self, id: Option<String>) {
+        {
+            let mut inner = self.inner.write().await;
+            if inner.active_database_id == id {
+                return;
+            }
+            let interceptor = DatabaseIdInterceptor::for_id(id.as_deref());
+            let channel = inner.channel.clone();
+            inner.node = NodeServiceClient::with_interceptor(channel.clone(), interceptor.clone());
+            inner.import =
+                ImportServiceClient::with_interceptor(channel.clone(), interceptor.clone());
+            inner.embeddings =
+                EmbeddingsServiceClient::with_interceptor(channel.clone(), interceptor.clone());
+            inner.agent_session = AgentSessionServiceClient::with_interceptor(channel, interceptor);
+            inner.active_database_id = id;
+        }
+        // Signal the watcher (outside the lock) to re-subscribe to the new
+        // database's event stream.
+        self.db_generation.send_modify(|g| *g = g.wrapping_add(1));
+    }
+
+    /// Subscribe to active-database switches. The value is an opaque generation
+    /// counter bumped on every [`set_active_database`]; the node-event watcher
+    /// awaits changes to re-open its `WatchNodes` stream against the new
+    /// database.
+    pub fn subscribe_active_database(&self) -> watch::Receiver<u64> {
+        self.db_generation.subscribe()
     }
 
     /// Clone of the underlying `tonic::transport::Channel`. Used by

--- a/packages/desktop-app/src-tauri/src/services/mod.rs
+++ b/packages/desktop-app/src-tauri/src/services/mod.rs
@@ -1,5 +1,8 @@
 pub mod grpc_client;
 pub mod pro_client;
 
-pub use grpc_client::{GrpcClient, GrpcClientError};
+pub use grpc_client::{
+    AgentSessionClient, DatabaseIdInterceptor, EmbeddingsClient, GrpcClient, GrpcClientError,
+    ImportClient, NodeClient,
+};
 pub use pro_client::{ProClient, ProTier};

--- a/packages/desktop-app/src-tauri/src/watcher.rs
+++ b/packages/desktop-app/src-tauri/src/watcher.rs
@@ -12,61 +12,65 @@
 //!
 //! # Behavior
 //!
-//! - Opens a `WatchNodes` stream against the build-variant-scoped socket
-//!   (see `daemon_setup::daemon_socket_relative`), or the path from `NODESPACED_SOCKET`.
-//! - Translates each proto `NodeEvent` to a Tauri event (id + optional node_type).
+//! - Opens a `WatchNodes` stream over the shared [`GrpcClient`], so the stream
+//!   carries the active database's `x-ns-database-id` routing header (ADR-053)
+//!   and rides the same h2 connection as every other data-plane request.
+//! - Translates each proto `NodeEvent` to a Tauri event (id + optional
+//!   node_type + originating `database_id`).
 //! - On stream error or disconnection, reconnects with exponential backoff
 //!   starting at 1 second and capped at 30 seconds.
+//! - Re-opens the stream immediately when the active database is switched, so
+//!   it streams the newly-selected database's events.
 //! - Exits cleanly when the supplied cancellation token is cancelled.
 
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use nodespace_proto::nodespace::{node_event::Event as NodeEventKind, WatchRequest};
-use nodespace_proto::NodeServiceClient;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Runtime};
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 
+use crate::services::GrpcClient;
+
 /// Exponential backoff bounds for reconnection attempts.
 const BACKOFF_START: Duration = Duration::from_secs(1);
 const BACKOFF_MAX: Duration = Duration::from_secs(30);
 
-/// Frontend payload — must stay structurally identical to
-/// `services::domain_event_forwarder::NodeIdPayload` so Svelte stores see no
-/// difference between the in-process and gRPC event paths.
+/// Frontend payload for `node:created` / `node:updated` / `node:deleted`.
+/// `database_id` (ADR-053) lets the frontend drop events from a database it is
+/// no longer viewing — a belt-and-suspenders guard against events from a watch
+/// stream that was open across a database switch.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct NodeIdPayload {
     id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     node_type: Option<String>,
-}
-
-/// Resolve the daemon socket path. Honors `NODESPACED_SOCKET`, then falls back
-/// to the build-variant-scoped default (see daemon_setup::daemon_socket_relative).
-#[cfg(unix)]
-fn socket_path() -> std::path::PathBuf {
-    if let Ok(p) = std::env::var("NODESPACED_SOCKET") {
-        return std::path::PathBuf::from(p);
-    }
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join(crate::daemon_setup::daemon_socket_relative())
+    #[serde(skip_serializing_if = "String::is_empty")]
+    database_id: String,
 }
 
 /// Spawn the watcher as a Tokio task. Returns immediately; the task runs
 /// until `cancel_token` is cancelled or the process exits.
 #[cfg(not(unix))]
-pub fn spawn(_app: AppHandle, _cancel_token: tokio_util::sync::CancellationToken) {
+pub fn spawn(
+    _app: AppHandle,
+    _grpc_client: GrpcClient,
+    _cancel_token: tokio_util::sync::CancellationToken,
+) {
     // No-op on Windows — watcher uses Unix Domain Socket transport.
 }
 
 #[cfg(unix)]
-pub fn spawn(app: AppHandle, cancel_token: tokio_util::sync::CancellationToken) {
+pub fn spawn(
+    app: AppHandle,
+    grpc_client: GrpcClient,
+    cancel_token: tokio_util::sync::CancellationToken,
+) {
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = run(app, cancel_token).await {
+        if let Err(e) = run(app, grpc_client, cancel_token).await {
             error!("Node watcher exited with error: {e:#}");
         } else {
             info!("Node watcher exited cleanly");
@@ -85,10 +89,13 @@ pub fn spawn(app: AppHandle, cancel_token: tokio_util::sync::CancellationToken) 
 #[cfg(unix)]
 pub async fn run<R: Runtime>(
     app: AppHandle<R>,
+    grpc_client: GrpcClient,
     cancel_token: tokio_util::sync::CancellationToken,
 ) -> Result<()> {
-    let sock = socket_path();
-    info!("Node watcher starting (sock={})", sock.display());
+    info!("Node watcher starting");
+    // Bumped on every active-database switch (ADR-053) — a change interrupts the
+    // current stream so we re-open against the newly-selected database.
+    let mut db_changed = grpc_client.subscribe_active_database();
 
     let mut backoff = BACKOFF_START;
     loop {
@@ -98,7 +105,14 @@ pub async fn run<R: Runtime>(
                 info!("Node watcher received shutdown signal, exiting");
                 return Ok(());
             }
-            outcome = stream_once(&app, &sock) => {
+            _ = db_changed.changed() => {
+                // Active database switched — drop the current stream and re-open
+                // immediately (backoff reset) so the new database streams at once.
+                debug!("Active database switched; re-opening WatchNodes stream");
+                backoff = BACKOFF_START;
+                continue;
+            }
+            outcome = stream_once(&app, &grpc_client) => {
                 match outcome {
                     Ok(()) => {
                         // Server closed the stream cleanly — reconnect immediately
@@ -113,11 +127,15 @@ pub async fn run<R: Runtime>(
             }
         }
 
-        // Wait for backoff or shutdown, whichever comes first.
+        // Wait for backoff, a database switch, or shutdown — whichever is first.
         tokio::select! {
             _ = cancel_token.cancelled() => {
                 info!("Node watcher cancelled during backoff");
                 return Ok(());
+            }
+            _ = db_changed.changed() => {
+                debug!("Active database switched during backoff; reconnecting now");
+                backoff = BACKOFF_START;
             }
             _ = tokio::time::sleep(backoff) => {
                 backoff = (backoff * 2).min(BACKOFF_MAX);
@@ -126,25 +144,13 @@ pub async fn run<R: Runtime>(
     }
 }
 
-/// Open a single WatchNodes stream and forward events until the stream ends
-/// or errors. Returns `Ok(())` on clean stream end, `Err` on transport or
-/// stream error.
+/// Open a single WatchNodes stream over the shared client and forward events
+/// until the stream ends or errors. The client carries the active database's
+/// routing header, so the daemon serves only that database's events. Returns
+/// `Ok(())` on clean stream end, `Err` on transport or stream error.
 #[cfg(unix)]
-async fn stream_once<R: Runtime>(app: &AppHandle<R>, sock: &std::path::Path) -> Result<()> {
-    use hyper_util::rt::TokioIo;
-    use tokio::net::UnixStream;
-    use tonic::transport::{Endpoint, Uri};
-    use tower::service_fn;
-
-    let sock = sock.to_path_buf();
-    let channel = Endpoint::from_static("http://localhost")
-        .connect_with_connector(service_fn(move |_: Uri| {
-            let sock = sock.clone();
-            async move { UnixStream::connect(&sock).await.map(TokioIo::new) }
-        }))
-        .await
-        .with_context(|| "failed to connect to nodespaced")?;
-    let mut client = NodeServiceClient::new(channel);
+async fn stream_once<R: Runtime>(app: &AppHandle<R>, grpc_client: &GrpcClient) -> Result<()> {
+    let mut client = grpc_client.client().await;
 
     let mut stream = client
         .watch_nodes(WatchRequest::default())
@@ -164,6 +170,10 @@ async fn stream_once<R: Runtime>(app: &AppHandle<R>, sock: &std::path::Path) -> 
 
 /// Translate a proto `NodeEvent` into the corresponding Tauri event.
 fn forward<R: Runtime>(app: &AppHandle<R>, event: nodespace_proto::nodespace::NodeEvent) {
+    // The database this event originated from (ADR-053). Empty when the daemon
+    // serves a single unregistered database (Pro daemon) — the frontend guard
+    // treats an empty id as "always applies".
+    let database_id = event.database_id;
     let Some(kind) = event.event else {
         debug!("Received NodeEvent with no event variant; ignoring");
         return;
@@ -174,6 +184,7 @@ fn forward<R: Runtime>(app: &AppHandle<R>, event: nodespace_proto::nodespace::No
             let payload = NodeIdPayload {
                 id: data.id.clone(),
                 node_type: Some(data.node_type),
+                database_id,
             };
             if let Err(e) = app.emit("node:created", &payload) {
                 error!("Failed to emit node:created for {}: {e}", data.id);
@@ -190,6 +201,7 @@ fn forward<R: Runtime>(app: &AppHandle<R>, event: nodespace_proto::nodespace::No
             let payload = NodeIdPayload {
                 id: data.id,
                 node_type: None,
+                database_id,
             };
             if let Err(e) = app.emit("node:updated", &payload) {
                 error!("Failed to emit node:updated for {}: {e}", payload.id);
@@ -202,6 +214,7 @@ fn forward<R: Runtime>(app: &AppHandle<R>, event: nodespace_proto::nodespace::No
             let payload = NodeIdPayload {
                 id: d.node_id.clone(),
                 node_type: Some(d.node_type),
+                database_id,
             };
             if let Err(e) = app.emit("node:deleted", &payload) {
                 error!("Failed to emit node:deleted for {}: {e}", d.node_id);
@@ -212,14 +225,19 @@ fn forward<R: Runtime>(app: &AppHandle<R>, event: nodespace_proto::nodespace::No
         // `properties` arrives JSON-encoded on the wire (proto schema is
         // stable); re-parse it here before emitting so the frontend gets a
         // real object (the `has_child` listener reads `properties.order`).
-        NodeEventKind::RelationshipCreated(r) => emit_relationship(app, "relationship:created", r),
-        NodeEventKind::RelationshipUpdated(r) => emit_relationship(app, "relationship:updated", r),
+        NodeEventKind::RelationshipCreated(r) => {
+            emit_relationship(app, "relationship:created", r, database_id)
+        }
+        NodeEventKind::RelationshipUpdated(r) => {
+            emit_relationship(app, "relationship:updated", r, database_id)
+        }
         NodeEventKind::RelationshipDeleted(r) => {
             let payload = RelationshipDeletedOut {
                 id: r.id.clone(),
                 from_id: r.from_id,
                 to_id: r.to_id,
                 relationship_type: r.relationship_type,
+                database_id,
             };
             if let Err(e) = app.emit("relationship:deleted", &payload) {
                 error!("Failed to emit relationship:deleted for {}: {e}", r.id);
@@ -238,6 +256,8 @@ struct RelationshipPayloadOut {
     to_id: String,
     relationship_type: String,
     properties: serde_json::Value,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    database_id: String,
 }
 
 /// Frontend payload for `relationship:deleted` (no `properties` field).
@@ -248,12 +268,15 @@ struct RelationshipDeletedOut {
     from_id: String,
     to_id: String,
     relationship_type: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    database_id: String,
 }
 
 fn emit_relationship<R: Runtime>(
     app: &AppHandle<R>,
     name: &str,
     r: nodespace_proto::nodespace::RelationshipPayload,
+    database_id: String,
 ) {
     // `r.properties` arrives JSON-encoded as a string on the wire so
     // the proto schema stays stable across additions to the
@@ -281,6 +304,7 @@ fn emit_relationship<R: Runtime>(
         to_id: r.to_id,
         relationship_type: r.relationship_type,
         properties: props,
+        database_id,
     };
     if let Err(e) = app.emit(name, &payload) {
         error!("Failed to emit {name} for {}: {e}", r.id);

--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -118,19 +118,20 @@ impl Drop for SpawnedDaemon {
 /// `GrpcClient::connect()` (which resolves it internally; there is no
 /// per-call socket argument), `GrpcClient::connect_lazy()`, or a raw
 /// `EnvGuard::set` for a Tauri command that reads it directly (e.g.
-/// `check_daemon_status`, `watcher::run`). Without this mutex, two
+/// `check_daemon_status`). Without this mutex, two
 /// `#[tokio::test]`s running concurrently — the default — can interleave
 /// their env mutations, so one test's client ends up dialing whichever
 /// socket happened to be live at the moment its call actually resolved the
 /// env var, not the daemon its own test spawned. Held across `.await`
 /// points, so this must be a `tokio::sync::Mutex`, not `std::sync::Mutex`.
 ///
-/// `watcher::run` re-resolves `NODESPACED_SOCKET` itself (independently of
-/// `GrpcClient`) the moment its spawned task starts, which can be AFTER
-/// `connected_client`'s own `EnvGuard` has already restored the prior value.
-/// Tests that spawn the watcher must hold a guard from
-/// `hold_connect_mutex_and_socket_env` for the watcher's entire lifetime,
-/// not just through `connect()` — see `optimistic_echo_race_test.rs`.
+/// `watcher::run` no longer resolves `NODESPACED_SOCKET` itself — it rides the
+/// shared `GrpcClient` channel, which is built from the env var once at
+/// `GrpcClient::connect()` time. Tests that spawn the watcher must therefore
+/// hold a guard from `hold_connect_mutex_and_socket_env` across the
+/// `GrpcClient` connection (and, conservatively, for the watcher's lifetime)
+/// so the shared channel dials the daemon the test spawned — see
+/// `optimistic_echo_race_test.rs`.
 ///
 /// `pub` so every `tests/*.rs` file that mutates `NODESPACED_SOCKET` shares
 /// this ONE lock rather than each defining its own same-purpose mutex under
@@ -165,9 +166,10 @@ async fn connected_client(daemon: &SpawnedDaemon, timeout: Duration) -> GrpcClie
 
 /// Holds `CONNECT_MUTEX` AND keeps `NODESPACED_SOCKET` set to `daemon`'s
 /// socket for as long as the returned guard lives — for tests that spawn
-/// `watcher::run`, which re-resolves the env var independently of
-/// `GrpcClient` when its task actually starts running, not at `connect()`
-/// time. Drop the returned guard only after the watcher task has been
+/// `watcher::run`. The watcher rides the shared `GrpcClient` channel (built
+/// from the env var at `connect()` time), so keeping the socket env stable
+/// across the connection guarantees the channel dials the daemon the test
+/// spawned. Drop the returned guard only after the watcher task has been
 /// cancelled and joined.
 pub async fn hold_connect_mutex_and_socket_env(
     daemon: &SpawnedDaemon,

--- a/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
+++ b/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
@@ -94,16 +94,19 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
     let state = harness.client_state();
     let handle = harness.handle();
 
-    // watcher::run re-resolves NODESPACED_SOCKET itself when its task starts
-    // running, independently of the GrpcClient already connected above — so
-    // this guard must stay held for the watcher's entire lifetime, not just
-    // through connect(). Serializes this test against every other test in
-    // the binary that touches NODESPACED_SOCKET, which is the accepted cost
-    // of a real, unmockable process-global env dependency.
+    // The watcher rides the shared GrpcClient's channel (fixed to whatever
+    // socket NODESPACED_SOCKET resolved to at connect() time). Hold this guard
+    // for the watcher's lifetime anyway to serialize this test against every
+    // other test in the binary that touches the process-global NODESPACED_SOCKET
+    // env var while this test's daemon is the intended target.
     let _socket_guard = hold_connect_mutex_and_socket_env(&daemon).await;
 
     let cancel_token = CancellationToken::new();
-    let watcher_handle = tokio::spawn(watcher::run(handle.clone(), cancel_token.child_token()));
+    let watcher_handle = tokio::spawn(watcher::run(
+        handle.clone(),
+        (*state).clone(),
+        cancel_token.child_token(),
+    ));
     // Give the watcher a moment to open its WatchNodes stream before the
     // first write, so its echo isn't lost to a stream that hasn't opened yet.
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -186,7 +189,11 @@ async fn watcher_delivers_a_real_node_created_event() {
     let _socket_guard = hold_connect_mutex_and_socket_env(&daemon).await;
 
     let cancel_token = CancellationToken::new();
-    let watcher_handle = tokio::spawn(watcher::run(handle.clone(), cancel_token.child_token()));
+    let watcher_handle = tokio::spawn(watcher::run(
+        handle.clone(),
+        (*state).clone(),
+        cancel_token.child_token(),
+    ));
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let created: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));

--- a/packages/desktop-app/src/lib/components/layout/database-name-dialog.svelte
+++ b/packages/desktop-app/src/lib/components/layout/database-name-dialog.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import * as Dialog from '$lib/components/ui/dialog';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+
+  interface Props {
+    open: boolean;
+    title: string;
+    description?: string;
+    label: string;
+    confirmLabel: string;
+    placeholder?: string;
+    initialValue?: string;
+    onConfirm: (_name: string) => void;
+  }
+
+  let {
+    open = $bindable(false),
+    title,
+    description,
+    label,
+    confirmLabel,
+    placeholder = '',
+    initialValue = '',
+    onConfirm
+  }: Props = $props();
+
+  let name = $state('');
+  let inputRef = $state<HTMLInputElement | null>(null);
+
+  // Seed the field from initialValue each time the dialog opens (rename reuses
+  // the same instance for different databases).
+  $effect(() => {
+    if (open) {
+      name = initialValue;
+      // Focus after the dialog mounts its content.
+      setTimeout(() => inputRef?.select(), 0);
+    }
+  });
+
+  const trimmed = $derived(name.trim());
+  const canConfirm = $derived(trimmed.length > 0);
+
+  function confirm() {
+    if (!canConfirm) return;
+    onConfirm(trimmed);
+    open = false;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      confirm();
+    }
+  }
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>{title}</Dialog.Title>
+      {#if description}
+        <Dialog.Description>{description}</Dialog.Description>
+      {/if}
+    </Dialog.Header>
+
+    <div class="grid gap-2">
+      <label class="text-muted-foreground text-sm font-medium" for="database-name-input">
+        {label}
+      </label>
+      <Input
+        id="database-name-input"
+        bind:ref={inputRef}
+        bind:value={name}
+        {placeholder}
+        onkeydown={handleKeydown}
+      />
+    </div>
+
+    <Dialog.Footer>
+      <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+      <Button variant="default" disabled={!canConfirm} onclick={confirm}>{confirmLabel}</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/packages/desktop-app/src/lib/components/layout/database-switcher.svelte
+++ b/packages/desktop-app/src/lib/components/layout/database-switcher.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { open as openDialog } from '@tauri-apps/plugin-dialog';
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+  import DatabaseNameDialog from './database-name-dialog.svelte';
+  import { databaseStore, type DatabaseInfo } from '$lib/stores/database.svelte';
+  import { createLogger } from '$lib/utils/logger';
+  import Check from '@lucide/svelte/icons/check';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import HardDrive from '@lucide/svelte/icons/hard-drive';
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+  import Plus from '@lucide/svelte/icons/plus';
+  import FolderOpen from '@lucide/svelte/icons/folder-open';
+
+  const log = createLogger('DatabaseSwitcher');
+
+  let newDialogOpen = $state(false);
+
+  const databases = $derived(databaseStore.databases);
+  const activeDatabase = $derived(databaseStore.activeDatabase);
+  const activeName = $derived(activeDatabase?.name ?? 'Default Database');
+
+  onMount(() => {
+    databaseStore.load();
+  });
+
+  function selectDatabase(id: string) {
+    databaseStore.switchTo(id);
+  }
+
+  // Defer opening a dialog until after the menu has closed so focus management
+  // doesn't fight between the closing menu and the opening dialog.
+  function openNewDialog() {
+    setTimeout(() => (newDialogOpen = true), 0);
+  }
+
+  async function createDatabase(name: string) {
+    const entry = await databaseStore.create(name);
+    if (entry) {
+      await databaseStore.switchTo(entry.id);
+    }
+  }
+
+  async function openExisting() {
+    try {
+      const selected = await openDialog({
+        directory: false,
+        multiple: false,
+        title: 'Open an existing NodeSpace database'
+      });
+      if (typeof selected !== 'string') return;
+      const entry = await databaseStore.register(selected);
+      if (entry) {
+        await databaseStore.switchTo(entry.id);
+      }
+    } catch (err) {
+      log.error('Failed to open existing database', err);
+    }
+  }
+</script>
+
+<div class="db-switcher">
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger
+      class="db-trigger"
+      aria-label="Switch database (current: {activeName})"
+    >
+      {#if activeDatabase?.status === 'missing'}
+        <TriangleAlert class="db-glyph db-glyph-missing" />
+      {:else}
+        <HardDrive class="db-glyph" />
+      {/if}
+      <span class="db-name">{activeName}</span>
+      <ChevronDown class="db-chevron" />
+    </DropdownMenu.Trigger>
+
+    <DropdownMenu.Content class="w-[220px]" align="start">
+      {#each databases as db (db.id)}
+        {@render databaseRow(db)}
+      {/each}
+
+      <DropdownMenu.Separator />
+
+      <DropdownMenu.Item onSelect={openNewDialog}>
+        <Plus />
+        <span>New Database…</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item onSelect={openExisting}>
+        <FolderOpen />
+        <span>Open Database…</span>
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu.Root>
+</div>
+
+{#snippet databaseRow(db: DatabaseInfo)}
+  <DropdownMenu.Item onSelect={() => selectDatabase(db.id)}>
+    <span class="db-check" aria-hidden="true">
+      {#if db.id === databaseStore.activeDatabaseId}
+        <Check />
+      {/if}
+    </span>
+    {#if db.status === 'missing'}
+      <TriangleAlert class="db-glyph db-glyph-missing" />
+    {:else}
+      <HardDrive class="db-glyph" />
+    {/if}
+    <span class="db-row-name">{db.name}</span>
+    {#if db.isDefault}
+      <span class="db-default-badge">default</span>
+    {/if}
+  </DropdownMenu.Item>
+{/snippet}
+
+<DatabaseNameDialog
+  bind:open={newDialogOpen}
+  title="New Database"
+  description="Create a new local database. It opens immediately once created."
+  label="Name"
+  confirmLabel="Create"
+  placeholder="e.g. Work"
+  onConfirm={createDatabase}
+/>
+
+<style>
+  .db-switcher {
+    margin: 0 -1rem 0.5rem;
+    padding: 0 1rem;
+  }
+
+  :global(.db-trigger) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    height: 40px;
+    padding: 0 0.5rem;
+    background: none;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    color: hsl(var(--foreground));
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-align: left;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
+  }
+
+  :global(.db-trigger:hover) {
+    background: hsl(var(--border));
+  }
+
+  :global(.db-trigger .db-glyph) {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    color: hsl(var(--muted-foreground));
+  }
+
+  :global(.db-trigger .db-glyph-missing),
+  :global(.db-glyph-missing) {
+    color: hsl(var(--destructive));
+  }
+
+  .db-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.db-trigger .db-chevron) {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .db-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    flex-shrink: 0;
+  }
+
+  .db-row-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .db-default-badge {
+    font-size: 0.6875rem;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--muted));
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.25rem;
+    flex-shrink: 0;
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -11,6 +11,7 @@
   import { formatDateISO } from '$lib/utils/date-formatting.js';
   import { v4 as uuidv4 } from 'uuid';
   import CollectionSubPanel from './collection-sub-panel.svelte';
+  import DatabaseSwitcher from './database-switcher.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { schemasStore, schemasData } from '$lib/stores/schemas.svelte';
   import { clearCollectionRefreshTimer, clearSchemaRefreshTimer } from '$lib/utils/collection-refresh';
@@ -261,6 +262,12 @@
 
   <!-- Navigation items -->
   <div class="nav-items">
+    <!-- Database switcher (ADR-053) — sidebar header. Hidden when collapsed
+         since the trigger needs room for the database name. -->
+    {#if !isCollapsed}
+      <DatabaseSwitcher />
+    {/if}
+
     <!-- Daily Journal (first item) -->
     {#each navItems.slice(0, 1) as item}
       <button

--- a/packages/desktop-app/src/lib/components/settings/sections/database-settings.svelte
+++ b/packages/desktop-app/src/lib/components/settings/sections/database-settings.svelte
@@ -1,14 +1,187 @@
 <script lang="ts">
-    import { settingsStore } from '$lib/stores/settings.svelte';
+  import { onMount } from 'svelte';
+  import { open as openDialog } from '@tauri-apps/plugin-dialog';
+  import * as Dialog from '$lib/components/ui/dialog';
+  import { Button } from '$lib/components/ui/button';
+  import DatabaseNameDialog from '$lib/components/layout/database-name-dialog.svelte';
+  import { databaseStore, type DatabaseInfo } from '$lib/stores/database.svelte';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('DatabaseSettings');
+
+  const databases = $derived(databaseStore.databases);
+  const activeDatabaseId = $derived(databaseStore.activeDatabaseId);
+
+  let newDialogOpen = $state(false);
+  let renameDialogOpen = $state(false);
+  let renameTarget = $state<DatabaseInfo | null>(null);
+  let removeDialogOpen = $state(false);
+  let removeTarget = $state<DatabaseInfo | null>(null);
+
+  onMount(() => {
+    databaseStore.load();
+  });
+
+  function statusLabel(status: string): string {
+    switch (status) {
+      case 'open':
+        return 'Open';
+      case 'closed':
+        return 'Closed';
+      case 'missing':
+        return 'File missing';
+      default:
+        return 'Unknown';
+    }
+  }
+
+  async function createDatabase(name: string) {
+    const entry = await databaseStore.create(name);
+    if (entry) {
+      await databaseStore.switchTo(entry.id);
+    }
+  }
+
+  async function openExisting() {
+    try {
+      const selected = await openDialog({
+        directory: false,
+        multiple: false,
+        title: 'Open an existing NodeSpace database'
+      });
+      if (typeof selected !== 'string') return;
+      const entry = await databaseStore.register(selected);
+      if (entry) {
+        await databaseStore.switchTo(entry.id);
+      }
+    } catch (err) {
+      log.error('Failed to open existing database', err);
+    }
+  }
+
+  function startRename(db: DatabaseInfo) {
+    renameTarget = db;
+    renameDialogOpen = true;
+  }
+
+  async function confirmRename(name: string) {
+    if (renameTarget) {
+      await databaseStore.rename(renameTarget.id, name);
+    }
+  }
+
+  function startRemove(db: DatabaseInfo) {
+    removeTarget = db;
+    removeDialogOpen = true;
+  }
+
+  async function confirmRemove() {
+    if (removeTarget) {
+      await databaseStore.remove(removeTarget.id);
+    }
+    removeDialogOpen = false;
+    removeTarget = null;
+  }
+
+  function setDefault(db: DatabaseInfo) {
+    databaseStore.setDefault(db.id);
+  }
 </script>
 
-<div class="max-w-[600px]">
-    <h2 class="text-foreground mb-6 text-xl font-semibold">Database</h2>
-
-    <div class="mb-6">
-        <span class="text-muted-foreground mb-2 block text-sm font-medium">Active Database Path</span>
-        <div class="text-foreground bg-muted rounded-[var(--radius)] break-all px-3 py-2 font-mono text-sm">
-            {settingsStore.appSettings?.activeDatabasePath ?? 'Loading...'}
-        </div>
+<div class="max-w-[720px]">
+  <div class="mb-6 flex items-center justify-between">
+    <h2 class="text-foreground text-xl font-semibold">Databases</h2>
+    <div class="flex gap-2">
+      <Button variant="outline" size="sm" onclick={() => (newDialogOpen = true)}>New</Button>
+      <Button variant="outline" size="sm" onclick={openExisting}>Open existing…</Button>
     </div>
+  </div>
+
+  {#if databaseStore.error}
+    <div
+      class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-[var(--radius)] border px-3 py-2 text-sm"
+      role="alert"
+    >
+      {databaseStore.error}
+    </div>
+  {/if}
+
+  <div class="flex flex-col gap-2">
+    {#each databases as db (db.id)}
+      <div
+        class="border-border bg-muted/40 flex items-start justify-between gap-4 rounded-[var(--radius)] border p-3"
+      >
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="text-foreground truncate font-medium">{db.name}</span>
+            {#if db.isDefault}
+              <span
+                class="text-muted-foreground bg-muted rounded px-1.5 py-0.5 text-xs"
+                title="The daemon's default database"
+              >
+                default
+              </span>
+            {/if}
+            {#if db.id === activeDatabaseId}
+              <span
+                class="text-primary bg-primary/10 rounded px-1.5 py-0.5 text-xs"
+                title="Currently viewing"
+              >
+                active
+              </span>
+            {/if}
+          </div>
+          <div class="text-muted-foreground mt-1 break-all font-mono text-xs">{db.path}</div>
+          <div class="text-muted-foreground mt-1 text-xs">{statusLabel(db.status)}</div>
+        </div>
+
+        <div class="flex shrink-0 flex-col gap-1.5">
+          {#if !db.isDefault}
+            <Button variant="ghost" size="sm" onclick={() => setDefault(db)}>Set as default</Button>
+          {/if}
+          <Button variant="ghost" size="sm" onclick={() => startRename(db)}>Rename</Button>
+          <Button variant="ghost" size="sm" onclick={() => startRemove(db)}>Remove</Button>
+        </div>
+      </div>
+    {/each}
+
+    {#if databases.length === 0 && !databaseStore.loading}
+      <div class="text-muted-foreground text-sm">No databases registered.</div>
+    {/if}
+  </div>
 </div>
+
+<DatabaseNameDialog
+  bind:open={newDialogOpen}
+  title="New Database"
+  description="Create a new local database. It opens immediately once created."
+  label="Name"
+  confirmLabel="Create"
+  placeholder="e.g. Work"
+  onConfirm={createDatabase}
+/>
+
+<DatabaseNameDialog
+  bind:open={renameDialogOpen}
+  title="Rename Database"
+  label="Name"
+  confirmLabel="Rename"
+  initialValue={renameTarget?.name ?? ''}
+  onConfirm={confirmRename}
+/>
+
+<Dialog.Root bind:open={removeDialogOpen}>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>Remove database</Dialog.Title>
+      <Dialog.Description>
+        Remove <strong>{removeTarget?.name}</strong> from NodeSpace? This only unregisters it — the
+        database file on disk is NOT deleted, and you can re-add it later with “Open existing…”.
+      </Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Button variant="ghost" onclick={() => (removeDialogOpen = false)}>Cancel</Button>
+      <Button variant="destructive" onclick={confirmRemove}>Remove</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -2181,13 +2181,29 @@ export class SharedNodeStore {
   }
 
   /**
-   * Clear all nodes (for testing)
+   * Evict every cached node and its per-node metadata.
+   *
+   * Used both by tests and by the ADR-053 database hot-swap: switching the
+   * active local database must never leave the previous database's nodes
+   * visible. Clearing the reactive `nodes` map plus notifying subscribers makes
+   * consumers re-derive against the now-empty store and reload from the
+   * newly-active database. Component subscriptions themselves are preserved.
+   *
+   * Hot-swap callers must flush pending saves (`flushAllPendingSaves`) BEFORE
+   * switching the routed clients so in-flight writes land in the database they
+   * were made against, not the one being switched to.
    */
   clearAll(): void {
     this.nodesClear();
     this.versions.clear();
     this.pendingUpdates.clear();
     this.persistedNodeIds.clear();
+    this.serverConfirmedVersions.clear();
+    this.lastPersistedContent.clear();
+    this.batchedNotifications.clear();
+    this.activeBatches.clear();
+    this.pendingTreeLoads.clear();
+    this.resyncingNodes.clear();
     this.notifyAllSubscribers();
   }
 

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -32,6 +32,7 @@ import { registerSchemaPlugin, unregisterSchemaPlugin } from '$lib/plugins/schem
 import { applyHasChildCreated, applyHasChildUpdated, applyHasChildDeleted } from './hierarchy-sync';
 import { normalizeNodeData } from './node-normalize';
 import { proSync } from '$lib/stores/pro-sync.svelte';
+import { isActiveDatabaseEvent } from '$lib/stores/database.svelte';
 
 const log = createLogger('TauriSync');
 
@@ -202,6 +203,9 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     // Issue #724: Events now send only node_id, fetch full data if needed
     // Issue #832: node:created includes nodeType for reactive UI updates
     await listen<NodeEventData>('node:created', (event) => {
+      // ADR-053: drop events from a database we are no longer viewing (guards
+      // the race where a watch stream open across a switch delivers stale events).
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       log.debug(`Node created: ${event.payload.id} (type: ${event.payload.nodeType})`);
 
       // Issue #832: If a collection node is created, refresh collections sidebar
@@ -224,12 +228,14 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     });
 
     await listen<NodeEventData>('node:updated', (event) => {
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       const nodeId = event.payload.id;
       log.debug(`node:updated received`, { nodeId });
       queueOrFetchNode(nodeId, 'node:updated');
     });
 
-    await listen<{ id: string }>('node:deleted', (event) => {
+    await listen<NodeEventData>('node:deleted', (event) => {
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       log.debug(`Node deleted: ${event.payload.id}`);
       // Evict any coalesced re-fetch first so a delete racing an upsert in the
       // same window can't be clobbered by the queued fetch re-adding the node.
@@ -249,6 +255,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     // ========================================================================
 
     await listen<RelationshipEvent>('relationship:created', (event) => {
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       const rel = event.payload;
       log.debug(`Relationship created: ${rel.relationshipType} (${rel.fromId} -> ${rel.toId})`);
 
@@ -290,6 +297,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     });
 
     await listen<RelationshipEvent>('relationship:updated', (event) => {
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       const rel = event.payload;
       log.debug(`Relationship updated: ${rel.relationshipType} (${rel.fromId} -> ${rel.toId})`);
       if (rel.relationshipType === 'has_child') {
@@ -302,6 +310,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     });
 
     await listen<RelationshipDeletedPayload>('relationship:deleted', (event) => {
+      if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       const { id, fromId, toId, relationshipType } = event.payload;
       log.debug(`Relationship deleted: ${relationshipType} (${id}) from ${fromId} to ${toId}`);
 

--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -1,0 +1,234 @@
+import { invoke } from '@tauri-apps/api/core';
+import { createLogger } from '$lib/utils/logger';
+import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
+import { collectionsData } from '$lib/stores/collections.svelte';
+import { schemasData } from '$lib/stores/schemas.svelte';
+import {
+  clearAllTabs,
+  addTab,
+  DAILY_JOURNAL_TAB_ID,
+  DEFAULT_PANE_ID
+} from '$lib/stores/navigation.svelte';
+import { formatDateISO } from '$lib/utils/date-formatting';
+
+const log = createLogger('DatabaseStore');
+
+/**
+ * A registered local database as surfaced by the `list_databases` command
+ * (ADR-053: "One Daemon, Multiple Local Databases"). Mirrors the Rust
+ * `DatabaseEntry` (camelCase).
+ */
+export interface DatabaseInfo {
+  id: string;
+  name: string;
+  path: string;
+  isDefault: boolean;
+  /** "closed" | "open" | "missing" | "unknown". */
+  status: string;
+  createdAt: string;
+  lastOpenedAt: string | null;
+}
+
+interface DatabaseListing {
+  databases: DatabaseInfo[];
+  defaultDatabaseId: string;
+}
+
+/**
+ * Manages the daemon's registry of local databases and the desktop-local
+ * "which database am I viewing" selection.
+ *
+ * Switching flushes the frontend's per-database caches and resets the
+ * workspace so open viewers remount against the newly-active database; the
+ * daemon-side re-subscribe (driven by the `set_active_database` command) makes
+ * live node events stream from the new database.
+ */
+class DatabaseStore {
+  databases = $state<DatabaseInfo[]>([]);
+  /** The database the app is currently viewing. `null` until `load()` runs. */
+  activeDatabaseId = $state<string | null>(null);
+  /** The daemon-wide default (the header-less routing target). */
+  defaultDatabaseId = $state<string | null>(null);
+  loading = $state(false);
+  error = $state<string | null>(null);
+
+  /**
+   * Monotonic token bumped on every `switchTo`. A switch awaits (flush, then the
+   * `set_active_database` command), so a second switch fired before the first
+   * finishes would otherwise race — leaving `activeDatabaseId` and the routed
+   * client transiently pointed at different databases. Each continuation checks
+   * its captured token and bails if a newer switch superseded it, so the latest
+   * switch always wins cleanly.
+   */
+  private switchSeq = 0;
+
+  /** The database currently being viewed, or `null` if none is selected. */
+  get activeDatabase(): DatabaseInfo | null {
+    return this.databases.find((db) => db.id === this.activeDatabaseId) ?? null;
+  }
+
+  /**
+   * Load the registry. Initializes `activeDatabaseId` to the daemon default the
+   * first time (later loads preserve the current selection so a background
+   * refresh never yanks the user back to the default).
+   */
+  async load(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    try {
+      const listing = await invoke<DatabaseListing>('list_databases');
+      this.databases = listing.databases;
+      this.defaultDatabaseId = listing.defaultDatabaseId || null;
+
+      if (this.activeDatabaseId === null) {
+        // Prefer the daemon default; fall back to the first registered database
+        // so the switcher always shows a concrete selection.
+        this.activeDatabaseId =
+          this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
+      }
+    } catch (err) {
+      this.error = String(err);
+      log.error('Failed to load databases', err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Switch the active database. Flushes pending writes to the current database
+   * first (so they never land in the target), then re-points the routed
+   * clients, clears the frontend caches, and resets the workspace so viewers
+   * reload from the newly-active database.
+   */
+  async switchTo(id: string): Promise<void> {
+    if (id === this.activeDatabaseId) return;
+    this.error = null;
+    const seq = ++this.switchSeq;
+    try {
+      // Land any in-flight debounced saves in the database they were made
+      // against before the routed clients re-point.
+      await sharedNodeStore.flushAllPendingSaves();
+      // A newer switch superseded this one while we flushed — let it win.
+      if (seq !== this.switchSeq) return;
+
+      await invoke('set_active_database', { id });
+      if (seq !== this.switchSeq) return;
+      this.activeDatabaseId = id;
+
+      // Evict the previous database's cached data. NOTE: a read (e.g.
+      // loadChildren) dispatched against the previous database *before* this
+      // switch whose response resolves after this clear can still setNode its
+      // rows into the now-active store; such orphans are unreferenced by the
+      // new database's tree but may surface via global search until the next
+      // reload. Fully closing this needs per-request database tagging — tracked
+      // as follow-on hardening.
+      sharedNodeStore.clearAll();
+      structureTree.clear();
+
+      // Reset the workspace: open tabs referenced the previous database's
+      // nodes, so drop them and land on the new database's daily journal
+      // (a date page exists in every database). Remounting the viewer reloads
+      // its content from the now-active database.
+      clearAllTabs();
+      addTab(
+        {
+          id: DAILY_JOURNAL_TAB_ID,
+          title: 'Daily Journal',
+          type: 'node',
+          content: { nodeId: formatDateISO(new Date()), nodeType: 'date' },
+          closeable: true,
+          paneId: DEFAULT_PANE_ID
+        },
+        true
+      );
+
+      // Reload the sidebar from the new database.
+      collectionsData.loadCollections();
+      schemasData.loadSchemas();
+    } catch (err) {
+      this.error = String(err);
+      log.error('Failed to switch database', { id, error: err });
+    }
+  }
+
+  /**
+   * Create a brand-new database and register it, then refresh the list. When
+   * `path` is omitted the daemon places the file under its managed directory.
+   * Returns the new entry so callers can switch to it.
+   */
+  async create(name: string, path?: string): Promise<DatabaseInfo | null> {
+    return this.mutate(() =>
+      invoke<DatabaseInfo>('create_database', { name, path: path ?? null })
+    );
+  }
+
+  /** Register an existing database file already on disk, then refresh the list. */
+  async register(path: string): Promise<DatabaseInfo | null> {
+    return this.mutate(() => invoke<DatabaseInfo>('register_database', { path }));
+  }
+
+  /** Rename a registered database's label, then refresh the list. */
+  async rename(id: string, name: string): Promise<DatabaseInfo | null> {
+    return this.mutate(() => invoke<DatabaseInfo>('rename_database', { id, name }));
+  }
+
+  /** Set the daemon-wide default database, then refresh the list. */
+  async setDefault(id: string): Promise<DatabaseInfo | null> {
+    return this.mutate(() => invoke<DatabaseInfo>('set_default_database', { id }));
+  }
+
+  /**
+   * Unregister a database (never deletes the file), then refresh the list. If
+   * the removed database was the active one, fall back to the daemon default.
+   */
+  async remove(id: string): Promise<void> {
+    this.error = null;
+    try {
+      await invoke<string>('remove_database', { id });
+      await this.load();
+      if (this.activeDatabaseId === id) {
+        const fallback = this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
+        if (fallback) {
+          await this.switchTo(fallback);
+        } else {
+          this.activeDatabaseId = null;
+        }
+      }
+    } catch (err) {
+      this.error = String(err);
+      log.error('Failed to remove database', { id, error: err });
+    }
+  }
+
+  /** Run a registry mutation, refresh the list, and return the mutation result. */
+  private async mutate(
+    op: () => Promise<DatabaseInfo>
+  ): Promise<DatabaseInfo | null> {
+    this.error = null;
+    try {
+      const result = await op();
+      await this.load();
+      return result;
+    } catch (err) {
+      this.error = String(err);
+      log.error('Database registry operation failed', err);
+      return null;
+    }
+  }
+}
+
+export const databaseStore = new DatabaseStore();
+
+/**
+ * True when a `database_id` event envelope belongs to the active database.
+ * An empty id (single-database / Pro daemon) or an as-yet-unloaded selection
+ * always applies — the guard only drops events explicitly tagged for a
+ * different database, closing the race where a watch stream open across a
+ * switch delivers the previous database's events.
+ */
+export function isActiveDatabaseEvent(databaseId: string | undefined): boolean {
+  if (!databaseId) return true;
+  if (databaseStore.activeDatabaseId === null) return true;
+  return databaseId === databaseStore.activeDatabaseId;
+}

--- a/packages/desktop-app/src/lib/types/event-types.ts
+++ b/packages/desktop-app/src/lib/types/event-types.ts
@@ -27,6 +27,12 @@ export interface NodeEventData {
   id: string;
   /** Node type - included in node:created events for reactive UI updates */
   nodeType?: string;
+  /**
+   * ADR-053: the database this event originated from. Empty/absent when the
+   * daemon serves a single unregistered database. Lets the frontend drop events
+   * from a database it is no longer viewing.
+   */
+  databaseId?: string;
 }
 
 // ============================================================================
@@ -70,6 +76,8 @@ export interface RelationshipEvent {
   relationshipType: string;
   /** Type-specific properties (order for has_child, context for mentions, etc.) */
   properties: Record<string, unknown>;
+  /** ADR-053: the database this event originated from (see NodeEventData). */
+  databaseId?: string;
 }
 
 /**
@@ -82,6 +90,8 @@ export interface RelationshipDeletedPayload {
   fromId: string;
   toId: string;
   relationshipType: string;
+  /** ADR-053: the database this event originated from (see NodeEventData). */
+  databaseId?: string;
 }
 
 // ============================================================================

--- a/packages/desktop-app/src/tests/stores/database.test.ts
+++ b/packages/desktop-app/src/tests/stores/database.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+// Collaborators exercised by switchTo — stubbed so we can assert the flush →
+// switch → clear → reset → reload orchestration without their real behavior.
+const flushAllPendingSaves = vi.fn((..._a: unknown[]) => Promise.resolve(new Set<string>()));
+const clearAll = vi.fn((..._a: unknown[]) => undefined);
+vi.mock('$lib/services/shared-node-store.svelte', () => ({
+  sharedNodeStore: {
+    flushAllPendingSaves: (...a: unknown[]) => flushAllPendingSaves(...a),
+    clearAll: (...a: unknown[]) => clearAll(...a)
+  }
+}));
+
+const structureTreeClear = vi.fn((..._a: unknown[]) => undefined);
+vi.mock('$lib/stores/reactive-structure-tree.svelte', () => ({
+  structureTree: { clear: (...a: unknown[]) => structureTreeClear(...a) }
+}));
+
+const loadCollections = vi.fn((..._a: unknown[]) => undefined);
+vi.mock('$lib/stores/collections.svelte', () => ({
+  collectionsData: { loadCollections: (...a: unknown[]) => loadCollections(...a) }
+}));
+
+const loadSchemas = vi.fn((..._a: unknown[]) => undefined);
+vi.mock('$lib/stores/schemas.svelte', () => ({
+  schemasData: { loadSchemas: (...a: unknown[]) => loadSchemas(...a) }
+}));
+
+const clearAllTabs = vi.fn((..._a: unknown[]) => undefined);
+const addTab = vi.fn((..._a: unknown[]) => undefined);
+vi.mock('$lib/stores/navigation.svelte', () => ({
+  clearAllTabs: (...a: unknown[]) => clearAllTabs(...a),
+  addTab: (...a: unknown[]) => addTab(...a),
+  DAILY_JOURNAL_TAB_ID: 'daily-journal',
+  DEFAULT_PANE_ID: 'pane-1'
+}));
+
+vi.mock('$lib/utils/date-formatting', () => ({
+  formatDateISO: () => '2026-07-09'
+}));
+
+import {
+  databaseStore,
+  isActiveDatabaseEvent,
+  type DatabaseInfo
+} from '$lib/stores/database.svelte';
+
+function db(id: string, overrides: Partial<DatabaseInfo> = {}): DatabaseInfo {
+  return {
+    id,
+    name: `db-${id}`,
+    path: `/tmp/${id}.db`,
+    isDefault: false,
+    status: 'closed',
+    createdAt: '2026-01-01T00:00:00Z',
+    lastOpenedAt: null,
+    ...overrides
+  };
+}
+
+describe('Database Store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    databaseStore.databases = [];
+    databaseStore.activeDatabaseId = null;
+    databaseStore.defaultDatabaseId = null;
+    databaseStore.error = null;
+  });
+
+  describe('load', () => {
+    it('lists databases and initializes the active id to the default', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        databases: [db('a'), db('b', { isDefault: true })],
+        defaultDatabaseId: 'b'
+      });
+
+      await databaseStore.load();
+
+      expect(mockInvoke).toHaveBeenCalledWith('list_databases');
+      expect(databaseStore.databases).toHaveLength(2);
+      expect(databaseStore.activeDatabaseId).toBe('b');
+      expect(databaseStore.activeDatabase?.id).toBe('b');
+    });
+
+    it('falls back to the first database when no default is set', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        databases: [db('a'), db('b')],
+        defaultDatabaseId: ''
+      });
+
+      await databaseStore.load();
+
+      expect(databaseStore.activeDatabaseId).toBe('a');
+    });
+
+    it('preserves an existing selection across a refresh', async () => {
+      databaseStore.activeDatabaseId = 'a';
+      mockInvoke.mockResolvedValueOnce({
+        databases: [db('a'), db('b', { isDefault: true })],
+        defaultDatabaseId: 'b'
+      });
+
+      await databaseStore.load();
+
+      expect(databaseStore.activeDatabaseId).toBe('a');
+    });
+
+    it('records an error when the list fails', async () => {
+      mockInvoke.mockRejectedValueOnce(new Error('boom'));
+      await databaseStore.load();
+      expect(databaseStore.error).toContain('boom');
+    });
+  });
+
+  describe('switchTo', () => {
+    beforeEach(() => {
+      databaseStore.databases = [db('a'), db('b')];
+      databaseStore.activeDatabaseId = 'a';
+    });
+
+    it('flushes, switches, clears caches, resets tabs, and reloads', async () => {
+      mockInvoke.mockResolvedValueOnce(undefined); // set_active_database
+
+      await databaseStore.switchTo('b');
+
+      expect(flushAllPendingSaves).toHaveBeenCalledOnce();
+      expect(mockInvoke).toHaveBeenCalledWith('set_active_database', { id: 'b' });
+      expect(databaseStore.activeDatabaseId).toBe('b');
+      expect(clearAll).toHaveBeenCalledOnce();
+      expect(structureTreeClear).toHaveBeenCalledOnce();
+      expect(clearAllTabs).toHaveBeenCalledOnce();
+      expect(addTab).toHaveBeenCalledOnce();
+      expect(loadCollections).toHaveBeenCalledOnce();
+      expect(loadSchemas).toHaveBeenCalledOnce();
+    });
+
+    it('no-ops when switching to the already-active database', async () => {
+      await databaseStore.switchTo('a');
+      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(clearAll).not.toHaveBeenCalled();
+    });
+
+    it('flushes pending saves BEFORE re-pointing the routed clients', async () => {
+      const order: string[] = [];
+      flushAllPendingSaves.mockImplementationOnce(async () => {
+        order.push('flush');
+        return new Set<string>();
+      });
+      mockInvoke.mockImplementationOnce(async () => {
+        order.push('switch');
+      });
+
+      await databaseStore.switchTo('b');
+
+      expect(order).toEqual(['flush', 'switch']);
+    });
+
+    it('lets the latest of two concurrent switches win and bails the superseded one', async () => {
+      databaseStore.databases = [db('a'), db('b'), db('c')];
+      databaseStore.activeDatabaseId = 'a';
+      mockInvoke.mockResolvedValue(undefined); // set_active_database (winner only)
+
+      // Fire both without awaiting: each captures its switch token synchronously
+      // before the first await, so the later call supersedes the earlier one.
+      const first = databaseStore.switchTo('b');
+      const second = databaseStore.switchTo('c');
+      await Promise.all([first, second]);
+
+      expect(databaseStore.activeDatabaseId).toBe('c');
+      // The superseded switch bailed before re-pointing the routed clients.
+      expect(mockInvoke).not.toHaveBeenCalledWith('set_active_database', { id: 'b' });
+      expect(mockInvoke).toHaveBeenCalledWith('set_active_database', { id: 'c' });
+      // Only the winner cleared caches and reloaded — no stale mid-switch state.
+      expect(clearAll).toHaveBeenCalledOnce();
+      expect(loadCollections).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('registry mutations', () => {
+    it('create refreshes the list and returns the new entry', async () => {
+      const created = db('c', { name: 'Work' });
+      mockInvoke
+        .mockResolvedValueOnce(created) // create_database
+        .mockResolvedValueOnce({ databases: [created], defaultDatabaseId: '' }); // load
+
+      const result = await databaseStore.create('Work');
+
+      expect(mockInvoke).toHaveBeenCalledWith('create_database', { name: 'Work', path: null });
+      expect(result?.id).toBe('c');
+      expect(databaseStore.databases).toHaveLength(1);
+    });
+
+    it('register passes the path through', async () => {
+      const registered = db('d');
+      mockInvoke
+        .mockResolvedValueOnce(registered)
+        .mockResolvedValueOnce({ databases: [registered], defaultDatabaseId: '' });
+
+      await databaseStore.register('/tmp/d.db');
+
+      expect(mockInvoke).toHaveBeenCalledWith('register_database', { path: '/tmp/d.db' });
+    });
+
+    it('remove unregisters and refreshes', async () => {
+      databaseStore.databases = [db('a'), db('b')];
+      databaseStore.activeDatabaseId = 'a';
+      mockInvoke
+        .mockResolvedValueOnce('b') // remove_database
+        .mockResolvedValueOnce({ databases: [db('a')], defaultDatabaseId: '' }); // load
+
+      await databaseStore.remove('b');
+
+      expect(mockInvoke).toHaveBeenCalledWith('remove_database', { id: 'b' });
+      expect(databaseStore.databases).toHaveLength(1);
+    });
+  });
+
+  describe('isActiveDatabaseEvent', () => {
+    it('passes events with no database id (single-database / Pro daemon)', () => {
+      databaseStore.activeDatabaseId = 'a';
+      expect(isActiveDatabaseEvent(undefined)).toBe(true);
+      expect(isActiveDatabaseEvent('')).toBe(true);
+    });
+
+    it('passes any event before a selection is loaded', () => {
+      databaseStore.activeDatabaseId = null;
+      expect(isActiveDatabaseEvent('a')).toBe(true);
+    });
+
+    it('drops events tagged for a different database', () => {
+      databaseStore.activeDatabaseId = 'a';
+      expect(isActiveDatabaseEvent('a')).toBe(true);
+      expect(isActiveDatabaseEvent('b')).toBe(false);
+    });
+  });
+});

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -7,6 +7,16 @@ pub mod nodespace {
     tonic::include_proto!("nodespace");
 }
 
+/// The gRPC metadata/header key a client sets to route a request at a specific
+/// registered local database (ADR-053: "One Daemon, Multiple Local Databases").
+///
+/// Absent → the daemon serves its default database (single-database clients are
+/// unchanged); present but unregistered → the routed handler rejects the request
+/// rather than silently serving the default (no cross-database leak). Defined
+/// here in the wire-contract crate so every client (CLI, desktop app) and the
+/// daemon reference one canonical key.
+pub const DATABASE_ID_HEADER: &str = "x-ns-database-id";
+
 pub use nodespace::agent_session_service_client::AgentSessionServiceClient;
 pub use nodespace::agent_session_service_server::AgentSessionServiceServer;
 pub use nodespace::database_service_client::DatabaseServiceClient;


### PR DESCRIPTION
## Summary

Desktop half of ADR-053 "One Daemon, Multiple Local Databases" (#1533). Adds a sidebar database switcher and client-side `x-ns-database-id` routing to the Tauri app, so a user can create, register, switch, and manage local databases live — no restart. Builds on the merged daemon side (#1532) and CLI half (#1597).

This is the desktop slice; it does not close #1533 (any remaining polish tracked separately).

## Changes

- **`GrpcClient` routing** (`services/grpc_client.rs`) — a concrete `DatabaseIdInterceptor` (mirroring the CLI's) stamps `x-ns-database-id` on the routed data-plane clients (node/import/embeddings/agent_session); settings/local_agent/database_service stay unrouted. `set_active_database(id)` rebuilds only the routed clients over the **same** channel (no reconnect) and bumps a generation `watch`; `subscribe_active_database()` feeds the watcher. `for_id` degrades an unparseable id to no-routing rather than poisoning requests.
- **Shared wire constant** — `DATABASE_ID_HEADER` moved to `packages/proto/src/lib.rs` and re-exported from the daemon's `db_routing.rs`, so the daemon and every client (CLI, desktop) reference one canonical key. `nodespace_daemon::DATABASE_ID_HEADER` still resolves (re-export), so the CLI is unaffected.
- **Watcher** (`watcher.rs`) — now rides the shared `GrpcClient`'s routed node client (so `WatchNodes` carries the active-database header) and `select!`s on the generation `watch`, re-opening the stream immediately on a switch. Each event's originating `database_id` is threaded onto the Tauri payloads.
- **Tauri commands** (`commands/database.rs`) — `list_databases`, `create_database`, `register_database`, `set_default_database`, `rename_database`, `remove_database`, `set_active_database`.
- **Frontend** — `database.svelte.ts` store (`load`, `switchTo` = flush pending → re-point → clear caches → reset workspace → reload, plus create/register/rename/setDefault/remove); `database-switcher.svelte` in the sidebar header (active db + local/synced glyph; dropdown lists databases with New…/Open…); `database-name-dialog.svelte` (New/Rename); `database-settings.svelte` rewritten as a management list; and an `isActiveDatabaseEvent` `database_id` guard on all six node/relationship listeners in `tauri-sync-listener.ts` (empty id = Pro single-db = always applies).
- **Cleanup** — deleted the orphaned `restart_app` command + its registration (zero callers after the earlier database-settings cleanup; `graceful_shutdown` is retained).

## Validation

- `bun run test`: **3965 passed** / 151 files (baseline 3952/150; +13 new `database.test.ts`, zero regressions).
- `bun run quality:fix` / svelte-check: **0 errors / 0 warnings**.
- Sidecar `cargo build --bin nodespaced --bin nodespace` succeeds; `cargo clippy -p nodespace-app --tests` and `cargo check -p nodespace-app --tests` clean; `cargo fmt --check` clean.

## Notes

- The `watcher::run` signature gained a `GrpcClient` param (it rides the shared channel now instead of opening its own); the two `optimistic_echo_race_test.rs` call sites were updated.
- Community-unchanged: a fresh install has one default database; with no switch, routed clients carry an empty interceptor and everything behaves exactly as before.
- No live GUI run was possible headless; the switch flow (flush/clear/reset/reload + Rust-side watcher re-subscribe) is covered by unit tests + type/clippy checks, and would benefit from a manual click-test on a build with two registered databases.
