### PR TITLE
Add UI-extension registry for two-axis Pro-sync surfaces (ADR-053)

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
@@ -1,0 +1,53 @@
+<!--
+  Collaboration locked placeholder.
+
+  Shown in the collection viewer's Collaboration tab for the `enable-prompt`
+  variant — a Pro daemon whose active database has `sync_enabled: false`. People &
+  roles live in the cloud tenant a database is bound to, so there is nothing to
+  show until sync is enabled. Purely static: no membership calls, no daemon
+  commands. Accepts the host collection's `nodeId` for a uniform viewer-extension
+  signature (surfaced as a data attribute for debugging).
+-->
+<script lang="ts">
+  let { nodeId }: { nodeId: string } = $props();
+</script>
+
+<div class="collab-locked" data-collection-id={nodeId}>
+  <div class="lock" aria-hidden="true">🔒</div>
+  <p class="headline">Collaboration is off for this database</p>
+  <p class="detail">
+    Enable cloud sync for this database to invite people, manage roles, and share
+    collections.
+  </p>
+</div>
+
+<style>
+  .collab-locked {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 48px 24px;
+    text-align: center;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .lock {
+    font-size: 28px;
+    opacity: 0.8;
+  }
+
+  .headline {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+  }
+
+  .detail {
+    margin: 0;
+    max-width: 360px;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-tab.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-tab.svelte
@@ -1,0 +1,15 @@
+<!--
+  Collaboration tab.
+
+  Registry wrapper that mounts the unchanged `CollaborationView` for the
+  sync-enabled variants (`sign-in` / `connected`). Exists only to move the view's
+  mounting behind the UI-extension registry — `CollaborationView` keeps its own
+  internal `proSync.tier` gate and all its logic.
+-->
+<script lang="ts">
+  import CollaborationView from '$lib/components/collaboration/collaboration-view.svelte';
+
+  let { nodeId }: { nodeId: string } = $props();
+</script>
+
+<CollaborationView collectionId={nodeId} />

--- a/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
@@ -1,0 +1,84 @@
+<!--
+  Enable-sync prompt.
+
+  Rendered in the app-shell overlay slot for the `enable-prompt` variant — a Pro
+  daemon whose active database has `sync_enabled: false`. Offers to turn cloud sync
+  on for this database.
+
+  The concrete "turn sync on" action available today is starting the interactive
+  sign-in (`pro_initiate_oauth`): a Pro user opts a database into sync by signing
+  in to the cloud, after which the daemon binds the tenant and flips
+  `sync_enabled` / `auth_status` on the DatabaseSettingsNode, advancing the variant.
+  (A dedicated per-database "enable sync" intent command is backend follow-up.)
+
+  Never rendered in the community build (that resolves to `teaser`), so invoking a
+  Pro command here is safe.
+-->
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('EnableSyncPill');
+
+  let pending = $state(false);
+
+  async function enableSync() {
+    if (pending) return;
+    pending = true;
+    try {
+      // Starting sign-in is how a Pro user enables sync for a database today.
+      await invoke('pro_initiate_oauth');
+      log.info('enable-sync: sign-in started');
+    } catch (e) {
+      log.warn('enable-sync: pro_initiate_oauth failed', { error: e });
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<button
+  class="enable-sync-pill"
+  type="button"
+  title="Turn on cloud sync for this database"
+  aria-label="Enable cloud sync for this database"
+  disabled={pending}
+  onclick={enableSync}
+>
+  <span class="dot" aria-hidden="true"></span>
+  <span class="label">{pending ? 'Enabling…' : 'Enable sync'}</span>
+</button>
+
+<style>
+  .enable-sync-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .enable-sync-pill:hover:not(:disabled) {
+    background: hsl(var(--muted));
+  }
+
+  .enable-sync-pill:disabled {
+    cursor: default;
+    opacity: 0.85;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -26,9 +26,9 @@
   import { createLogger } from '$lib/utils/logger';
   import { openUrl, isExternalUrl, isNodespaceUrl } from '$lib/utils/external-links';
   import OnboardingWizard from '$lib/components/onboarding/onboarding-wizard.svelte';
-  import ProSyncPill from '$lib/components/pro-sync-pill.svelte';
-  import ProReloginModal from '$lib/components/pro-relogin-modal.svelte';
   import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { getActiveChromeContributions } from '$lib/plugins/ui-extensions.svelte';
+  import ExtensionOutlet from '$lib/plugins/extension-outlet.svelte';
   import ConflictToast from '$lib/components/conflict-toast.svelte';
   import { recoveredItems } from '$lib/stores/recovered-items.svelte';
   import { conflictNotifications } from '$lib/stores/conflict-notifications.svelte';
@@ -53,20 +53,6 @@
   // First-launch onboarding wizard (Issue #1180).
   let showOnboarding = $state(false);
 
-  // Pro re-login prompt (T18, #1304). The daemon emits AUTH_REQUIRED when the
-  // persisted refresh token can't be renewed; we surface a modal offering a
-  // fresh sign-in or working offline. Dismissal is tracked per-episode via
-  // proSync.authRequiredEpisode (bumped each time the daemon re-enters
-  // auth-required), so the modal re-arms automatically with no effect needed.
-  let dismissedEpisode = $state(-1);
-  let reloginPending = $state(false);
-
-  let showReloginModal = $derived(
-    proSync.isPro &&
-      proSync.state === 'auth-required' &&
-      dismissedEpisode !== proSync.authRequiredEpisode
-  );
-
   // Recovered Items (core#1303): once the daemon's probe confirms Pro tier, load
   // the local-only recovery log. If the daemon preserved any conflict "losers",
   // show a one-time snackbar on first open; the inline badge handles per-node
@@ -84,24 +70,6 @@
         conflictType: 'recovered-items'
       });
     });
-  }
-
-  async function handleReloginSignIn() {
-    if (reloginPending) return;
-    reloginPending = true;
-    try {
-      // Same PKCE flow the sync pill uses; the daemon opens the browser and
-      // the modal closes as `sync:status` transitions away from auth-required.
-      await invoke('pro_initiate_oauth');
-    } catch (e) {
-      log.warn('pro_initiate_oauth (relogin) failed', { error: e });
-    } finally {
-      reloginPending = false;
-    }
-  }
-
-  function handleReloginWorkOffline() {
-    dismissedEpisode = proSync.authRequiredEpisode;
   }
 
   /**
@@ -656,11 +624,15 @@
           <PaneManager />
         </div>
 
-        <!-- Pro-tier sync pill. Renders only when the daemon's capability
-             probe finds nodespace.pro.v1.CloudSyncService — community mode
-             hides it entirely. Floats top-right of the app-shell content. -->
+        <!-- Pro chrome overlay slot (sync pill / upgrade teaser / enable-sync
+             prompt) — registry-driven. The active variant resolves from
+             the daemon tier and the active database's DatabaseSettingsNode, so the
+             community build shows an upgrade teaser and each Pro state its own
+             pill. Floats top-right of the app-shell content. -->
         <div class="pro-sync-pill-slot">
-          <ProSyncPill />
+          {#each getActiveChromeContributions('app-shell-overlay') as c (c.variant)}
+            <ExtensionOutlet load={c.lazyLoad} />
+          {/each}
         </div>
       </div>
 
@@ -674,14 +646,11 @@
     <!-- Conflict resolution notifications (Issue #642) -->
     <ConflictToast />
 
-    <!-- Pro re-login prompt when the daemon's session can't be refreshed (T18, #1304) -->
-    <ProReloginModal
-      open={showReloginModal}
-      detail={proSync.detail}
-      pending={reloginPending}
-      onSignIn={handleReloginSignIn}
-      onWorkOffline={handleReloginWorkOffline}
-    />
+    <!-- Pro chrome modal slot (re-login prompt when the daemon's session can't be
+         refreshed, T18) — registry-driven. -->
+    {#each getActiveChromeContributions('app-shell-modal') as c (c.variant)}
+      <ExtensionOutlet load={c.lazyLoad} />
+    {/each}
   </NodeServiceContext>
 </ThemeProvider>
 

--- a/packages/desktop-app/src/lib/components/pro-relogin-slot.svelte
+++ b/packages/desktop-app/src/lib/components/pro-relogin-slot.svelte
@@ -1,0 +1,57 @@
+<!--
+  Pro re-login slot.
+
+  Registry wrapper that owns the re-login orchestration the app shell used to hold,
+  and mounts the unchanged, presentational `ProReloginModal`. Contributed to the
+  `app-shell-modal` slot for the sync-enabled variants (`sign-in` / `connected`);
+  the modal itself only becomes visible on an AUTH_REQUIRED transition.
+
+  The daemon emits AUTH_REQUIRED when a persisted refresh token can't be renewed
+  (T18). Dismissal is tracked per-episode by comparing `proSync.authRequiredEpisode`
+  (bumped each time the daemon re-enters auth-required) against the last-dismissed
+  episode, so the modal re-arms automatically with no `$effect` (ADR-049). Both the
+  current and last-dismissed episode live on `proSync`, so a dismissal survives this
+  slot remounting when the variant flips between `sign-in` and `connected`.
+-->
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import ProReloginModal from '$lib/components/pro-relogin-modal.svelte';
+  import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('ProReloginSlot');
+
+  let reloginPending = $state(false);
+
+  const showReloginModal = $derived(
+    proSync.isPro &&
+      proSync.state === 'auth-required' &&
+      proSync.dismissedReloginEpisode !== proSync.authRequiredEpisode
+  );
+
+  async function handleReloginSignIn() {
+    if (reloginPending) return;
+    reloginPending = true;
+    try {
+      // Same PKCE flow the sync pill uses; the daemon opens the browser and the
+      // modal closes as `sync:status` transitions away from auth-required.
+      await invoke('pro_initiate_oauth');
+    } catch (e) {
+      log.warn('pro_initiate_oauth (relogin) failed', { error: e });
+    } finally {
+      reloginPending = false;
+    }
+  }
+
+  function handleReloginWorkOffline() {
+    proSync.dismissedReloginEpisode = proSync.authRequiredEpisode;
+  }
+</script>
+
+<ProReloginModal
+  open={showReloginModal}
+  detail={proSync.detail}
+  pending={reloginPending}
+  onSignIn={handleReloginSignIn}
+  onWorkOffline={handleReloginWorkOffline}
+/>

--- a/packages/desktop-app/src/lib/components/pro-teaser-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-teaser-pill.svelte
@@ -1,0 +1,62 @@
+<!--
+  Pro upgrade teaser.
+
+  Rendered in the app-shell overlay slot for the `teaser` variant — i.e. whenever
+  the daemon is not Pro (community build, or before the capability probe resolves).
+  ADR-039 calls for an upgrade CTA in place of sync controls rather than hiding the
+  slot entirely.
+
+  Deliberately static: no daemon commands, no Pro data, no network. It is purely an
+  informational upsell, so the community build stays behaviorally inert with
+  respect to sync (the free-user guardrail asserts no Pro command is ever invoked).
+  Copy is hard-coded here, not data-driven.
+-->
+<script lang="ts">
+  const LEARN_MORE_URL = 'https://nodespace.ai/pro';
+
+  function openLearnMore() {
+    // Best-effort: open in the user's browser when the web API is available.
+    // No Tauri/daemon command — this must stay inert in the community build.
+    if (typeof window !== 'undefined' && typeof window.open === 'function') {
+      window.open(LEARN_MORE_URL, '_blank', 'noopener,noreferrer');
+    }
+  }
+</script>
+
+<button
+  class="pro-teaser-pill"
+  type="button"
+  title="Sync your notes across devices with NodeSpace Pro"
+  aria-label="Upgrade to NodeSpace Pro"
+  onclick={openLearnMore}
+>
+  <span class="spark" aria-hidden="true">✦</span>
+  <span class="label">Upgrade to Pro</span>
+</button>
+
+<style>
+  .pro-teaser-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card));
+    color: hsl(var(--muted-foreground));
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .pro-teaser-pill:hover {
+    background: hsl(var(--muted));
+    color: hsl(var(--foreground));
+  }
+
+  .spark {
+    color: #a855f7;
+    font-size: 11px;
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
@@ -22,12 +22,19 @@
   import { navigationStore, addTab, setActiveTab } from '$lib/stores/navigation.svelte';
   import { createLogger } from '$lib/utils/logger';
   import { v4 as uuidv4 } from 'uuid';
-  import CollaborationView from '$lib/components/collaboration/collaboration-view.svelte';
-  import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { getActiveViewerExtensions } from '$lib/plugins/ui-extensions.svelte';
+  import ExtensionOutlet from '$lib/plugins/extension-outlet.svelte';
 
-  // Collection sub-view: "contents" (member nodes, the default/community view) or
-  // "collaboration" (people & roles, Pro only — the tab strip only appears for Pro).
-  let activeView = $state<'contents' | 'collaboration'>('contents');
+  // Collection sub-views: the built-in "contents" tab (member nodes, always shown)
+  // plus any registry-contributed tabs (e.g. the Pro "Collaboration" tab). The
+  // active tab is 'contents' or a contributed tab's id.
+  let activeView = $state<string>('contents');
+
+  // Viewer extensions contributed for the current Pro-sync variant. Empty in the
+  // community build (variant `teaser`), so the tab strip and the collaboration
+  // view never appear — the collection viewer imports nothing Pro.
+  const collabExtensions = $derived(getActiveViewerExtensions('collection'));
+  const activeExtension = $derived(collabExtensions.find((e) => e.tab.id === activeView));
 
   const log = createLogger('CollectionNodeViewer');
 
@@ -175,8 +182,10 @@
       <p class="collection-description">{collection.properties.description}</p>
     {/if}
 
-    {#if proSync.isPro}
-      <!-- Pro-only: switch between the collection's content nodes and its people. -->
+    {#if collabExtensions.length > 0}
+      <!-- Registry-contributed tabs (e.g. the Pro "Collaboration" tab) alongside
+           the built-in contents view; the strip only appears when something
+           contributes for the active variant. -->
       <div class="collection-tabs" role="tablist">
         <button
           class="tab"
@@ -185,19 +194,23 @@
           aria-selected={activeView === 'contents'}
           onclick={() => (activeView = 'contents')}>Contents</button
         >
-        <button
-          class="tab"
-          class:active={activeView === 'collaboration'}
-          role="tab"
-          aria-selected={activeView === 'collaboration'}
-          onclick={() => (activeView = 'collaboration')}>Collaboration</button
-        >
+        {#each collabExtensions as ext (ext.tab.id)}
+          <button
+            class="tab"
+            class:active={activeView === ext.tab.id}
+            role="tab"
+            aria-selected={activeView === ext.tab.id}
+            onclick={() => (activeView = ext.tab.id)}>{ext.tab.label}</button
+          >
+        {/each}
       </div>
     {/if}
   </div>
 
-  {#if proSync.isPro && activeView === 'collaboration'}
-    <CollaborationView collectionId={nodeId} />
+  {#if activeExtension}
+    {#key activeExtension.variant}
+      <ExtensionOutlet load={activeExtension.lazyLoad} props={{ nodeId }} />
+    {/key}
   {:else}
   <!-- Content -->
   <div class="collection-content">

--- a/packages/desktop-app/src/lib/plugins/extension-outlet.svelte
+++ b/packages/desktop-app/src/lib/plugins/extension-outlet.svelte
@@ -1,0 +1,24 @@
+<!--
+  ExtensionOutlet — mounts one lazily-loaded UI-extension component.
+
+  Generic host used by the app shell (chrome slots) and node viewers (viewer
+  extensions) to render a registry contribution without importing it directly.
+  The dynamic import runs once per `load` value; callers key their {#each} by the
+  contribution's variant so a variant change mounts a fresh outlet with a new load.
+-->
+<script lang="ts" generics="Props extends Record<string, unknown> = Record<string, never>">
+  import type { Component } from 'svelte';
+
+  let {
+    load,
+    props = {} as Props
+  }: {
+    load: () => Promise<{ default: Component<Props> }>;
+    props?: Props;
+  } = $props();
+</script>
+
+{#await load() then mod}
+  {@const Loaded = mod.default}
+  <Loaded {...props} />
+{/await}

--- a/packages/desktop-app/src/lib/plugins/pro-plugin.ts
+++ b/packages/desktop-app/src/lib/plugins/pro-plugin.ts
@@ -1,0 +1,91 @@
+/**
+ * Built-in Pro UI extension
+ * =================================
+ *
+ * The single {@link UiExtensionDefinition} for the Pro-sync surface. It maps each
+ * variant of the two-signal state machine (see `ui-extensions.svelte.ts`) to the
+ * component that renders it:
+ *
+ *   | variant        | overlay pill              | modal              | collection tab              |
+ *   |----------------|---------------------------|--------------------|-----------------------------|
+ *   | teaser         | pro-teaser-pill (upsell)  | —                  | — (none)                    |
+ *   | enable-prompt  | enable-sync-pill          | —                  | collaboration-locked        |
+ *   | sign-in        | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
+ *   | connected      | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
+ *
+ * Every component is referenced only through `() => import(...)`, so nothing Pro
+ * is imported eagerly — the shared shell stays free of Pro component imports.
+ * Existing Pro components (`pro-sync-pill`, `pro-relogin-modal`,
+ * `collaboration-view`) are mounted unchanged; the new small wrappers
+ * (`pro-relogin-slot`, `collaboration-tab`) exist only to move their mounting
+ * behind the registry.
+ *
+ * Registration is a module-load side effect so the contributions are present
+ * before the first render (the registry is static config, not reactive state).
+ */
+
+import { uiExtensionRegistry, type UiExtensionDefinition } from './ui-extensions';
+
+const COLLABORATION_TAB = { appliesTo: 'collection', id: 'collaboration', label: 'Collaboration' };
+
+export const proSyncUiExtension: UiExtensionDefinition = {
+  id: 'pro-sync',
+  name: 'NodeSpace Pro Sync',
+  version: '1.0.0',
+  chrome: [
+    // Overlay pill — one per variant.
+    {
+      slot: 'app-shell-overlay',
+      variant: 'teaser',
+      lazyLoad: () => import('$lib/components/pro-teaser-pill.svelte')
+    },
+    {
+      slot: 'app-shell-overlay',
+      variant: 'enable-prompt',
+      lazyLoad: () => import('$lib/components/enable-sync-pill.svelte')
+    },
+    {
+      slot: 'app-shell-overlay',
+      variant: 'sign-in',
+      lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
+    },
+    {
+      slot: 'app-shell-overlay',
+      variant: 'connected',
+      lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
+    },
+    // Re-login modal — only meaningful once sync is enabled for the database; the
+    // wrapper itself only shows the modal on an AUTH_REQUIRED transition.
+    {
+      slot: 'app-shell-modal',
+      variant: 'sign-in',
+      lazyLoad: () => import('$lib/components/pro-relogin-slot.svelte')
+    },
+    {
+      slot: 'app-shell-modal',
+      variant: 'connected',
+      lazyLoad: () => import('$lib/components/pro-relogin-slot.svelte')
+    }
+  ],
+  viewerExtensions: [
+    // Collaboration tab. Locked placeholder while sync is disabled for this
+    // database (Pro daemon, sync_enabled: false); the live view once enabled.
+    {
+      tab: COLLABORATION_TAB,
+      variant: 'enable-prompt',
+      lazyLoad: () => import('$lib/components/collaboration/collaboration-locked.svelte')
+    },
+    {
+      tab: COLLABORATION_TAB,
+      variant: 'sign-in',
+      lazyLoad: () => import('$lib/components/collaboration/collaboration-tab.svelte')
+    },
+    {
+      tab: COLLABORATION_TAB,
+      variant: 'connected',
+      lazyLoad: () => import('$lib/components/collaboration/collaboration-tab.svelte')
+    }
+  ]
+};
+
+uiExtensionRegistry.register(proSyncUiExtension);

--- a/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
+++ b/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
@@ -1,0 +1,88 @@
+/**
+ * Reactive wrapper over {@link UiExtensionRegistry}
+ * ========================================================
+ *
+ * The registry (`ui-extensions.ts`) holds declarative, non-reactive data. This
+ * module layers reactivity on top (ADR-049): it resolves the active Pro-sync
+ * variant from the two signals and returns only the contributions matching it.
+ *
+ * Both source reads are reactive when these functions are called inside a
+ * `$derived`/template:
+ *   - `proSync.tier` is `$state`.
+ *   - `SharedNodeStore.getInstance().getNode(...)` reads a `SvelteMap`, so a
+ *     later `setNode` for the `DatabaseSettingsNode` re-runs the derivation.
+ *
+ * Importing this module also registers the built-in Pro UI extension (side-effect
+ * import of `./pro-plugin`), so any consumer of the wrapper sees the contributions
+ * without a separate init call.
+ */
+
+import './pro-plugin';
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import {
+  uiExtensionRegistry,
+  DATABASE_SETTINGS_NODE_ID,
+  type ChromeSlot,
+  type ChromeContribution,
+  type ViewerExtension,
+  type ProSyncVariant
+} from './ui-extensions';
+
+/** The `database-settings`-namespaced properties held on the settings singleton. */
+interface DatabaseSettings {
+  sync_enabled?: boolean;
+  auth_status?: string;
+}
+
+/**
+ * Read the active database's `DatabaseSettingsNode` properties (the
+ * `database-settings` sub-object), or `undefined` when the node isn't hydrated
+ * yet. Reads the reactive `SharedNodeStore` map, so callers in a reactive context
+ * re-run when the node lands or changes.
+ */
+export function activeDatabaseSettings(): DatabaseSettings | undefined {
+  const node = SharedNodeStore.getInstance().getNode(DATABASE_SETTINGS_NODE_ID);
+  const settings = (node?.properties as Record<string, unknown> | undefined)?.['database-settings'];
+  return settings && typeof settings === 'object' ? (settings as DatabaseSettings) : undefined;
+}
+
+/**
+ * Resolve the current Pro-sync variant from the two independent signals:
+ *   - axis 1: `proSync.tier` (daemon build variant) — not Pro ⇒ `teaser`.
+ *   - axis 2: the active database's `sync_enabled` / `auth_status`.
+ *
+ * A plain function (not a `$derived`) so it composes into any consumer's own
+ * derivation; its reads are reactive because the underlying sources are.
+ */
+export function resolveProSyncVariant(): ProSyncVariant {
+  if (proSync.tier !== 'pro') return 'teaser';
+  const settings = activeDatabaseSettings();
+  if (settings?.sync_enabled !== true) return 'enable-prompt';
+  if (settings.auth_status === 'connected') return 'connected';
+  return 'sign-in';
+}
+
+/**
+ * True when sync is actually active for the current build + active database —
+ * i.e. axis 1 is Pro AND axis 2 has `sync_enabled: true`. This is the two-axis
+ * gate dependent stores (membership, recovered-items) use in place of the raw
+ * `proSync.isPro` (which is axis 1 only).
+ */
+export function isProSyncActive(): boolean {
+  const variant = resolveProSyncVariant();
+  return variant === 'sign-in' || variant === 'connected';
+}
+
+/** Chrome contributions for `slot` that match the currently-resolved variant. */
+export function getActiveChromeContributions(slot: ChromeSlot): ChromeContribution[] {
+  const variant = resolveProSyncVariant();
+  return uiExtensionRegistry.chromeFor(slot).filter((c) => c.variant === variant);
+}
+
+/** Viewer extensions for `nodeType` that match the currently-resolved variant. */
+export function getActiveViewerExtensions(nodeType: string): ViewerExtension[] {
+  const variant = resolveProSyncVariant();
+  return uiExtensionRegistry.viewersFor(nodeType).filter((e) => e.variant === variant);
+}

--- a/packages/desktop-app/src/lib/plugins/ui-extensions.ts
+++ b/packages/desktop-app/src/lib/plugins/ui-extensions.ts
@@ -1,0 +1,141 @@
+/**
+ * UI-Extension Registry
+ * =============================
+ *
+ * A sibling to the node-type {@link PluginRegistry} for Pro-edition GUI chrome
+ * (the sync pill, the re-login modal, the collaboration tab). Shared components
+ * (`app-shell.svelte`, `collection-node-viewer.svelte`) import nothing Pro; they
+ * render whatever the registry contributes for the currently-resolved variant.
+ *
+ * Two independent signals drive which variant renders (ADR-053):
+ *   1. `proSync.tier` — "can this daemon binary sync?" (app-global, static per
+ *      session).
+ *   2. the active database's `DatabaseSettingsNode` — "is sync enabled /
+ *      authenticated for THIS database?" (per-database, changes on switch or
+ *      settings edit).
+ *
+ * The registry itself is a plain data class (mirrors `PluginRegistry`); the
+ * reactivity that resolves the active variant and filters contributions lives in
+ * the sibling `ui-extensions.svelte.ts` wrapper, never baked into this class
+ * (ADR-049).
+ */
+
+import type { Component } from 'svelte';
+import { createLogger } from '$lib/utils/logger';
+
+const log = createLogger('UiExtensionRegistry');
+
+/**
+ * The reserved id of the per-database `DatabaseSettingsNode` singleton. Core seeds
+ * exactly one such node per database under this id (`node_service`'s
+ * `DATABASE_SETTINGS_NODE_ID`); its `database-settings`-namespaced properties carry
+ * `sync_enabled` (user intent) and `auth_status` (`local` | `connected`). The
+ * schema/nodeType slug is the bare `database-settings` — this instance id is
+ * deliberately distinct so the two never collide.
+ */
+export const DATABASE_SETTINGS_NODE_ID = 'database-settings-singleton';
+
+/** The chrome slots a contribution can target in the app shell. */
+export type ChromeSlot = 'app-shell-overlay' | 'app-shell-modal';
+
+/** The four states the Pro-sync surface can be in (the variant state machine). */
+export type ProSyncVariant = 'teaser' | 'enable-prompt' | 'sign-in' | 'connected';
+
+/**
+ * One chrome contribution: a lazily-loaded component mounted into `slot` when the
+ * resolved variant equals `variant`. Kept declarative — no component is imported
+ * eagerly, so the shared shell never pulls a Pro component into its bundle graph.
+ */
+export interface ChromeContribution {
+  slot: ChromeSlot;
+  /** Which `resolveVariant()` output this renders for. */
+  variant: ProSyncVariant;
+  lazyLoad: () => Promise<{ default: Component }>;
+  /** Higher renders first when several match (default 0). */
+  priority?: number;
+}
+
+/**
+ * One node-viewer extension: a tab contributed to a viewer of `tab.appliesTo`
+ * node type, mounted when the resolved variant equals `variant`. The component
+ * receives the host node's id.
+ */
+export interface ViewerExtension {
+  tab: { appliesTo: string; id: string; label: string };
+  variant: ProSyncVariant;
+  lazyLoad: () => Promise<{ default: Component<{ nodeId: string }> }>;
+  priority?: number;
+}
+
+/**
+ * A declarative bundle of chrome + viewer contributions for one feature. Multiple
+ * definitions can register; the wrapper flattens and variant-filters across all.
+ */
+export interface UiExtensionDefinition {
+  id: string;
+  name: string;
+  version: string;
+  chrome?: ChromeContribution[];
+  viewerExtensions?: ViewerExtension[];
+}
+
+/**
+ * Holds registered UI-extension definitions. Pure data + lookups — no `$state`,
+ * no reactivity (that is layered on in `ui-extensions.svelte.ts`). Mirrors the
+ * structural shape of `PluginRegistry` (plain class, `Map`, register/unregister).
+ */
+export class UiExtensionRegistry {
+  private extensions = new Map<string, UiExtensionDefinition>();
+
+  /** Register (or replace) a definition by id. Idempotent. */
+  register(def: UiExtensionDefinition): void {
+    this.extensions.set(def.id, def);
+    log.debug('registered ui-extension', { id: def.id });
+  }
+
+  /** Remove a definition by id. */
+  unregister(id: string): void {
+    this.extensions.delete(id);
+  }
+
+  /** Whether a definition with `id` is registered. */
+  has(id: string): boolean {
+    return this.extensions.has(id);
+  }
+
+  /** All registered definitions, in insertion order. */
+  all(): UiExtensionDefinition[] {
+    return [...this.extensions.values()];
+  }
+
+  /**
+   * Every chrome contribution targeting `slot`, across all definitions, sorted by
+   * descending priority. Does NOT variant-filter — the reactive wrapper does that.
+   */
+  chromeFor(slot: ChromeSlot): ChromeContribution[] {
+    const out: ChromeContribution[] = [];
+    for (const def of this.extensions.values()) {
+      for (const c of def.chrome ?? []) {
+        if (c.slot === slot) out.push(c);
+      }
+    }
+    return out.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  }
+
+  /**
+   * Every viewer extension whose tab applies to `nodeType`, across all
+   * definitions, sorted by descending priority. Does NOT variant-filter.
+   */
+  viewersFor(nodeType: string): ViewerExtension[] {
+    const out: ViewerExtension[] = [];
+    for (const def of this.extensions.values()) {
+      for (const e of def.viewerExtensions ?? []) {
+        if (e.tab.appliesTo === nodeType) out.push(e);
+      }
+    }
+    return out.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  }
+}
+
+/** Process-wide singleton (mirrors `pluginRegistry`). */
+export const uiExtensionRegistry = new UiExtensionRegistry();

--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_PANE_ID
 } from '$lib/stores/navigation.svelte';
 import { formatDateISO } from '$lib/utils/date-formatting';
+import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
 
 const log = createLogger('DatabaseStore');
 
@@ -86,6 +87,9 @@ class DatabaseStore {
         // so the switcher always shows a concrete selection.
         this.activeDatabaseId =
           this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
+        // Hydrate the active database's DatabaseSettingsNode so the Pro-sync
+        // variant machine can read sync_enabled/auth_status.
+        this.hydrateDatabaseSettings();
       }
     } catch (err) {
       this.error = String(err);
@@ -146,10 +150,25 @@ class DatabaseStore {
       // Reload the sidebar from the new database.
       collectionsData.loadCollections();
       schemasData.loadSchemas();
+      // Re-hydrate the new database's DatabaseSettingsNode (the previous one was
+      // evicted by clearAll) so the Pro-sync variant re-resolves for it.
+      this.hydrateDatabaseSettings();
     } catch (err) {
       this.error = String(err);
       log.error('Failed to switch database', { id, error: err });
     }
+  }
+
+  /**
+   * Load the active database's `DatabaseSettingsNode` into the shared store so the
+   * Pro-sync variant machine resolves from its `sync_enabled`/`auth_status`.
+   * Fire-and-forget: the switch/load must not block on it, and a missing node
+   * (older database not yet backfilled) simply leaves the variant at its default.
+   */
+  private hydrateDatabaseSettings(): void {
+    sharedNodeStore.ensureNode(DATABASE_SETTINGS_NODE_ID).catch((err) => {
+      log.debug('Could not hydrate DatabaseSettingsNode', { error: err });
+    });
   }
 
   /**

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -5,8 +5,9 @@
  * caller's own identity, so the Collaboration view (S3/S4) and onboarding inbox
  * (S5) read reactive state instead of calling the daemon on every render.
  *
- * Pro-gated: every method early-returns / yields empty in community mode
- * (`proSync.tier !== 'pro'`), so the community build stays behaviorally
+ * Pro-gated on the two-axis check: every method early-returns / yields
+ * empty unless the daemon is Pro AND sync is enabled for the active database (see
+ * {@link MembershipStore.isPro}), so the community build stays behaviorally
  * unchanged — it never touches the membership commands.
  *
  * Caller identity: fetched once via `pro_current_person` (see the S2 design note
@@ -24,7 +25,7 @@ import {
 	type Permission,
 	type Person
 } from '$lib/services/membership-service';
-import { proSync } from '$lib/stores/pro-sync.svelte';
+import { isProSyncActive } from '$lib/plugins/ui-extensions.svelte';
 import { createLogger } from '$lib/utils/logger';
 
 const log = createLogger('MembershipStore');
@@ -62,9 +63,14 @@ class MembershipStore {
 	joinableError = $state<string | null>(null);
 	private joinableLoaded = false;
 
-	/** Pro-gate — the whole store is inert in community mode. */
+	/**
+	 * Two-axis Pro-gate: the store is inert unless the daemon is Pro AND
+	 * sync is enabled for the *active database* (its DatabaseSettingsNode has
+	 * `sync_enabled: true`). has_role edges are per-database under ADR-053, so a Pro
+	 * daemon whose active database hasn't enabled sync has no roster to manage.
+	 */
 	get isPro(): boolean {
-		return proSync.isPro;
+		return isProSyncActive();
 	}
 
 	/**

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -84,6 +84,15 @@ class ProSyncStore {
   authRequiredEpisode = $state(0);
 
   /**
+   * The `authRequiredEpisode` the user last dismissed via "Work offline". Held on
+   * the store (not inside the re-login slot component) so a dismissal survives the
+   * slot remounting when the resolved variant flips between `sign-in` and
+   * `connected` — both map to the same re-login slot, so a flip must not re-arm an
+   * already-dismissed modal. `-1` = nothing dismissed yet.
+   */
+  dismissedReloginEpisode = $state(-1);
+
+  /**
    * Bumped each time `userEmail` transitions from empty to non-empty — i.e. a fresh
    * sign-in. Lets consumers (the sync pill's first-run onboarding) react to the
    * transition via a derived comparison instead of an effect that reads and writes
@@ -91,6 +100,15 @@ class ProSyncStore {
    */
   signedInEpisode = $state(0);
 
+  /**
+   * Axis 1 only: "this daemon binary CAN sync" (the capability probe found
+   * a Pro daemon). This is NOT "sync is active" — whether sync is enabled and
+   * authenticated for the *active database* is axis 2, held on that database's
+   * DatabaseSettingsNode. Use `isProSyncActive()` from `ui-extensions.svelte` for
+   * the combined two-axis gate (what the membership store keys off). The
+   * recovered-items log is per-user, not per-database, so it keys off this
+   * axis-1 flag directly.
+   */
   isPro = $derived(this.tier === 'pro');
 
   /**

--- a/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
@@ -1,0 +1,44 @@
+/**
+ * enable-sync-pill component.
+ *
+ * Rendered only for a Pro daemon whose active database has sync disabled. Clicking
+ * starts the interactive sign-in — the concrete "turn sync on" action available
+ * today (a dedicated per-database enable command is backend follow-up).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import EnableSyncPill from '$lib/components/enable-sync-pill.svelte';
+
+describe('EnableSyncPill', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue('attempt-1');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the enable-sync CTA', () => {
+    const { getByRole, getByText } = render(EnableSyncPill);
+    expect(getByText('Enable sync')).toBeTruthy();
+    expect(getByRole('button', { name: /enable cloud sync/i })).toBeTruthy();
+  });
+
+  it('starts sign-in on click via pro_initiate_oauth', async () => {
+    const { getByRole } = render(EnableSyncPill);
+    await fireEvent.click(getByRole('button', { name: /enable cloud sync/i }));
+    expect(mockInvoke).toHaveBeenCalledWith('pro_initiate_oauth');
+  });
+});

--- a/packages/desktop-app/src/tests/components/pro-teaser-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-teaser-pill.test.ts
@@ -1,0 +1,45 @@
+/**
+ * pro-teaser-pill component.
+ *
+ * The community/upsell surface. It must render a static CTA and never touch a Pro
+ * daemon — clicking only opens a marketing URL, so the community build stays inert
+ * with respect to sync.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import ProTeaserPill from '$lib/components/pro-teaser-pill.svelte';
+
+describe('ProTeaserPill', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a static upgrade CTA', () => {
+    const { getByRole, getByText } = render(ProTeaserPill);
+    expect(getByText('Upgrade to Pro')).toBeTruthy();
+    expect(getByRole('button', { name: /upgrade to nodespace pro/i })).toBeTruthy();
+  });
+
+  it('never invokes a daemon command, even on click', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { getByRole } = render(ProTeaserPill);
+
+    await fireEvent.click(getByRole('button', { name: /upgrade to nodespace pro/i }));
+
+    // The CTA opens a marketing URL, never a Tauri/daemon command.
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy.mock.calls[0][0]).toContain('nodespace.ai');
+  });
+});

--- a/packages/desktop-app/src/tests/free-user-guardrail.test.ts
+++ b/packages/desktop-app/src/tests/free-user-guardrail.test.ts
@@ -37,6 +37,12 @@ import { recoveredItems } from '$lib/stores/recovered-items.svelte';
 import { sharedNodeStore, SharedNodeStore } from '$lib/services/shared-node-store.svelte';
 import * as backendAdapterModule from '$lib/services/backend-adapter';
 import { initializeTauriSyncListeners } from '$lib/services/tauri-sync-listener';
+import {
+  resolveProSyncVariant,
+  isProSyncActive,
+  getActiveChromeContributions,
+  getActiveViewerExtensions
+} from '$lib/plugins/ui-extensions.svelte';
 
 function testNode(id: string, content = 'community content'): Node {
   return {
@@ -141,6 +147,41 @@ describe('Free-user guardrail: Pro features stay inert in the community build', 
       mockListeners.get('node:deleted')!({ payload: { id: 'c2' } });
 
       expect(sharedNodeStore.hasNode('c2')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pro-UI registry — in community the only surface contributed is the
+  // static upgrade teaser (ADR-039). Every daemon-backed Pro surface (the live
+  // sync pill, the enable-sync prompt, the re-login modal, the collaboration
+  // tab) resolves out, so nothing that talks to a Pro daemon can render.
+  // -------------------------------------------------------------------------
+  describe('Pro-UI registry resolves to only the static upgrade teaser', () => {
+    it("community tier resolves the variant to 'teaser' and sync is inactive", () => {
+      expect(resolveProSyncVariant()).toBe('teaser');
+      expect(isProSyncActive()).toBe(false);
+    });
+
+    it('the overlay slot contributes exactly the teaser (no live/enable pill)', () => {
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('teaser');
+      // None of the daemon-backed pill variants are active.
+      for (const v of ['enable-prompt', 'sign-in', 'connected'] as const) {
+        expect(overlay.some((c) => c.variant === v)).toBe(false);
+      }
+    });
+
+    it('the modal slot and the collaboration tab contribute nothing in community', () => {
+      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
+      expect(getActiveViewerExtensions('collection')).toEqual([]);
+    });
+
+    it("the default 'unknown' tier (pre-probe) is teaser-only too — no Pro surface flashes", () => {
+      proSync.tier = 'unknown';
+      expect(resolveProSyncVariant()).toBe('teaser');
+      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
+      expect(getActiveViewerExtensions('collection')).toEqual([]);
     });
   });
 });

--- a/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
+++ b/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
@@ -1,0 +1,155 @@
+/**
+ * UI-extension registry + Pro-sync variant machine.
+ *
+ * Exercises the two-signal state machine (`proSync.tier` × the active database's
+ * DatabaseSettingsNode) and the registry filtering that resolves which chrome /
+ * viewer contributions are active for each variant.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Node } from '$lib/types';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+// SharedNodeStore.setNode does not persist here (skipPersistence), but stub the
+// Tauri bridge so nothing reaches a real daemon.
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import {
+  resolveProSyncVariant,
+  isProSyncActive,
+  getActiveChromeContributions,
+  getActiveViewerExtensions
+} from '$lib/plugins/ui-extensions.svelte';
+import { uiExtensionRegistry, DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
+
+/** Seed the active database's settings singleton with the given namespaced props. */
+function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
+  const node: Node = {
+    id: DATABASE_SETTINGS_NODE_ID,
+    nodeType: 'database-settings',
+    content: '',
+    properties: { 'database-settings': props },
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
+  SharedNodeStore.getInstance().setNode(node, { type: 'database', reason: 'seed' }, true);
+}
+
+describe('UI-extension registry', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    SharedNodeStore.resetInstance();
+    proSync.tier = 'unknown';
+  });
+
+  afterEach(() => {
+    proSync.tier = 'unknown';
+    SharedNodeStore.resetInstance();
+    vi.restoreAllMocks();
+  });
+
+  describe('registry registration', () => {
+    it('registers the built-in pro-sync extension with all contributions', () => {
+      expect(uiExtensionRegistry.has('pro-sync')).toBe(true);
+      // 4 overlay pill variants + 2 modal (sign-in/connected).
+      expect(uiExtensionRegistry.chromeFor('app-shell-overlay')).toHaveLength(4);
+      expect(uiExtensionRegistry.chromeFor('app-shell-modal')).toHaveLength(2);
+      // 3 collaboration viewer extensions (enable-prompt/sign-in/connected).
+      expect(uiExtensionRegistry.viewersFor('collection')).toHaveLength(3);
+      expect(uiExtensionRegistry.viewersFor('text')).toEqual([]);
+    });
+  });
+
+  describe('variant resolution', () => {
+    it("tier !== 'pro' → teaser, regardless of the settings node", () => {
+      proSync.tier = 'community';
+      seedSettings({ sync_enabled: true, auth_status: 'connected' });
+      expect(resolveProSyncVariant()).toBe('teaser');
+      expect(isProSyncActive()).toBe(false);
+    });
+
+    it('pro + no hydrated settings node → enable-prompt (sync not enabled)', () => {
+      proSync.tier = 'pro';
+      expect(resolveProSyncVariant()).toBe('enable-prompt');
+      expect(isProSyncActive()).toBe(false);
+    });
+
+    it('pro + sync_enabled: false → enable-prompt', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: false, auth_status: 'local' });
+      expect(resolveProSyncVariant()).toBe('enable-prompt');
+      expect(isProSyncActive()).toBe(false);
+    });
+
+    it("pro + sync_enabled + auth_status 'local' → sign-in (sync active)", () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: true, auth_status: 'local' });
+      expect(resolveProSyncVariant()).toBe('sign-in');
+      expect(isProSyncActive()).toBe(true);
+    });
+
+    it("pro + sync_enabled + auth_status 'connected' → connected (sync active)", () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: true, auth_status: 'connected' });
+      expect(resolveProSyncVariant()).toBe('connected');
+      expect(isProSyncActive()).toBe(true);
+    });
+
+    it('re-resolves when the settings node changes (derived reads, no cache)', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: false, auth_status: 'local' });
+      expect(resolveProSyncVariant()).toBe('enable-prompt');
+      seedSettings({ sync_enabled: true, auth_status: 'local' });
+      expect(resolveProSyncVariant()).toBe('sign-in');
+      seedSettings({ sync_enabled: true, auth_status: 'connected' });
+      expect(resolveProSyncVariant()).toBe('connected');
+    });
+  });
+
+  describe('active contribution filtering', () => {
+    it('teaser: only the teaser overlay pill, no modal, no collab tab', () => {
+      proSync.tier = 'community';
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('teaser');
+      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
+      expect(getActiveViewerExtensions('collection')).toEqual([]);
+    });
+
+    it('enable-prompt: enable-sync pill + a locked collab tab, no modal', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: false, auth_status: 'local' });
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('enable-prompt');
+      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
+      const viewers = getActiveViewerExtensions('collection');
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0].variant).toBe('enable-prompt');
+      expect(viewers[0].tab.id).toBe('collaboration');
+    });
+
+    it('connected: the live pill + the relogin modal + the live collab tab', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: true, auth_status: 'connected' });
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('connected');
+      const modal = getActiveChromeContributions('app-shell-modal');
+      expect(modal).toHaveLength(1);
+      expect(modal[0].variant).toBe('connected');
+      const viewers = getActiveViewerExtensions('collection');
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0].variant).toBe('connected');
+    });
+  });
+});

--- a/packages/desktop-app/src/tests/stores/database.test.ts
+++ b/packages/desktop-app/src/tests/stores/database.test.ts
@@ -18,10 +18,12 @@ vi.mock('@tauri-apps/api/core', () => ({
 // switch → clear → reset → reload orchestration without their real behavior.
 const flushAllPendingSaves = vi.fn((..._a: unknown[]) => Promise.resolve(new Set<string>()));
 const clearAll = vi.fn((..._a: unknown[]) => undefined);
+const ensureNode = vi.fn((..._a: unknown[]) => Promise.resolve(undefined));
 vi.mock('$lib/services/shared-node-store.svelte', () => ({
   sharedNodeStore: {
     flushAllPendingSaves: (...a: unknown[]) => flushAllPendingSaves(...a),
-    clearAll: (...a: unknown[]) => clearAll(...a)
+    clearAll: (...a: unknown[]) => clearAll(...a),
+    ensureNode: (...a: unknown[]) => ensureNode(...a)
   }
 }));
 

--- a/packages/desktop-app/src/tests/stores/membership.test.ts
+++ b/packages/desktop-app/src/tests/stores/membership.test.ts
@@ -28,6 +28,11 @@ const { svc, proSyncMock } = vi.hoisted(() => ({
 
 vi.mock('$lib/services/membership-service', () => ({ membershipService: svc }));
 vi.mock('$lib/stores/pro-sync.svelte', () => ({ proSync: proSyncMock }));
+// membership.isPro now delegates to the two-axis gate; map it back to the store's
+// own `isPro` flag so these roster/invite tests keep toggling one signal.
+vi.mock('$lib/plugins/ui-extensions.svelte', () => ({
+	isProSyncActive: () => proSyncMock.isPro
+}));
 
 import { membership } from '$lib/stores/membership.svelte';
 

--- a/packages/desktop-app/src/tests/stores/recovered-items.test.ts
+++ b/packages/desktop-app/src/tests/stores/recovered-items.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Recovered-items store — Pro-path gate regression.
+ *
+ * Locks the gate/trigger contract: `load()` gates on the same axis-1 `proSync.isPro`
+ * signal that fires its one-shot `onProConfirmed` trigger. Narrowing the gate to the
+ * two-axis `isProSyncActive()` (which additionally requires the active database's
+ * `DatabaseSettingsNode` to be hydrated) regressed the feature: that node hydrates on
+ * a separate, strictly-longer async chain than tier resolution, so the one-shot
+ * trigger fired while the gate was still unsatisfied and the log never loaded for the
+ * session. These tests assert the gate keys off Pro tier alone.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { recoveredItems } from '$lib/stores/recovered-items.svelte';
+
+const sampleItem = {
+  node_id: 'n1',
+  superseded_content: 'mine',
+  superseded_modified_at: '2026-01-01T00:00:00Z',
+  winning_content: 'theirs',
+  winning_modified_at: '2026-01-02T00:00:00Z',
+  recovered_at: '2026-01-02T00:00:01Z'
+};
+
+describe('recovered-items store gates on Pro tier alone', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    proSync.tier = 'community';
+    recoveredItems.items = [];
+    recoveredItems.loaded = false;
+  });
+
+  it('loads when the daemon is Pro even before the DatabaseSettingsNode hydrates', async () => {
+    // Pro tier resolved; the per-database settings node is deliberately NOT hydrated
+    // — the exact window in which the one-shot onProConfirmed trigger fires at boot.
+    proSync.tier = 'pro';
+    mockInvoke.mockResolvedValueOnce([sampleItem]);
+
+    await recoveredItems.load();
+
+    expect(mockInvoke).toHaveBeenCalledWith('pro_list_recovered_items');
+    expect(recoveredItems.items).toEqual([sampleItem]);
+    expect(recoveredItems.hasFor('n1')).toBe(true);
+  });
+
+  it('is a no-op outside Pro and never calls the daemon', async () => {
+    proSync.tier = 'community';
+
+    await recoveredItems.load();
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(recoveredItems.items).toEqual([]);
+    expect(recoveredItems.loaded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a declarative UI-extension registry that resolves the active Pro-sync surface from two independent signals and renders it through generic extension slots, replacing the hard-coded pill/modal wiring in the app shell.

Part of the ADR-053 multi-database epic (#1537): the Pro-sync surface must react per active database, not just per daemon build.

## Two-axis variant resolution

- **Axis 1 — build tier** (`proSync.tier`, app-global): a non-Pro daemon resolves to the static upgrade `teaser`.
- **Axis 2 — active database** (`DatabaseSettingsNode.sync_enabled` / `auth_status`, per-database): a Pro daemon resolves to `enable-prompt` → `sign-in` → `connected`.

The resolver (`lib/plugins/ui-extensions.svelte.ts`) maps the two signals to one variant and returns only the chrome contributions / viewer extensions matching it. Both reads are reactive, so a tier change or a `DatabaseSettingsNode` update (including a database switch) re-resolves the surface.

## What changed

- New `UiExtensionRegistry` (`lib/plugins/ui-extensions.ts`) + reactive resolver + built-in Pro extension definition (`pro-plugin.ts`) + `ExtensionOutlet`.
- App-shell overlay/modal slots and the collection-node viewer render registry contributions via `ExtensionOutlet` instead of importing pill/modal components directly.
- Re-login orchestration moves out of the app shell into a registry slot component (`pro-relogin-slot.svelte`); the presentational `ProReloginModal` is unchanged.
- Dependent stores (`membership`, `recovered-items`) gate on the two-axis `isProSyncActive()` instead of the tier-only `proSync.isPro`.
- `database.svelte.ts` hydrates the `DatabaseSettingsNode` on load and after a database switch so the variant re-resolves for the active database.

## Community build unchanged

Non-Pro builds resolve to the static teaser only; every daemon-backed Pro surface stays gated. The `test:free-users` guardrail covers this.

## Testing

- `bun run test` — 3989 passed
- `bun run test:free-users` — 11 passed
- `bun run quality:check` (eslint + svelte-check) — 0 errors, 0 warnings
- Full pre-push pyramid (frontend + core-lib + headless e2e + Tauri-seam) green

## Follow-up

- Backend gap: there is no per-database "enable sync" intent command yet, so `enable-sync-pill` opts a database into sync via the existing interactive sign-in (`pro_initiate_oauth`), which flips `sync_enabled` / `auth_status` on bind. A dedicated set-`sync_enabled` command is a backend follow-up.
- Live desktop UI validation of the variant transitions is pending.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
