### PR TITLE
Add OpenAI-compatible provider backend (closes #1530)

### DIFF
--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -255,6 +255,8 @@ pub enum ModelFamily {
     MistralSmall,
     /// Model served via Ollama (family determined by Ollama).
     Ollama,
+    /// Model served via a user-configured OpenAI-compatible endpoint.
+    OpenAiCompat,
 }
 
 /// Backend used to serve a language model.

--- a/packages/agent/src/local_agent/mod.rs
+++ b/packages/agent/src/local_agent/mod.rs
@@ -5,6 +5,7 @@ pub mod model_manager;
 pub mod ollama_inference;
 pub mod ollama_model_manager;
 pub mod ollama_ndjson;
+pub mod openai_compat_inference;
 pub mod otlp_tracer;
 pub mod prompt_dump;
 pub mod prompt_templates;

--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -465,8 +465,8 @@ impl GgufModelManager {
     /// - `Ministral`: 8B at or above [`RAM_THRESHOLD_MEDIUM`] (16 GB), otherwise 3B.
     /// - `Gemma4`:    three-tier — 31B at or above [`RAM_THRESHOLD_LARGE`],
     ///   12B at or above [`RAM_THRESHOLD_MEDIUM`], otherwise E4B.
-    /// - `Ollama`:    has no GGUF catalog entries; falls back to the default
-    ///   Ministral recommendation.
+    /// - `Ollama` / `OpenAiCompat`: have no GGUF catalog entries; fall back to
+    ///   the default Ministral recommendation.
     pub fn recommended_model_id_for(family: ModelFamily) -> &'static str {
         let total_ram = detect_system_ram();
         let large = total_ram >= RAM_THRESHOLD_LARGE;
@@ -492,7 +492,7 @@ impl GgufModelManager {
             ModelFamily::Qwen35 => QWEN35_9B.id,
             ModelFamily::Qwen36 => QWEN36_35B_A3B.id,
             ModelFamily::MistralSmall => MISTRAL_SMALL_3_2.id,
-            ModelFamily::Ollama => {
+            ModelFamily::Ollama | ModelFamily::OpenAiCompat => {
                 if medium {
                     MINISTRAL_8B.id
                 } else {

--- a/packages/agent/src/local_agent/openai_compat_inference.rs
+++ b/packages/agent/src/local_agent/openai_compat_inference.rs
@@ -39,10 +39,11 @@ pub struct OpenAiCompatInferenceEngine {
     /// are sent to "<base_url>/chat/completions".
     base_url: String,
     api_key: String,
-    /// Model name sent in the request body. OpenAI-compatible servers vary in
-    /// how strictly they validate this; many (LM Studio, Ollama) ignore it if
-    /// only one model is loaded, so a fixed placeholder is used when the
-    /// caller does not have a specific downstream model name.
+    /// Model identifier sent as the request body's "model" field — must be
+    /// the provider's actual model id (e.g. "gpt-4o"), not a cosmetic UI
+    /// label. Real OpenAI-API and multi-model servers reject or misroute an
+    /// unrecognized value; single-model local servers (Ollama, LM Studio)
+    /// generally ignore it.
     model_name: String,
 }
 
@@ -54,6 +55,15 @@ impl OpenAiCompatInferenceEngine {
             api_key,
             model_name,
         }
+    }
+
+    /// The wire-protocol model identifier this engine sends as the request
+    /// body's "model" field. Exposed so callers (and tests) can distinguish
+    /// it from a config's cosmetic `name` — see
+    /// `LocalAgentService::load_model_and_collect_events`, which must pass
+    /// `config.model`, not `config.name`, into [`Self::new`].
+    pub fn model_name(&self) -> &str {
+        &self.model_name
     }
 }
 
@@ -456,5 +466,18 @@ mod tests {
         let count = futures::executor::block_on(engine.token_count(text))
             .expect("token_count should succeed");
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn model_name_reflects_the_constructor_arg_not_a_display_label() {
+        // Regression guard: callers (LocalAgentService::load_model_and_collect_events)
+        // must pass the config's wire-protocol `model` field into `new`, never the
+        // cosmetic `name` field a user typed into the Settings UI.
+        let engine = OpenAiCompatInferenceEngine::new(
+            "https://api.openai.com/v1".to_string(),
+            "sk-test".to_string(),
+            "gpt-4o".to_string(),
+        );
+        assert_eq!(engine.model_name(), "gpt-4o");
     }
 }

--- a/packages/agent/src/local_agent/openai_compat_inference.rs
+++ b/packages/agent/src/local_agent/openai_compat_inference.rs
@@ -1,0 +1,460 @@
+//! `ChatInferenceEngine` implementation for user-configured OpenAI-compatible
+//! HTTP endpoints (e.g. a self-hosted vLLM/LM Studio server, or Ollama's own
+//! `/v1/chat/completions`).
+//!
+//! Mirrors [`crate::local_agent::ollama_inference::OllamaInferenceEngine`] but
+//! speaks the standard OpenAI chat-completions request/response shape and
+//! authenticates with a bearer token.
+
+use crate::agent_types::{
+    ChatInferenceEngine, ChatModelSpec, InferenceError, InferenceRequest, InferenceUsage,
+    ModelFamily, StreamingChunk,
+};
+use crate::local_agent::ollama_ndjson::NdjsonLineBuffer;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+/// Prefix used to identify OpenAI-compatible provider configs. The suffix is
+/// the UUID of the config stored in daemon.toml (`[[openai_compat.configs]]`).
+pub const OPENAI_COMPAT_PREFIX: &str = "openai-compat:";
+
+/// Check if a model ID represents an OpenAI-compatible provider config.
+pub fn is_openai_compat(model_id: &str) -> bool {
+    model_id.starts_with(OPENAI_COMPAT_PREFIX)
+}
+
+/// Strip the `"openai-compat:"` prefix, returning the config UUID.
+///
+/// Returns the original model ID unchanged if it does not have the prefix.
+pub fn strip_openai_compat_prefix(model_id: &str) -> &str {
+    model_id
+        .strip_prefix(OPENAI_COMPAT_PREFIX)
+        .unwrap_or(model_id)
+}
+
+pub struct OpenAiCompatInferenceEngine {
+    http_client: reqwest::Client,
+    /// Base URL of the endpoint, e.g. "https://api.openai.com/v1". Requests
+    /// are sent to "<base_url>/chat/completions".
+    base_url: String,
+    api_key: String,
+    /// Model name sent in the request body. OpenAI-compatible servers vary in
+    /// how strictly they validate this; many (LM Studio, Ollama) ignore it if
+    /// only one model is loaded, so a fixed placeholder is used when the
+    /// caller does not have a specific downstream model name.
+    model_name: String,
+}
+
+impl OpenAiCompatInferenceEngine {
+    pub fn new(base_url: String, api_key: String, model_name: String) -> Self {
+        Self {
+            http_client: reqwest::Client::new(),
+            base_url,
+            api_key,
+            model_name,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private types for OpenAI chat-completions API serialization/deserialization
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct OpenAiChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<OpenAiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<OpenAiTool>>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage {
+    role: String,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OpenAiTool {
+    #[serde(rename = "type")]
+    tool_type: String,
+    function: OpenAiFunction,
+}
+
+#[derive(Serialize)]
+struct OpenAiFunction {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+/// Shape shared by both the non-streaming response body and each streaming
+/// SSE `data:` chunk — OpenAI's `chat.completion` and `chat.completion.chunk`
+/// objects differ only in whether `message` or `delta` is populated.
+#[derive(Deserialize)]
+struct OpenAiChatResponse {
+    #[serde(default)]
+    choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    #[serde(default)]
+    message: Option<OpenAiResponseMessage>,
+    #[serde(default)]
+    delta: Option<OpenAiResponseMessage>,
+}
+
+#[derive(Deserialize, Default)]
+struct OpenAiResponseMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<OpenAiToolCall>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiToolCall {
+    #[serde(default)]
+    id: Option<String>,
+    function: OpenAiToolCallFunction,
+}
+
+#[derive(Deserialize)]
+struct OpenAiToolCallFunction {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+#[async_trait]
+impl ChatInferenceEngine for OpenAiCompatInferenceEngine {
+    async fn generate(
+        &self,
+        request: InferenceRequest,
+        on_chunk: Box<dyn Fn(StreamingChunk) + Send>,
+    ) -> Result<InferenceUsage, InferenceError> {
+        let messages: Vec<OpenAiMessage> = request
+            .messages
+            .iter()
+            .map(|msg| OpenAiMessage {
+                role: msg.role.as_str().to_string(),
+                content: msg.content.clone(),
+                tool_call_id: msg.tool_call_id.clone(),
+            })
+            .collect();
+
+        let tools = request.tools.map(|tool_defs| {
+            tool_defs
+                .iter()
+                .map(|t| OpenAiTool {
+                    tool_type: "function".to_string(),
+                    function: OpenAiFunction {
+                        name: t.name.clone(),
+                        description: t.description.clone(),
+                        parameters: t.parameters_schema.clone(),
+                    },
+                })
+                .collect()
+        });
+
+        // Tool-calling responses are not reliably delivered incrementally by
+        // every OpenAI-compatible server, so use the same non-streaming
+        // fallback strategy as the Ollama engine when tools are present.
+        let use_stream = tools.is_none();
+        let openai_request = OpenAiChatRequest {
+            model: &self.model_name,
+            messages,
+            tools,
+            stream: use_stream,
+            temperature: request.temperature,
+            max_tokens: request.max_tokens,
+        };
+
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            if let Ok(json) = serde_json::to_string_pretty(&openai_request) {
+                tracing::debug!(base_url = %self.base_url, payload = %json, "OpenAI-compat request");
+            }
+        }
+        tracing::info!(
+            base_url = %self.base_url,
+            message_count = openai_request.messages.len(),
+            tool_count = openai_request.tools.as_ref().map(|t| t.len()).unwrap_or(0),
+            "Sending request to OpenAI-compatible endpoint"
+        );
+
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let mut req_builder = self.http_client.post(&url).json(&openai_request);
+        if !self.api_key.is_empty() {
+            req_builder = req_builder.bearer_auth(&self.api_key);
+        }
+
+        let response = req_builder
+            .send()
+            .await
+            .map_err(|e| InferenceError::Engine(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(InferenceError::Engine(format!(
+                "OpenAI-compat API error {}: {}",
+                status, body
+            )));
+        }
+
+        let mut final_usage = InferenceUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+        };
+
+        if use_stream {
+            let mut stream = response.bytes_stream();
+            let mut buffer = NdjsonLineBuffer::new();
+            // Accumulates streamed tool-call fragments by index, since the
+            // SSE delta format sends id/name once and arguments incrementally.
+            let mut tool_call_ids: Vec<Option<String>> = Vec::new();
+
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(|e| InferenceError::Engine(e.to_string()))?;
+                let lines = buffer
+                    .push(&chunk)
+                    .map_err(|e| InferenceError::Engine(e.to_string()))?;
+
+                for line in lines {
+                    let Some(data) = line.strip_prefix("data:") else {
+                        continue;
+                    };
+                    let data = data.trim();
+                    if data == "[DONE]" {
+                        on_chunk(StreamingChunk::Done { usage: final_usage });
+                        return Ok(final_usage);
+                    }
+
+                    match serde_json::from_str::<OpenAiChatResponse>(data) {
+                        Ok(resp) => {
+                            if let Some(usage) = &resp.usage {
+                                final_usage = InferenceUsage {
+                                    prompt_tokens: usage.prompt_tokens,
+                                    completion_tokens: usage.completion_tokens,
+                                };
+                            }
+                            for choice in &resp.choices {
+                                if let Some(delta) = &choice.delta {
+                                    if let Some(content) = &delta.content {
+                                        if !content.is_empty() {
+                                            on_chunk(StreamingChunk::Token {
+                                                text: content.clone(),
+                                            });
+                                        }
+                                    }
+                                    for (i, tool_call) in delta.tool_calls.iter().enumerate() {
+                                        if tool_call_ids.len() <= i {
+                                            tool_call_ids.resize(i + 1, None);
+                                        }
+                                        if let Some(id) = &tool_call.id {
+                                            tool_call_ids[i] = Some(id.clone());
+                                            on_chunk(StreamingChunk::ToolCallStart {
+                                                id: id.clone(),
+                                                name: tool_call
+                                                    .function
+                                                    .name
+                                                    .clone()
+                                                    .unwrap_or_default(),
+                                            });
+                                        }
+                                        if !tool_call.function.arguments.is_empty() {
+                                            let id = tool_call_ids
+                                                .get(i)
+                                                .cloned()
+                                                .flatten()
+                                                .unwrap_or_else(|| format!("call_{}", i));
+                                            on_chunk(StreamingChunk::ToolCallArgs {
+                                                id,
+                                                args_json: tool_call.function.arguments.clone(),
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => tracing::warn!("Failed to parse OpenAI-compat SSE chunk: {e}"),
+                    }
+                }
+            }
+            // Stream ended without an explicit [DONE] sentinel.
+            on_chunk(StreamingChunk::Done { usage: final_usage });
+        } else {
+            let body = response
+                .text()
+                .await
+                .map_err(|e| InferenceError::Engine(e.to_string()))?;
+
+            match serde_json::from_str::<OpenAiChatResponse>(&body) {
+                Ok(resp) => {
+                    if let Some(usage) = &resp.usage {
+                        final_usage = InferenceUsage {
+                            prompt_tokens: usage.prompt_tokens,
+                            completion_tokens: usage.completion_tokens,
+                        };
+                    }
+                    if let Some(choice) = resp.choices.first() {
+                        if let Some(msg) = &choice.message {
+                            if let Some(content) = &msg.content {
+                                if !content.is_empty() {
+                                    on_chunk(StreamingChunk::Token {
+                                        text: content.clone(),
+                                    });
+                                }
+                            }
+                            for (i, tool_call) in msg.tool_calls.iter().enumerate() {
+                                let call_id = tool_call
+                                    .id
+                                    .clone()
+                                    .unwrap_or_else(|| format!("call_{}", i));
+                                on_chunk(StreamingChunk::ToolCallStart {
+                                    id: call_id.clone(),
+                                    name: tool_call.function.name.clone().unwrap_or_default(),
+                                });
+                                on_chunk(StreamingChunk::ToolCallArgs {
+                                    id: call_id,
+                                    args_json: tool_call.function.arguments.clone(),
+                                });
+                            }
+                        }
+                    }
+                    on_chunk(StreamingChunk::Done { usage: final_usage });
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse OpenAI-compat non-streaming response: {e}");
+                    on_chunk(StreamingChunk::Done {
+                        usage: InferenceUsage::default(),
+                    });
+                }
+            }
+        }
+
+        Ok(final_usage)
+    }
+
+    async fn model_info(&self) -> Result<Option<ChatModelSpec>, InferenceError> {
+        // OpenAI-compatible servers have no standard equivalent of Ollama's
+        // /api/show for context-window introspection. Callers fall back to a
+        // conservative default via the None case.
+        Ok(Some(ChatModelSpec {
+            model_id: self.model_name.clone(),
+            family: ModelFamily::OpenAiCompat,
+            context_window: 32_768,
+            default_temperature: 0.7,
+            type_k: None,
+            type_v: None,
+        }))
+    }
+
+    async fn token_count(&self, text: &str) -> Result<u32, InferenceError> {
+        Ok((text.len() / 4) as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_openai_compat_prefix() {
+        assert!(is_openai_compat("openai-compat:abc-123"));
+        assert!(!is_openai_compat("ollama:llama3.2:3b"));
+        assert!(!is_openai_compat("ministral-3b-q4km"));
+        assert!(is_openai_compat("openai-compat:"));
+    }
+
+    #[test]
+    fn test_strip_openai_compat_prefix() {
+        assert_eq!(
+            strip_openai_compat_prefix("openai-compat:abc-123"),
+            "abc-123"
+        );
+        assert_eq!(strip_openai_compat_prefix("ministral"), "ministral");
+    }
+
+    #[test]
+    fn test_parse_non_streaming_response_with_tool_calls() {
+        let json = r#"{
+            "choices": [{
+                "message": {
+                    "content": null,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc",
+                            "function": {
+                                "name": "search",
+                                "arguments": "{\"query\":\"test\"}"
+                            }
+                        }
+                    ]
+                }
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        }"#;
+
+        let resp: OpenAiChatResponse = serde_json::from_str(json).expect("should deserialize");
+        let usage = resp.usage.expect("usage should be present");
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 5);
+
+        let msg = resp.choices[0].message.as_ref().expect("message present");
+        assert_eq!(msg.tool_calls.len(), 1);
+        assert_eq!(msg.tool_calls[0].id.as_deref(), Some("call_abc"));
+        assert_eq!(msg.tool_calls[0].function.name.as_deref(), Some("search"));
+        assert_eq!(msg.tool_calls[0].function.arguments, "{\"query\":\"test\"}");
+    }
+
+    #[test]
+    fn test_parse_streaming_delta_token() {
+        let json = r#"{
+            "choices": [{
+                "delta": {"content": "hello"}
+            }]
+        }"#;
+
+        let resp: OpenAiChatResponse = serde_json::from_str(json).expect("should deserialize");
+        let delta = resp.choices[0].delta.as_ref().expect("delta present");
+        assert_eq!(delta.content.as_deref(), Some("hello"));
+        assert!(delta.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn test_token_count_estimate() {
+        let engine = OpenAiCompatInferenceEngine::new(
+            "http://127.0.0.1:11434/v1".to_string(),
+            String::new(),
+            "placeholder".to_string(),
+        );
+        let text = "hello world"; // len=11, 11/4=2 by integer division
+        let count = futures::executor::block_on(engine.token_count(text))
+            .expect("token_count should succeed");
+        assert_eq!(count, 2);
+    }
+}

--- a/packages/daemon/src/services/assembly.rs
+++ b/packages/daemon/src/services/assembly.rs
@@ -184,11 +184,15 @@ pub async fn build_database_services(
         shared.pty_manager.clone(),
         assembler,
         node_service.clone(),
-        capture_config_path,
+        capture_config_path.clone(),
     );
 
     let import = ImportServiceImpl::new(node_service.clone());
-    let local_agent = LocalAgentServiceImpl::new(node_service.clone(), embedding_svc_state.clone());
+    let local_agent = LocalAgentServiceImpl::new(
+        node_service.clone(),
+        embedding_svc_state.clone(),
+        capture_config_path,
+    );
     local_agent.start_event_watcher();
 
     // Wire this database's embedding processor from the shared model once it

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -92,6 +92,9 @@ struct LocalAgentServiceInner {
     /// `Arc` clones tonic hands to request handlers, so a single `shutdown()`
     /// stops the watcher spawned from any clone.
     shutdown_token: CancellationToken,
+    /// Path to `~/.nodespace/daemon.toml`, read to resolve OpenAI-compatible
+    /// provider configs by UUID when loading an `openai-compat:<uuid>` model.
+    daemon_config_path: std::path::PathBuf,
 }
 
 /// tonic-compatible handle. `Clone` (cheap Arc clone) so tonic can hand
@@ -102,7 +105,11 @@ pub struct LocalAgentServiceImpl {
 }
 
 impl LocalAgentServiceImpl {
-    pub fn new(node_service: Arc<NodeService>, embedding_service: SharedEmbeddingService) -> Self {
+    pub fn new(
+        node_service: Arc<NodeService>,
+        embedding_service: SharedEmbeddingService,
+        daemon_config_path: std::path::PathBuf,
+    ) -> Self {
         let gguf =
             Arc::new(GgufModelManager::new().expect("GgufModelManager initialization failed"));
         let ollama = Arc::new(OllamaModelManager::new());
@@ -124,6 +131,7 @@ impl LocalAgentServiceImpl {
                 token_tx,
                 turn_tokens: Arc::new(Mutex::new(HashMap::new())),
                 shutdown_token: CancellationToken::new(),
+                daemon_config_path,
             }),
         }
     }
@@ -924,9 +932,76 @@ impl LocalAgentServiceImpl {
     async fn load_model_and_collect_events(&self, model_id: &str) -> Vec<ModelLoadProgressEvent> {
         use nodespace_agent::local_agent::inference::LlamaChatInferenceEngine;
         use nodespace_agent::local_agent::ollama_inference::OllamaInferenceEngine;
+        use nodespace_agent::local_agent::openai_compat_inference::{
+            is_openai_compat, strip_openai_compat_prefix, OpenAiCompatInferenceEngine,
+        };
         use nodespace_nlp_engine::chat::ChatConfig;
 
         let mut events = Vec::new();
+
+        // OpenAI-compat configs are user-defined (stored in daemon.toml), not part
+        // of the model catalog `list()` returns — resolve and branch on them first
+        // so they never fall through to the "Unknown model" / GGUF path below.
+        if is_openai_compat(model_id) {
+            let config_id = strip_openai_compat_prefix(model_id);
+
+            events.push(ModelLoadProgressEvent {
+                event_type: "loading".to_string(),
+                model_id: model_id.to_string(),
+                message: Some("Connecting to OpenAI-compatible endpoint...".to_string()),
+                ..Default::default()
+            });
+
+            let config = match crate::services::settings_service::find_openai_compat_config(
+                &self.inner.daemon_config_path,
+                config_id,
+            )
+            .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    events.push(ModelLoadProgressEvent {
+                        event_type: "error".to_string(),
+                        model_id: model_id.to_string(),
+                        error_message: Some(format!(
+                            "No OpenAI-compatible provider config found for '{config_id}'. Check Settings > Integrations."
+                        )),
+                        ..Default::default()
+                    });
+                    return events;
+                }
+                Err(e) => {
+                    events.push(ModelLoadProgressEvent {
+                        event_type: "error".to_string(),
+                        model_id: model_id.to_string(),
+                        error_message: Some(format!(
+                            "Failed to read OpenAI-compatible provider config: {e}"
+                        )),
+                        ..Default::default()
+                    });
+                    return events;
+                }
+            };
+
+            let engine = OpenAiCompatInferenceEngine::new(
+                config.base_url.clone(),
+                config.api_key.clone(),
+                config.name.clone(),
+            );
+            let swapped = self
+                .replace_engine_if_changed(model_id, Arc::new(engine))
+                .await;
+
+            events.push(ModelLoadProgressEvent {
+                event_type: "ready".to_string(),
+                model_id: model_id.to_string(),
+                message: Some(format!("{} ready", config.name)),
+                engine_swapped: Some(swapped),
+                ..Default::default()
+            });
+
+            return events;
+        }
 
         let models = match self.inner.model_manager.list().await {
             Ok(m) => m,
@@ -1296,7 +1371,8 @@ mod tests {
         );
         let node_service = Arc::new(CoreNodeService::new(&mut store).await.expect("NodeService"));
         let embedding: SharedEmbeddingService = Arc::new(RwLock::new(None));
-        let svc = LocalAgentServiceImpl::new(node_service.clone(), embedding);
+        let daemon_config_path = tempdir.path().join("daemon.toml");
+        let svc = LocalAgentServiceImpl::new(node_service.clone(), embedding, daemon_config_path);
         (svc, node_service, tempdir)
     }
 
@@ -1350,5 +1426,61 @@ mod tests {
             .collect();
         assert_eq!(assistants.len(), 2);
         assert!(assistants.iter().all(|m| m.reasoning.is_none()));
+    }
+
+    #[tokio::test]
+    async fn load_openai_compat_model_without_config_returns_clear_error() {
+        let (svc, _node_service, _tempdir) = test_service().await;
+
+        // No daemon.toml exists yet, so the config lookup returns None. This
+        // must surface a specific "no config found" error, not fall through to
+        // the GGUF path-resolution failure the bug report described.
+        let events = svc
+            .load_model_and_collect_events("openai-compat:missing-uuid")
+            .await;
+
+        let error_event = events
+            .iter()
+            .find(|e| e.event_type == "error")
+            .expect("an error event should be emitted");
+        let message = error_event
+            .error_message
+            .as_deref()
+            .expect("error_message should be set");
+        assert!(
+            message.contains("No OpenAI-compatible provider config found"),
+            "unexpected error message: {message}"
+        );
+        assert!(
+            !message.to_lowercase().contains("gguf"),
+            "error must not leak the GGUF path-resolution failure: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_openai_compat_model_with_config_swaps_engine() {
+        let (svc, _node_service, tempdir) = test_service().await;
+        let config_path = tempdir.path().join("daemon.toml");
+        let toml = r#"
+[[openai_compat.configs]]
+id = "abc-123"
+name = "My Endpoint"
+base_url = "http://127.0.0.1:9999/v1"
+api_key = "sk-test"
+"#;
+        tokio::fs::write(&config_path, toml)
+            .await
+            .expect("write daemon.toml");
+
+        let events = svc
+            .load_model_and_collect_events("openai-compat:abc-123")
+            .await;
+
+        let ready_event = events
+            .iter()
+            .find(|e| e.event_type == "ready")
+            .expect("a ready event should be emitted");
+        assert_eq!(ready_event.engine_swapped, Some(true));
+        assert!(events.iter().all(|e| e.event_type != "error"));
     }
 }

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -983,10 +983,21 @@ impl LocalAgentServiceImpl {
                 }
             };
 
+            // `model` is the wire-protocol identifier (e.g. "gpt-4o"); `name` is
+            // only a cosmetic UI label and must never be sent as the request's
+            // "model" field — real OpenAI-API and multi-model servers reject or
+            // misroute an arbitrary display string. Empty only for configs
+            // created before this field existed; single-model local servers
+            // (Ollama, LM Studio) generally ignore the field either way.
+            let model = if config.model.is_empty() {
+                "default".to_string()
+            } else {
+                config.model.clone()
+            };
             let engine = OpenAiCompatInferenceEngine::new(
                 config.base_url.clone(),
                 config.api_key.clone(),
-                config.name.clone(),
+                model,
             );
             let swapped = self
                 .replace_engine_if_changed(model_id, Arc::new(engine))

--- a/packages/daemon/src/services/settings_service.rs
+++ b/packages/daemon/src/services/settings_service.rs
@@ -43,6 +43,10 @@ pub struct OpenAiCompatConfig {
     pub base_url: String,
     #[serde(default)]
     pub api_key: String,
+    /// Model identifier sent as the wire-protocol "model" field — distinct
+    /// from `name`, which is only a cosmetic UI label.
+    #[serde(default)]
+    pub model: String,
 }
 
 impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfig {
@@ -52,6 +56,7 @@ impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfig {
             name: c.name,
             base_url: c.base_url,
             api_key: c.api_key,
+            model: c.model,
         }
     }
 }
@@ -63,6 +68,7 @@ impl From<OpenAiCompatConfig> for ProtoOpenAiCompatConfig {
             name: c.name,
             base_url: c.base_url,
             api_key: c.api_key,
+            model: c.model,
         }
     }
 }
@@ -330,6 +336,7 @@ mod tests {
             name: "My Endpoint".to_string(),
             base_url: "https://api.example.com/v1".to_string(),
             api_key: "sk-test".to_string(),
+            model: "gpt-4o".to_string(),
         };
 
         let set_resp = svc
@@ -361,6 +368,7 @@ mod tests {
             name: "A".to_string(),
             base_url: "https://a.example.com".to_string(),
             api_key: String::new(),
+            model: "model-a".to_string(),
         };
         svc.set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
             configs: vec![first],
@@ -373,6 +381,7 @@ mod tests {
             name: "B".to_string(),
             base_url: "https://b.example.com".to_string(),
             api_key: String::new(),
+            model: "model-b".to_string(),
         };
         let resp = svc
             .set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
@@ -395,6 +404,7 @@ mod tests {
             name: "Target".to_string(),
             base_url: "https://target.example.com".to_string(),
             api_key: "key".to_string(),
+            model: "target-model".to_string(),
         };
         svc.set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
             configs: vec![config],
@@ -437,6 +447,7 @@ mod tests {
                 name: "A".to_string(),
                 base_url: "https://a.example.com".to_string(),
                 api_key: "sk-secret".to_string(),
+                model: "gpt-4o".to_string(),
             }],
         }))
         .await

--- a/packages/daemon/src/services/settings_service.rs
+++ b/packages/daemon/src/services/settings_service.rs
@@ -13,7 +13,9 @@ use tonic::{Request, Response, Status};
 
 use crate::nodespace::{
     settings_service_server::SettingsService as GrpcSettingsService, CaptureContentLevel,
-    CaptureSettingsResponse, GetCaptureSettingsRequest, UpdateCaptureSettingsRequest,
+    CaptureSettingsResponse, GetCaptureSettingsRequest, ListOpenAiCompatConfigsRequest,
+    ListOpenAiCompatConfigsResponse, OpenAiCompatConfig as ProtoOpenAiCompatConfig,
+    SetOpenAiCompatConfigsRequest, UpdateCaptureSettingsRequest,
 };
 
 /// On-disk representation of `~/.nodespace/daemon.toml`.
@@ -21,6 +23,48 @@ use crate::nodespace::{
 struct DaemonConfig {
     #[serde(default)]
     capture: CaptureConfig,
+    #[serde(default)]
+    openai_compat: OpenAiCompatSettings,
+}
+
+/// OpenAI-compatible provider configs persisted in daemon.toml under
+/// `[[openai_compat.configs]]`. The Settings GUI is the only writer; the
+/// daemon reads this by UUID when loading an `openai-compat:<uuid>` model.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct OpenAiCompatSettings {
+    #[serde(default)]
+    pub configs: Vec<OpenAiCompatConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenAiCompatConfig {
+    pub id: String,
+    pub name: String,
+    pub base_url: String,
+    #[serde(default)]
+    pub api_key: String,
+}
+
+impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfig {
+    fn from(c: ProtoOpenAiCompatConfig) -> Self {
+        Self {
+            id: c.id,
+            name: c.name,
+            base_url: c.base_url,
+            api_key: c.api_key,
+        }
+    }
+}
+
+impl From<OpenAiCompatConfig> for ProtoOpenAiCompatConfig {
+    fn from(c: OpenAiCompatConfig) -> Self {
+        Self {
+            id: c.id,
+            name: c.name,
+            base_url: c.base_url,
+            api_key: c.api_key,
+        }
+    }
 }
 
 /// Session capture settings persisted in daemon.toml under `[capture]`.
@@ -83,6 +127,27 @@ pub async fn read_capture_settings(config_path: &std::path::Path) -> anyhow::Res
             Ok(config.capture)
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(CaptureConfig::default()),
+        Err(e) => Err(anyhow::anyhow!("failed to read daemon config: {}", e)),
+    }
+}
+
+/// Look up a single OpenAI-compatible provider config by UUID. Used by
+/// `LocalAgentService` when loading an `openai-compat:<uuid>` model.
+pub async fn find_openai_compat_config(
+    config_path: &std::path::Path,
+    id: &str,
+) -> anyhow::Result<Option<OpenAiCompatConfig>> {
+    match tokio::fs::read_to_string(config_path).await {
+        Ok(contents) => {
+            let config: DaemonConfig = toml::from_str(&contents)
+                .map_err(|e| anyhow::anyhow!("failed to parse daemon config: {}", e))?;
+            Ok(config
+                .openai_compat
+                .configs
+                .into_iter()
+                .find(|c| c.id == id))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(anyhow::anyhow!("failed to read daemon config: {}", e)),
     }
 }
@@ -177,5 +242,169 @@ impl GrpcSettingsService for SettingsServiceImpl {
 
         self.write_config(&config).await?;
         Ok(Response::new(Self::capture_to_response(&config.capture)))
+    }
+
+    async fn list_open_ai_compat_configs(
+        &self,
+        _request: Request<ListOpenAiCompatConfigsRequest>,
+    ) -> Result<Response<ListOpenAiCompatConfigsResponse>, Status> {
+        let config = self.read_config().await?;
+        Ok(Response::new(ListOpenAiCompatConfigsResponse {
+            configs: config
+                .openai_compat
+                .configs
+                .into_iter()
+                .map(ProtoOpenAiCompatConfig::from)
+                .collect(),
+        }))
+    }
+
+    async fn set_open_ai_compat_configs(
+        &self,
+        request: Request<SetOpenAiCompatConfigsRequest>,
+    ) -> Result<Response<ListOpenAiCompatConfigsResponse>, Status> {
+        let req = request.into_inner();
+        let _guard = self.write_lock.lock().await;
+
+        let mut config = self.read_config().await?;
+        config.openai_compat.configs = req
+            .configs
+            .into_iter()
+            .map(OpenAiCompatConfig::from)
+            .collect();
+
+        self.write_config(&config).await?;
+        Ok(Response::new(ListOpenAiCompatConfigsResponse {
+            configs: config
+                .openai_compat
+                .configs
+                .into_iter()
+                .map(ProtoOpenAiCompatConfig::from)
+                .collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_impl() -> (SettingsServiceImpl, tempfile::TempDir) {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("daemon.toml");
+        (SettingsServiceImpl::new(config_path), tempdir)
+    }
+
+    #[tokio::test]
+    async fn list_openai_compat_configs_empty_when_no_file() {
+        let (svc, _tempdir) = test_impl();
+        let resp = svc
+            .list_open_ai_compat_configs(Request::new(ListOpenAiCompatConfigsRequest {}))
+            .await
+            .expect("list should succeed")
+            .into_inner();
+        assert!(resp.configs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_then_list_openai_compat_configs_roundtrips() {
+        let (svc, _tempdir) = test_impl();
+        let config = ProtoOpenAiCompatConfig {
+            id: "abc-123".to_string(),
+            name: "My Endpoint".to_string(),
+            base_url: "https://api.example.com/v1".to_string(),
+            api_key: "sk-test".to_string(),
+        };
+
+        let set_resp = svc
+            .set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
+                configs: vec![config.clone()],
+            }))
+            .await
+            .expect("set should succeed")
+            .into_inner();
+        assert_eq!(set_resp.configs.len(), 1);
+
+        let list_resp = svc
+            .list_open_ai_compat_configs(Request::new(ListOpenAiCompatConfigsRequest {}))
+            .await
+            .expect("list should succeed")
+            .into_inner();
+        assert_eq!(list_resp.configs.len(), 1);
+        assert_eq!(list_resp.configs[0].id, "abc-123");
+        assert_eq!(list_resp.configs[0].name, "My Endpoint");
+        assert_eq!(list_resp.configs[0].base_url, "https://api.example.com/v1");
+        assert_eq!(list_resp.configs[0].api_key, "sk-test");
+    }
+
+    #[tokio::test]
+    async fn set_openai_compat_configs_replaces_full_list() {
+        let (svc, _tempdir) = test_impl();
+        let first = ProtoOpenAiCompatConfig {
+            id: "a".to_string(),
+            name: "A".to_string(),
+            base_url: "https://a.example.com".to_string(),
+            api_key: String::new(),
+        };
+        svc.set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
+            configs: vec![first],
+        }))
+        .await
+        .expect("first set should succeed");
+
+        let second = ProtoOpenAiCompatConfig {
+            id: "b".to_string(),
+            name: "B".to_string(),
+            base_url: "https://b.example.com".to_string(),
+            api_key: String::new(),
+        };
+        let resp = svc
+            .set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
+                configs: vec![second],
+            }))
+            .await
+            .expect("second set should succeed")
+            .into_inner();
+
+        assert_eq!(resp.configs.len(), 1);
+        assert_eq!(resp.configs[0].id, "b");
+    }
+
+    #[tokio::test]
+    async fn find_openai_compat_config_by_id() {
+        let (svc, tempdir) = test_impl();
+        let config_path = tempdir.path().join("daemon.toml");
+        let config = ProtoOpenAiCompatConfig {
+            id: "target".to_string(),
+            name: "Target".to_string(),
+            base_url: "https://target.example.com".to_string(),
+            api_key: "key".to_string(),
+        };
+        svc.set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
+            configs: vec![config],
+        }))
+        .await
+        .expect("set should succeed");
+
+        let found = find_openai_compat_config(&config_path, "target")
+            .await
+            .expect("read should succeed");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "Target");
+
+        let missing = find_openai_compat_config(&config_path, "nonexistent")
+            .await
+            .expect("read should succeed");
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_openai_compat_config_returns_none_when_file_missing() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("daemon.toml");
+        let found = find_openai_compat_config(&config_path, "anything")
+            .await
+            .expect("missing file should not error");
+        assert!(found.is_none());
     }
 }

--- a/packages/daemon/src/services/settings_service.rs
+++ b/packages/daemon/src/services/settings_service.rs
@@ -197,7 +197,23 @@ impl SettingsServiceImpl {
             .map_err(|e| Status::internal(format!("Failed to serialize daemon config: {}", e)))?;
         tokio::fs::write(&self.config_path, contents)
             .await
-            .map_err(|e| Status::internal(format!("Failed to write daemon config: {}", e)))
+            .map_err(|e| Status::internal(format!("Failed to write daemon config: {}", e)))?;
+
+        // daemon.toml now holds real third-party API keys (openai_compat.configs) —
+        // restrict to owner-only so other local accounts on a shared machine can't
+        // read them off disk. Unix-only; this is a macOS/Linux desktop app.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            tokio::fs::set_permissions(&self.config_path, perms)
+                .await
+                .map_err(|e| {
+                    Status::internal(format!("Failed to set daemon config permissions: {}", e))
+                })?;
+        }
+
+        Ok(())
     }
 
     fn capture_to_response(capture: &CaptureConfig) -> CaptureSettingsResponse {
@@ -406,5 +422,34 @@ mod tests {
             .await
             .expect("missing file should not error");
         assert!(found.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_config_restricts_daemon_toml_to_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (svc, tempdir) = test_impl();
+        let config_path = tempdir.path().join("daemon.toml");
+        svc.set_open_ai_compat_configs(Request::new(SetOpenAiCompatConfigsRequest {
+            configs: vec![ProtoOpenAiCompatConfig {
+                id: "a".to_string(),
+                name: "A".to_string(),
+                base_url: "https://a.example.com".to_string(),
+                api_key: "sk-secret".to_string(),
+            }],
+        }))
+        .await
+        .expect("set should succeed");
+
+        let metadata = tokio::fs::metadata(&config_path)
+            .await
+            .expect("daemon.toml should exist after write");
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "daemon.toml should be owner-read/write only, got {:o}",
+            mode
+        );
     }
 }

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -206,6 +206,9 @@ pub struct OpenAiCompatConfigResult {
     pub name: String,
     pub base_url: String,
     pub api_key: String,
+    /// Model identifier sent as the wire-protocol "model" field — distinct
+    /// from `name`, which is only a cosmetic UI label.
+    pub model: String,
 }
 
 impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfigResult {
@@ -215,6 +218,7 @@ impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfigResult {
             name: c.name,
             base_url: c.base_url,
             api_key: c.api_key,
+            model: c.model,
         }
     }
 }
@@ -226,6 +230,7 @@ impl From<OpenAiCompatConfigResult> for ProtoOpenAiCompatConfig {
             name: c.name,
             base_url: c.base_url,
             api_key: c.api_key,
+            model: c.model,
         }
     }
 }

--- a/packages/desktop-app/src-tauri/src/commands/settings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/settings.rs
@@ -12,7 +12,9 @@
 
 use crate::services::GrpcClient;
 use nodespace_proto::nodespace::{
-    GetCaptureSettingsRequest, ListDatabasesRequest, UpdateCaptureSettingsRequest,
+    GetCaptureSettingsRequest, ListDatabasesRequest, ListOpenAiCompatConfigsRequest,
+    OpenAiCompatConfig as ProtoOpenAiCompatConfig, SetOpenAiCompatConfigsRequest,
+    UpdateCaptureSettingsRequest,
 };
 use tauri::{AppHandle, Manager};
 
@@ -189,4 +191,85 @@ fn str_to_content_level(s: &str) -> Result<i32, String> {
             other
         )),
     }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible provider configs
+// ---------------------------------------------------------------------------
+
+/// An OpenAI-compatible provider config as sent to/from the frontend. Mirrors
+/// `OpenAiCompatConfig` in `$lib/types/ai-chat-node.ts`.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenAiCompatConfigResult {
+    pub id: String,
+    pub name: String,
+    pub base_url: String,
+    pub api_key: String,
+}
+
+impl From<ProtoOpenAiCompatConfig> for OpenAiCompatConfigResult {
+    fn from(c: ProtoOpenAiCompatConfig) -> Self {
+        Self {
+            id: c.id,
+            name: c.name,
+            base_url: c.base_url,
+            api_key: c.api_key,
+        }
+    }
+}
+
+impl From<OpenAiCompatConfigResult> for ProtoOpenAiCompatConfig {
+    fn from(c: OpenAiCompatConfigResult) -> Self {
+        Self {
+            id: c.id,
+            name: c.name,
+            base_url: c.base_url,
+            api_key: c.api_key,
+        }
+    }
+}
+
+/// Get all configured OpenAI-compatible provider configs from the daemon.
+#[tauri::command]
+pub async fn get_openai_compat_configs(
+    grpc_client: tauri::State<'_, GrpcClient>,
+) -> Result<Vec<OpenAiCompatConfigResult>, String> {
+    let mut client = grpc_client.settings_client().await;
+    let resp = client
+        .list_open_ai_compat_configs(ListOpenAiCompatConfigsRequest {})
+        .await
+        .map_err(|e| format!("Failed to list OpenAI-compat configs: {}", e))?
+        .into_inner();
+
+    Ok(resp
+        .configs
+        .into_iter()
+        .map(OpenAiCompatConfigResult::from)
+        .collect())
+}
+
+/// Replace the full set of OpenAI-compatible provider configs on the daemon.
+#[tauri::command]
+pub async fn set_openai_compat_configs(
+    grpc_client: tauri::State<'_, GrpcClient>,
+    configs: Vec<OpenAiCompatConfigResult>,
+) -> Result<Vec<OpenAiCompatConfigResult>, String> {
+    let mut client = grpc_client.settings_client().await;
+    let resp = client
+        .set_open_ai_compat_configs(SetOpenAiCompatConfigsRequest {
+            configs: configs
+                .into_iter()
+                .map(ProtoOpenAiCompatConfig::from)
+                .collect(),
+        })
+        .await
+        .map_err(|e| format!("Failed to save OpenAI-compat configs: {}", e))?
+        .into_inner();
+
+    Ok(resp
+        .configs
+        .into_iter()
+        .map(OpenAiCompatConfigResult::from)
+        .collect())
 }

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -506,6 +506,8 @@ pub fn run() {
             commands::settings::update_display_settings,
             commands::settings::get_capture_settings,
             commands::settings::update_capture_settings,
+            commands::settings::get_openai_compat_configs,
+            commands::settings::set_openai_compat_configs,
             // Local database registry commands (ADR-053)
             commands::database::list_databases,
             commands::database::create_database,

--- a/packages/desktop-app/src/lib/components/settings/model-manager.svelte
+++ b/packages/desktop-app/src/lib/components/settings/model-manager.svelte
@@ -9,7 +9,11 @@
     saveDefaultModelSelection,
     type ModelSelection,
   } from '$lib/stores/settings.svelte';
-  import { ollamaAvailable, chatModelList } from '$lib/services/tauri-commands';
+  import {
+    ollamaAvailable,
+    chatModelList,
+    getOpenAiCompatConfigsFromDaemon,
+  } from '$lib/services/tauri-commands';
   import type { OpenAiCompatConfig } from '$lib/types/ai-chat-node';
   import type { ModelFamily } from '$lib/types/agent-types';
   import { createLogger } from '$lib/utils/logger';
@@ -90,8 +94,22 @@
 
   onMount(async () => {
     if (models.length === 0) modelStore.refreshModels();
+    // Show the local cache immediately, then refresh from the daemon (source
+    // of truth) — avoids a blank list while the round-trip is in flight.
     openAiConfigs = getOpenAiConfigs();
     defaultModel = getDefaultModelSelection();
+    try {
+      const daemonConfigs = await getOpenAiCompatConfigsFromDaemon();
+      openAiConfigs = daemonConfigs.map((c) => ({
+        id: c.id,
+        name: c.name,
+        baseUrl: c.baseUrl,
+        apiKey: c.apiKey,
+      }));
+      buildDefaultOptions();
+    } catch (e) {
+      log.warn('Failed to refresh OpenAI-compat configs from daemon', e);
+    }
 
     await checkOllama();
   });
@@ -128,7 +146,7 @@
     editForm = { name: config.name, baseUrl: config.baseUrl, apiKey: config.apiKey };
   }
 
-  function saveConfig() {
+  async function saveConfig() {
     if (!editingConfig) return;
     const updated = { ...editingConfig, ...editForm };
     if (isNewConfig) {
@@ -136,14 +154,14 @@
     } else {
       openAiConfigs = openAiConfigs.map((c) => (c.id === updated.id ? updated : c));
     }
-    saveOpenAiConfigs(openAiConfigs);
+    await saveOpenAiConfigs(openAiConfigs);
     editingConfig = null;
     buildDefaultOptions();
   }
 
-  function deleteConfig(id: string) {
+  async function deleteConfig(id: string) {
     openAiConfigs = openAiConfigs.filter((c) => c.id !== id);
-    saveOpenAiConfigs(openAiConfigs);
+    await saveOpenAiConfigs(openAiConfigs);
     if (defaultModel?.configId === id) {
       defaultModel = null;
       saveDefaultModelSelection(null);

--- a/packages/desktop-app/src/lib/components/settings/model-manager.svelte
+++ b/packages/desktop-app/src/lib/components/settings/model-manager.svelte
@@ -62,7 +62,7 @@
   // --- OpenAI-compat configs ---
   let openAiConfigs = $state<OpenAiCompatConfig[]>([]);
   let editingConfig = $state<OpenAiCompatConfig | null>(null);
-  let editForm = $state({ name: '', baseUrl: '', apiKey: '' });
+  let editForm = $state({ name: '', baseUrl: '', apiKey: '', model: '' });
   let isNewConfig = $state(false);
 
   // --- Default model ---
@@ -105,6 +105,7 @@
         name: c.name,
         baseUrl: c.baseUrl,
         apiKey: c.apiKey,
+        model: c.model,
       }));
       buildDefaultOptions();
     } catch (e) {
@@ -136,14 +137,25 @@
   // --- OpenAI-compat CRUD ---
   function startAdd() {
     isNewConfig = true;
-    editForm = { name: '', baseUrl: '', apiKey: '' };
-    editingConfig = { id: globalThis.crypto.randomUUID(), name: '', baseUrl: '', apiKey: '' };
+    editForm = { name: '', baseUrl: '', apiKey: '', model: '' };
+    editingConfig = {
+      id: globalThis.crypto.randomUUID(),
+      name: '',
+      baseUrl: '',
+      apiKey: '',
+      model: '',
+    };
   }
 
   function startEdit(config: OpenAiCompatConfig) {
     isNewConfig = false;
     editingConfig = config;
-    editForm = { name: config.name, baseUrl: config.baseUrl, apiKey: config.apiKey };
+    editForm = {
+      name: config.name,
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
+      model: config.model,
+    };
   }
 
   async function saveConfig() {
@@ -363,11 +375,16 @@
           <input class="form-input" type="url" bind:value={editForm.baseUrl} placeholder="https://api.openai.com/v1" />
         </label>
         <label class="form-label">
+          Model
+          <input class="form-input" type="text" bind:value={editForm.model} placeholder="e.g. gpt-4o" />
+        </label>
+        <p class="mm-desc">The exact model identifier the endpoint expects — required by the real OpenAI API and any server hosting more than one model.</p>
+        <label class="form-label">
           API Key
           <input class="form-input" type="password" bind:value={editForm.apiKey} placeholder="sk-…" />
         </label>
         <div class="form-actions">
-          <button class="btn btn--primary btn--sm" onclick={saveConfig} disabled={!editForm.name || !editForm.baseUrl}>Save</button>
+          <button class="btn btn--primary btn--sm" onclick={saveConfig} disabled={!editForm.name || !editForm.baseUrl || !editForm.model}>Save</button>
           <button class="btn btn--sm" onclick={cancelEdit}>Cancel</button>
         </div>
       </div>

--- a/packages/desktop-app/src/lib/components/viewers/ai-chat-model-selector.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/ai-chat-model-selector.svelte
@@ -124,6 +124,7 @@
           name: c.name,
           baseUrl: c.baseUrl,
           apiKey: c.apiKey,
+          model: c.model,
         })) ?? getOpenAiConfigs();
     } catch (err) {
       log.error('Failed to load model list', err);

--- a/packages/desktop-app/src/lib/components/viewers/ai-chat-model-selector.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/ai-chat-model-selector.svelte
@@ -28,6 +28,7 @@
     chatModelList,
     ollamaAvailable,
     getSystemRamGb,
+    getOpenAiCompatConfigsFromDaemon,
     type ChatModelEntry,
   } from '$lib/services/tauri-commands';
   import { AGENT_EVENTS } from '$lib/types/agent-types';
@@ -105,15 +106,25 @@
 
   async function refresh(): Promise<void> {
     try {
-      const [list, ram, ollama] = await Promise.all([
+      const [list, ram, ollama, daemonConfigs] = await Promise.all([
         chatModelList(),
         getSystemRamGb(),
         ollamaAvailable(),
+        getOpenAiCompatConfigsFromDaemon().catch((err) => {
+          log.warn('Failed to load OpenAI-compat configs from daemon, using local cache', err);
+          return null;
+        }),
       ]);
       models = list;
       ramGb = ram;
       ollamaRunning = ollama;
-      openAiConfigs = getOpenAiConfigs();
+      openAiConfigs =
+        daemonConfigs?.map((c) => ({
+          id: c.id,
+          name: c.name,
+          baseUrl: c.baseUrl,
+          apiKey: c.apiKey,
+        })) ?? getOpenAiConfigs();
     } catch (err) {
       log.error('Failed to load model list', err);
     } finally {

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -270,6 +270,31 @@ export async function updateCaptureSettings(
 }
 
 // ============================================================================
+// OpenAI-compatible Provider Config Commands
+// ============================================================================
+
+export interface OpenAiCompatConfigDto {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+}
+
+/** Read all OpenAI-compatible provider configs from the daemon (source of truth). */
+export async function getOpenAiCompatConfigsFromDaemon(): Promise<OpenAiCompatConfigDto[]> {
+  if (!isTauri()) return [];
+  return invoke<OpenAiCompatConfigDto[]>('get_openai_compat_configs');
+}
+
+/** Replace the full set of OpenAI-compatible provider configs on the daemon. */
+export async function setOpenAiCompatConfigsOnDaemon(
+  configs: OpenAiCompatConfigDto[]
+): Promise<OpenAiCompatConfigDto[]> {
+  if (!isTauri()) return configs;
+  return invoke<OpenAiCompatConfigDto[]>('set_openai_compat_configs', { configs });
+}
+
+// ============================================================================
 // PTY Agent Availability Commands (Issue #1124)
 // ============================================================================
 

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -278,6 +278,7 @@ export interface OpenAiCompatConfigDto {
   name: string;
   baseUrl: string;
   apiKey: string;
+  model: string;
 }
 
 /** Read all OpenAI-compatible provider configs from the daemon (source of truth). */

--- a/packages/desktop-app/src/lib/stores/settings.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/settings.svelte.ts
@@ -86,6 +86,7 @@ class SettingsStore {
           name: c.name,
           baseUrl: c.baseUrl,
           apiKey: c.apiKey,
+          model: c.model,
         }));
         writeLocalSettings({ openAiConfigs });
       } catch (err) {
@@ -138,7 +139,13 @@ class SettingsStore {
     }
     try {
       await setOpenAiCompatConfigsOnDaemon(
-        configs.map((c) => ({ id: c.id, name: c.name, baseUrl: c.baseUrl, apiKey: c.apiKey }))
+        configs.map((c) => ({
+          id: c.id,
+          name: c.name,
+          baseUrl: c.baseUrl,
+          apiKey: c.apiKey,
+          model: c.model,
+        }))
       );
     } catch (err) {
       log.error('Failed to persist OpenAI-compat configs to daemon:', err);

--- a/packages/desktop-app/src/lib/stores/settings.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/settings.svelte.ts
@@ -1,6 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '$lib/utils/logger';
 import type { OpenAiCompatConfig, AiChatProvider } from '$lib/types/ai-chat-node';
+import {
+  getOpenAiCompatConfigsFromDaemon,
+  setOpenAiCompatConfigsOnDaemon,
+} from '$lib/services/tauri-commands';
 
 const log = createLogger('SettingsStore');
 
@@ -26,6 +30,11 @@ export interface AppSettings {
 
 // ---------------------------------------------------------------------------
 // localStorage helpers for client-side settings
+//
+// OpenAI-compat configs are persisted on the daemon (~/.nodespace/daemon.toml,
+// via SettingsService) — that is the source of truth the backend reads by
+// UUID when loading an "openai-compat:<uuid>" model. localStorage is kept as
+// a synchronous read cache only, refreshed from the daemon on loadSettings().
 // ---------------------------------------------------------------------------
 
 interface LocalPersistedSettings {
@@ -65,9 +74,27 @@ class SettingsStore {
       const settings =
         await invoke<Omit<AppSettings, 'openAiConfigs' | 'defaultModelSelection'>>('get_settings');
       const local = readLocalSettings();
+
+      // Refresh the OpenAI-compat cache from the daemon (source of truth).
+      // Falls back to the local cache if the daemon call fails (e.g. offline
+      // dev-proxy mode) so the UI still has something to show.
+      let openAiConfigs = local.openAiConfigs ?? [];
+      try {
+        const daemonConfigs = await getOpenAiCompatConfigsFromDaemon();
+        openAiConfigs = daemonConfigs.map((c) => ({
+          id: c.id,
+          name: c.name,
+          baseUrl: c.baseUrl,
+          apiKey: c.apiKey,
+        }));
+        writeLocalSettings({ openAiConfigs });
+      } catch (err) {
+        log.warn('Failed to load OpenAI-compat configs from daemon, using local cache', err);
+      }
+
       this.appSettings = {
         ...settings,
-        openAiConfigs: local.openAiConfigs ?? [],
+        openAiConfigs,
         defaultModelSelection: local.defaultModelSelection ?? null,
       };
     } catch (err) {
@@ -98,10 +125,23 @@ class SettingsStore {
     }
   }
 
-  saveOpenAiConfigs(configs: OpenAiCompatConfig[]): void {
+  /**
+   * Persist the full set of OpenAI-compat configs. Writes to the local cache
+   * immediately (so synchronous getOpenAiConfigs() readers see the change),
+   * then pushes to the daemon — the backend-accessible source of truth used
+   * to resolve "openai-compat:<uuid>" models.
+   */
+  async saveOpenAiConfigs(configs: OpenAiCompatConfig[]): Promise<void> {
     writeLocalSettings({ openAiConfigs: configs });
     if (this.appSettings) {
       this.appSettings = { ...this.appSettings, openAiConfigs: configs };
+    }
+    try {
+      await setOpenAiCompatConfigsOnDaemon(
+        configs.map((c) => ({ id: c.id, name: c.name, baseUrl: c.baseUrl, apiKey: c.apiKey }))
+      );
+    } catch (err) {
+      log.error('Failed to persist OpenAI-compat configs to daemon:', err);
     }
   }
 
@@ -123,8 +163,8 @@ export function getOpenAiConfigs(): OpenAiCompatConfig[] {
   return readLocalSettings().openAiConfigs ?? [];
 }
 
-export function saveOpenAiConfigs(configs: OpenAiCompatConfig[]): void {
-  settingsStore.saveOpenAiConfigs(configs);
+export function saveOpenAiConfigs(configs: OpenAiCompatConfig[]): Promise<void> {
+  return settingsStore.saveOpenAiConfigs(configs);
 }
 
 export function getDefaultModelSelection(): ModelSelection | null {

--- a/packages/desktop-app/src/lib/types/ai-chat-node.ts
+++ b/packages/desktop-app/src/lib/types/ai-chat-node.ts
@@ -5,9 +5,10 @@ export type AiChatProvider = 'native' | 'ollama' | 'openai' | 'openai-compat' | 
 
 export interface OpenAiCompatConfig {
   id: string;       // uuid, generated client-side
-  name: string;     // user-provided display name
+  name: string;     // user-provided display name (cosmetic only, never sent to the endpoint)
   baseUrl: string;  // e.g. "https://api.openai.com/v1"
-  apiKey: string;   // stored locally
+  apiKey: string;   // stored on the daemon (~/.nodespace/daemon.toml, 0600)
+  model: string;    // wire-protocol "model" field, e.g. "gpt-4o" — required by the real OpenAI API
 }
 
 export interface AiChatMessage {

--- a/packages/desktop-app/src/tests/stores/settings.test.ts
+++ b/packages/desktop-app/src/tests/stores/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('$lib/utils/logger', () => ({
   createLogger: () => ({
@@ -14,7 +14,12 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args)
 }));
 
-import { settingsStore, loadSettings, updateDisplaySetting } from '$lib/stores/settings.svelte';
+import {
+  settingsStore,
+  loadSettings,
+  updateDisplaySetting,
+  saveOpenAiConfigs,
+} from '$lib/stores/settings.svelte';
 import type { AppSettings } from '$lib/stores/settings.svelte';
 
 describe('Settings Store', () => {
@@ -28,9 +33,27 @@ describe('Settings Store', () => {
     defaultModelSelection: null,
   };
 
+  function enableTauri(): void {
+    (globalThis.window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+  }
+
+  function disableTauri(): void {
+    delete (globalThis.window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     settingsStore.appSettings = null;
+    localStorage.clear();
+    disableTauri();
+  });
+
+  afterEach(() => {
+    // singleFork test execution shares one `window` across every test file
+    // in the run — an enabled flag left set here would leak into unrelated
+    // suites (e.g. tauri-commands.test.ts's "outside Tauri" fallback tests).
+    disableTauri();
+    localStorage.clear();
   });
 
   describe('appSettings store', () => {
@@ -106,6 +129,83 @@ describe('Settings Store', () => {
 
       // Optimistic update on null store should keep it null
       expect(settingsStore.appSettings).toBeNull();
+    });
+  });
+
+  describe('OpenAI-compat config daemon persistence', () => {
+    it('loadSettings refreshes openAiConfigs from the daemon when running under Tauri', async () => {
+      enableTauri();
+      const backendSettings = {
+        activeDatabasePath: mockSettings.activeDatabasePath,
+        display: mockSettings.display,
+      };
+      const daemonConfigs = [
+        { id: 'abc', name: 'My Endpoint', baseUrl: 'https://api.example.com/v1', apiKey: 'sk-test' },
+      ];
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_settings') return Promise.resolve(backendSettings);
+        if (cmd === 'get_openai_compat_configs') return Promise.resolve(daemonConfigs);
+        return Promise.resolve(undefined);
+      });
+
+      await loadSettings();
+
+      expect(mockInvoke).toHaveBeenCalledWith('get_openai_compat_configs');
+      expect(settingsStore.appSettings?.openAiConfigs).toEqual(daemonConfigs);
+    });
+
+    it('loadSettings falls back to the local cache if the daemon call fails', async () => {
+      enableTauri();
+      const backendSettings = {
+        activeDatabasePath: mockSettings.activeDatabasePath,
+        display: mockSettings.display,
+      };
+      localStorage.setItem(
+        'nodespace-settings',
+        JSON.stringify({
+          openAiConfigs: [
+            { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '' },
+          ],
+        })
+      );
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_settings') return Promise.resolve(backendSettings);
+        if (cmd === 'get_openai_compat_configs') return Promise.reject(new Error('daemon unreachable'));
+        return Promise.resolve(undefined);
+      });
+
+      await loadSettings();
+
+      expect(settingsStore.appSettings?.openAiConfigs).toEqual([
+        { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '' },
+      ]);
+    });
+
+    it('saveOpenAiConfigs writes to localStorage immediately and pushes to the daemon', async () => {
+      enableTauri();
+      mockInvoke.mockResolvedValue([]);
+      const configs = [
+        { id: 'new-id', name: 'New Endpoint', baseUrl: 'https://new.example.com', apiKey: 'sk-new' },
+      ];
+
+      await saveOpenAiConfigs(configs);
+
+      expect(mockInvoke).toHaveBeenCalledWith('set_openai_compat_configs', { configs });
+      const cached = JSON.parse(localStorage.getItem('nodespace-settings') ?? '{}');
+      expect(cached.openAiConfigs).toEqual(configs);
+    });
+
+    it('saveOpenAiConfigs keeps the local write even if the daemon push fails', async () => {
+      enableTauri();
+      mockInvoke.mockRejectedValue(new Error('daemon unreachable'));
+      const configs = [
+        { id: 'x', name: 'X', baseUrl: 'https://x.example.com', apiKey: '' },
+      ];
+
+      await saveOpenAiConfigs(configs);
+
+      const cached = JSON.parse(localStorage.getItem('nodespace-settings') ?? '{}');
+      expect(cached.openAiConfigs).toEqual(configs);
     });
   });
 });

--- a/packages/desktop-app/src/tests/stores/settings.test.ts
+++ b/packages/desktop-app/src/tests/stores/settings.test.ts
@@ -140,7 +140,7 @@ describe('Settings Store', () => {
         display: mockSettings.display,
       };
       const daemonConfigs = [
-        { id: 'abc', name: 'My Endpoint', baseUrl: 'https://api.example.com/v1', apiKey: 'sk-test' },
+        { id: 'abc', name: 'My Endpoint', baseUrl: 'https://api.example.com/v1', apiKey: 'sk-test', model: 'gpt-4o' },
       ];
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'get_settings') return Promise.resolve(backendSettings);
@@ -164,7 +164,7 @@ describe('Settings Store', () => {
         'nodespace-settings',
         JSON.stringify({
           openAiConfigs: [
-            { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '' },
+            { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '', model: 'cached-model' },
           ],
         })
       );
@@ -177,7 +177,7 @@ describe('Settings Store', () => {
       await loadSettings();
 
       expect(settingsStore.appSettings?.openAiConfigs).toEqual([
-        { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '' },
+        { id: 'cached', name: 'Cached', baseUrl: 'https://cached.example.com', apiKey: '', model: 'cached-model' },
       ]);
     });
 
@@ -185,7 +185,7 @@ describe('Settings Store', () => {
       enableTauri();
       mockInvoke.mockResolvedValue([]);
       const configs = [
-        { id: 'new-id', name: 'New Endpoint', baseUrl: 'https://new.example.com', apiKey: 'sk-new' },
+        { id: 'new-id', name: 'New Endpoint', baseUrl: 'https://new.example.com', apiKey: 'sk-new', model: 'gpt-4o' },
       ];
 
       await saveOpenAiConfigs(configs);
@@ -199,7 +199,7 @@ describe('Settings Store', () => {
       enableTauri();
       mockInvoke.mockRejectedValue(new Error('daemon unreachable'));
       const configs = [
-        { id: 'x', name: 'X', baseUrl: 'https://x.example.com', apiKey: '' },
+        { id: 'x', name: 'X', baseUrl: 'https://x.example.com', apiKey: '', model: 'model-x' },
       ];
 
       await saveOpenAiConfigs(configs);

--- a/packages/proto/proto/settings_service.proto
+++ b/packages/proto/proto/settings_service.proto
@@ -70,7 +70,8 @@ message OpenAiCompatConfig {
   // UUID generated client-side when the config is created. Referenced by
   // ai-chat nodes as model = "openai-compat:<id>".
   string id = 1;
-  // User-provided display name shown in the model selector.
+  // User-provided display name shown in the model selector. Cosmetic only —
+  // never sent to the endpoint.
   string name = 2;
   // Base URL of the endpoint, e.g. "https://api.openai.com/v1". Requests are
   // sent to "<base_url>/chat/completions".
@@ -78,6 +79,11 @@ message OpenAiCompatConfig {
   // API key sent as "Authorization: Bearer <api_key>". May be empty for
   // endpoints that do not require auth (e.g. a local Ollama server).
   string api_key = 4;
+  // Model identifier sent as the JSON "model" field in chat-completions
+  // requests, e.g. "gpt-4o" or "llama-3.1-8b-instruct". Required by the real
+  // OpenAI API and any server hosting more than one model; single-model
+  // local servers (Ollama, LM Studio) generally ignore it.
+  string model = 5;
 }
 
 message ListOpenAiCompatConfigsRequest {}

--- a/packages/proto/proto/settings_service.proto
+++ b/packages/proto/proto/settings_service.proto
@@ -17,6 +17,14 @@ service SettingsService {
   // Persist session capture settings. Changes take effect immediately for
   // sessions launched after this call.
   rpc UpdateCaptureSettings(UpdateCaptureSettingsRequest) returns (CaptureSettingsResponse);
+
+  // List all configured OpenAI-compatible provider configs (API keys included —
+  // this RPC is only reachable over the local Tauri<->daemon gRPC connection).
+  rpc ListOpenAiCompatConfigs(ListOpenAiCompatConfigsRequest) returns (ListOpenAiCompatConfigsResponse);
+
+  // Replace the full set of OpenAI-compatible provider configs. The Settings
+  // GUI sends the complete list on every add/edit/remove.
+  rpc SetOpenAiCompatConfigs(SetOpenAiCompatConfigsRequest) returns (ListOpenAiCompatConfigsResponse);
 }
 
 // ---------------------------------------------------------------------------
@@ -50,4 +58,34 @@ message CaptureSettingsResponse {
   bool enabled = 1;
   bool sync = 2;
   CaptureContentLevel content = 3;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible provider configs
+// ---------------------------------------------------------------------------
+
+// A user-configured OpenAI-compatible chat completions endpoint (e.g. a
+// self-hosted vLLM/LM Studio server, or Ollama's own /v1/chat/completions).
+message OpenAiCompatConfig {
+  // UUID generated client-side when the config is created. Referenced by
+  // ai-chat nodes as model = "openai-compat:<id>".
+  string id = 1;
+  // User-provided display name shown in the model selector.
+  string name = 2;
+  // Base URL of the endpoint, e.g. "https://api.openai.com/v1". Requests are
+  // sent to "<base_url>/chat/completions".
+  string base_url = 3;
+  // API key sent as "Authorization: Bearer <api_key>". May be empty for
+  // endpoints that do not require auth (e.g. a local Ollama server).
+  string api_key = 4;
+}
+
+message ListOpenAiCompatConfigsRequest {}
+
+message ListOpenAiCompatConfigsResponse {
+  repeated OpenAiCompatConfig configs = 1;
+}
+
+message SetOpenAiCompatConfigsRequest {
+  repeated OpenAiCompatConfig configs = 1;
 }


### PR DESCRIPTION
## Summary
- Implements `OpenAiCompatInferenceEngine` (streaming SSE + non-streaming, tool calls, bearer auth) mirroring `OllamaInferenceEngine`
- Adds `SettingsService.ListOpenAiCompatConfigs`/`SetOpenAiCompatConfigs` RPCs, persisting provider configs (name/baseUrl/apiKey) in `daemon.toml` as the backend-accessible source of truth
- Routes `openai-compat:<uuid>` models in `LocalAgentService::load_model_and_collect_events` before the GGUF catalog lookup, with a clear "no config found" error instead of the previous misleading GGUF path-resolution failure
- Frontend settings store and model pickers (`model-manager.svelte`, `ai-chat-model-selector.svelte`) now read/write configs through the daemon via new Tauri commands, keeping localStorage only as a synchronous UI cache

Closes #1530.

## Test plan
- [x] `bun run test` (frontend baseline + new tests): 156 files / 3995 tests passing
- [x] `cargo test -p nodespace-agent --lib`: 286 passing, including new `openai_compat_inference` unit tests (prefix routing, streaming/non-streaming response parsing)
- [x] `cargo test -p nodespace-daemon --lib`: 59 passing, including new routing tests (`load_openai_compat_model_without_config_returns_clear_error`, `load_openai_compat_model_with_config_swaps_engine`) and `settings_service` config CRUD roundtrip tests
- [x] `bun run quality:fix`: clean (eslint, svelte-check, tsc, cargo fmt, clippy -D warnings)
- [x] `bun run test:all` + pre-push gate (full test:all, `cargo build --bin nodespaced`, `test:e2e`): all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)