### PR TITLE
Make ADR-048 Tauri-seam e2e tests tolerant of machine load (closes #1610)

### DIFF
--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -31,6 +31,22 @@ use std::time::Duration;
 use nodespace_app_lib::services::GrpcClient;
 use tauri::Manager;
 
+/// Default timeout for `TauriTestApp::connect`'s daemon-health wait, shared
+/// by every `tests/*.rs` call site instead of each hardcoding its own
+/// duplicate literal.
+///
+/// 60s, not the 30s this used to be: spawning a whole OS process (daemon
+/// binary load + socket bind) is CPU-bound work, and within a single
+/// `tests/*.rs` binary `#[tokio::test]`s run concurrently by default, so
+/// several real daemon spawns can contend for the same cores at once —
+/// worse on a machine that also has an unrelated `cargo test` running
+/// elsewhere (see #1610). 30s was tuned for an unloaded machine and had no
+/// headroom for that; 60s gives slack without materially raising the
+/// wall-clock cost of a clean, unloaded run, since `wait_for_daemon` returns
+/// as soon as the socket is healthy rather than sleeping out the full
+/// duration.
+pub const DAEMON_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// A running headless `nodespaced` pointed at a temp-dir socket and database.
 /// Killed on drop so a panicking test never leaks the process.
 pub struct SpawnedDaemon {

--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -22,6 +22,14 @@
 //! flagging whichever subset any single test binary doesn't happen to call
 //! as unused — `-D warnings` in `rust:lint` would otherwise hard-fail on
 //! that per-binary view.
+//!
+//! Running this crate's tests directly with a bare `cargo test -p
+//! nodespace-app` uses cargo's default per-binary test concurrency, NOT the
+//! `--test-threads=1` the pre-push gate (`scripts/test-gate.ts`) applies —
+//! see that file's comment for why serializing matters here. Prefer `cargo
+//! test -p nodespace-app -- --test-threads=1` when iterating locally on more
+//! than one test in the same file to avoid the same daemon-spawn contention
+//! #1610 fixed in the gate.
 
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
@@ -44,7 +52,10 @@ use tauri::Manager;
 /// headroom for that; 60s gives slack without materially raising the
 /// wall-clock cost of a clean, unloaded run, since `wait_for_daemon` returns
 /// as soon as the socket is healthy rather than sleeping out the full
-/// duration.
+/// duration. This is a ceiling on the failure case, not an added cost on
+/// the success path — a healthy daemon returns in well under a second, so
+/// raising this value does not add 60s to every test's typical run time,
+/// only to how long a genuinely stuck run takes to fail.
 pub const DAEMON_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A running headless `nodespaced` pointed at a temp-dir socket and database.

--- a/packages/desktop-app/src-tauri/tests/adapter_contract_test.rs
+++ b/packages/desktop-app/src-tauri/tests/adapter_contract_test.rs
@@ -16,13 +16,11 @@
 //! a change that breaks the contract on one path and not the other shows up
 //! as exactly one of the two suites failing.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::nodes::{
     create_node, get_children, move_node, update_task_node, CreateNodeInput, InsertPositionInput,
 };
 use nodespace_app_lib::types::{TaskNodeUpdate, TaskStatus};
-use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT};
 use serde_json::json;
 
 fn text_input(id: &str, content: &str, parent_id: Option<String>) -> CreateNodeInput {
@@ -52,7 +50,7 @@ fn task_input(id: &str) -> CreateNodeInput {
 #[tokio::test]
 async fn task_tri_state_update_clear_set_no_change_matches_the_http_adapter_contract() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -108,7 +106,7 @@ async fn task_tri_state_update_clear_set_no_change_matches_the_http_adapter_cont
 #[tokio::test]
 async fn create_node_insert_position_matches_the_http_adapter_contract() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let parent_id = uuid::Uuid::new_v4().to_string();
@@ -146,7 +144,7 @@ async fn create_node_insert_position_matches_the_http_adapter_contract() {
 #[tokio::test]
 async fn move_node_insert_position_matches_the_http_adapter_contract() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let parent_a_id = uuid::Uuid::new_v4().to_string();

--- a/packages/desktop-app/src-tauri/tests/ai_chat_send_to_idle_test.rs
+++ b/packages/desktop-app/src-tauri/tests/ai_chat_send_to_idle_test.rs
@@ -28,7 +28,9 @@ use std::time::Duration;
 
 use nodespace_app_lib::commands::nodes::{create_node, get_node, update_node, CreateNodeInput};
 use nodespace_app_lib::types::NodeUpdate;
-use nodespace_app_test_support::{model_file_available, SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{
+    model_file_available, SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT,
+};
 use nodespace_proto::nodespace::EnsureModelReadyRequest;
 use serde_json::json;
 use tokio_stream::StreamExt;
@@ -114,7 +116,7 @@ async fn ai_chat_send_reaches_idle_with_no_stuck_processing_state() {
     }
 
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     // chat_model_load's gRPC call only updates the model manager's
@@ -177,8 +179,15 @@ async fn ai_chat_send_reaches_idle_with_no_stuck_processing_state() {
         "update_node's own response must reflect the processing status just written: {after_send:?}"
     );
 
+    // 300s, not the 180s this used to be: this is a real inference call
+    // competing for the same CPU as every other daemon-spawning test in this
+    // suite (see DAEMON_CONNECT_TIMEOUT's comment) — under representative
+    // background load a token-by-token completion can take meaningfully
+    // longer than on an idle machine. poll_until_idle_with_new_assistant_reply
+    // returns as soon as the turn completes, so this only raises the ceiling
+    // for a genuinely slow/stuck run, not the typical wall-clock cost.
     let final_node =
-        poll_until_idle_with_new_assistant_reply(&state, &id, 0, Duration::from_secs(180)).await;
+        poll_until_idle_with_new_assistant_reply(&state, &id, 0, Duration::from_secs(300)).await;
 
     assert_eq!(final_node["status"], json!("idle"));
     let messages = final_node["messages"]

--- a/packages/desktop-app/src-tauri/tests/commits_per_edit_test.rs
+++ b/packages/desktop-app/src-tauri/tests/commits_per_edit_test.rs
@@ -9,12 +9,10 @@
 //! before the prior write's confirmation lands would be caught here, not
 //! just hoped away.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::nodes::create_node;
 use nodespace_app_lib::commands::nodes::{update_node, CreateNodeInput};
 use nodespace_app_lib::types::NodeUpdate;
-use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT};
 use serde_json::json;
 
 fn text_input(id: &str, content: &str) -> CreateNodeInput {
@@ -36,7 +34,7 @@ fn text_input(id: &str, content: &str) -> CreateNodeInput {
 #[tokio::test]
 async fn one_coalesced_edit_produces_exactly_one_version_increment() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -78,7 +76,7 @@ async fn one_coalesced_edit_produces_exactly_one_version_increment() {
 #[tokio::test]
 async fn second_coalesced_edit_uses_the_confirmed_version_not_a_stale_guess() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();

--- a/packages/desktop-app/src-tauri/tests/cross_window_hierarchy_sync_test.rs
+++ b/packages/desktop-app/src-tauri/tests/cross_window_hierarchy_sync_test.rs
@@ -9,10 +9,8 @@
 //! `TauriTestApp::connect` calls against the same `SpawnedDaemon` model:
 //! two independent command-layer clients, sharing nothing but the daemon.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::nodes::{create_node, get_children, move_node, CreateNodeInput};
-use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT};
 use serde_json::json;
 
 fn text_input(id: &str, content: &str, parent_id: Option<String>) -> CreateNodeInput {
@@ -34,8 +32,8 @@ fn text_input(id: &str, content: &str, parent_id: Option<String>) -> CreateNodeI
 #[tokio::test]
 async fn a_second_independent_client_observes_hierarchy_changes_made_by_the_first() {
     let daemon = SpawnedDaemon::spawn();
-    let window_a = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
-    let window_b = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let window_a = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
+    let window_b = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
 
     let a_state = window_a.client_state();
     let b_state = window_b.client_state();
@@ -103,7 +101,7 @@ async fn a_second_independent_client_observes_hierarchy_changes_made_by_the_firs
 #[tokio::test]
 async fn a_client_connecting_after_writes_immediately_sees_converged_state() {
     let daemon = SpawnedDaemon::spawn();
-    let window_a = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let window_a = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let a_state = window_a.client_state();
 
     let root_id = uuid::Uuid::new_v4().to_string();
@@ -121,7 +119,7 @@ async fn a_client_connecting_after_writes_immediately_sees_converged_state() {
     }
 
     // A late-joining window, connected only after all writes completed.
-    let window_c = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let window_c = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let c_children = get_children(window_c.client_state(), root_id)
         .await
         .expect("window C: get_children failed");

--- a/packages/desktop-app/src-tauri/tests/daemon_readiness_test.rs
+++ b/packages/desktop-app/src-tauri/tests/daemon_readiness_test.rs
@@ -23,10 +23,8 @@
 //! generates (see the comment on `daemon_status_body` in `lib.rs`). No
 //! Tauri mock runtime is needed to exercise it for real.
 
-use std::time::Duration;
-
 use nodespace_app_lib::daemon_setup::{check_daemon_socket, wait_for_daemon, DaemonStatus};
-use nodespace_app_test_support::{EnvGuard, SpawnedDaemon, CONNECT_MUTEX};
+use nodespace_app_test_support::{EnvGuard, SpawnedDaemon, CONNECT_MUTEX, DAEMON_CONNECT_TIMEOUT};
 
 #[tokio::test]
 async fn not_running_before_daemon_starts() {
@@ -61,7 +59,7 @@ async fn wait_for_daemon_observes_a_real_bind_as_healthy() {
 
     // Recovered: wait_for_daemon polls check_daemon_socket across the real
     // daemon's startup and bind, however long that actually takes.
-    let status = wait_for_daemon(&daemon.socket_path, Duration::from_secs(30)).await;
+    let status = wait_for_daemon(&daemon.socket_path, DAEMON_CONNECT_TIMEOUT).await;
     assert_eq!(
         status,
         DaemonStatus::Healthy,
@@ -90,7 +88,7 @@ async fn check_daemon_status_command_agrees_with_the_real_daemon() {
     // Wait for the real daemon to finish starting (however long that takes;
     // see the comment above these tests for why we don't race an
     // intermediate NotRunning read against it).
-    let status = wait_for_daemon(&daemon.socket_path, Duration::from_secs(30)).await;
+    let status = wait_for_daemon(&daemon.socket_path, DAEMON_CONNECT_TIMEOUT).await;
     assert_eq!(status, DaemonStatus::Healthy, "daemon never became healthy");
 
     assert_eq!(

--- a/packages/desktop-app/src-tauri/tests/indent_outdent_rapid_ordering_test.rs
+++ b/packages/desktop-app/src-tauri/tests/indent_outdent_rapid_ordering_test.rs
@@ -11,12 +11,10 @@
 //! command functions directly, so the OCC conflict (or its absence, once
 //! calls are properly sequenced) is real, not simulated.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::nodes::{
     create_node, get_children, move_node, reorder_node, CreateNodeInput, InsertPositionInput,
 };
-use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT};
 use serde_json::json;
 
 fn text_input(id: &str, content: &str, parent_id: Option<String>) -> CreateNodeInput {
@@ -38,7 +36,7 @@ fn text_input(id: &str, content: &str, parent_id: Option<String>) -> CreateNodeI
 #[tokio::test]
 async fn rapid_indent_then_outdent_survives_against_a_real_daemon() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let root_id = uuid::Uuid::new_v4().to_string();
@@ -108,7 +106,7 @@ async fn rapid_indent_then_outdent_survives_against_a_real_daemon() {
 #[tokio::test]
 async fn rapid_sibling_creation_preserves_insertion_order() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let root_id = uuid::Uuid::new_v4().to_string();
@@ -159,7 +157,7 @@ async fn rapid_sibling_creation_preserves_insertion_order() {
 #[tokio::test]
 async fn concurrent_reorders_of_distinct_nodes_all_succeed() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let root_id = uuid::Uuid::new_v4().to_string();
@@ -212,7 +210,7 @@ async fn concurrent_reorders_of_distinct_nodes_all_succeed() {
 #[ignore = "known race — see #1561"]
 async fn concurrent_reorders_produce_correct_final_order() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let root_id = uuid::Uuid::new_v4().to_string();

--- a/packages/desktop-app/src-tauri/tests/model_download_terminal_state_test.rs
+++ b/packages/desktop-app/src-tauri/tests/model_download_terminal_state_test.rs
@@ -24,12 +24,12 @@
 //! state contract is the same regardless of how long the `downloading`
 //! phase runs.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::chat_models::{
     chat_model_cancel_download, chat_model_list, chat_model_load, chat_model_unload,
 };
-use nodespace_app_test_support::{model_file_available, SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{
+    model_file_available, SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT,
+};
 use nodespace_proto::nodespace::DownloadModelRequest;
 use serde_json::json;
 use tokio_stream::StreamExt;
@@ -88,7 +88,7 @@ async fn drain_download_events(harness: &TauriTestApp, model_id: &str) -> Vec<St
 async fn download_of_an_already_present_model_reaches_ready_with_no_error() {
     skip_if_model_absent!();
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
 
     let event_types = drain_download_events(&harness, MODEL_ID).await;
 
@@ -106,7 +106,7 @@ async fn download_of_an_already_present_model_reaches_ready_with_no_error() {
 async fn chat_model_list_still_succeeds_after_a_download() {
     skip_if_model_absent!();
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     drain_download_events(&harness, MODEL_ID).await;
@@ -127,7 +127,7 @@ async fn chat_model_list_still_succeeds_after_a_download() {
 #[tokio::test]
 async fn cancel_of_a_download_with_no_stray_downloading_state_left_behind() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     // Cancelling a model that isn't mid-download must not error and must
@@ -156,7 +156,7 @@ async fn cancel_of_a_download_with_no_stray_downloading_state_left_behind() {
 async fn load_then_unload_reaches_a_clean_terminal_state() {
     skip_if_model_absent!();
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     drain_download_events(&harness, MODEL_ID).await;

--- a/packages/desktop-app/src-tauri/tests/node_crud_tauri_seam_test.rs
+++ b/packages/desktop-app/src-tauri/tests/node_crud_tauri_seam_test.rs
@@ -7,12 +7,10 @@
 //! through `HttpAdapter`, but through the adapter that actually ships in the
 //! desktop build.
 
-use std::time::Duration;
-
 use nodespace_app_lib::commands::nodes::CreateNodeInput;
 use nodespace_app_lib::commands::nodes::{create_node, delete_node, get_node, update_node};
 use nodespace_app_lib::types::NodeUpdate;
-use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT};
 use serde_json::json;
 
 fn text_input(id: &str, content: &str) -> CreateNodeInput {
@@ -29,7 +27,7 @@ fn text_input(id: &str, content: &str) -> CreateNodeInput {
 #[tokio::test]
 async fn creates_a_node_and_reads_it_back() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -52,7 +50,7 @@ async fn creates_a_node_and_reads_it_back() {
 #[tokio::test]
 async fn updates_a_node_and_increments_version_each_time() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -98,7 +96,7 @@ async fn updates_a_node_and_increments_version_each_time() {
 #[tokio::test]
 async fn deletes_a_node_and_confirms_it_is_absent() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -120,7 +118,7 @@ async fn deletes_a_node_and_confirms_it_is_absent() {
 #[tokio::test]
 async fn creates_a_parent_child_hierarchy_through_the_command_layer() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let parent_id = uuid::Uuid::new_v4().to_string();
@@ -147,7 +145,7 @@ async fn creates_a_parent_child_hierarchy_through_the_command_layer() {
 #[tokio::test]
 async fn persists_node_properties_through_the_round_trip() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
 
     let id = uuid::Uuid::new_v4().to_string();

--- a/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
+++ b/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
@@ -27,7 +27,9 @@ use std::time::Duration;
 use nodespace_app_lib::commands::nodes::{create_node, update_node, CreateNodeInput};
 use nodespace_app_lib::types::NodeUpdate;
 use nodespace_app_lib::watcher;
-use nodespace_app_test_support::{hold_connect_mutex_and_socket_env, SpawnedDaemon, TauriTestApp};
+use nodespace_app_test_support::{
+    hold_connect_mutex_and_socket_env, SpawnedDaemon, TauriTestApp, DAEMON_CONNECT_TIMEOUT,
+};
 use serde_json::json;
 use tauri::Listener;
 use tokio_util::sync::CancellationToken;
@@ -90,7 +92,7 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
     // immune to later env changes). The guard acquired below is a SEPARATE,
     // later, longer-held acquisition — for watcher::run, not for this
     // connect() call.
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
     let handle = harness.handle();
 
@@ -183,7 +185,7 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
 #[tokio::test]
 async fn watcher_delivers_a_real_node_created_event() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, Duration::from_secs(30)).await;
+    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
     let state = harness.client_state();
     let handle = harness.handle();
     let _socket_guard = hold_connect_mutex_and_socket_env(&daemon).await;

--- a/packages/desktop-app/src-tauri/tests/startup_readiness_data_plane_test.rs
+++ b/packages/desktop-app/src-tauri/tests/startup_readiness_data_plane_test.rs
@@ -22,7 +22,9 @@
 use std::time::Duration;
 
 use nodespace_app_lib::commands::nodes::{create_node, CreateNodeInput};
-use nodespace_app_test_support::{hold_connect_mutex_and_socket_env, SpawnedDaemon};
+use nodespace_app_test_support::{
+    hold_connect_mutex_and_socket_env, SpawnedDaemon, DAEMON_CONNECT_TIMEOUT,
+};
 use serde_json::json;
 use tauri::Manager;
 
@@ -88,7 +90,7 @@ async fn a_command_fails_cleanly_before_readiness_and_succeeds_after_without_rec
     // new GrpcClient, no explicit reconnect call.
     let status = nodespace_app_lib::daemon_setup::wait_for_daemon(
         &daemon.socket_path,
-        Duration::from_secs(30),
+        DAEMON_CONNECT_TIMEOUT,
     )
     .await;
     assert_eq!(

--- a/scripts/test-gate.ts
+++ b/scripts/test-gate.ts
@@ -42,17 +42,23 @@ await run("bun run test:e2e (headless daemon round-trip)", () => {
 await run("cargo test -p nodespace-app (Tauri-seam integration tests, ADR-048)", () => {
   const binaryName = process.platform === "win32" ? "nodespaced.exe" : "nodespaced";
   const binary = `${process.cwd()}/target/debug/${binaryName}`;
-  // --test-threads=2: every test in this suite spawns a real nodespaced
-  // process and waits for it to bind a socket — far more load-sensitive
-  // than nodespace-core's in-process assertions (which cap the same way,
-  // see rust:test above). Cargo already runs each tests/*.rs file's binary
+  // --test-threads=1: every test in this suite spawns a real nodespaced
+  // process, which loads a real embedding model (Metal shader compilation
+  // included) before its socket binds — far more load-sensitive than
+  // nodespace-core's in-process assertions (which cap concurrency the same
+  // way, see rust:test above, though that suite has no equivalent per-test
+  // process-spawn cost). Cargo already runs each tests/*.rs file's binary
   // sequentially, but within one binary (e.g. node_crud_tauri_seam_test.rs's
   // 5 tests) all tests run concurrently by default, so several real daemon
-  // spawns can still contend for CPU at once inside a single binary — on
-  // top of whatever else is running on the machine, which is what actually
-  // produced the daemon-health timeouts in #1610. Capping to 2 trades a
-  // modest wall-clock increase for run reliability under background load.
-  return $`cargo test -p nodespace-app -- --test-threads=2`.env({
+  // spawns can contend for CPU/GPU at once inside a single binary — on top
+  // of whatever else is running on the machine (confirmed empirically:
+  // --test-threads=2 still reproduced #1610's exact daemon-health timeout
+  // against a live sibling `cargo build` on this machine; =1 did not,
+  // across repeated runs under the same contention). Serializing daemon
+  // spawns costs almost nothing here — the suite's total wall-clock is
+  // dominated by the one real-inference test (~25-40s), and the rest are
+  // sub-second each — so =1 trades no meaningful time for real reliability.
+  return $`cargo test -p nodespace-app -- --test-threads=1`.env({
     ...process.env,
     NODESPACED_TEST_BIN: binary,
   });

--- a/scripts/test-gate.ts
+++ b/scripts/test-gate.ts
@@ -42,7 +42,20 @@ await run("bun run test:e2e (headless daemon round-trip)", () => {
 await run("cargo test -p nodespace-app (Tauri-seam integration tests, ADR-048)", () => {
   const binaryName = process.platform === "win32" ? "nodespaced.exe" : "nodespaced";
   const binary = `${process.cwd()}/target/debug/${binaryName}`;
-  return $`cargo test -p nodespace-app`.env({ ...process.env, NODESPACED_TEST_BIN: binary });
+  // --test-threads=2: every test in this suite spawns a real nodespaced
+  // process and waits for it to bind a socket — far more load-sensitive
+  // than nodespace-core's in-process assertions (which cap the same way,
+  // see rust:test above). Cargo already runs each tests/*.rs file's binary
+  // sequentially, but within one binary (e.g. node_crud_tauri_seam_test.rs's
+  // 5 tests) all tests run concurrently by default, so several real daemon
+  // spawns can still contend for CPU at once inside a single binary — on
+  // top of whatever else is running on the machine, which is what actually
+  // produced the daemon-health timeouts in #1610. Capping to 2 trades a
+  // modest wall-clock increase for run reliability under background load.
+  return $`cargo test -p nodespace-app -- --test-threads=2`.env({
+    ...process.env,
+    NODESPACED_TEST_BIN: binary,
+  });
 });
 
 console.log("\n✓ All tests passed — pushing.\n");

--- a/scripts/test-gate.ts
+++ b/scripts/test-gate.ts
@@ -49,15 +49,18 @@ await run("cargo test -p nodespace-app (Tauri-seam integration tests, ADR-048)",
   // way, see rust:test above, though that suite has no equivalent per-test
   // process-spawn cost). Cargo already runs each tests/*.rs file's binary
   // sequentially, but within one binary (e.g. node_crud_tauri_seam_test.rs's
-  // 5 tests) all tests run concurrently by default, so several real daemon
-  // spawns can contend for CPU/GPU at once inside a single binary — on top
-  // of whatever else is running on the machine (confirmed empirically:
-  // --test-threads=2 still reproduced #1610's exact daemon-health timeout
-  // against a live sibling `cargo build` on this machine; =1 did not,
-  // across repeated runs under the same contention). Serializing daemon
-  // spawns costs almost nothing here — the suite's total wall-clock is
-  // dominated by the one real-inference test (~25-40s), and the rest are
-  // sub-second each — so =1 trades no meaningful time for real reliability.
+  // 5 tests) all tests run concurrently by default. `SpawnedDaemon::spawn()`
+  // happens BEFORE any test acquires test-support's CONNECT_MUTEX (which
+  // only serializes the health-wait/connect step, not the spawn itself), so
+  // without this flag several real daemon processes can be mid-spawn at
+  // once fully uncoordinated — self-inflicted CPU/GPU contention this suite
+  // creates on its own, made worse by whatever else is running on the
+  // machine (see #1610). Tried --test-threads=2 first; it still reproduced
+  // #1610's exact daemon-health timeout under real background load, so =1
+  // was needed, not just a higher timeout. Serializing daemon spawns costs
+  // almost nothing here — the suite's total wall-clock is dominated by the
+  // one real-inference test (~25-40s), and the rest are sub-second each —
+  // so =1 trades no meaningful time for real reliability.
   return $`cargo test -p nodespace-app -- --test-threads=1`.env({
     ...process.env,
     NODESPACED_TEST_BIN: binary,


### PR DESCRIPTION
## Summary
- Centralize the daemon-connect timeout as `DAEMON_CONNECT_TIMEOUT` (60s, up from a duplicated 30s literal at every call site) in `test-support/src/lib.rs`
- Raise `ai_chat_send_to_idle_test`'s turn-completion wait (180s → 300s) — a real inference call, same load-sensitivity class
- Serialize `cargo test -p nodespace-app` to `--test-threads=1` in the pre-push gate (`scripts/test-gate.ts`)

## Why `--test-threads=1`, not `=2`
Every test in this suite spawns a real `nodespaced` process that loads a real embedding model (Metal shader compilation included) before its socket binds. I initially tried `--test-threads=2` (matching `nodespace-core`'s existing cap) but reproduced the exact failure from the issue against real contention — a concurrent `cargo build -p nodespace-daemon` in a sibling worktree — with the daemon reporting `NotRunning` after the *full* 60s wait, not just running close to it. `--test-threads=1` passed cleanly and repeatedly under the same live contention. Serializing costs almost no wall-clock: the suite's total runtime is dominated by the one real-inference test (~25-40s) regardless of thread count, since every other test is sub-second.

## Test plan
- [x] `cargo test -p nodespace-app -- --test-threads=1` passes on an idle machine
- [x] Same command passes repeatedly against a live competing `cargo build -p nodespace-daemon` (reproducing the issue's background-load scenario)
- [x] Full `bun run scripts/test-gate.ts` (pre-push gate) passes end-to-end
- [x] `bun run quality:fix` — 0 errors, 0 warnings, clippy clean

Closes #1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)