### PR TITLE
Pin OPENSSL_ROOT_DIR in CI so the llama.cpp cold build finds OpenSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
 
-      - name: Install Protobuf
+      - name: Install Protobuf and OpenSSL
         run: |
           export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           brew untap aws/tap azure/bicep 2>/dev/null || true
-          brew install protobuf
+          brew install protobuf openssl@3
+          # llama.cpp's vendored cpp-httplib compiles with LLAMA_OPENSSL=ON, so a
+          # cold build needs OpenSSL headers. Homebrew's openssl@3 is not on CMake's
+          # default search path, so find_package(OpenSSL) intermittently misses and
+          # the build fails on <openssl/err.h>. Pin OPENSSL_ROOT_DIR so it is found
+          # deterministically on every runner.
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -72,11 +78,17 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
 
-      - name: Install Protobuf
+      - name: Install Protobuf and OpenSSL
         run: |
           export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           brew untap aws/tap azure/bicep 2>/dev/null || true
-          brew install protobuf
+          brew install protobuf openssl@3
+          # llama.cpp's vendored cpp-httplib compiles with LLAMA_OPENSSL=ON, so a
+          # cold build needs OpenSSL headers. Homebrew's openssl@3 is not on CMake's
+          # default search path, so find_package(OpenSSL) intermittently misses and
+          # the build fails on <openssl/err.h>. Pin OPENSSL_ROOT_DIR so it is found
+          # deterministically on every runner.
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Kills the recurring `test:all` flake where the Rust build fails with:

```
llama.cpp/vendor/cpp-httplib/httplib.h:389:10: fatal error: 'openssl/err.h' file not found
```

## Root cause

`llama-cpp-sys-2` builds vendored `llama.cpp`, whose `CMakeLists.txt` sets `option(LLAMA_OPENSSL "..." ON)` by default. With that on, the vendored `cpp-httplib` compiles with `CPPHTTPLIB_OPENSSL_SUPPORT` and `#include <openssl/err.h>`. On the `macos-latest` runners, Homebrew's `openssl@3` is present but **not on CMake's default search path**, so `find_package(OpenSSL)` intermittently fails to locate it and the compile errors on the missing header.

It presents as *intermittent* because `swatinem/rust-cache` skips the compile entirely on a warm cache — the failure only surfaces on a **cold** cache (eviction, or a fork PR, which can't read the base repo's cache), which is exactly when a re-run "fixes" it. The crate's `build.rs` only forwards `CMAKE_*`-prefixed env vars as CMake defines, so `LLAMA_OPENSSL=OFF` can't be passed to disable it — the correct fix is to make OpenSSL discoverable.

## Fix

In both the `test:all` and `test:e2e` jobs, install `openssl@3` and pin `OPENSSL_ROOT_DIR` to its Homebrew prefix so `find_package(OpenSSL)` succeeds deterministically:

```yaml
brew install protobuf openssl@3
echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
```

No product code changes; runtime behavior is unaffected (the daemon does not use cpp-httplib — this only makes the vendored build compile reliably).

## Validation

This PR is raised from a fork, so its own CI runs on a **cold** cache and rebuilds `llama-cpp-sys-2` — a green `test:all` here directly exercises and confirms the fix (the very build that previously flaked).
