### PR TITLE
Scope daemon compute per database (ADR-053): active-first embedding priority, close + idle eviction

### DIFF
--- a/packages/cli/tests/cli_integration.rs
+++ b/packages/cli/tests/cli_integration.rs
@@ -56,7 +56,11 @@ async fn spawn_test_daemon() -> (PathBuf, oneshot::Sender<()>, TempDir) {
             .await
             .expect("failed to build NodeService"),
     );
-    let service = NodeServiceImpl::new(node_service, Arc::new(tokio::sync::RwLock::new(None)));
+    let service = NodeServiceImpl::new(
+        node_service,
+        Arc::new(tokio::sync::RwLock::new(None)),
+        Arc::new(nodespace_core::services::EmbeddingScheduler::new()),
+    );
 
     let listener = UnixListener::bind(&sock_path).expect("failed to bind test UDS socket");
     let incoming = UnixListenerStream::new(listener);
@@ -96,6 +100,7 @@ fn routing_test_context() -> SharedContext {
         pty_manager: Arc::new(PtySessionManager::new()),
         model,
         has_model: false,
+        scheduler: Arc::new(nodespace_core::services::EmbeddingScheduler::new()),
     }
 }
 

--- a/packages/core/src/services/embedding_processor.rs
+++ b/packages/core/src/services/embedding_processor.rs
@@ -96,21 +96,35 @@ pub struct EmbeddingScheduler {
 }
 
 /// A held scheduler slot. Dropping it releases the shared-model gate and, for an
-/// active-database batch, decrements the active-waiter count and wakes any
-/// deferred non-active waiters so priority is re-evaluated.
+/// active-database batch, drops the [`HighPriorityReservation`] which decrements
+/// the active-waiter count and wakes any deferred non-active waiters so priority
+/// is re-evaluated.
 pub struct SchedulerPermit<'a> {
     _permit: SemaphorePermit<'a>,
-    scheduler: &'a EmbeddingScheduler,
-    is_active: bool,
+    /// Present only for an active-database batch.
+    _reservation: Option<HighPriorityReservation<'a>>,
 }
 
-impl Drop for SchedulerPermit<'_> {
+/// RAII active-waiter reservation. Bumping `high_waiters` *before* the gate is
+/// acquired is what makes concurrent non-active batches defer; guarding it in a
+/// drop type ensures an `acquire` future cancelled while awaiting the gate can
+/// never leak the count (a leak would defer every non-active database forever).
+struct HighPriorityReservation<'a> {
+    scheduler: &'a EmbeddingScheduler,
+}
+
+impl<'a> HighPriorityReservation<'a> {
+    fn new(scheduler: &'a EmbeddingScheduler) -> Self {
+        scheduler.high_waiters.fetch_add(1, Ordering::SeqCst);
+        Self { scheduler }
+    }
+}
+
+impl Drop for HighPriorityReservation<'_> {
     fn drop(&mut self) {
-        if self.is_active {
-            self.scheduler.high_waiters.fetch_sub(1, Ordering::SeqCst);
-            // Wake deferred non-active waiters so they re-check the backlog.
-            self.scheduler.notify.notify_waiters();
-        }
+        self.scheduler.high_waiters.fetch_sub(1, Ordering::SeqCst);
+        // Wake deferred non-active waiters so they re-check the backlog.
+        self.scheduler.notify.notify_waiters();
     }
 }
 
@@ -163,9 +177,11 @@ impl EmbeddingScheduler {
     /// re-evaluated each time.
     pub async fn acquire(&self, db_id: &str) -> SchedulerPermit<'_> {
         if self.is_active(db_id) {
-            // Register before contending so any concurrent non-active waiter sees
-            // this batch and defers.
-            self.high_waiters.fetch_add(1, Ordering::SeqCst);
+            // Register as a high-priority waiter BEFORE contending for the gate so
+            // any concurrent non-active waiter sees this batch and defers. The
+            // reservation is RAII-guarded, so if this future is dropped while
+            // awaiting the gate the count is released rather than leaked.
+            let reservation = HighPriorityReservation::new(self);
             let permit = self
                 .gate
                 .acquire()
@@ -173,8 +189,7 @@ impl EmbeddingScheduler {
                 .expect("scheduler semaphore never closes");
             SchedulerPermit {
                 _permit: permit,
-                scheduler: self,
-                is_active: true,
+                _reservation: Some(reservation),
             }
         } else {
             // Defer while the active database has batches queued. Register on the
@@ -196,8 +211,7 @@ impl EmbeddingScheduler {
                 .expect("scheduler semaphore never closes");
             SchedulerPermit {
                 _permit: permit,
-                scheduler: self,
-                is_active: false,
+                _reservation: None,
             }
         }
     }
@@ -525,52 +539,54 @@ mod tests {
     /// non-active database's batch that was requested first — proving
     /// active-first priority without loading any embedding model.
     #[tokio::test]
-    async fn scheduler_grants_active_batch_before_deferred_non_active() {
+    async fn scheduler_prioritizes_active_over_earlier_queued_non_active() {
+        // Distinguishes active-first priority from a plain FIFO gate: a non-active
+        // batch requests the gate BEFORE a second active batch, yet the active one
+        // must still be granted first. A FIFO gate would grant the earlier request
+        // and yield ["B", "A2"].
         let scheduler = Arc::new(EmbeddingScheduler::new());
         scheduler.set_active(Some("A".to_string()));
 
         let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
 
-        // A non-active batch grabs the single gate permit and holds it, so any
-        // subsequent acquire must wait.
-        let b1 = scheduler.acquire("B").await;
+        // An active batch holds the gate (high_waiters -> 1).
+        let a1 = scheduler.acquire("A").await;
 
-        // Spawn the active database's batch. It registers as a high-priority
-        // waiter (high_waiters -> 1) and then blocks on the gate held by b1.
-        let sched_a = scheduler.clone();
-        let order_a = order.clone();
-        let a_task = tokio::spawn(async move {
-            let _p = sched_a.acquire("A").await;
-            order_a.lock().unwrap().push("A");
+        // A non-active batch requests next. Because active work is pending it
+        // parks on the notifier instead of queueing on the gate. The single-thread
+        // test runtime runs it to that park on one yield.
+        let sched_b = scheduler.clone();
+        let order_b = order.clone();
+        let b_task = tokio::spawn(async move {
+            let _p = sched_b.acquire("B").await;
+            order_b.lock().unwrap().push("B");
         });
+        tokio::task::yield_now().await;
 
-        // Wait until the active batch has registered its intent. Reading the
-        // private counter is possible because this test lives in-module.
-        while scheduler.high_waiters.load(Ordering::SeqCst) == 0 {
+        // A SECOND active batch requests *after* B and queues on the gate. Reading
+        // the private counter is possible because this test lives in-module.
+        let sched_a2 = scheduler.clone();
+        let order_a2 = order.clone();
+        let a2_task = tokio::spawn(async move {
+            let _p = sched_a2.acquire("A").await;
+            order_a2.lock().unwrap().push("A2");
+        });
+        while scheduler.high_waiters.load(Ordering::SeqCst) < 2 {
             tokio::task::yield_now().await;
         }
 
-        // Spawn a second non-active batch. It sees high_waiters > 0 and defers on
-        // the notifier rather than contending for the gate.
-        let sched_b2 = scheduler.clone();
-        let order_b2 = order.clone();
-        let b2_task = tokio::spawn(async move {
-            let _p = sched_b2.acquire("B").await;
-            order_b2.lock().unwrap().push("B2");
-        });
+        // Release the first active batch. The second active batch wins the gate
+        // over the earlier-requested non-active batch, which stays parked until
+        // all active work drains.
+        drop(a1);
 
-        // Release the gate. The active batch (already blocked on the gate) is
-        // granted next; only after it drains (high_waiters -> 0) is the deferred
-        // non-active batch woken.
-        drop(b1);
-
-        a_task.await.unwrap();
-        b2_task.await.unwrap();
+        a2_task.await.unwrap();
+        b_task.await.unwrap();
 
         assert_eq!(
             *order.lock().unwrap(),
-            vec!["A", "B2"],
-            "active database's batch must be granted before the deferred non-active batch"
+            vec!["A2", "B"],
+            "an active batch requested after a non-active one must still be granted first"
         );
     }
 }

--- a/packages/core/src/services/embedding_processor.rs
+++ b/packages/core/src/services/embedding_processor.rs
@@ -30,9 +30,10 @@
 
 use crate::services::error::NodeServiceError;
 use crate::services::NodeEmbeddingService;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify, Semaphore, SemaphorePermit};
 
 /// Handle to wake the embedding processor
 ///
@@ -63,6 +64,140 @@ impl EmbeddingWaker {
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 tracing::warn!("EmbeddingProcessor has shut down, wake ignored");
+            }
+        }
+    }
+}
+
+/// Process-global gate that gives the active database's embedding work priority
+/// over every other open database (ADR-053: per-database compute scoping).
+///
+/// The embedding model is a single process-global resource, so only one database
+/// may run a batch through it at a time. This scheduler enforces that mutual
+/// exclusion *and* a priority: while the active database has embedding batches
+/// queued, batches from other databases defer. When the active database drains,
+/// the others proceed. Priority is re-evaluated per batch, so a non-active
+/// database is never starved permanently — it resumes the moment the active
+/// database goes idle.
+///
+/// The scheduler keys on the database id as a plain [`String`] (the registry
+/// ULID) so this core type stays free of any daemon-side identifier type.
+pub struct EmbeddingScheduler {
+    /// The database whose live edit stream marks it active, if any.
+    active: Mutex<Option<String>>,
+    /// Single-permit gate: only one database runs a batch through the shared
+    /// model at a time.
+    gate: Semaphore,
+    /// Count of active-database batches queued or in flight. Non-active batches
+    /// wait while this is non-zero.
+    high_waiters: AtomicUsize,
+    /// Wakes deferred non-active waiters when the active backlog drains.
+    notify: Notify,
+}
+
+/// A held scheduler slot. Dropping it releases the shared-model gate and, for an
+/// active-database batch, decrements the active-waiter count and wakes any
+/// deferred non-active waiters so priority is re-evaluated.
+pub struct SchedulerPermit<'a> {
+    _permit: SemaphorePermit<'a>,
+    scheduler: &'a EmbeddingScheduler,
+    is_active: bool,
+}
+
+impl Drop for SchedulerPermit<'_> {
+    fn drop(&mut self) {
+        if self.is_active {
+            self.scheduler.high_waiters.fetch_sub(1, Ordering::SeqCst);
+            // Wake deferred non-active waiters so they re-check the backlog.
+            self.scheduler.notify.notify_waiters();
+        }
+    }
+}
+
+impl Default for EmbeddingScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmbeddingScheduler {
+    /// Create a scheduler with no active database.
+    pub fn new() -> Self {
+        Self {
+            active: Mutex::new(None),
+            gate: Semaphore::new(1),
+            high_waiters: AtomicUsize::new(0),
+            notify: Notify::new(),
+        }
+    }
+
+    /// Mark which database is active (the one with a live edit stream), or clear
+    /// it with `None`. The active database's embedding batches take priority.
+    pub fn set_active(&self, db_id: Option<String>) {
+        *self.active.lock().expect("scheduler active lock poisoned") = db_id;
+    }
+
+    /// The currently active database id, if any.
+    pub fn active_id(&self) -> Option<String> {
+        self.active
+            .lock()
+            .expect("scheduler active lock poisoned")
+            .clone()
+    }
+
+    /// Whether `db_id` is currently the active database.
+    pub fn is_active(&self, db_id: &str) -> bool {
+        self.active
+            .lock()
+            .expect("scheduler active lock poisoned")
+            .as_deref()
+            == Some(db_id)
+    }
+
+    /// Acquire the shared-model gate for one batch on behalf of `db_id`.
+    ///
+    /// The active database registers itself as a high-priority waiter and then
+    /// contends for the gate directly. A non-active database first waits until no
+    /// active-database batches are queued, then contends for the gate. The
+    /// returned permit must be dropped between batches so priority is
+    /// re-evaluated each time.
+    pub async fn acquire(&self, db_id: &str) -> SchedulerPermit<'_> {
+        if self.is_active(db_id) {
+            // Register before contending so any concurrent non-active waiter sees
+            // this batch and defers.
+            self.high_waiters.fetch_add(1, Ordering::SeqCst);
+            let permit = self
+                .gate
+                .acquire()
+                .await
+                .expect("scheduler semaphore never closes");
+            SchedulerPermit {
+                _permit: permit,
+                scheduler: self,
+                is_active: true,
+            }
+        } else {
+            // Defer while the active database has batches queued. Register on the
+            // notifier *before* re-checking the count so an active batch that
+            // drains between the check and the await cannot be missed.
+            loop {
+                let notified = self.notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if self.high_waiters.load(Ordering::SeqCst) == 0 {
+                    break;
+                }
+                notified.await;
+            }
+            let permit = self
+                .gate
+                .acquire()
+                .await
+                .expect("scheduler semaphore never closes");
+            SchedulerPermit {
+                _permit: permit,
+                scheduler: self,
+                is_active: false,
             }
         }
     }
@@ -100,10 +235,19 @@ impl EmbeddingProcessor {
     ///
     /// # Arguments
     /// * `embedding_service` - The embedding service for processing nodes
+    /// * `scheduler` - Process-global gate that grants the active database's
+    ///   batches priority over other databases (ADR-053: per-database compute
+    ///   scoping)
+    /// * `db_id` - This database's registry id, used to ask the scheduler
+    ///   whether this database is the active one
     ///
     /// # Returns
     /// A new EmbeddingProcessor instance with active background task
-    pub fn new(embedding_service: Arc<NodeEmbeddingService>) -> Result<Self, NodeServiceError> {
+    pub fn new(
+        embedding_service: Arc<NodeEmbeddingService>,
+        scheduler: Arc<EmbeddingScheduler>,
+        db_id: String,
+    ) -> Result<Self, NodeServiceError> {
         tracing::info!("EmbeddingProcessor initializing (purely event-driven model)");
 
         let (trigger_tx, mut trigger_rx) = mpsc::channel::<()>(10);
@@ -132,7 +276,8 @@ impl EmbeddingProcessor {
                         while trigger_rx.try_recv().is_ok() {}
 
                         // Process embeddings that have passed their debounce window
-                        let has_pending = Self::process_until_empty(&service_clone).await;
+                        let has_pending =
+                            Self::process_until_empty(&service_clone, &scheduler, &db_id).await;
 
                         // If there are pending embeddings that haven't passed debounce yet,
                         // schedule a delayed wake to process them later
@@ -177,12 +322,27 @@ impl EmbeddingProcessor {
     ///
     /// Returns true if there are pending stale embeddings that haven't passed
     /// their debounce window yet (requiring a delayed wake to be scheduled).
-    async fn process_until_empty(service: &Arc<NodeEmbeddingService>) -> bool {
+    ///
+    /// Each batch runs under a [`SchedulerPermit`] so the active database's
+    /// embedding work takes priority over other open databases (ADR-053). The
+    /// permit is released between batches, re-evaluating priority every batch.
+    async fn process_until_empty(
+        service: &Arc<NodeEmbeddingService>,
+        scheduler: &Arc<EmbeddingScheduler>,
+        db_id: &str,
+    ) -> bool {
         const BATCH_SIZE: usize = 10;
         let mut total_processed = 0;
 
         loop {
-            match service.process_stale_embeddings(Some(BATCH_SIZE)).await {
+            // Hold the shared-model gate only for the duration of one batch, then
+            // drop it before checking for more work so a higher-priority database
+            // can interleave.
+            let batch_result = {
+                let _permit = scheduler.acquire(db_id).await;
+                service.process_stale_embeddings(Some(BATCH_SIZE)).await
+            };
+            match batch_result {
                 Ok(0) => {
                     // No more stale embeddings ready to process
                     if total_processed > 0 {
@@ -332,5 +492,85 @@ mod tests {
         // Both wakes should have sent signals
         assert!(trigger_rx.try_recv().is_ok(), "First wake should send");
         assert!(trigger_rx.try_recv().is_ok(), "Second wake should send");
+    }
+
+    #[test]
+    fn scheduler_tracks_active_database() {
+        let scheduler = EmbeddingScheduler::new();
+        assert!(scheduler.active_id().is_none());
+        assert!(!scheduler.is_active("A"));
+
+        scheduler.set_active(Some("A".to_string()));
+        assert!(scheduler.is_active("A"));
+        assert!(!scheduler.is_active("B"));
+        assert_eq!(scheduler.active_id().as_deref(), Some("A"));
+
+        scheduler.set_active(None);
+        assert!(!scheduler.is_active("A"));
+        assert!(scheduler.active_id().is_none());
+    }
+
+    /// With no active database, a batch acquires the gate immediately (no
+    /// deferral) — the community single-database path is unaffected.
+    #[tokio::test]
+    async fn scheduler_grants_immediately_when_no_active_database() {
+        let scheduler = EmbeddingScheduler::new();
+        let permit = scheduler.acquire("only-db").await;
+        drop(permit);
+        // A second acquire also succeeds immediately (gate released on drop).
+        let _permit = scheduler.acquire("only-db").await;
+    }
+
+    /// The active database's batch is granted the shared-model gate ahead of a
+    /// non-active database's batch that was requested first — proving
+    /// active-first priority without loading any embedding model.
+    #[tokio::test]
+    async fn scheduler_grants_active_batch_before_deferred_non_active() {
+        let scheduler = Arc::new(EmbeddingScheduler::new());
+        scheduler.set_active(Some("A".to_string()));
+
+        let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+
+        // A non-active batch grabs the single gate permit and holds it, so any
+        // subsequent acquire must wait.
+        let b1 = scheduler.acquire("B").await;
+
+        // Spawn the active database's batch. It registers as a high-priority
+        // waiter (high_waiters -> 1) and then blocks on the gate held by b1.
+        let sched_a = scheduler.clone();
+        let order_a = order.clone();
+        let a_task = tokio::spawn(async move {
+            let _p = sched_a.acquire("A").await;
+            order_a.lock().unwrap().push("A");
+        });
+
+        // Wait until the active batch has registered its intent. Reading the
+        // private counter is possible because this test lives in-module.
+        while scheduler.high_waiters.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        // Spawn a second non-active batch. It sees high_waiters > 0 and defers on
+        // the notifier rather than contending for the gate.
+        let sched_b2 = scheduler.clone();
+        let order_b2 = order.clone();
+        let b2_task = tokio::spawn(async move {
+            let _p = sched_b2.acquire("B").await;
+            order_b2.lock().unwrap().push("B2");
+        });
+
+        // Release the gate. The active batch (already blocked on the gate) is
+        // granted next; only after it drains (high_waiters -> 0) is the deferred
+        // non-active batch woken.
+        drop(b1);
+
+        a_task.await.unwrap();
+        b2_task.await.unwrap();
+
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec!["A", "B2"],
+            "active database's batch must be granted before the deferred non-active batch"
+        );
     }
 }

--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -183,7 +183,9 @@ pub use collection_service::{
     COLLECTION_PATH_DELIMITER, MAX_COLLECTION_DEPTH,
 };
 #[cfg(feature = "nlp")]
-pub use embedding_processor::{EmbeddingProcessor, EmbeddingWaker};
+pub use embedding_processor::{
+    EmbeddingProcessor, EmbeddingScheduler, EmbeddingWaker, SchedulerPermit,
+};
 #[cfg(feature = "nlp")]
 pub use embedding_service::{NodeEmbeddingService, EMBEDDING_DIMENSION};
 pub use error::NodeServiceError;

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -15,13 +15,13 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use nodespace_agent::local_agent::otlp_tracer;
-use nodespace_daemon::services::embeddings_service::EmbeddingReady;
 use nodespace_daemon::tray::layer::TrayMetricsLayer;
 use nodespace_daemon::{
     build_base_router, build_shared_services, resolve_db_path, tray, BaseServices, DatabaseManager,
     DatabaseServiceImpl, DatabaseServices, DbManagerLayer, SharedContext,
 };
-use tokio::sync::RwLock;
+use nodespace_nlp_engine::EmbeddingService;
+use tokio::sync::watch;
 use tonic::transport::Server;
 
 /// ADR-053: construct the [`DatabaseManager`], register + lazily open the
@@ -191,6 +191,11 @@ async fn serve_headless() -> Result<()> {
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
     let (shared, _model_task) = build_shared_services().await?;
     let (manager, bundle) = open_default_database(&db_path, shared.context.clone()).await?;
+    // Reap idle non-default databases so a switched-away database stops consuming
+    // compute (ADR-053: per-database compute scoping).
+    manager.spawn_idle_reaper();
+    let shared_model = shared.context.model.clone();
+    let shutdown_manager = manager.clone();
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent)
@@ -220,7 +225,9 @@ async fn serve_headless() -> Result<()> {
     .await
     .context("gRPC server terminated with error")?;
     let _ = tokio::fs::remove_file(&sock_cleanup).await;
-    drain_gpu(bundle.embedding_state.clone()).await;
+    // Drain every open database's compute, then release the shared GPU once.
+    shutdown_manager.shutdown_all().await;
+    release_shared_gpu(&shared_model).await;
     Ok(())
 }
 
@@ -241,6 +248,11 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
     let (shared, _model_task) = build_shared_services().await?;
     let (manager, bundle) = open_default_database(&db_path, shared.context.clone()).await?;
+    // Reap idle non-default databases so a switched-away database stops consuming
+    // compute (ADR-053: per-database compute scoping).
+    manager.spawn_idle_reaper();
+    let shared_model = shared.context.model.clone();
+    let shutdown_manager = manager.clone();
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent)
@@ -280,7 +292,9 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     .await
     .context("gRPC server terminated with error")?;
     let _ = tokio::fs::remove_file(&sock_cleanup).await;
-    drain_gpu(bundle.embedding_state.clone()).await;
+    // Drain every open database's compute, then release the shared GPU once.
+    shutdown_manager.shutdown_all().await;
+    release_shared_gpu(&shared_model).await;
     Ok(())
 }
 
@@ -345,6 +359,11 @@ async fn serve_headless() -> Result<()> {
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
     let (shared, _model_task) = build_shared_services().await?;
     let (manager, bundle) = open_default_database(&db_path, shared.context.clone()).await?;
+    // Reap idle non-default databases so a switched-away database stops consuming
+    // compute (ADR-053: per-database compute scoping).
+    manager.spawn_idle_reaper();
+    let shared_model = shared.context.model.clone();
+    let shutdown_manager = manager.clone();
 
     tracing::info!(pipe = %name, "gRPC server listening (Named Pipe)");
 
@@ -397,7 +416,9 @@ async fn serve_headless() -> Result<()> {
     })
     .await
     .context("gRPC server terminated with error")?;
-    drain_gpu(bundle.embedding_state.clone()).await;
+    // Drain every open database's compute, then release the shared GPU once.
+    shutdown_manager.shutdown_all().await;
+    release_shared_gpu(&shared_model).await;
     Ok(())
 }
 
@@ -417,6 +438,11 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
     let (shared, _model_task) = build_shared_services().await?;
     let (manager, bundle) = open_default_database(&db_path, shared.context.clone()).await?;
+    // Reap idle non-default databases so a switched-away database stops consuming
+    // compute (ADR-053: per-database compute scoping).
+    manager.spawn_idle_reaper();
+    let shared_model = shared.context.model.clone();
+    let shutdown_manager = manager.clone();
 
     let shutdown_controller = controller.clone();
     let combined_shutdown = async move {
@@ -474,21 +500,28 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     })
     .await
     .context("gRPC server terminated with error")?;
-    drain_gpu(bundle.embedding_state.clone()).await;
+    // Drain every open database's compute, then release the shared GPU once.
+    shutdown_manager.shutdown_all().await;
+    release_shared_gpu(&shared_model).await;
     Ok(())
 }
 
-/// GPU drain protocol: drop processor first (shuts down background task),
-/// then release the GPU context from the NLP engine.
-async fn drain_gpu(state: Arc<RwLock<Option<EmbeddingReady>>>) {
-    let ready = state.write().await.take();
-    if let Some(ready) = ready {
-        drop(ready.processor);
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        tracing::info!("Releasing GPU context...");
-        ready.embedding_service.nlp_engine().release_gpu_context();
-        tracing::info!("GPU context released");
-    }
+/// Release the process-global GPU context after every database has been drained
+/// (ADR-053: per-database compute scoping).
+///
+/// `DatabaseManager::shutdown_all` has already dropped each database's embedding
+/// processor, so this releases the single shared NLP engine's GPU context
+/// exactly once. `release_gpu_context` is one-way and global — it must never run
+/// on a per-database close, only here on daemon shutdown. A short settle lets any
+/// in-flight batch unwind before the model is torn down.
+async fn release_shared_gpu(model: &watch::Receiver<Option<Arc<EmbeddingService>>>) {
+    let Some(nlp) = model.borrow().clone() else {
+        return; // no model was ever loaded
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tracing::info!("Releasing GPU context...");
+    nlp.release_gpu_context();
+    tracing::info!("GPU context released");
 }
 
 /// Install the shutdown signal future at boot time so a failure to register

--- a/packages/daemon/src/services/assembly.rs
+++ b/packages/daemon/src/services/assembly.rs
@@ -14,7 +14,9 @@ use nodespace_agent::prompt_assembler::PromptAssembler;
 use nodespace_agent::pty::PtySessionManager;
 use nodespace_agent::skill_pipeline::{seed_skill_nodes, seed_tool_nodes};
 use nodespace_core::markdown::prepare_nodes_from_template;
-use nodespace_core::services::{EmbeddingProcessor, NodeAccessor, NodeEmbeddingService};
+use nodespace_core::services::{
+    EmbeddingProcessor, EmbeddingScheduler, NodeAccessor, NodeEmbeddingService,
+};
 use nodespace_core::{NodeService as CoreNodeService, SqliteStore};
 use nodespace_nlp_engine::EmbeddingService;
 use tokio::sync::{watch, RwLock};
@@ -41,6 +43,11 @@ pub struct SharedContext {
     /// Whether an NLP model file was found at startup. Gates both the
     /// per-database embedding wiring and the `EmbeddingsService` registration.
     pub has_model: bool,
+    /// Process-global embedding scheduler (ADR-053: per-database compute
+    /// scoping). Grants the active database's embedding batches priority over
+    /// other open databases so foreground work is not blocked by another
+    /// database's backlog. Shared by every database's `EmbeddingProcessor`.
+    pub scheduler: Arc<EmbeddingScheduler>,
 }
 
 /// Process-global services shared across every database the daemon serves
@@ -95,6 +102,10 @@ pub async fn build_shared_services() -> Result<(SharedServices, Option<tokio::ta
         })
     });
 
+    // One scheduler backs every database's embedding processor so the active
+    // database's batches take priority on the single shared model (ADR-053).
+    let scheduler = Arc::new(EmbeddingScheduler::new());
+
     Ok((
         SharedServices {
             settings,
@@ -102,6 +113,7 @@ pub async fn build_shared_services() -> Result<(SharedServices, Option<tokio::ta
                 pty_manager,
                 model: model_rx,
                 has_model,
+                scheduler,
             },
         },
         model_task,
@@ -146,8 +158,12 @@ pub async fn build_database_services(
 
     let node_service = Arc::new(node_service);
 
-    let node_service_grpc = NodeServiceImpl::new(node_service.clone(), embedding_state.clone())
-        .with_database_id(database_id.to_string());
+    let node_service_grpc = NodeServiceImpl::new(
+        node_service.clone(),
+        embedding_state.clone(),
+        shared.scheduler.clone(),
+    )
+    .with_database_id(database_id.to_string());
 
     // EmbeddingsService is only registered when a model file exists at startup
     // (the shared model). If the model appears later, the endpoint is absent
@@ -184,8 +200,10 @@ pub async fn build_database_services(
         let ns = node_service.clone();
         let state = embedding_state.clone();
         let svc_state = embedding_svc_state.clone();
+        let scheduler = shared.scheduler.clone();
+        let db_id = database_id.to_string();
         tokio::spawn(async move {
-            wire_database_embeddings_bg(model, store, ns, state, svc_state).await;
+            wire_database_embeddings_bg(model, store, ns, state, svc_state, scheduler, db_id).await;
         })
     });
 
@@ -297,6 +315,8 @@ async fn wire_database_embeddings_bg(
     node_service: Arc<CoreNodeService>,
     state: Arc<RwLock<Option<EmbeddingReady>>>,
     svc_state: Arc<RwLock<Option<Arc<NodeEmbeddingService>>>>,
+    scheduler: Arc<EmbeddingScheduler>,
+    db_id: String,
 ) {
     // Wait for the shared model to be published (or the sender to drop).
     let nlp = loop {
@@ -317,7 +337,7 @@ async fn wire_database_embeddings_bg(
         behaviors,
     ));
 
-    let processor = match EmbeddingProcessor::new(embedding_service.clone()) {
+    let processor = match EmbeddingProcessor::new(embedding_service.clone(), scheduler, db_id) {
         Ok(p) => Arc::new(p),
         Err(e) => {
             tracing::warn!(error = %e, "Failed to init EmbeddingProcessor — semantic search disabled");

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -526,10 +526,14 @@ impl DatabaseManager {
                 .filter(|(id, _)| default_id.as_ref() != Some(*id))
                 .filter(|(id, _)| active_id.as_deref() != Some(id.as_str()))
                 .filter(|(id, _)| {
+                    // A database with no recorded activity has only just been
+                    // inserted into `open` (the touch lands a moment later) — treat
+                    // it as freshly used, never as idle, so it can't be evicted in
+                    // that window.
                     activity
                         .get(*id)
                         .map(|seen| now.duration_since(*seen) > window)
-                        .unwrap_or(true)
+                        .unwrap_or(false)
                 })
                 .map(|(id, services)| (id.clone(), services.clone()))
                 .collect()

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -15,14 +15,36 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
+use nodespace_core::models::EmbeddingConfig;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use ulid::Ulid;
 
 use super::assembly::{build_database_services, DatabaseServices, SharedContext};
+
+/// How often the idle reaper scans open databases for eviction (ADR-053:
+/// per-database compute scoping).
+const IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Default idle window before a non-default, non-active database is evicted.
+/// Overridable via `NODESPACE_DB_IDLE_SECS`.
+const DEFAULT_IDLE_WINDOW: Duration = Duration::from_secs(5 * 60);
+
+/// Resolve the idle-eviction window, honoring `NODESPACE_DB_IDLE_SECS` (seconds)
+/// when set to a valid non-zero value; otherwise the built-in default.
+fn idle_window() -> Duration {
+    match std::env::var("NODESPACE_DB_IDLE_SECS") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(secs) if secs > 0 => Duration::from_secs(secs),
+            _ => DEFAULT_IDLE_WINDOW,
+        },
+        Err(_) => DEFAULT_IDLE_WINDOW,
+    }
+}
 
 /// Stable identifier for a registered database.
 ///
@@ -160,6 +182,10 @@ pub struct DatabaseManager {
     /// by [`DatabaseManager::get_or_open`]; the shared `Arc` is what request
     /// routing hands to the gRPC handlers.
     open: RwLock<HashMap<DatabaseId, Arc<DatabaseServices>>>,
+    /// Last time each open database served a routed request (ADR-053:
+    /// per-database compute scoping). Drives idle eviction. `Instant` is
+    /// monotonic, so this is unaffected by wall-clock changes.
+    last_activity: RwLock<HashMap<DatabaseId, Instant>>,
     /// Process-global build context (PTY manager + embedding model) every
     /// per-database service set is assembled from.
     context: SharedContext,
@@ -175,6 +201,7 @@ impl DatabaseManager {
             registry_path,
             registry: RwLock::new(registry),
             open: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
             context,
         })
     }
@@ -264,7 +291,10 @@ impl DatabaseManager {
             }
             registry.save(&self.registry_path).await?;
         }
-        self.open.write().await.remove(id);
+        // Tear down the database's compute (processor + event watcher) as well as
+        // its registry entry — unregistering must not leave a detached watcher
+        // running (ADR-053: per-database compute scoping).
+        self.close(id).await;
         Ok(())
     }
 
@@ -374,6 +404,7 @@ impl DatabaseManager {
     pub async fn get_or_open(&self, id: &DatabaseId) -> Result<Arc<DatabaseServices>> {
         // Fast path: already open.
         if let Some(services) = self.open.read().await.get(id).cloned() {
+            self.touch(id).await;
             return Ok(services);
         }
 
@@ -398,10 +429,125 @@ impl DatabaseManager {
         // drop ours and reuse theirs so every request shares one open handle.
         let mut open = self.open.write().await;
         if let Some(existing) = open.get(id).cloned() {
+            drop(open);
+            self.touch(id).await;
             return Ok(existing);
         }
         open.insert(id.clone(), services.clone());
+        drop(open);
+        self.touch(id).await;
         Ok(services)
+    }
+
+    /// Record that `id` just served a request, resetting its idle timer
+    /// (ADR-053: per-database compute scoping).
+    async fn touch(&self, id: &DatabaseId) {
+        self.last_activity
+            .write()
+            .await
+            .insert(id.clone(), Instant::now());
+    }
+
+    /// Close one open database, dropping only that database's compute — its
+    /// `EmbeddingProcessor` and event watcher (ADR-053: per-database compute
+    /// scoping). Returns `true` if the database was open.
+    ///
+    /// This never touches the process-global embedding model: the shared NLP
+    /// engine and its GPU context stay up for the other databases. Releasing the
+    /// GPU context is one-way and belongs solely to daemon shutdown. Callers must
+    /// not close the default or the active database.
+    pub async fn close(&self, id: &DatabaseId) -> bool {
+        let services = self.open.write().await.remove(id);
+        self.last_activity.write().await.remove(id);
+        let Some(services) = services else {
+            return false;
+        };
+        // Stop the per-database ai-chat event watcher.
+        services.local_agent.shutdown();
+        // Drop only this database's embedding processor (stops its background
+        // task on drop). The shared model is left untouched.
+        if let Some(ready) = services.embedding_state.write().await.take() {
+            drop(ready.processor);
+        }
+        true
+    }
+
+    /// Close every open database (ADR-053: per-database compute scoping),
+    /// dropping each one's processor and event watcher. Called on daemon
+    /// shutdown before the process-global GPU context is released exactly once.
+    pub async fn shutdown_all(&self) {
+        let mut open = self.open.write().await;
+        for services in open.values() {
+            services.local_agent.shutdown();
+            if let Some(ready) = services.embedding_state.write().await.take() {
+                drop(ready.processor);
+            }
+        }
+        open.clear();
+        self.last_activity.write().await.clear();
+    }
+
+    /// Spawn the background idle reaper (ADR-053: per-database compute scoping).
+    ///
+    /// Every [`IDLE_CHECK_INTERVAL`] it evicts each open database that is all of:
+    /// not the default, not the active database, idle beyond the configured
+    /// window, and not mid-drain on embeddings. Evicted databases reopen
+    /// transparently on their next request via [`DatabaseManager::get_or_open`].
+    /// The default and active databases are never evicted, so the single-database
+    /// community path is unaffected.
+    pub fn spawn_idle_reaper(self: &Arc<Self>) {
+        let this = Arc::clone(self);
+        let window = idle_window();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(IDLE_CHECK_INTERVAL);
+            // Skip the immediate first tick so nothing is evicted at boot.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                this.evict_idle_databases(window).await;
+            }
+        });
+    }
+
+    /// Evict every open database that has been idle longer than `window` and is
+    /// neither the default, the active database, nor mid-drain on embeddings
+    /// (ADR-053: per-database compute scoping).
+    pub async fn evict_idle_databases(&self, window: Duration) {
+        let default_id = self.registry.read().await.default_database.clone();
+        let active_id = self.context.scheduler.active_id();
+        let now = Instant::now();
+
+        // Collect candidates under the read locks, then close them afterward so
+        // we never hold `open` while awaiting the per-database writes in `close`.
+        let candidates: Vec<(DatabaseId, Arc<DatabaseServices>)> = {
+            let open = self.open.read().await;
+            let activity = self.last_activity.read().await;
+            open.iter()
+                .filter(|(id, _)| default_id.as_ref() != Some(*id))
+                .filter(|(id, _)| active_id.as_deref() != Some(id.as_str()))
+                .filter(|(id, _)| {
+                    activity
+                        .get(*id)
+                        .map(|seen| now.duration_since(*seen) > window)
+                        .unwrap_or(true)
+                })
+                .map(|(id, services)| (id.clone(), services.clone()))
+                .collect()
+        };
+
+        for (id, services) in candidates {
+            // Never evict a database with embedding work still queued — its
+            // processor is mid-drain.
+            if has_pending_embeddings(&services).await {
+                continue;
+            }
+            if self.close(&id).await {
+                tracing::info!(
+                    database_id = %id,
+                    "Evicted idle database (ADR-053 per-database compute scoping)"
+                );
+            }
+        }
     }
 
     /// Push a new entry into the registry and persist it. The first registered
@@ -429,10 +575,37 @@ impl DatabaseManager {
     }
 }
 
+/// Whether a database still has stale embeddings queued (ADR-053). Used to hold
+/// off idle eviction while its processor is mid-drain. A database whose model
+/// has not yet wired (or has none) has no processor running, so it reports no
+/// pending work.
+async fn has_pending_embeddings(services: &DatabaseServices) -> bool {
+    let guard = services.embedding_state.read().await;
+    let Some(ready) = guard.as_ref() else {
+        return false;
+    };
+    // Debounce window `0` counts every stale root, not just those past debounce —
+    // any queued work should defer eviction.
+    match ready
+        .embedding_service
+        .store()
+        .get_stale_embedding_root_ids(None, 0, EmbeddingConfig::default().max_retries)
+        .await
+    {
+        Ok(ids) => !ids.is_empty(),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to check pending embeddings during idle sweep");
+            // On error, be conservative and treat the database as busy.
+            true
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use nodespace_agent::pty::PtySessionManager;
+    use nodespace_core::services::EmbeddingScheduler;
     use nodespace_nlp_engine::EmbeddingService;
     use tokio::sync::watch;
 
@@ -445,6 +618,7 @@ mod tests {
             pty_manager: Arc::new(PtySessionManager::new()),
             model,
             has_model: false,
+            scheduler: Arc::new(EmbeddingScheduler::new()),
         }
     }
 

--- a/packages/daemon/src/services/database_service.rs
+++ b/packages/daemon/src/services/database_service.rs
@@ -164,6 +164,7 @@ mod tests {
     use super::*;
     use crate::services::assembly::SharedContext;
     use nodespace_agent::pty::PtySessionManager;
+    use nodespace_core::services::EmbeddingScheduler;
     use nodespace_nlp_engine::EmbeddingService;
     use tokio::sync::watch;
 
@@ -176,6 +177,7 @@ mod tests {
             pty_manager: Arc::new(PtySessionManager::new()),
             model,
             has_model: false,
+            scheduler: Arc::new(EmbeddingScheduler::new()),
         }
     }
 

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -1035,6 +1035,7 @@ mod tests {
     use super::*;
     use crate::services::SharedContext;
     use nodespace_agent::pty::PtySessionManager;
+    use nodespace_core::services::EmbeddingScheduler;
     use nodespace_nlp_engine::EmbeddingService;
     use tokio::sync::watch;
 
@@ -1044,6 +1045,7 @@ mod tests {
             pty_manager: Arc::new(PtySessionManager::new()),
             model,
             has_model: false,
+            scheduler: Arc::new(EmbeddingScheduler::new()),
         }
     }
 

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -87,6 +87,11 @@ struct LocalAgentServiceInner {
     token_tx: broadcast::Sender<AgentChunk>,
     /// Cancellation tokens keyed by node_id.
     turn_tokens: TurnTokens,
+    /// Cancels this database's background event watcher when the database is
+    /// closed (ADR-053: per-database compute scoping). Shared across the cheap
+    /// `Arc` clones tonic hands to request handlers, so a single `shutdown()`
+    /// stops the watcher spawned from any clone.
+    shutdown_token: CancellationToken,
 }
 
 /// tonic-compatible handle. `Clone` (cheap Arc clone) so tonic can hand
@@ -118,8 +123,17 @@ impl LocalAgentServiceImpl {
                 embedding_service,
                 token_tx,
                 turn_tokens: Arc::new(Mutex::new(HashMap::new())),
+                shutdown_token: CancellationToken::new(),
             }),
         }
+    }
+
+    /// Stop this database's background event watcher (ADR-053: per-database
+    /// compute scoping). Called when the owning database is closed or evicted so
+    /// its watcher does not keep subscribing to a now-detached event bus.
+    /// Idempotent and cheap — cancelling an already-cancelled token is a no-op.
+    pub fn shutdown(&self) {
+        self.inner.shutdown_token.cancel();
     }
 
     fn build_noop_service(
@@ -210,7 +224,19 @@ impl LocalAgentServiceImpl {
 
             let mut rx = this.inner.node_service.subscribe_to_events();
             loop {
-                match rx.recv().await {
+                let event = tokio::select! {
+                    // Stop promptly when the owning database is closed (ADR-053),
+                    // even if no further events arrive on the bus.
+                    _ = this.inner.shutdown_token.cancelled() => {
+                        tracing::info!(
+                            "LocalAgentService event watcher: database closed, stopping"
+                        );
+                        break;
+                    }
+                    event = rx.recv() => event,
+                };
+
+                match event {
                     Ok(envelope) => {
                         let (node_id, node_type) = match &envelope.event {
                             nodespace_core::db::events::DomainEvent::NodeCreated {

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -28,8 +28,8 @@ use nodespace_core::ops::{
     OpsError,
 };
 use nodespace_core::services::{
-    InsertPosition, InsertPositionOwned, NodeAccessor, NodeService as CoreNodeService,
-    NodeServiceError,
+    EmbeddingScheduler, InsertPosition, InsertPositionOwned, NodeAccessor,
+    NodeService as CoreNodeService, NodeServiceError,
 };
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
@@ -74,17 +74,22 @@ pub struct NodeServiceImpl {
     /// `WatchNodes` events. Empty when the daemon serves a single unregistered
     /// database (Pro daemon) or when the impl is constructed directly in tests.
     database_id: String,
+    /// Process-global embedding scheduler (ADR-053). A live `WatchNodes` stream
+    /// marks this database active so its embedding batches take priority.
+    scheduler: Arc<EmbeddingScheduler>,
 }
 
 impl NodeServiceImpl {
     pub fn new(
         node_service: Arc<CoreNodeService>,
         embedding_state: Arc<RwLock<Option<EmbeddingReady>>>,
+        scheduler: Arc<EmbeddingScheduler>,
     ) -> Self {
         Self {
             node_service,
             embedding_state,
             database_id: String::new(),
+            scheduler,
         }
     }
 
@@ -1256,6 +1261,14 @@ impl GrpcNodeService for NodeServiceImpl {
         request: Request<WatchRequest>,
     ) -> Result<Response<Self::WatchNodesStream>, Status> {
         let this = self.route(&request).await?;
+
+        // A live edit stream marks this database active (ADR-053: per-database
+        // compute scoping): its embedding batches now take priority over other
+        // open databases' backlogs on the shared model. The desktop opens this
+        // stream on the database the user is looking at, so the active signal
+        // tracks the foreground database with no extra protocol.
+        this.scheduler.set_active(Some(this.database_id.clone()));
+
         let req = request.into_inner();
         if !req.node_type.is_empty() || !req.root_id.is_empty() {
             // Filtering is intentionally out of scope for the initial implementation
@@ -1568,7 +1581,9 @@ mod tests {
     use nodespace_agent::pty::PtySessionManager;
     use nodespace_core::db::SqliteStore;
     use nodespace_core::ops::node_ops;
-    use nodespace_core::services::{CollectionService, NodeService as CoreNodeService};
+    use nodespace_core::services::{
+        CollectionService, EmbeddingScheduler, NodeService as CoreNodeService,
+    };
     use nodespace_nlp_engine::EmbeddingService;
     use std::sync::Arc;
     use tempfile::TempDir;
@@ -1582,6 +1597,7 @@ mod tests {
         let svc = Arc::new(NodeServiceImpl::new(
             core_svc,
             Arc::new(tokio::sync::RwLock::new(None)),
+            Arc::new(EmbeddingScheduler::new()),
         ));
         (svc, tmp)
     }
@@ -1594,6 +1610,7 @@ mod tests {
             pty_manager: Arc::new(PtySessionManager::new()),
             model,
             has_model: false,
+            scheduler: Arc::new(EmbeddingScheduler::new()),
         }
     }
 

--- a/packages/daemon/tests/database_service_e2e.rs
+++ b/packages/daemon/tests/database_service_e2e.rs
@@ -60,6 +60,7 @@ fn test_context() -> SharedContext {
         pty_manager: Arc::new(PtySessionManager::new()),
         model,
         has_model: false,
+        scheduler: Arc::new(nodespace_core::services::EmbeddingScheduler::new()),
     }
 }
 

--- a/packages/daemon/tests/grpc_round_trip.rs
+++ b/packages/daemon/tests/grpc_round_trip.rs
@@ -45,7 +45,11 @@ async fn spawn_test_daemon() -> (
             .await
             .expect("failed to build NodeService"),
     );
-    let service = NodeServiceImpl::new(node_service, Arc::new(tokio::sync::RwLock::new(None)));
+    let service = NodeServiceImpl::new(
+        node_service,
+        Arc::new(tokio::sync::RwLock::new(None)),
+        Arc::new(nodespace_core::services::EmbeddingScheduler::new()),
+    );
 
     // Bind to an ephemeral port so parallel test runs don't collide on 50051.
     let listener = TcpListener::bind("127.0.0.1:0")

--- a/packages/daemon/tests/import_round_trip.rs
+++ b/packages/daemon/tests/import_round_trip.rs
@@ -44,6 +44,7 @@ async fn spawn_import_daemon() -> (
     let node_svc = NodeServiceImpl::new(
         Arc::clone(&node_service),
         Arc::new(tokio::sync::RwLock::new(None)),
+        Arc::new(nodespace_core::services::EmbeddingScheduler::new()),
     );
     let import_svc = ImportServiceImpl::new(Arc::clone(&node_service));
 

--- a/packages/daemon/tests/per_db_compute.rs
+++ b/packages/daemon/tests/per_db_compute.rs
@@ -1,0 +1,259 @@
+//! Acceptance tests for per-database compute scoping (ADR-053).
+//!
+//! These drive the `DatabaseManager` public API directly (no model needed) to
+//! prove the per-database lifecycle guarantees:
+//!   - an idle, non-default, non-active database is evicted and reopens
+//!     transparently;
+//!   - the default and the active database are never evicted;
+//!   - `shutdown_all` drops every open database's compute;
+//!   - per-database routing keeps one database's nodes invisible to another
+//!     (no cross-database leak).
+//!
+//! Active-first embedding priority is proven cheaply by the `EmbeddingScheduler`
+//! unit test in `nodespace-core` (grant ordering with a shared record), which
+//! needs no llama model.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nodespace_agent::pty::PtySessionManager;
+use nodespace_core::services::EmbeddingScheduler;
+use nodespace_daemon::nodespace::node_service_server::NodeService as _;
+use nodespace_daemon::nodespace::{CreateNodeRequest, GetNodeRequest};
+use nodespace_daemon::services::DatabaseStatus;
+use nodespace_daemon::{DatabaseManager, SharedContext, DATABASE_ID_HEADER};
+use nodespace_nlp_engine::EmbeddingService;
+use tempfile::TempDir;
+use tokio::sync::watch;
+use tonic::{Code, Request};
+
+/// A model-less build context that shares an explicit scheduler so tests can
+/// drive the active-database signal. `has_model = false` skips all embedding
+/// wiring, so the dropped watch sender is harmless.
+fn test_context() -> (SharedContext, Arc<EmbeddingScheduler>) {
+    let scheduler = Arc::new(EmbeddingScheduler::new());
+    let (_tx, model) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
+    let context = SharedContext {
+        pty_manager: Arc::new(PtySessionManager::new()),
+        model,
+        has_model: false,
+        scheduler: scheduler.clone(),
+    };
+    (context, scheduler)
+}
+
+async fn manager_with_two_dbs() -> (Arc<DatabaseManager>, Arc<EmbeddingScheduler>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let (context, scheduler) = test_context();
+    let manager = Arc::new(
+        DatabaseManager::load(dir.path().join("databases.toml"), context)
+            .await
+            .unwrap(),
+    );
+    manager
+        .ensure_default_registered("Default".into(), dir.path().join("default.db"))
+        .await
+        .unwrap();
+    manager
+        .create("Second".into(), Some(dir.path().join("second.db")))
+        .await
+        .unwrap();
+    (manager, scheduler, dir)
+}
+
+fn status_of(
+    manager_snapshot: &nodespace_daemon::services::RegistrySnapshot,
+    name: &str,
+) -> DatabaseStatus {
+    manager_snapshot
+        .databases
+        .iter()
+        .find(|d| d.entry.name == name)
+        .expect("database present in registry")
+        .status
+}
+
+/// An idle, non-default, non-active database is evicted from the open set and
+/// reopens transparently on its next request.
+#[tokio::test]
+async fn idle_non_default_database_is_evicted_then_reopens() {
+    let (manager, _scheduler, _dir) = manager_with_two_dbs().await;
+    let second_id = manager
+        .list()
+        .await
+        .databases
+        .iter()
+        .find(|d| d.entry.name == "Second")
+        .unwrap()
+        .entry
+        .id
+        .clone();
+
+    // Open the second database; it is now serving.
+    manager.get_or_open(&second_id).await.unwrap();
+    assert_eq!(
+        status_of(&manager.list().await, "Second"),
+        DatabaseStatus::Open
+    );
+
+    // Let its idle timer age past the eviction window, then run one sweep.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    manager.evict_idle_databases(Duration::from_millis(1)).await;
+
+    // Evicted: no longer open, but the file remains so it reports Closed.
+    assert_eq!(
+        status_of(&manager.list().await, "Second"),
+        DatabaseStatus::Closed,
+        "idle non-default database must be evicted from the open set"
+    );
+
+    // A subsequent request rebuilds it transparently.
+    manager.get_or_open(&second_id).await.unwrap();
+    assert_eq!(
+        status_of(&manager.list().await, "Second"),
+        DatabaseStatus::Open,
+        "evicted database must reopen on next request"
+    );
+}
+
+/// The default database is never evicted, even when idle past the window.
+#[tokio::test]
+async fn default_database_is_never_evicted() {
+    let (manager, _scheduler, _dir) = manager_with_two_dbs().await;
+    let default_id = manager.list().await.default_database.unwrap();
+
+    manager.get_or_open(&default_id).await.unwrap();
+    assert_eq!(
+        status_of(&manager.list().await, "Default"),
+        DatabaseStatus::Open
+    );
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    manager.evict_idle_databases(Duration::from_millis(1)).await;
+
+    assert_eq!(
+        status_of(&manager.list().await, "Default"),
+        DatabaseStatus::Open,
+        "the default database must never be evicted"
+    );
+}
+
+/// The active database (the one with a live edit stream) is never evicted while
+/// active, even when idle past the window.
+#[tokio::test]
+async fn active_database_is_never_evicted() {
+    let (manager, scheduler, _dir) = manager_with_two_dbs().await;
+    let second_id = manager
+        .list()
+        .await
+        .databases
+        .iter()
+        .find(|d| d.entry.name == "Second")
+        .unwrap()
+        .entry
+        .id
+        .clone();
+
+    manager.get_or_open(&second_id).await.unwrap();
+    // Mark the second database active, as a live WatchNodes stream would.
+    scheduler.set_active(Some(second_id.to_string()));
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    manager.evict_idle_databases(Duration::from_millis(1)).await;
+
+    assert_eq!(
+        status_of(&manager.list().await, "Second"),
+        DatabaseStatus::Open,
+        "the active database must never be evicted"
+    );
+}
+
+/// `shutdown_all` drops every open database's compute and clears the open set.
+#[tokio::test]
+async fn shutdown_all_closes_every_open_database() {
+    let (manager, _scheduler, _dir) = manager_with_two_dbs().await;
+    let default_id = manager.list().await.default_database.unwrap();
+    let second_id = manager
+        .list()
+        .await
+        .databases
+        .iter()
+        .find(|d| d.entry.name == "Second")
+        .unwrap()
+        .entry
+        .id
+        .clone();
+
+    manager.get_or_open(&default_id).await.unwrap();
+    manager.get_or_open(&second_id).await.unwrap();
+
+    manager.shutdown_all().await;
+
+    let snapshot = manager.list().await;
+    assert_ne!(status_of(&snapshot, "Default"), DatabaseStatus::Open);
+    assert_ne!(status_of(&snapshot, "Second"), DatabaseStatus::Open);
+}
+
+/// Per-database routing isolates compute state: an ai-chat node created against
+/// one database is invisible to another — no cross-database leak.
+#[tokio::test]
+async fn ai_chat_nodes_do_not_leak_across_databases() {
+    let (manager, _scheduler, dir) = manager_with_two_dbs().await;
+    let default_id = manager.list().await.default_database.unwrap();
+    let second_id = manager
+        .list()
+        .await
+        .databases
+        .iter()
+        .find(|d| d.entry.name == "Second")
+        .unwrap()
+        .entry
+        .id
+        .clone();
+    let _ = dir; // keep the temp dir alive for the duration of the test
+
+    // The registered handler is the default database's, as the serve loop wires
+    // it into the router; routing then dispatches per the header.
+    let svc = manager
+        .get_or_open(&default_id)
+        .await
+        .unwrap()
+        .node_service_grpc
+        .clone();
+
+    // Create an ai-chat node targeting the second database.
+    let mut create = Request::new(CreateNodeRequest {
+        id: None,
+        node_type: "ai-chat".into(),
+        content: "in-second".into(),
+        parent_id: None,
+        collection: None,
+        lifecycle_status: None,
+        properties: serde_json::json!({ "ai-chat": { "messages": [] } }).to_string(),
+        position: None,
+    });
+    create.extensions_mut().insert(manager.clone());
+    create
+        .metadata_mut()
+        .insert(DATABASE_ID_HEADER, second_id.as_str().parse().unwrap());
+    let node_id = svc.create_node(create).await.unwrap().into_inner().node_id;
+
+    // Visible when the same second-database header is supplied.
+    let mut get_second = Request::new(GetNodeRequest {
+        node_id: node_id.clone(),
+    });
+    get_second.extensions_mut().insert(manager.clone());
+    get_second
+        .metadata_mut()
+        .insert(DATABASE_ID_HEADER, second_id.as_str().parse().unwrap());
+    assert!(svc.get_node(get_second).await.is_ok());
+
+    // Invisible to the default database (no header) — no cross-database leak.
+    let mut get_default = Request::new(GetNodeRequest { node_id });
+    get_default.extensions_mut().insert(manager.clone());
+    assert_eq!(
+        svc.get_node(get_default).await.unwrap_err().code(),
+        Code::NotFound,
+        "ai-chat node created in one database must not leak into another"
+    );
+}


### PR DESCRIPTION
## Summary

ADR-053 §1/§4 compute follow-through: with N databases open in one daemon, the store-bound background machinery is now scoped per database while sharing the single loaded embedding model.

Most per-database scoping already landed with the ADR-053 daemon core — each open database already has its own `EmbeddingProcessor` (draining its own store's stale queue), its own `LocalAgentServiceImpl` event watcher (subscribed to that database's event bus, filtered to `ai-chat`), its own `GraphContextAssembler`, and its own `AgentSessionHandler` over the shared `PtySessionManager`; the embedding model is process-global (published once over a `watch` channel, shared text-keyed LRU). This change adds the remaining lifecycle and priority behavior.

## What's new

- **Active-first embedding priority** — a process-global `EmbeddingScheduler` (in `nodespace-core`, keyed on the database ULID as a plain `String` so core stays free of any daemon type) that all per-database `EmbeddingProcessor`s share. Each processor acquires a permit around every batch; while the active database has batches queued, non-active databases defer at batch granularity, so a background bulk import into B cannot starve foreground semantic-search freshness in A. The active-database signal is the live `WatchNodes` stream — the desktop already opens exactly one on the database it displays and re-subscribes on switch, so no protocol change is needed. A non-active database is never permanently starved: it resumes the moment the active database goes idle, and with no active database (`None`) every database runs immediately.
- **Per-database close + task cancellation** — `DatabaseManager::close(id)` drops only that database's `EmbeddingProcessor` and cancels its agent event watcher (a new `CancellationToken` on `LocalAgentServiceImpl`). It never calls `release_gpu_context()`/`shutdown()` on the shared nlp-engine model — that is one-way and global, reserved for daemon shutdown.
- **Shutdown drains all open databases** — previously only the boot database's processor was drained; shutdown now iterates every open database (`shutdown_all`), then releases the shared GPU context exactly once.
- **Idle eviction** — a reaper closes non-default, non-active, idle (default 5 min, overridable via `NODESPACE_DB_IDLE_SECS`) local-only databases that have no pending embeddings, releasing their store connection; the next request reopens transparently via the existing lazy `get_or_open`.

## Acceptance criteria

- [x] Embedding backlogs drain independently per database; the active database's queue takes priority — `EmbeddingScheduler` + a unit test that distinguishes active-first from a plain FIFO gate (a non-active batch queued before a later active batch is still granted second).
- [x] Agent events and chat sessions in database A never leak into database B — per-database event watcher + session handler; covered by `per_db_compute` test.
- [x] Idle local-only databases close and release their store connection; next request reopens transparently — reaper + `close` + `get_or_open` rebuild; covered by tests.
- [x] One embedding model instance serves all databases — the model stays process-global; no second load.
- [x] `bun run test:all` green; `cargo fmt` + `cargo clippy --workspace -- -D warnings` clean.

## Non-goals (unchanged)

Per-database fairness beyond simple active-first; sync residency pinning (the sync issue pins the active synced database). Community single-database behavior is unchanged — one open database, always effectively active, never evicted.

## Review

Independently reviewed (adversarial pass over the scheduler concurrency, GPU-teardown safety, eviction guards, and watcher cancellation) — no deadlock, no lost-wakeup, no permanent starvation, teardown once-only-on-shutdown. Follow-up fixes from that review: strengthened the active-first unit test to genuinely distinguish priority from FIFO, RAII-guarded the active-waiter count so a cancelled acquire can't leak it, and made the reaper treat a not-yet-recorded database as freshly used rather than idle.

Closes #1534.
