### PR TITLE
Resolve the registry path through NODESPACE_HOME so a redirected DB can't poison it (closes #1648)

### DIFF
--- a/packages/daemon/src/lib.rs
+++ b/packages/daemon/src/lib.rs
@@ -14,24 +14,44 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+/// Resolve NodeSpace's home directory — the parent of the `.nodespace/` state
+/// directory that holds the database registry (`databases.toml`) and the
+/// managed database files.
+///
+/// Honors `NODESPACE_HOME` so a test harness or alternate deployment can
+/// redirect *all* NodeSpace state — registry and databases together — with a
+/// single override. This is what keeps a redirected database from poisoning the
+/// real user's registry: without it, pointing only the database elsewhere (via
+/// `NODESPACED_DB_PATH`) while inheriting the real home dir would seed the real
+/// `~/.nodespace/databases.toml` with a throwaway path (ADR-053). Falls back to
+/// the user's home directory.
+pub fn nodespace_home() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var("NODESPACE_HOME") {
+        return Ok(PathBuf::from(custom));
+    }
+    dirs::home_dir().context(
+        "Cannot determine the NodeSpace home directory: home directory is unknown and NODESPACE_HOME not set",
+    )
+}
+
+/// The `.nodespace/` state directory under [`nodespace_home`].
+pub fn nodespace_dir() -> Result<PathBuf> {
+    Ok(nodespace_home()?.join(".nodespace"))
+}
+
 /// Resolve the on-disk database path the daemon (and any in-process clients
 /// such as the CLI's `diagnostics` subcommand) should consult.
 ///
 /// Honors `NODESPACED_DB_PATH` if set so integration tests and alternate
-/// deployments can redirect storage without recompiling; otherwise defaults
-/// to `$HOME/.nodespace/database/nodespace.db`.
+/// deployments can redirect a single database file without recompiling;
+/// otherwise defaults to `<nodespace_dir>/database/nodespace.db` (which itself
+/// follows `NODESPACE_HOME`).
 pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(custom) = std::env::var("NODESPACED_DB_PATH") {
         return Ok(PathBuf::from(custom));
     }
 
-    let home = dirs::home_dir().context(
-        "Cannot determine database path: home directory is unknown and NODESPACED_DB_PATH not provided",
-    )?;
-    Ok(home
-        .join(".nodespace")
-        .join("database")
-        .join("nodespace.db"))
+    Ok(nodespace_dir()?.join("database").join("nodespace.db"))
 }
 
 // Re-export proto types from the lightweight nodespace-proto crate so existing

--- a/packages/daemon/src/main.rs
+++ b/packages/daemon/src/main.rs
@@ -61,10 +61,20 @@ async fn open_default_database(
 ) -> Result<(Arc<DatabaseManager>, Arc<DatabaseServices>)> {
     let manager =
         Arc::new(DatabaseManager::load(DatabaseManager::default_registry_path()?, context).await?);
+    // Guard against a registry whose default was seeded with a throwaway temp
+    // path (e.g. a test/dev run that redirected the database but not the home
+    // dir): the OS purges temp dirs, so serving one silently loses user data.
+    // Re-points the default to the standard path before we open it.
+    manager.repair_doomed_default(db_path).await?;
     let default_id = manager
         .ensure_default_registered("Default".to_string(), db_path.to_path_buf())
         .await?;
     let bundle = manager.get_or_open(&default_id).await?;
+    // Log the path the registry actually resolved the default to — not the
+    // boot-time `db_path`, which the registry can and does override.
+    if let Some(served) = manager.default_database_path().await {
+        tracing::info!(served_db_path = %served.display(), "serving default database");
+    }
     Ok((manager, bundle))
 }
 
@@ -205,7 +215,7 @@ async fn serve_headless() -> Result<()> {
     let sock = socket_path();
     let db_path = resolve_db_path()?;
 
-    tracing::info!(db_path = %db_path.display(), sock = %sock.display(), "Starting nodespaced (headless)");
+    tracing::info!(requested_db_path = %db_path.display(), sock = %sock.display(), "Starting nodespaced (headless)");
 
     let shutdown = install_shutdown_handler().context("Failed to install signal handlers")?;
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
@@ -261,7 +271,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     let sock = socket_path();
     let db_path = resolve_db_path()?;
 
-    tracing::info!(db_path = %db_path.display(), sock = %sock.display(), "Starting nodespaced (tray)");
+    tracing::info!(requested_db_path = %db_path.display(), sock = %sock.display(), "Starting nodespaced (tray)");
 
     let signal_shutdown =
         install_shutdown_handler().context("Failed to install signal handlers")?;
@@ -373,7 +383,7 @@ async fn serve_headless() -> Result<()> {
     let name = pipe_name();
     let db_path = resolve_db_path()?;
 
-    tracing::info!(db_path = %db_path.display(), pipe = %name, "Starting nodespaced (headless, Windows)");
+    tracing::info!(requested_db_path = %db_path.display(), pipe = %name, "Starting nodespaced (headless, Windows)");
 
     let shutdown = install_shutdown_handler().context("Failed to install signal handlers")?;
     // _model_task: dropping a JoinHandle does not cancel the task in tokio — it detaches.
@@ -457,7 +467,7 @@ async fn serve_grpc(controller: tray::TrayController) -> Result<()> {
     let name = pipe_name();
     let db_path = resolve_db_path()?;
 
-    tracing::info!(db_path = %db_path.display(), pipe = %name, "Starting nodespaced (tray, Windows)");
+    tracing::info!(requested_db_path = %db_path.display(), pipe = %name, "Starting nodespaced (tray, Windows)");
 
     let signal_shutdown =
         install_shutdown_handler().context("Failed to install signal handlers")?;

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -200,6 +200,34 @@ pub struct DatabaseManager {
     context: SharedContext,
 }
 
+/// True if `path` lives under a system temporary directory. macOS purges
+/// `$TMPDIR` (`/var/folders/**`) and `/tmp` periodically, so any database file
+/// stored there is doomed. Used to catch a registry whose default database was
+/// seeded with a throwaway path by a temp-DB run (ADR-053).
+fn is_under_system_temp(path: &Path) -> bool {
+    // `std::env::temp_dir()` is this process's `$TMPDIR`; also cover the
+    // well-known temp roots directly (and their macOS `/private` twins) so the
+    // check holds regardless of the daemon's own `$TMPDIR`.
+    let mut roots: Vec<PathBuf> = vec![std::env::temp_dir()];
+    for extra in [
+        "/tmp",
+        "/private/tmp",
+        "/var/folders",
+        "/private/var/folders",
+    ] {
+        roots.push(PathBuf::from(extra));
+    }
+    roots.iter().any(|root| path.starts_with(root))
+}
+
+/// Decide whether the registry's default database is doomed: its file lives
+/// under a system temp directory while the registry itself does not. A registry
+/// that itself lives under a temp dir is an intentionally isolated test/dev
+/// environment, where a temp default is expected and must be left alone.
+fn default_is_doomed(registry_path: &Path, default_path: &Path) -> bool {
+    !is_under_system_temp(registry_path) && is_under_system_temp(default_path)
+}
+
 impl DatabaseManager {
     /// Load the manager, reading any existing registry from `registry_path`.
     /// `context` is the process-global build context used to assemble each
@@ -215,15 +243,14 @@ impl DatabaseManager {
         })
     }
 
-    /// Default registry path `~/.nodespace/databases.toml`.
+    /// Default registry path `<nodespace_dir>/databases.toml`.
+    ///
+    /// Resolved through [`crate::nodespace_dir`] so it follows `NODESPACE_HOME`
+    /// in lockstep with the database path — redirecting one without the other is
+    /// exactly what let a temp-DB test run poison the real user's registry
+    /// (ADR-053).
     pub fn default_registry_path() -> Result<PathBuf> {
-        Ok(Self::nodespace_dir()?.join("databases.toml"))
-    }
-
-    fn nodespace_dir() -> Result<PathBuf> {
-        let home = dirs::home_dir()
-            .context("cannot determine the database registry path: home directory is unknown")?;
-        Ok(home.join(".nodespace"))
+        Ok(crate::nodespace_dir()?.join("databases.toml"))
     }
 
     /// Snapshot every registered database with its current status.
@@ -265,7 +292,7 @@ impl DatabaseManager {
         let id = DatabaseId::generate();
         let path = match path {
             Some(path) => path,
-            None => Self::nodespace_dir()?
+            None => crate::nodespace_dir()?
                 .join("database")
                 .join(format!("{id}.db")),
         };
@@ -389,6 +416,74 @@ impl DatabaseManager {
             id: id.clone(),
             name,
             path,
+            created_at: Utc::now(),
+            last_opened_at: None,
+            bound_tenant_schema: None,
+            bound_tenant_collection: None,
+        });
+        registry.default_database = Some(id.clone());
+        registry.save(&self.registry_path).await?;
+        Ok(id)
+    }
+
+    /// The on-disk path of the default database, if a default is set.
+    ///
+    /// This is the path the daemon actually serves for header-less requests —
+    /// resolved from the registry, not the `NODESPACED_DB_PATH`/default the
+    /// caller passed at boot — so callers can log the truth rather than a value
+    /// the registry may override.
+    pub async fn default_database_path(&self) -> Option<PathBuf> {
+        let registry = self.registry.read().await;
+        let id = registry.default_database.as_ref()?;
+        registry.find(id).map(|entry| entry.path.clone())
+    }
+
+    /// Guard against silent data loss (ADR-053): if the registry's default
+    /// database points under a system temp directory — which the OS periodically
+    /// purges — replace it with a fresh default at `standard_path` so the daemon
+    /// never serves a disappearing database as the user's "Default".
+    ///
+    /// A no-op when there is no default, when the default already lives at a
+    /// durable path, or when the registry itself lives under a temp directory
+    /// (an intentionally isolated test/dev environment). Returns the new default
+    /// id when a repair occurred.
+    pub async fn repair_doomed_default(&self, standard_path: &Path) -> Result<Option<DatabaseId>> {
+        let doomed = {
+            let registry = self.registry.read().await;
+            match registry
+                .default_database
+                .as_ref()
+                .and_then(|id| registry.find(id))
+            {
+                Some(entry) if default_is_doomed(&self.registry_path, &entry.path) => {
+                    entry.path.clone()
+                }
+                _ => return Ok(None),
+            }
+        };
+        let new_id = self.set_standard_default(standard_path).await?;
+        tracing::warn!(
+            doomed_path = %doomed.display(),
+            repaired_to = %standard_path.display(),
+            "registry default database pointed under a system temp directory (the OS purges these); re-pointed the default to the standard location to prevent silent data loss"
+        );
+        Ok(Some(new_id))
+    }
+
+    /// Drop the current default entry (if any) and register a fresh "Default"
+    /// at `standard_path`, marking it the default. Persists the registry and
+    /// returns the new id. The doomed file itself is never touched — only the
+    /// registry entry is replaced.
+    async fn set_standard_default(&self, standard_path: &Path) -> Result<DatabaseId> {
+        let mut registry = self.registry.write().await;
+        if let Some(prev) = registry.default_database.take() {
+            registry.databases.retain(|entry| entry.id != prev);
+        }
+        let id = DatabaseId::generate();
+        registry.databases.push(DatabaseEntry {
+            id: id.clone(),
+            name: "Default".to_string(),
+            path: standard_path.to_path_buf(),
             created_at: Utc::now(),
             last_opened_at: None,
             bound_tenant_schema: None,
@@ -692,6 +787,63 @@ mod tests {
         let snap = mgr.list().await;
         assert_eq!(snap.databases.len(), 1);
         assert_eq!(snap.databases[0].entry.name, "Default");
+    }
+
+    #[test]
+    fn default_is_doomed_flags_temp_default_under_a_durable_registry() {
+        let temp_default = std::env::temp_dir().join("throwaway").join("db");
+        let durable_registry = PathBuf::from("/durable-home/.nodespace/databases.toml");
+        let durable_default = PathBuf::from("/durable-home/.nodespace/database/nodespace.db");
+
+        // Durable registry + temp default → doomed (the poisoning we repair).
+        assert!(default_is_doomed(&durable_registry, &temp_default));
+        // Durable registry + durable default → healthy.
+        assert!(!default_is_doomed(&durable_registry, &durable_default));
+        // Isolated registry (itself under temp) → never doomed; a temp default
+        // is intentional there, and repairing it would clobber test fixtures.
+        let temp_registry = std::env::temp_dir().join("iso").join("databases.toml");
+        assert!(!default_is_doomed(&temp_registry, &temp_default));
+    }
+
+    #[tokio::test]
+    async fn repair_doomed_default_is_noop_for_isolated_registry() {
+        // temp_manager's registry lives under a temp dir → isolated env, so even
+        // a temp default must be left alone. This is what keeps the daemon's own
+        // test suites from "repairing" (and clobbering) their own fixtures.
+        let (mgr, _dir) = temp_manager().await;
+        let temp_db = std::env::temp_dir().join("iso-db").join("nodespace.db");
+        mgr.ensure_default_registered("Default".into(), temp_db.clone())
+            .await
+            .unwrap();
+
+        let repaired = mgr
+            .repair_doomed_default(&PathBuf::from(
+                "/durable-home/.nodespace/database/nodespace.db",
+            ))
+            .await
+            .unwrap();
+
+        assert!(repaired.is_none());
+        assert_eq!(mgr.default_database_path().await.as_ref(), Some(&temp_db));
+    }
+
+    #[tokio::test]
+    async fn set_standard_default_replaces_the_previous_default() {
+        let (mgr, _dir) = temp_manager().await;
+        let doomed = std::env::temp_dir().join("old").join("db");
+        mgr.ensure_default_registered("Default".into(), doomed)
+            .await
+            .unwrap();
+
+        let standard = PathBuf::from("/durable-home/.nodespace/database/nodespace.db");
+        let new_id = mgr.set_standard_default(&standard).await.unwrap();
+
+        // Exactly one entry — the doomed one is gone, replaced by the standard
+        // default the registry now serves.
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases.len(), 1);
+        assert_eq!(snap.default_database.as_ref(), Some(&new_id));
+        assert_eq!(mgr.default_database_path().await.as_ref(), Some(&standard));
     }
 
     #[tokio::test]

--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -83,6 +83,11 @@ impl SpawnedDaemon {
         let mut child = Command::new(&binary)
             .env("NODESPACED_SOCKET", &socket_path)
             .env("NODESPACED_DB_PATH", &db_path)
+            // Isolate the whole `.nodespace` home under the temp dir so the
+            // real user's database registry is never touched by a spawned
+            // daemon (ADR-053): without this, the daemon inherits the real HOME
+            // and seeds `~/.nodespace/databases.toml` with this temp db path.
+            .env("NODESPACE_HOME", tmp_dir.path())
             .env("NODESPACED_HEADLESS", "1")
             .env("RUST_LOG", "warn")
             .stdin(Stdio::null())

--- a/packages/desktop-app/src/tests/e2e/daemon-harness.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-harness.ts
@@ -141,6 +141,10 @@ async function spawnDaemonAndProxy(): Promise<SpawnedProcesses> {
     ...process.env,
     NODESPACED_SOCKET: socketPath,
     NODESPACED_DB_PATH: dbPath,
+    // Isolate the whole `.nodespace` home under the temp dir so a spawned
+    // daemon never seeds the real user's `~/.nodespace/databases.toml` with
+    // this throwaway db path (ADR-053).
+    NODESPACE_HOME: tmpDir,
     NODESPACED_HEADLESS: '1',
     RUST_LOG: 'warn'
   };

--- a/scripts/run-nemo-vs-8b-matrix.sh
+++ b/scripts/run-nemo-vs-8b-matrix.sh
@@ -28,10 +28,12 @@ run_matrix() {
   # Clean DB
   rm -f "$DB" "${DB}-wal" "${DB}-shm"
 
-  # Start daemon
+  # Start daemon. NODESPACE_HOME keeps the registry under the temp dir so this
+  # benchmark run never seeds the real ~/.nodespace/databases.toml (ADR-053).
   NODESPACE_PROMPT_DUMP="$dump" \
   NODESPACED_SOCKET="$SOCK" \
   NODESPACED_DB_PATH="$DB" \
+  NODESPACE_HOME="$(dirname "$DB")" \
     "$NODESPACED" \
     > "$log" 2>&1 &
   local daemon_pid=$!


### PR DESCRIPTION
## Problem

`~/.nodespace/databases.toml` (the user-level database registry) could be seeded with a temp-dir path by test harnesses or temp-DB daemon runs, after which every boot served a doomed temp database as "Default". macOS purges `/var/folders`, so all data written there silently disappears — and the boot log printed a different path than the one actually served.

Root cause: the registry path was hard-wired to the real `$HOME/.nodespace` while the served DB path honored `NODESPACED_DB_PATH`. A harness that redirected the DB but inherited `HOME` wrote its temp path into the real registry.

## Fix

- **`NODESPACE_HOME`** — new `nodespace_home()`/`nodespace_dir()` resolver; both the registry path and `resolve_db_path`'s default route through it, so one override isolates *all* NodeSpace state in lockstep.
- **Boot repair** — `repair_doomed_default` re-points the default to the standard path when it lives under a system temp dir while the registry itself does not; a no-op for intentionally isolated (temp) registries, so test fixtures are never clobbered.
- **Truthful log** — boot now logs the registry-resolved served path (`serving default database`) instead of the requested boot path; the `Starting` line's field is renamed `requested_db_path`.
- **Harness isolation** — the real-binary spawn harnesses (test-support `SpawnedDaemon`, the e2e `daemon-harness.ts`, and the benchmark script) set `NODESPACE_HOME` under their temp dir, so test runs never touch `~/.nodespace`.

## Tests
- New daemon unit tests: `default_is_doomed` truth table, `repair_doomed_default` no-op for an isolated registry, `set_standard_default` replaces the previous default. Daemon lib suite green (67 tests).
- Full pre-push gate (`test:all` + `cargo build --bin nodespaced` + `test:e2e`) green locally.

## Acceptance
- [x] Running the test suites never mutates `~/.nodespace/databases.toml`.
- [x] A registry whose default path is gone/temp produces a visible warning + safe fallback, and the boot log reflects the DB actually served.

Closes #1648.