### PR TITLE
Remove greenfield backward-compat leftovers in task/markdown code (closes #1522)

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -706,7 +706,7 @@ impl NodeBehavior for TaskNodeBehavior {
                 "status": "open",
                 "priority": "medium",
                 "due_date": null,
-                "assignee_id": null
+                "assignee": null
             }
         })
     }
@@ -2817,7 +2817,7 @@ mod tests {
         assert_eq!(metadata["task"]["status"], "open");
         assert_eq!(metadata["task"]["priority"], "medium");
         assert!(metadata["task"]["due_date"].is_null());
-        assert!(metadata["task"]["assignee_id"].is_null());
+        assert!(metadata["task"]["assignee"].is_null());
     }
 
     #[test]

--- a/packages/core/src/markdown/mod.rs
+++ b/packages/core/src/markdown/mod.rs
@@ -1578,7 +1578,6 @@ async fn parse_markdown(
             &node.node_type,
             &node.content,
             actual_parent_id,
-            context.root_id.clone(),
             position,
             Some(node.properties.clone()),
         )
@@ -1603,7 +1602,6 @@ async fn create_node(
     node_type: &str,
     content: &str,
     parent_id: Option<String>,
-    _root_node_id: Option<String>, // Deprecated - kept for backward compat but ignored (root auto-derived from parent)
     position: crate::services::InsertPositionOwned,
     custom_properties: Option<Value>, // Custom properties from markdown parsing (e.g., task status)
 ) -> Result<String, MarkdownError> {
@@ -2015,22 +2013,11 @@ pub struct UpdateRootFromMarkdownParams {
 /// **For production use**: Consider implementing transaction support if atomicity
 /// guarantees are required for your use case.
 ///
-/// # Backward Compatibility
-///
-/// This function accepts both `root_id` (preferred) and `container_id` (deprecated).
-/// If both are provided, `root_id` takes precedence.
-///
 /// # Example
 ///
 /// ```ignore
-/// // New style (preferred)
 /// let params = json!({
 ///     "root_id": "root-123",
-///     "markdown": "# Updated Plan\n- New task 1\n- New task 2"
-/// });
-/// // Or deprecated style (still works)
-/// let params = json!({
-///     "container_id": "root-123",
 ///     "markdown": "# Updated Plan\n- New task 1\n- New task 2"
 /// });
 /// let result = handle_update_root_from_markdown(&operations, params).await?;

--- a/packages/core/src/models/task_node.rs
+++ b/packages/core/src/models/task_node.rs
@@ -377,9 +377,9 @@ impl TaskNode {
     ///
     /// # Property Formats
     ///
-    /// Supports both property formats (Issue #397):
-    /// - New nested format: `properties.task.status`
-    /// - Old flat format: `properties.status` (deprecated, for backward compat)
+    /// Supports both property formats:
+    /// - Nested format: `properties.task.status`
+    /// - Flat format: `properties.status` (used by the markdown importer)
     ///
     /// # Errors
     ///
@@ -420,12 +420,8 @@ impl TaskNode {
             .and_then(parse_to_date_string);
 
         // Extract assignee from properties
-        // Note: Supports both "assignee_id" (legacy) and "assignee" (canonical) field names.
-        // The struct field is `assignee`, and `into_node()` serializes as "assignee".
-        // We read both for backward compatibility with any older data using "assignee_id".
         let assignee = props
-            .get("assignee_id")
-            .or_else(|| props.get("assignee"))
+            .get("assignee")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 

--- a/packages/core/src/models/task_node.rs
+++ b/packages/core/src/models/task_node.rs
@@ -392,7 +392,7 @@ impl TaskNode {
             )));
         }
 
-        // Try new nested format first, fall back to old flat format (Issue #397)
+        // Try nested format first, fall back to flat format (used by the markdown importer)
         let task_props = node
             .properties
             .get("task")

--- a/packages/core/src/models/task_node_test.rs
+++ b/packages/core/src/models/task_node_test.rs
@@ -142,7 +142,7 @@ mod tests {
         let node = Node::new(
             "task".to_string(),
             "Test".to_string(),
-            json!({"assignee_id": "user-123"}),
+            json!({"assignee": "user-123"}),
         );
         let task = TaskNode::from_node(node).unwrap();
         assert_eq!(task.assignee_id(), Some("user-123".to_string()));
@@ -171,7 +171,7 @@ mod tests {
         let node = Node::new(
             "task".to_string(),
             "Test".to_string(),
-            json!({"assignee_id": "user-123"}),
+            json!({"assignee": "user-123"}),
         );
         let mut task = TaskNode::from_node(node).unwrap();
 

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -115,7 +115,6 @@ fn task_node_to_value(node: Node) -> Result<serde_json::Value, String> {
 
     let assignee = props
         .get("assignee")
-        .or_else(|| props.get("assignee_id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 


### PR DESCRIPTION
## Summary
Issue #1522 asked for two things: (1) remove empty `mcp`/`agent-tools` placeholder packages, (2) remove backward-compat prose/params contradicting the greenfield policy.

- **(1) already done**: `packages/mcp` and `packages/agent-tools` were deleted in prior PR #1270 (`f7069db4`) before this branch existed — no changes needed here.
- **(2) this PR**: fixes a stale `assignee_id`/`assignee` JSON-key mismatch (default_metadata wrote `assignee_id` while TaskNode read/wrote `assignee` everywhere else), removes an unused ignored parameter from `markdown::create_node`, and deletes a stale doc comment describing a `container_id` parameter that doesn't exist on `UpdateRootFromMarkdownParams`.

## Test plan
- [x] `cargo build -p nodespace-core -p nodespace-types`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::unused-async`
- [x] `cargo test -p nodespace-core` (976 passed)
- [x] `cargo test -p nodespace-types` (10 passed)
- [x] `bun run quality:fix` (clean)
- [x] `bun run test:all` (pre-push gate, green)