### PR TITLE
Remove vestigial SettingsService daemon-config RPCs (ADR-053)

### DIFF
--- a/packages/daemon/src/services/settings_service.rs
+++ b/packages/daemon/src/services/settings_service.rs
@@ -13,19 +13,12 @@ use tonic::{Request, Response, Status};
 
 use crate::nodespace::{
     settings_service_server::SettingsService as GrpcSettingsService, CaptureContentLevel,
-    CaptureSettingsResponse, DaemonConfigResponse, GetCaptureSettingsRequest,
-    GetDaemonConfigRequest, UpdateCaptureSettingsRequest, UpdateDaemonConfigRequest,
+    CaptureSettingsResponse, GetCaptureSettingsRequest, UpdateCaptureSettingsRequest,
 };
-
-fn default_socket_path() -> String {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    format!("{home}/.nodespace/daemon.sock")
-}
 
 /// On-disk representation of `~/.nodespace/daemon.toml`.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct DaemonConfig {
-    grpc_address: Option<String>,
     #[serde(default)]
     capture: CaptureConfig,
 }
@@ -96,8 +89,8 @@ pub async fn read_capture_settings(config_path: &std::path::Path) -> anyhow::Res
 
 pub struct SettingsServiceImpl {
     config_path: PathBuf,
-    /// Serializes concurrent UpdateDaemonConfig / UpdateCaptureSettings RPCs
-    /// so read-modify-write operations on daemon.toml are not interleaved.
+    /// Serializes concurrent UpdateCaptureSettings RPCs so read-modify-write
+    /// operations on daemon.toml are not interleaved.
     write_lock: Arc<Mutex<()>>,
 }
 
@@ -142,15 +135,6 @@ impl SettingsServiceImpl {
             .map_err(|e| Status::internal(format!("Failed to write daemon config: {}", e)))
     }
 
-    fn config_to_response(config: &DaemonConfig) -> DaemonConfigResponse {
-        DaemonConfigResponse {
-            grpc_address: config
-                .grpc_address
-                .clone()
-                .unwrap_or_else(default_socket_path),
-        }
-    }
-
     fn capture_to_response(capture: &CaptureConfig) -> CaptureSettingsResponse {
         CaptureSettingsResponse {
             enabled: capture.enabled,
@@ -162,31 +146,6 @@ impl SettingsServiceImpl {
 
 #[tonic::async_trait]
 impl GrpcSettingsService for SettingsServiceImpl {
-    async fn get_daemon_config(
-        &self,
-        _request: Request<GetDaemonConfigRequest>,
-    ) -> Result<Response<DaemonConfigResponse>, Status> {
-        let config = self.read_config().await?;
-        Ok(Response::new(Self::config_to_response(&config)))
-    }
-
-    async fn update_daemon_config(
-        &self,
-        request: Request<UpdateDaemonConfigRequest>,
-    ) -> Result<Response<DaemonConfigResponse>, Status> {
-        let req = request.into_inner();
-        let _guard = self.write_lock.lock().await;
-
-        let mut config = self.read_config().await?;
-
-        if !req.grpc_address.is_empty() {
-            config.grpc_address = Some(req.grpc_address);
-        }
-
-        self.write_config(&config).await?;
-        Ok(Response::new(Self::config_to_response(&config)))
-    }
-
     async fn get_capture_settings(
         &self,
         _request: Request<GetCaptureSettingsRequest>,

--- a/packages/proto/proto/settings_service.proto
+++ b/packages/proto/proto/settings_service.proto
@@ -2,9 +2,8 @@ syntax = "proto3";
 
 package nodespace;
 
-// SettingsService exposes daemon-owned configuration (gRPC address, session
-// capture) over gRPC so Tauri and CLI clients can read and update config
-// without direct file access.
+// SettingsService exposes daemon-owned session capture settings over gRPC so
+// Tauri and CLI clients can read and update them without direct file access.
 //
 // The active database path is owned by DatabaseService (ADR-053), not this
 // service — clients read it from the registry, not daemon.toml.
@@ -12,31 +11,12 @@ package nodespace;
 // Display preferences (theme, render_markdown) stay in Tauri local storage
 // and are NOT part of this service.
 service SettingsService {
-  // Read current daemon configuration.
-  rpc GetDaemonConfig(GetDaemonConfigRequest) returns (DaemonConfigResponse);
-
-  // Persist updated daemon configuration. Takes effect on the next daemon
-  // start.
-  rpc UpdateDaemonConfig(UpdateDaemonConfigRequest) returns (DaemonConfigResponse);
-
   // Read session capture settings.
   rpc GetCaptureSettings(GetCaptureSettingsRequest) returns (CaptureSettingsResponse);
 
   // Persist session capture settings. Changes take effect immediately for
   // sessions launched after this call.
   rpc UpdateCaptureSettings(UpdateCaptureSettingsRequest) returns (CaptureSettingsResponse);
-}
-
-message GetDaemonConfigRequest {}
-
-message UpdateDaemonConfigRequest {
-  // New gRPC bind address. Empty string means "no change".
-  string grpc_address = 2;
-}
-
-message DaemonConfigResponse {
-  // gRPC bind address the daemon is currently configured to use.
-  string grpc_address = 2;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-on cleanup after ADR-053 removed `active_database_path` (#1595). The `SettingsService.GetDaemonConfig`/`UpdateDaemonConfig` RPCs and their sole remaining field `grpc_address` are vestigial — zero callers, and `grpc_address` is never consumed (the daemon binds its UDS via `socket_path()`/`NODESPACED_SOCKET`, not this field).

Deletes the two RPCs + their `GetDaemonConfigRequest`/`UpdateDaemonConfigRequest`/`DaemonConfigResponse` messages from the proto, and the matching handler impls, `config_to_response`, the now-dead `default_socket_path` helper, the `grpc_address` field on `DaemonConfig`, and the now-unused imports. Keeps `DaemonConfig.capture` and the live `GetCaptureSettings`/`UpdateCaptureSettings` RPCs.

Net: 2 files, +5 / −66.

## Validation
- Tree-wide grep (incl. the `nodespace-sync` repo) confirms zero callers of any removed symbol — only generated build artifacts referenced them.
- `cargo fmt --check` + `cargo clippy -p nodespace-daemon --all-targets -- -D warnings` clean.
- `cargo test -p nodespace-daemon` green (51+... 0 failed).
- `cargo check -p nodespace-cli` and `cargo check -p nodespace-app` (against the regenerated proto) both clean.

Closes #1596