### PR TITLE
Per-database bound-tenant storage (ADR-053 per-database cloud sync, S1)

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -2085,8 +2085,10 @@ impl NodeBehavior for PersonNodeBehavior {
 /// Built-in behavior for the database-settings singleton node
 ///
 /// DatabaseSettingsNode is the single container for database-level configuration:
-/// `sync_enabled` (user intent to sync) and `auth_status` (system-managed cloud
-/// bind state). Tenant roles are NOT stored here — they live on the `has_role`
+/// `sync_enabled` (user intent to sync), `auth_status` (system-managed cloud
+/// bind state), and `bound_tenant_schema`/`bound_tenant_collection` (the cloud
+/// tenant this database binds to under ADR-053 per-database cloud sync — empty
+/// until bound). Tenant roles are NOT stored here — they live on the `has_role`
 /// edge (PersonNode → DatabaseSettingsNode). Per ADR-037, both `role` and
 /// `auth_status` were moved off PersonNode as part of that revision.
 pub struct DatabaseSettingsNodeBehavior;
@@ -2118,6 +2120,17 @@ impl NodeBehavior for DatabaseSettingsNodeBehavior {
                 return Err(NodeValidationError::InvalidProperties(
                     "sync_enabled must be a boolean".to_string(),
                 ));
+            }
+        }
+
+        // Validate the bound-tenant fields are strings if present (ADR-053).
+        for field in ["bound_tenant_schema", "bound_tenant_collection"] {
+            if let Some(value) = node.properties.get(field) {
+                if !value.is_string() && !value.is_null() {
+                    return Err(NodeValidationError::InvalidProperties(format!(
+                        "{field} must be a string"
+                    )));
+                }
             }
         }
 

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -1000,6 +1000,45 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
                     fields: None,
                     item_fields: None,
                 },
+                SchemaField {
+                    name: "bound_tenant_schema".to_string(),
+                    field_type: "string".to_string(),
+                    protection: SchemaProtectionLevel::Core,
+                    core_values: None,
+                    user_values: None,
+                    indexed: false,
+                    required: Some(false),
+                    extensible: None,
+                    default: None,
+                    description: Some(
+                        "The cloud tenant this database binds to (ADR-053 per-database \
+                         cloud sync), as a Supabase schema name. Empty until the Pro sync \
+                         daemon binds the database; inert on the free/community tier."
+                            .to_string(),
+                    ),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+                SchemaField {
+                    name: "bound_tenant_collection".to_string(),
+                    field_type: "string".to_string(),
+                    protection: SchemaProtectionLevel::Core,
+                    core_values: None,
+                    user_values: None,
+                    indexed: false,
+                    required: Some(false),
+                    extensible: None,
+                    default: None,
+                    description: Some(
+                        "The default collection id within the bound tenant (ADR-053 \
+                         per-database cloud sync). Empty until the database is bound."
+                            .to_string(),
+                    ),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
             ],
             relationships: vec![],
             title_template: None,
@@ -1146,13 +1185,15 @@ mod tests {
     fn test_database_settings_schema_has_fields() {
         // ADR-037: database-settings is a Core singleton carrying sync_enabled
         // (boolean) and auth_status (Core-protected enum: local/connected).
+        // ADR-053 added bound_tenant_schema/bound_tenant_collection (per-database
+        // cloud tenant binding).
         let schemas = get_core_schemas();
         let settings = schemas
             .iter()
             .find(|s| s.id == "database-settings")
             .unwrap();
 
-        assert_eq!(settings.fields.len(), 2);
+        assert_eq!(settings.fields.len(), 4);
 
         let sync_enabled = settings
             .get_field("sync_enabled")
@@ -1175,6 +1216,16 @@ mod tests {
             .map(|ev| ev.value.as_str())
             .collect();
         assert_eq!(values, vec!["local", "connected"]);
+
+        for name in ["bound_tenant_schema", "bound_tenant_collection"] {
+            let field = settings
+                .get_field(name)
+                .unwrap_or_else(|| panic!("database-settings has {name}"));
+            assert_eq!(field.field_type, "string");
+            assert_eq!(field.protection, SchemaProtectionLevel::Core);
+            assert_eq!(field.required, Some(false));
+            assert_eq!(field.default, None);
+        }
     }
 
     #[test]

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -94,6 +94,15 @@ pub struct DatabaseEntry {
     /// Last time the database was opened, if ever.
     #[serde(default)]
     pub last_opened_at: Option<DateTime<Utc>>,
+    /// The cloud tenant schema this database binds to (ADR-053 per-database cloud
+    /// sync), mirrored from the database's DatabaseSettingsNode so the bound
+    /// tenant can be shown before the database is opened. Empty until bound.
+    #[serde(default)]
+    pub bound_tenant_schema: Option<String>,
+    /// The default collection id within the bound tenant, mirrored alongside
+    /// `bound_tenant_schema`. Empty until bound.
+    #[serde(default)]
+    pub bound_tenant_collection: Option<String>,
 }
 
 /// Runtime status of a registered database, derived at read time.
@@ -322,6 +331,28 @@ impl DatabaseManager {
         registry.save(&self.registry_path).await
     }
 
+    /// Mirror a database's bound cloud tenant into the registry (ADR-053
+    /// per-database cloud sync) so the binding can be shown before the database
+    /// is opened. Pass `None` to clear it on unbind. The authoritative record is
+    /// the database's DatabaseSettingsNode; this registry field is a display
+    /// mirror kept in step with it.
+    pub async fn set_bound_tenant(
+        &self,
+        id: &DatabaseId,
+        schema: Option<String>,
+        collection: Option<String>,
+    ) -> Result<()> {
+        let mut registry = self.registry.write().await;
+        let entry = registry
+            .databases
+            .iter_mut()
+            .find(|e| &e.id == id)
+            .ok_or_else(|| anyhow!("no database registered with id {id}"))?;
+        entry.bound_tenant_schema = schema;
+        entry.bound_tenant_collection = collection;
+        registry.save(&self.registry_path).await
+    }
+
     /// Ensure a default database is registered, returning its id.
     ///
     /// On first boot the registry is empty; this registers `path` under `name`
@@ -360,6 +391,8 @@ impl DatabaseManager {
             path,
             created_at: Utc::now(),
             last_opened_at: None,
+            bound_tenant_schema: None,
+            bound_tenant_collection: None,
         });
         registry.default_database = Some(id.clone());
         registry.save(&self.registry_path).await?;
@@ -568,6 +601,8 @@ impl DatabaseManager {
             path,
             created_at: Utc::now(),
             last_opened_at: None,
+            bound_tenant_schema: None,
+            bound_tenant_collection: None,
         };
         let mut registry = self.registry.write().await;
         registry.databases.push(entry.clone());
@@ -657,6 +692,52 @@ mod tests {
         let snap = mgr.list().await;
         assert_eq!(snap.databases.len(), 1);
         assert_eq!(snap.databases[0].entry.name, "Default");
+    }
+
+    #[tokio::test]
+    async fn set_bound_tenant_mirrors_persists_and_clears() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("databases.toml");
+        let mgr = DatabaseManager::load(path.clone(), test_context())
+            .await
+            .unwrap();
+        let id = mgr
+            .ensure_default_registered("Default".into(), PathBuf::from("/tmp/ns.db"))
+            .await
+            .unwrap();
+
+        // Fresh registrations are unbound.
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases[0].entry.bound_tenant_schema, None);
+        assert_eq!(snap.databases[0].entry.bound_tenant_collection, None);
+
+        mgr.set_bound_tenant(&id, Some("tenant_demo".into()), Some("c0".into()))
+            .await
+            .unwrap();
+        let snap = mgr.list().await;
+        assert_eq!(
+            snap.databases[0].entry.bound_tenant_schema.as_deref(),
+            Some("tenant_demo")
+        );
+        assert_eq!(
+            snap.databases[0].entry.bound_tenant_collection.as_deref(),
+            Some("c0")
+        );
+
+        // The binding survives a reload — the mirror is persisted to the registry.
+        drop(mgr);
+        let mgr = DatabaseManager::load(path, test_context()).await.unwrap();
+        let snap = mgr.list().await;
+        assert_eq!(
+            snap.databases[0].entry.bound_tenant_schema.as_deref(),
+            Some("tenant_demo")
+        );
+
+        // Unbind clears the mirror.
+        mgr.set_bound_tenant(&id, None, None).await.unwrap();
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases[0].entry.bound_tenant_schema, None);
+        assert_eq!(snap.databases[0].entry.bound_tenant_collection, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

First slice (S1) of ADR-053 per-database cloud sync (#1535): the additive, community-safe **storage** foundation for binding a database to a cloud tenant at runtime, replacing the current build-time-baked single tenant.

- **`DatabaseSettingsNode`** (the authoritative per-database record) gains `bound_tenant_schema` and `bound_tenant_collection` string fields, with `is_string`/null validation in the behavior. Both are empty until the Pro sync daemon binds the database.
- **`DatabaseEntry`** in `databases.toml` mirrors the same two fields (`#[serde(default)]`, so existing registries parse) so the bound tenant can be shown before the database is opened, with a `DatabaseManager::set_bound_tenant(id, schema, collection)` setter that keeps the mirror in step (pass `None` to clear on unbind).

No behavior change yet — nothing reads these fields; later slices (remove build-time injection, per-database session config, activate/deactivate lifecycle, status plumbing) build on them. The community build is unaffected (the fields are inert without the Pro sync daemon).

## Tests

- Behavior: existing `database_settings_*` suite stays green (schema presence, defaults, validation).
- `set_bound_tenant_mirrors_persists_and_clears`: a fresh registration is unbound; set → the mirror reflects the schema/collection; it survives a reload from disk; unbind clears it.
- Validated green locally before the PR: full `test:all` + `test:e2e` + `cargo test -p nodespace-app` via the pre-push gate; `cargo fmt` + `cargo clippy --workspace -- -D warnings` clean.

Part of #1535 (this is S1 of the S1–S8 decomposition posted on the issue).
