### PR TITLE
Wire the dead Search sidebar item to a working search view (closes #1646)

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -216,6 +216,31 @@
     }
   }
 
+  /**
+   * Open (or focus) the Search view. Search is not a node, so it opens a
+   * singleton non-node tab — mirroring how Settings is opened from the menu —
+   * rather than the daily-journal node-tab path.
+   */
+  function openSearchTab() {
+    const currentState = navigationStore.state;
+    const existingTab = currentState.tabs.find((tab) => tab.type === 'search');
+
+    if (existingTab) {
+      setActiveTab(existingTab.id, existingTab.paneId);
+    } else {
+      addTab(
+        {
+          id: 'search',
+          title: 'Search',
+          type: 'search',
+          closeable: true,
+          paneId: getTargetPaneId()
+        },
+        true
+      );
+    }
+  }
+
   // Handle navigation item clicks
   function handleNavItemClick(itemId: string) {
     // Close sub-panels when clicking non-collection nav items
@@ -223,11 +248,12 @@
       collectionsState.clearSelection();
     }
 
-    // Special handling for Daily Journal
+    // Each nav item opens its own view (Favorites is not implemented yet).
     if (itemId === 'daily-journal') {
       handleDailyJournalClick();
+    } else if (itemId === 'search') {
+      openSearchTab();
     }
-
 
     // Update active state in navigation items
     layoutStore.setActiveNavItem(itemId);

--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -7,6 +7,7 @@
   import type { Pane } from '$lib/stores/navigation.svelte';
   import { createLogger } from '$lib/utils/logger';
   import SettingsPane from '$lib/components/settings/settings-pane.svelte';
+  import SearchPane from '$lib/components/search/search-pane.svelte';
 
   const log = createLogger('PaneContent');
 
@@ -139,6 +140,8 @@
 
 {#if activeTab?.type === 'settings'}
   <SettingsPane />
+{:else if activeTab?.type === 'search'}
+  <SearchPane />
 {:else if activeTab?.content}
   {@const content = activeTab.content}
   {@const nodeType = content.nodeType ?? 'text'}

--- a/packages/desktop-app/src/lib/components/search/search-pane.svelte
+++ b/packages/desktop-app/src/lib/components/search/search-pane.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { invoke } from '@tauri-apps/api/core';
+  import { navigationStore, addTab, setActiveTab } from '$lib/stores/navigation.svelte';
+  import { pluginRegistry } from '$lib/plugins/plugin-registry';
+  import { createLogger } from '$lib/utils/logger';
+  import type { Node } from '$lib/types/node';
+  import { v4 as uuidv4 } from 'uuid';
+
+  const log = createLogger('SearchPane');
+
+  const SEARCH_LIMIT = 25;
+  const DEBOUNCE_MS = 300;
+
+  let query = $state('');
+  let results = $state<Node[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let hasSearched = $state(false);
+
+  let inputEl: HTMLInputElement | null = $state(null);
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  // Monotonic token so a slow response from an earlier query can never clobber
+  // the results of a later one.
+  let requestToken = 0;
+
+  onMount(() => inputEl?.focus());
+  onDestroy(() => clearTimeout(debounceTimer));
+
+  async function runSearch(term: string) {
+    const trimmed = term.trim();
+    if (!trimmed) {
+      requestToken++; // cancel any in-flight response
+      results = [];
+      hasSearched = false;
+      error = null;
+      loading = false;
+      return;
+    }
+
+    const token = ++requestToken;
+    loading = true;
+    error = null;
+
+    try {
+      const found = await invoke<Node[]>('search_roots', {
+        params: { query: trimmed, limit: SEARCH_LIMIT }
+      });
+      if (token !== requestToken) return; // superseded by a newer query
+      results = found;
+      hasSearched = true;
+    } catch (e) {
+      if (token !== requestToken) return;
+      log.error('search_roots failed', e);
+      error = e instanceof Error ? e.message : String(e);
+      results = [];
+      hasSearched = true;
+    } finally {
+      if (token === requestToken) loading = false;
+    }
+  }
+
+  function onInput() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => runSearch(query), DEBOUNCE_MS);
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      clearTimeout(debounceTimer);
+      runSearch(query);
+    }
+  }
+
+  function resultTitle(node: Node): string {
+    const pluginTitle = pluginRegistry.getNodeTitle(node);
+    if (pluginTitle && pluginTitle.trim()) return pluginTitle.trim();
+    const firstLine = node.content?.split('\n').find((line) => line.trim());
+    return firstLine?.trim() || '(untitled)';
+  }
+
+  function targetPaneId(): string {
+    const state = navigationStore.state;
+    const paneExists = state.panes.some((pane) => pane.id === state.activePaneId);
+    return paneExists ? state.activePaneId : (state.panes[0]?.id ?? 'pane-1');
+  }
+
+  function openResult(node: Node) {
+    const state = navigationStore.state;
+    const existingTab = state.tabs.find((tab) => tab.content?.nodeId === node.id);
+    if (existingTab) {
+      setActiveTab(existingTab.id, existingTab.paneId);
+      return;
+    }
+    addTab(
+      {
+        id: uuidv4(),
+        title: 'Loading...', // Viewer sets the real title on mount
+        type: 'node',
+        content: { nodeId: node.id, nodeType: node.nodeType },
+        closeable: true,
+        paneId: targetPaneId()
+      },
+      true
+    );
+  }
+</script>
+
+<div class="search-pane">
+  <div class="search-header">
+    <input
+      bind:this={inputEl}
+      class="search-input"
+      type="text"
+      placeholder="Search nodes…"
+      bind:value={query}
+      oninput={onInput}
+      onkeydown={onKeydown}
+    />
+  </div>
+
+  <div class="search-results">
+    {#if loading}
+      <div class="search-status">Searching…</div>
+    {:else if error}
+      <div class="search-status search-error">{error}</div>
+    {:else if hasSearched && results.length === 0}
+      <div class="search-status">No results for “{query.trim()}”.</div>
+    {:else if results.length > 0}
+      <ul class="result-list">
+        {#each results as node (node.id)}
+          <li>
+            <button type="button" class="result-item" onclick={() => openResult(node)}>
+              <span class="result-title">{resultTitle(node)}</span>
+              <span class="result-type">{node.nodeType}</span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <div class="search-status">Type to search your nodes.</div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .search-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: hsl(var(--background));
+  }
+
+  .search-header {
+    padding: 1.5rem 2rem 0.75rem;
+  }
+
+  .search-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.6rem 0.9rem;
+    font-size: 1rem;
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted));
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.5rem;
+    outline: none;
+  }
+
+  .search-input:focus {
+    border-color: hsl(var(--ring));
+  }
+
+  .search-results {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 1rem 1.5rem;
+  }
+
+  .search-status {
+    padding: 1rem 1rem;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.9rem;
+  }
+
+  .search-error {
+    color: hsl(var(--destructive));
+  }
+
+  .result-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .result-item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    width: 100%;
+    text-align: left;
+    padding: 0.55rem 0.75rem;
+    background: transparent;
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    color: hsl(var(--foreground));
+  }
+
+  .result-item:hover {
+    background: hsl(var(--muted));
+  }
+
+  .result-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .result-type {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+  }
+</style>

--- a/packages/desktop-app/src/lib/services/tab-persistence-service.ts
+++ b/packages/desktop-app/src/lib/services/tab-persistence-service.ts
@@ -139,7 +139,10 @@ export class TabPersistenceService {
         return (
           typeof t.id === 'string' &&
           typeof t.title === 'string' &&
-          (t.type === 'node' || t.type === 'placeholder' || t.type === 'settings') &&
+          (t.type === 'node' ||
+            t.type === 'placeholder' ||
+            t.type === 'settings' ||
+            t.type === 'search') &&
           typeof t.closeable === 'boolean' &&
           typeof t.paneId === 'string'
         );

--- a/packages/desktop-app/src/lib/stores/navigation.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/navigation.svelte.ts
@@ -9,7 +9,7 @@ const log = createLogger('Navigation');
 export interface Tab {
   id: string;
   title: string;
-  type: 'node' | 'placeholder' | 'settings';
+  type: 'node' | 'placeholder' | 'settings' | 'search';
   content?: {
     nodeId: string;
     nodeType?: string;

--- a/packages/desktop-app/src/tests/components/search-pane.test.ts
+++ b/packages/desktop-app/src/tests/components/search-pane.test.ts
@@ -1,0 +1,84 @@
+/**
+ * search-pane component.
+ *
+ * The Search view opened from the sidebar's Search nav item. Queries the
+ * daemon's semantic root search (`search_roots`) and opens a node tab when a
+ * result is clicked. Regression coverage for the dead-Search-nav bug.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+import SearchPane from '$lib/components/search/search-pane.svelte';
+import { navigationStore, resetTabState } from '$lib/stores/navigation.svelte';
+
+describe('SearchPane', () => {
+  beforeEach(() => {
+    resetTabState();
+    mockInvoke.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('prompts the user to search before any query is entered', () => {
+    mockInvoke.mockResolvedValue([]);
+    const { getByPlaceholderText, getByText } = render(SearchPane);
+    expect(getByPlaceholderText('Search nodes…')).toBeTruthy();
+    expect(getByText('Type to search your nodes.')).toBeTruthy();
+  });
+
+  it('queries search_roots on Enter and lists the results', async () => {
+    mockInvoke.mockResolvedValue([
+      { id: 'n1', nodeType: 'text', content: 'Alpha doc' },
+      { id: 'n2', nodeType: 'text', content: 'Beta doc' }
+    ]);
+    const { getByPlaceholderText, findByText } = render(SearchPane);
+
+    const input = getByPlaceholderText('Search nodes…');
+    await fireEvent.input(input, { target: { value: 'doc' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await findByText('Alpha doc')).toBeTruthy();
+    expect(await findByText('Beta doc')).toBeTruthy();
+    expect(mockInvoke).toHaveBeenCalledWith('search_roots', {
+      params: { query: 'doc', limit: 25 }
+    });
+  });
+
+  it('opens a node tab when a result is clicked', async () => {
+    mockInvoke.mockResolvedValue([{ id: 'n1', nodeType: 'text', content: 'Alpha doc' }]);
+    const { getByPlaceholderText, findByText } = render(SearchPane);
+
+    const input = getByPlaceholderText('Search nodes…');
+    await fireEvent.input(input, { target: { value: 'alpha' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    await fireEvent.click(await findByText('Alpha doc'));
+
+    const opened = navigationStore.state.tabs.find((t) => t.content?.nodeId === 'n1');
+    expect(opened).toBeTruthy();
+    expect(opened?.type).toBe('node');
+  });
+
+  it('shows an empty state when there are no matches', async () => {
+    mockInvoke.mockResolvedValue([]);
+    const { getByPlaceholderText, findByText } = render(SearchPane);
+
+    const input = getByPlaceholderText('Search nodes…');
+    await fireEvent.input(input, { target: { value: 'zzz' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await findByText(/No results for/)).toBeTruthy();
+  });
+});

--- a/packages/desktop-app/src/tests/stores/navigation.test.ts
+++ b/packages/desktop-app/src/tests/stores/navigation.test.ts
@@ -24,6 +24,7 @@ import {
 } from '$lib/stores/navigation.svelte';
 import { TabPersistenceService } from '$lib/services/tab-persistence-service';
 import { NodeExpansionCoordinator } from '$lib/services/node-expansion-coordinator';
+import { computeTabTitle } from '$lib/utils/tab-title';
 
 describe('Navigation Store - Pane Management', () => {
   beforeEach(() => {
@@ -1629,5 +1630,66 @@ describe('Navigation Store - Tab Management', () => {
       expect(mockGetExpandedNodeIds).toHaveBeenCalledWith('test-tab-2');
       expect(mockGetExpandedNodeIds).toHaveBeenCalledTimes(3);
     });
+  });
+});
+
+describe('Navigation Store - Search tab', () => {
+  beforeEach(() => {
+    resetTabState();
+    localStorage.clear();
+  });
+
+  // Mirrors navigation-sidebar's openSearchTab: Search is a singleton non-node
+  // tab, opened or focused the same way Settings is.
+  function openSearch() {
+    const existing = navigationStore.state.tabs.find((t) => t.type === 'search');
+    if (existing) {
+      setActiveTab(existing.id, existing.paneId);
+    } else {
+      addTab(
+        { id: 'search', title: 'Search', type: 'search', closeable: true, paneId: DEFAULT_PANE_ID },
+        true
+      );
+    }
+  }
+
+  it('opens a singleton search tab and reuses it on a second open', () => {
+    openSearch();
+    const searchTabs = navigationStore.state.tabs.filter((t) => t.type === 'search');
+    expect(searchTabs).toHaveLength(1);
+    expect(searchTabs[0].id).toBe('search');
+    expect(navigationStore.state.activeTabIds[DEFAULT_PANE_ID]).toBe('search');
+
+    // A second open focuses the existing tab rather than creating a duplicate.
+    openSearch();
+    expect(navigationStore.state.tabs.filter((t) => t.type === 'search')).toHaveLength(1);
+  });
+
+  it('titles a search tab "Search" (non-node tabs keep their static title)', () => {
+    const searchTab: Tab = {
+      id: 'search',
+      title: 'Search',
+      type: 'search',
+      closeable: true,
+      paneId: DEFAULT_PANE_ID
+    };
+    expect(computeTabTitle(searchTab, () => undefined)).toBe('Search');
+  });
+
+  it('a persisted search tab survives state validation on reload', () => {
+    // Guards the persistence allowlist: if 'search' were not accepted, the whole
+    // persisted state would be discarded on reload and every tab would be lost.
+    const persisted = {
+      version: 1,
+      tabs: [{ id: 'search', title: 'Search', type: 'search', closeable: true, paneId: 'pane-1' }],
+      panes: [{ id: 'pane-1', width: 100, tabIds: ['search'] }],
+      activePaneId: 'pane-1',
+      activeTabIds: { 'pane-1': 'search' }
+    };
+    localStorage.setItem('nodespace:tab-state', JSON.stringify(persisted));
+
+    const loaded = TabPersistenceService.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.tabs.some((t) => t.type === 'search')).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

The **Search** item in the left sidebar highlighted but did nothing — `handleNavItemClick` only branched on `daily-journal`, so Search (and Favorites) fell through to a cosmetic active-flag update with no action. Search was also the only path to a collection's page (which hosts the **Collaboration** tab), so this left the admin UI unreachable from the sidebar.

## Fix

Search is not a node, so it opens a singleton non-node tab the same way Settings does, rather than the daily-journal node-tab path:

- Add a `'search'` tab type; render it as a new `SearchPane` in `pane-content`.
- `SearchPane` queries the existing (previously unused) `search_roots` Tauri command and opens a node tab when a result is clicked, reusing an already-open tab. Debounced, with out-of-order response guarding, loading/empty/error states.
- Wire the Search nav item to open/focus that tab; allow the `'search'` type through tab persistence so it survives reload.

**Favorites** has no store or view yet and is a much larger feature; left out of scope for this bug.

No backend changes — `search_roots` was already registered and returns `Vec<Node>`.

## Tests
- `search-pane.test.ts` (new): renders, queries `search_roots`, lists results, opens a node tab on click, empty state.
- `navigation.test.ts`: search-tab singleton open/reuse, title, and persistence-validation survival.
- Frontend lint + svelte-check clean; full pre-push gate (`test:all` + build + `test:e2e`) green locally.

Closes #1646.