### PR TITLE
Drop build-time tenant baking from the Pro daemon plist (ADR-053 per-database cloud sync, S2 core)

### DIFF
--- a/packages/desktop-app/src-tauri/src/daemon_setup.rs
+++ b/packages/desktop-app/src-tauri/src/daemon_setup.rs
@@ -42,8 +42,6 @@ const SYSTEMD_SERVICE_NAME: &str = "nodespace.service";
 // project's PUBLISHABLE key (safe to bake into the binary).
 const PRO_SUPABASE_URL: Option<&str> = option_env!("NODESPACE_PRO_SUPABASE_URL");
 const PRO_ANON_KEY: Option<&str> = option_env!("NODESPACE_PRO_ANON_KEY");
-const PRO_SCHEMA: Option<&str> = option_env!("NODESPACE_PRO_SCHEMA");
-const PRO_COLLECTION: Option<&str> = option_env!("NODESPACE_PRO_COLLECTION");
 
 /// True when this binary was built as the Pro edition (cloud env baked in).
 fn is_pro_build() -> bool {
@@ -629,19 +627,18 @@ fn write_plist(home: &Path, plist_path: &Path, daemon_bin: &Path) -> Result<()> 
             .to_string_lossy(),
     );
 
-    // Pro edition: inject the Supabase cloud env the sync daemon needs (#156). The
-    // values are baked at build time; all are XML-safe (JWT chars / URLs / schema
-    // names contain no `<>&`). Empty for a community build.
+    // Pro edition: inject the deployment-wide Supabase endpoint the sync daemon
+    // needs. Only the project URL and publishable anon key are baked in — both are
+    // deployment-wide, not tenant-specific. The tenant a database syncs to (schema +
+    // collection) is bound per database at runtime and is deliberately NOT injected
+    // here (ADR-053 per-database cloud sync). Both values are XML-safe (JWT chars /
+    // URLs contain no `<>&`). Empty for a community build.
     let pro_env = if is_pro_build() {
         format!(
             "        <key>NODESPACED_PRO_SUPABASE_URL</key>\n        <string>{url}</string>\n\
-             \x20       <key>NODESPACED_PRO_ANON_KEY</key>\n        <string>{key}</string>\n\
-             \x20       <key>NODESPACED_PRO_SCHEMA</key>\n        <string>{schema}</string>\n\
-             \x20       <key>NODESPACED_PRO_COLLECTION</key>\n        <string>{coll}</string>\n",
+             \x20       <key>NODESPACED_PRO_ANON_KEY</key>\n        <string>{key}</string>\n",
             url = xml_escape(PRO_SUPABASE_URL.unwrap_or_default()),
             key = xml_escape(PRO_ANON_KEY.unwrap_or_default()),
-            schema = xml_escape(PRO_SCHEMA.unwrap_or_default()),
-            coll = xml_escape(PRO_COLLECTION.unwrap_or_default()),
         )
     } else {
         String::new()


### PR DESCRIPTION
## Summary

S2 (core half) of ADR-053 per-database cloud sync (#1535): stop baking the **tenant** (schema + collection) into the Pro daemon's launchd plist at build time. Only the deployment-wide Supabase **endpoint** — project URL + publishable anon key — stays build-time; the tenant a database syncs to is bound per database at runtime and is no longer an install-time constant.

- Removed the `PRO_SCHEMA` / `PRO_COLLECTION` `option_env!` constants (`NODESPACE_PRO_SCHEMA` / `NODESPACE_PRO_COLLECTION` build-time env).
- Removed the `NODESPACED_PRO_SCHEMA` / `NODESPACED_PRO_COLLECTION` keys from the Pro `EnvironmentVariables` block the app writes into `~/Library/LaunchAgents`. `NODESPACED_PRO_SUPABASE_URL` + `NODESPACED_PRO_ANON_KEY` remain (deployment-wide, not tenant-specific).

The tenant model for this epic is a Postgres **schema in one shared Supabase project**, so the URL + anon key are legitimately deployment-wide and correct to keep build-time; only schema/collection are per-tenant. With this change a Pro install no longer carries a single baked tenant — the daemon takes its tenant from its runtime configuration (the per-database bound tenant added in S1, wired into the daemon's session path in a later slice).

## Community safety

Fully inert for the community build: these env keys were only ever emitted when `is_pro_build()` (i.e. a Pro build with `NODESPACE_PRO_SUPABASE_URL` baked in). The community `nodespaced` daemon never received them. No behavior change to the community edition.

## Tests

- `cargo fmt -p nodespace-app -- --check` clean; `cargo clippy -p nodespace-app --all-targets -- -D warnings` clean; `cargo test -p nodespace-app` green (no test asserts on the plist tenant keys — the plist writer has no snapshot coverage, and no other code referenced `PRO_SCHEMA` / `PRO_COLLECTION`).
- Change is isolated to the Pro plist generation in `daemon_setup.rs` — no core-lib, frontend, or e2e surface touched.

The matching sync-repo change (remove the `.pkg` plist template placeholders + the `build-pro-pkg.sh` / `build-pro-dmg.sh` tenant substitutions) lands as a follow-up PR in nodespace-sync and must merge after this one, so a Pro build never emits an empty schema.

Part of #1535 (S2 of the S1–S8 decomposition on the issue).
