### PR TITLE
Drop in-flight database reads after an active-database switch (ADR-053)

### DIFF
--- a/packages/desktop-app/src/lib/components/chat/node-card-inline.svelte
+++ b/packages/desktop-app/src/lib/components/chat/node-card-inline.svelte
@@ -38,8 +38,11 @@
   // reactive watch (ADR-049). Once fetched, `node` updates via the store read above.
   onMount(() => {
     if (sharedNodeStore.getNode(nodeId)) return;
+    // ADR-053: capture the database generation so a switch mid-fetch drops this
+    // read instead of writing the previous database's node into the now-active store.
+    const epoch = sharedNodeStore.currentEpoch();
     backendAdapter.getNode(nodeId).then((fetched) => {
-      if (fetched) {
+      if (fetched && sharedNodeStore.currentEpoch() === epoch) {
         sharedNodeStore.setNode(fetched, { type: 'database', reason: 'node-card-fetch' }, true);
       }
     }).catch((e) => {

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -130,8 +130,12 @@
       async (event) => {
         log.debug('[MCP] Node updated:', event.payload.node_id);
         try {
+          // ADR-053: capture the database generation so a switch mid-fetch drops
+          // this write instead of writing the previous database's node into the
+          // now-active store.
+          const epoch = sharedNodeStore.currentEpoch();
           const node = await invoke<Node>('get_node', { id: event.payload.node_id });
-          if (node) {
+          if (node && sharedNodeStore.currentEpoch() === epoch) {
             sharedNodeStore.setNode(node, { type: 'mcp-server' }, false);
 
             // Invalidate collection member caches since node title may have changed

--- a/packages/desktop-app/src/lib/components/viewers/ai-chat-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/ai-chat-node-viewer.svelte
@@ -340,8 +340,12 @@
       if (cancelled || attempts >= MAX_ATTEMPTS) return;
       attempts++;
       try {
+        // ADR-053: drop this poll's write if the active database switches while
+        // the fetch is in flight, so the previous database's node isn't written
+        // into the now-active store.
+        const epoch = sharedNodeStore.currentEpoch();
         const fetched = await backendAdapter.getNode(nodeId);
-        if (fetched && !cancelled) {
+        if (fetched && !cancelled && sharedNodeStore.currentEpoch() === epoch) {
           sharedNodeStore.setNode(fetched, { type: 'database', reason: 'poll' }, true);
           // If SSE is down, nudge it to reconnect.
           if (!browserSyncService.isConnected()) {

--- a/packages/desktop-app/src/lib/components/viewers/query-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/query-node-viewer.svelte
@@ -71,6 +71,9 @@
 
   async function loadAndQuery(schemaId: string) {
     const loadId = ++currentLoadId;
+    // ADR-053: capture the database generation so a switch mid-load drops these
+    // rows instead of writing the previous database's nodes into the now-active store.
+    const epoch = sharedNodeStore.currentEpoch();
     queryState = 'loading';
     error = null;
     schemaNode = null;
@@ -97,6 +100,8 @@
       // so updates from other panes propagate reactively without re-querying.
       const nodes = await backendAdapter.queryNodes({ nodeType: schema.id });
       if (loadId !== currentLoadId) return;
+      // Drop the write if the active database switched while the query was in flight.
+      if (sharedNodeStore.currentEpoch() !== epoch) return;
       const databaseSource = { type: 'database' as const, reason: 'query-node-viewer initial load' };
       for (const node of nodes) {
         sharedNodeStore.setNode(node, databaseSource);

--- a/packages/desktop-app/src/lib/services/browser-sync-service.ts
+++ b/packages/desktop-app/src/lib/services/browser-sync-service.ts
@@ -318,7 +318,13 @@ class BrowserSyncService {
    */
   private async fetchAndUpdateNode(nodeId: string, eventType: string): Promise<void> {
     try {
+      // ADR-053: capture the database generation before the read for parity with
+      // the Tauri path. Browser (HTTP-adapter) mode does not currently support
+      // switching databases, so the epoch never advances here — the guard is
+      // defensive and future-proof.
+      const epoch = sharedNodeStore.currentEpoch();
       const node = await backendAdapter.getNode(nodeId);
+      if (sharedNodeStore.currentEpoch() !== epoch) return;
       if (node) {
         // Normalize node data to type-specific format (e.g., TaskNode with flat status)
         const normalizedNode = normalizeNodeData(node);

--- a/packages/desktop-app/src/lib/services/navigation-service.ts
+++ b/packages/desktop-app/src/lib/services/navigation-service.ts
@@ -69,6 +69,9 @@ export class NavigationService {
       const { backendAdapter } = await import('./backend-adapter');
 
       try {
+        // ADR-053: capture the database generation before the daemon read so a
+        // switch mid-fetch drops the write below.
+        const epoch = sharedNodeStore.currentEpoch();
         const fetchedNode = await backendAdapter.getNode(nodeId);
         if (!fetchedNode) {
           log.error(`Node ${nodeId} not found in backend`);
@@ -76,7 +79,15 @@ export class NavigationService {
         }
         node = fetchedNode;
 
-        // Add to store for future use
+        // The active database switched while this read was in flight — the
+        // fetched row belongs to the previous database. Drop it and abort the
+        // navigation rather than opening a tab for a node absent from the
+        // now-active store.
+        if (sharedNodeStore.currentEpoch() !== epoch) {
+          return null;
+        }
+
+        // Add to store for future use.
         // Use type 'database' and skipPersistence since already in backend (or virtual)
         sharedNodeStore.setNode(
           node,

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -753,6 +753,19 @@ export class SharedNodeStore {
   // Track nodes currently being resynced to prevent concurrent resync operations
   private resyncingNodes = new Set<string>();
 
+  /**
+   * Monotonic database generation. ADR-053 ("One Daemon, Multiple Local
+   * Databases") lets the desktop hot-swap the active database; `clearAll()`
+   * (invoked by the switch) bumps this counter so any read dispatched against
+   * the previous database — whose promise resolves *after* the swap — is
+   * detectable as stale and dropped, instead of populating the now-active store
+   * with the previous database's rows (orphans unreferenced by the new tree
+   * that would otherwise surface via global search / mention resolution until
+   * the next reload). Fetch-then-write paths capture `currentEpoch()` before
+   * awaiting the daemon and re-check it before applying the result.
+   */
+  private databaseEpoch = 0;
+
   private constructor() {
     // Private constructor for singleton
   }
@@ -948,7 +961,12 @@ export class SharedNodeStore {
     const cached = this.nodes.get(nodeId);
     if (cached) return cached;
 
+    const epoch = this.databaseEpoch;
     const fetched = await backendAdapter.getNode(nodeId);
+    // ADR-053: the active database switched while this read was in flight — the
+    // fetched row belongs to the previous database, so drop it instead of
+    // populating the now-active store.
+    if (this.databaseEpoch !== epoch) return undefined;
     if (fetched) {
       this.setNode(fetched, { type: 'database', reason: 'ensure-node' });
       return fetched;
@@ -2181,6 +2199,17 @@ export class SharedNodeStore {
   }
 
   /**
+   * The current database generation (see `databaseEpoch`). A fetch-then-write
+   * path captures this before awaiting the daemon; if it has advanced by the
+   * time the response lands, the active database was switched underneath the
+   * read and the result belongs to the previous database — the caller must drop
+   * it rather than write it into the now-active store.
+   */
+  currentEpoch(): number {
+    return this.databaseEpoch;
+  }
+
+  /**
    * Evict every cached node and its per-node metadata.
    *
    * Used both by tests and by the ADR-053 database hot-swap: switching the
@@ -2192,8 +2221,13 @@ export class SharedNodeStore {
    * Hot-swap callers must flush pending saves (`flushAllPendingSaves`) BEFORE
    * switching the routed clients so in-flight writes land in the database they
    * were made against, not the one being switched to.
+   *
+   * Bumps `databaseEpoch` so any read dispatched against the previous database
+   * but still in flight is dropped rather than written into the now-active
+   * store — see `currentEpoch()`.
    */
   clearAll(): void {
+    this.databaseEpoch++;
     this.nodesClear();
     this.versions.clear();
     this.pendingUpdates.clear();
@@ -2225,17 +2259,30 @@ export class SharedNodeStore {
       // databaseSource is reused for both the parent prefetch and the children below.
       const databaseSource = { type: 'database' as const, reason: 'loaded-from-db' };
 
+      // ADR-053: capture the database generation before any daemon read so a
+      // switch mid-flight is detectable below and the results are dropped
+      // rather than written into the now-active database's store.
+      const epoch = this.databaseEpoch;
+
       // Ensure the parent node itself is in the store before loading children.
       // This prevents BaseNodeViewer from treating a not-yet-loaded parent as a
       // stale/deleted node and closing the tab prematurely (issue #941).
+      let parentNode: Node | null = null;
       if (!this.nodes.has(parentId)) {
-        const parentNode = await backendAdapter.getNode(parentId);
-        if (parentNode) {
-          this.setNode(parentNode, databaseSource);
-        }
+        parentNode = await backendAdapter.getNode(parentId);
       }
 
       const nodes = await backendAdapter.getChildren(parentId);
+
+      // The active database switched while these reads were in flight — the
+      // rows belong to the previous database, so apply none of them (writing
+      // them, or their structureTree edges, would orphan the previous
+      // database's nodes into the now-active store).
+      if (this.databaseEpoch !== epoch) return [];
+
+      if (parentNode) {
+        this.setNode(parentNode, databaseSource);
+      }
 
       // Add nodes to store with database source
       // Database source type will automatically mark nodes as persisted (see determinePersistenceBehavior)
@@ -2297,7 +2344,15 @@ export class SharedNodeStore {
 
   private async doLoadChildrenTree(parentId: string): Promise<Node[]> {
     try {
+      // ADR-053: capture the database generation before the daemon read so a
+      // switch mid-flight is detectable below.
+      const epoch = this.databaseEpoch;
       const tree = await backendAdapter.getChildrenTree(parentId);
+
+      // The active database switched while this read was in flight — the tree
+      // belongs to the previous database, so drop it rather than batch it (and
+      // its structureTree edges) into the now-active store.
+      if (this.databaseEpoch !== epoch) return [];
 
       if (!tree) {
         // Date nodes are virtual — they are created lazily in the backend when their first
@@ -2605,7 +2660,13 @@ export class SharedNodeStore {
     this.resyncingNodes.add(nodeId);
 
     try {
+      // ADR-053: capture the database generation before the daemon read.
+      const epoch = this.databaseEpoch;
       const serverNode = await backendAdapter.getNode(nodeId);
+
+      // The active database switched while this resync was in flight — the
+      // fetched row belongs to the previous database, so drop it.
+      if (this.databaseEpoch !== epoch) return;
 
       if (serverNode) {
         // Replace in-memory node with server state

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -102,6 +102,12 @@ async function flushPendingNodeFetches(): Promise<void> {
   flushInProgress = true;
   tombstonedDuringFlush.clear();
   try {
+    // ADR-053: capture the database generation before the reads so a switch
+    // mid-flush drops the whole burst rather than writing the previous
+    // database's rows into the now-active store. isActiveDatabaseEvent gates on
+    // event arrival, before these async fetches dispatch, so it cannot close
+    // this in-flight window on its own.
+    const epoch = sharedNodeStore.currentEpoch();
     const fetched = await Promise.all(
       ids.map((id) =>
         backendAdapter.getNode(id).catch((error) => {
@@ -110,6 +116,10 @@ async function flushPendingNodeFetches(): Promise<void> {
         })
       )
     );
+
+    // The active database switched while these reads were in flight — the rows
+    // belong to the previous database, so apply none of them.
+    if (sharedNodeStore.currentEpoch() !== epoch) return;
 
     // Synchronous apply loop — no `await` between setNode calls, so Svelte
     // coalesces the resulting reactive updates into a single render. A node
@@ -166,7 +176,13 @@ function stripNodePrefix(id: string): string {
  */
 async function fetchAndUpdateNode(nodeId: string, eventType: string): Promise<void> {
   try {
+    // ADR-053: capture the database generation before the read so a switch
+    // mid-fetch drops the write rather than writing the previous database's row
+    // into the now-active store (isActiveDatabaseEvent gates before this async
+    // fetch dispatches, so it does not cover the in-flight window).
+    const epoch = sharedNodeStore.currentEpoch();
     const node = await backendAdapter.getNode(nodeId);
+    if (sharedNodeStore.currentEpoch() !== epoch) return;
     if (node) {
       const normalizedNode = normalizeNodeData(node);
       sharedNodeStore.setNode(normalizedNode, { type: 'database', reason: 'domain-event' }, true);

--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -116,13 +116,13 @@ class DatabaseStore {
       if (seq !== this.switchSeq) return;
       this.activeDatabaseId = id;
 
-      // Evict the previous database's cached data. NOTE: a read (e.g.
-      // loadChildren) dispatched against the previous database *before* this
-      // switch whose response resolves after this clear can still setNode its
-      // rows into the now-active store; such orphans are unreferenced by the
-      // new database's tree but may surface via global search until the next
-      // reload. Fully closing this needs per-request database tagging — tracked
-      // as follow-on hardening.
+      // Evict the previous database's cached data. `clearAll()` also bumps the
+      // store's database epoch, which closes the in-flight-read window: a read
+      // (e.g. loadChildren/getNode) dispatched against the previous database
+      // *before* this switch whose response resolves after this clear captured
+      // the old epoch and is dropped instead of writing the previous
+      // database's rows into the now-active store (see
+      // `sharedNodeStore.currentEpoch()`).
       sharedNodeStore.clearAll();
       structureTree.clear();
 

--- a/packages/desktop-app/src/tests/components/chat-markdown-reconcile.test.ts
+++ b/packages/desktop-app/src/tests/components/chat-markdown-reconcile.test.ts
@@ -37,6 +37,9 @@ vi.mock('$lib/services/shared-node-store.svelte', () => ({
   sharedNodeStore: {
     getNode: vi.fn().mockReturnValue(undefined),
     setNode: vi.fn(),
+    // ADR-053 epoch guard: the on-mount fetch captures currentEpoch() and
+    // re-checks it before setNode. A stable value keeps the read in-epoch.
+    currentEpoch: vi.fn().mockReturnValue(0),
   },
 }));
 

--- a/packages/desktop-app/src/tests/components/node-card-inline.test.ts
+++ b/packages/desktop-app/src/tests/components/node-card-inline.test.ts
@@ -18,11 +18,15 @@ vi.mock('$lib/utils/logger', () => ({
 const getNode = vi.fn();
 const setNode = vi.fn();
 const fetchNode = vi.fn();
+const currentEpoch = vi.fn().mockReturnValue(0);
 
 vi.mock('$lib/services/shared-node-store.svelte', () => ({
   sharedNodeStore: {
     getNode: (...a: unknown[]) => getNode(...a),
-    setNode: (...a: unknown[]) => setNode(...a)
+    setNode: (...a: unknown[]) => setNode(...a),
+    // ADR-053 epoch guard: the on-mount fetch captures currentEpoch() and
+    // re-checks it before setNode. A stable value keeps the read in-epoch.
+    currentEpoch: (...a: unknown[]) => currentEpoch(...a)
   }
 }));
 

--- a/packages/desktop-app/src/tests/services/shared-node-store-database-epoch.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-database-epoch.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SharedNodeStore - ADR-053 database epoch guard
+ *
+ * ADR-053 ("One Daemon, Multiple Local Databases") lets the desktop hot-swap
+ * the active database. `clearAll()` (invoked by the switch) bumps a monotonic
+ * database epoch. A read (e.g. loadChildren/getNode) dispatched against the
+ * previous database whose response resolves *after* the switch captured the
+ * old epoch and must be dropped — otherwise the previous database's rows are
+ * written into the now-active store as orphans (invisible in the outliner but
+ * reachable via global search / mention resolution until the next reload).
+ *
+ * These tests lock that guard in place: a read whose response lands after the
+ * epoch advances must NOT populate the store, while a read within the same
+ * epoch must apply exactly as before.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SharedNodeStore } from '../../lib/services/shared-node-store.svelte';
+import { backendAdapter } from '../../lib/services/backend-adapter';
+import type { Node } from '../../lib/types';
+
+describe('SharedNodeStore - ADR-053 database epoch guard', () => {
+  let store: SharedNodeStore;
+
+  const makeNode = (id: string): Node => ({
+    id,
+    nodeType: 'text',
+    content: `content-${id}`,
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1,
+    properties: {},
+    mentions: []
+  });
+
+  beforeEach(() => {
+    SharedNodeStore.resetInstance();
+    store = SharedNodeStore.getInstance();
+  });
+
+  afterEach(() => {
+    store.clearAll();
+    SharedNodeStore.resetInstance();
+    vi.restoreAllMocks();
+  });
+
+  it('bumps the epoch on clearAll', () => {
+    const before = store.currentEpoch();
+    store.clearAll();
+    expect(store.currentEpoch()).toBe(before + 1);
+  });
+
+  it('drops a read whose response resolves after the active database switched', async () => {
+    // Defer getChildren so the epoch can advance while the read is in flight.
+    let resolveChildren: (nodes: Node[]) => void = () => {};
+    const childrenPromise = new Promise<Node[]>((resolve) => {
+      resolveChildren = resolve;
+    });
+    vi.spyOn(backendAdapter, 'getChildren').mockReturnValue(childrenPromise);
+
+    // Seed the parent so loadChildrenForParent skips the parent prefetch and the
+    // only in-flight read is getChildren.
+    store.setNode(makeNode('parent'), { type: 'database', reason: 'seed' });
+    const epochBefore = store.currentEpoch();
+
+    // Read dispatched under epoch N (against "database A").
+    const loadPromise = store.loadChildrenForParent('parent');
+
+    // The active database switches while the read is in flight: clearAll bumps
+    // the epoch to N+1 and empties the store (as the real switch does).
+    store.clearAll();
+    expect(store.currentEpoch()).toBe(epochBefore + 1);
+
+    // Database A's response lands after the switch.
+    resolveChildren([makeNode('stale-child')]);
+    const result = await loadPromise;
+
+    // The stale row must NOT have populated the now-active (empty) store.
+    expect(store.hasNode('stale-child')).toBe(false);
+    expect(store.getNodeCount()).toBe(0);
+    expect(result).toEqual([]);
+  });
+
+  it('applies a read that resolves within the same epoch', async () => {
+    vi.spyOn(backendAdapter, 'getChildren').mockResolvedValue([makeNode('fresh-child')]);
+
+    store.setNode(makeNode('parent'), { type: 'database', reason: 'seed' });
+
+    // No intervening switch: the read applies exactly as before.
+    const result = await store.loadChildrenForParent('parent');
+
+    expect(store.hasNode('fresh-child')).toBe(true);
+    expect(result.map((n) => n.id)).toEqual(['fresh-child']);
+  });
+});

--- a/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
@@ -323,6 +323,67 @@ describe('TauriSyncListener', () => {
 		});
 	});
 
+	// ADR-053: switching the active database bumps the store's database epoch.
+	// A domain-event hydration whose read was already in flight across that
+	// switch resolves with the previous database's row — it must be dropped, not
+	// written into the now-active store, or the switch leaks orphan nodes.
+	describe('ADR-053 in-flight read drop across a database switch', () => {
+		beforeEach(async () => {
+			await initializeTauriSyncListeners();
+		});
+
+		afterEach(() => {
+			proSync.tier = 'unknown'; // singleton — restore for later tests
+		});
+
+		it('community path drops a node:created fetch that resolves after a switch', async () => {
+			proSync.tier = 'community'; // direct fetchAndUpdateNode path
+
+			// getNode hangs so the database can switch while the read is in flight.
+			let resolveGet!: (node: Node | null) => void;
+			const pending = new Promise<Node | null>((resolve) => {
+				resolveGet = resolve;
+			});
+			vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
+
+			// The event dispatches the fetch (now pending on the previous database).
+			emitTauriEvent('node:created', { id: 'node1' });
+
+			// The active database switches while the read is outstanding.
+			sharedNodeStore.clearAll();
+
+			// The read finally resolves with the previous database's row.
+			resolveGet(createTestNode('node1'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Dropped — not written into the now-active store.
+			expect(sharedNodeStore.hasNode('node1')).toBe(false);
+		});
+
+		it('Pro coalescer drops a queued burst that resolves after a switch', async () => {
+			proSync.tier = 'pro'; // flushPendingNodeFetches path
+
+			let resolveGet!: (node: Node | null) => void;
+			const pending = new Promise<Node | null>((resolve) => {
+				resolveGet = resolve;
+			});
+			vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
+
+			// Queue the event; let the coalescing window fire so the flush reaches
+			// its (now-pending) read.
+			emitTauriEvent('node:created', { id: 'node1' });
+			await new Promise((resolve) => setTimeout(resolve, 40));
+
+			// Switch databases while the coalesced read is outstanding.
+			sharedNodeStore.clearAll();
+
+			resolveGet(createTestNode('node1'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(sharedNodeStore.hasNode('node1')).toBe(false);
+		});
+	});
+
 	describe('Unified Relationship Events - has_child (Issue #811)', () => {
 		beforeEach(async () => {
 			await initializeTauriSyncListeners();


### PR DESCRIPTION
## Summary

Follow-on hardening from the ADR-053 desktop switcher (#1533 / #1598). When the active database is switched, a read dispatched against the *previous* database before the switch — whose response resolves *after* the switch's `clearAll()` — could `setNode` the old database's rows into the now-active store. Those nodes are unreferenced by the new tree (invisible in the outliner) but linger in `sharedNodeStore` and can surface via global search / mention resolution until the next reload.

This closes that window using the issue's **Option A**: a monotonic database epoch on `SharedNodeStore`, bumped by `clearAll()` (already called by `switchTo`). Every path that reads from the daemon and then writes into the store captures the epoch before awaiting and drops the write if it has advanced.

## Changes

- **`shared-node-store.svelte.ts`** — `private databaseEpoch`, `currentEpoch()` getter, `clearAll()` bumps it. Guards on `ensureNode`, `loadChildrenForParent` (restructured so both daemon reads complete before a single staleness check gates the parent, children, and structureTree-edge writes together), `doLoadChildrenTree`, `resyncNodeFromServer`.
- **`tauri-sync-listener.ts`** — guards on `fetchAndUpdateNode` (per-event hydration) and `flushPendingNodeFetches` (Pro reconnect-replay coalescer, whole-burst drop). `isActiveDatabaseEvent` gates on event *arrival*, before these async fetches dispatch, so it cannot close the in-flight window on its own.
- **`browser-sync-service.ts`** — `fetchAndUpdateNode` guard (HTTP-adapter parity; browser mode can't switch databases today, so defensive/future-proof).
- **`navigation-service.ts`** — link-click resolution now aborts (returns `null`) when the epoch advances, rather than opening a tab for a node absent from the now-active store.
- Also guarded: `node-card-inline`, `query-node-viewer`, `ai-chat-node-viewer`, `app-shell` MCP node-updated listener.
- `switchTo` comment updated to describe the epoch guard that closes this window.

## Tests

- `shared-node-store-database-epoch.test.ts` (new, 3) — store-level: a read resolving after the epoch advances is dropped; within the same epoch it is applied.
- `tauri-sync-listener.test.ts` (+2) — the community per-event path and the Pro coalescer path each drop an in-flight read across a switch.
- Full file green (31/31); eslint + svelte-check 0/0 (1738 files).

## Acceptance

- [x] A read issued against database A that resolves after a switch to B does not leave A's nodes in the B store (regression tests above).
- [x] No behavior change in the common (no in-flight read across a switch) case — the guard is a same-epoch no-op.

Closes #1599.
