### PR TITLE
Add the enable-sync intent + first-Pro consent modal (part of #1645, #1654)

### DIFF
--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1095,6 +1095,76 @@ impl NodeService {
         Ok(())
     }
 
+    /// Merge fields into the DatabaseSettingsNode singleton's `database-settings`
+    /// namespace, preserving every sibling field (tenant binding, sync state,
+    /// auth status). The singleton is seeded on database open, so a missing one
+    /// is an error rather than a silent no-op.
+    async fn merge_database_settings(
+        &self,
+        fields: &[(&str, serde_json::Value)],
+    ) -> Result<(), NodeServiceError> {
+        let node = self
+            .query_nodes_by_type("database-settings", None)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                NodeServiceError::InitializationError(
+                    "cannot update database settings: DatabaseSettingsNode singleton not found"
+                        .to_string(),
+                )
+            })?;
+
+        let mut properties = node.properties.clone();
+        let root = properties.as_object_mut().ok_or_else(|| {
+            NodeServiceError::InitializationError(
+                "DatabaseSettingsNode properties are not a JSON object".to_string(),
+            )
+        })?;
+        let settings = root
+            .entry("database-settings")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .ok_or_else(|| {
+                NodeServiceError::InitializationError(
+                    "DatabaseSettingsNode `database-settings` is not a JSON object".to_string(),
+                )
+            })?;
+        for (key, value) in fields {
+            settings.insert((*key).to_string(), value.clone());
+        }
+
+        self.update_node(
+            &node.id,
+            node.version,
+            NodeUpdate::new().with_properties(properties),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Enable (or disable) per-database cloud sync by writing `sync_enabled` on
+    /// the DatabaseSettingsNode singleton (ADR-053). This is the field the
+    /// registry-driven Pro UI gates its collaboration surfaces on; nothing else
+    /// advances it, so this is the authoritative writer the first-Pro consent
+    /// flow calls once the user opts in.
+    pub async fn set_sync_enabled(&self, enabled: bool) -> Result<(), NodeServiceError> {
+        self.merge_database_settings(&[("sync_enabled", serde_json::Value::Bool(enabled))])
+            .await
+    }
+
+    /// Set the per-database cloud auth status (`local` or `connected`) on the
+    /// DatabaseSettingsNode singleton (ADR-053). The Pro daemon advances this to
+    /// `connected` once identity is bound and back to `local` on sign-out, which
+    /// drives the Pro UI from the sign-in variant to the connected variant.
+    pub async fn set_auth_status(&self, status: &str) -> Result<(), NodeServiceError> {
+        self.merge_database_settings(&[(
+            "auth_status",
+            serde_json::Value::String(status.to_string()),
+        )])
+        .await
+    }
+
     /// Seed core schema definitions if database is fresh
     ///
     /// Checks if schema nodes exist. If not, creates all core schemas
@@ -3199,6 +3269,63 @@ mod tests {
         // Empty schema or collection is treated as unbound.
         service.set_bound_tenant("", "").await.unwrap();
         assert_eq!(service.get_bound_tenant().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_set_sync_enabled_and_auth_status_roundtrip() {
+        let (service, _temp) = create_test_service().await;
+        const COLL: &str = "c0000000-0000-0000-0000-000000000001";
+
+        // Fresh install defaults.
+        let node = &service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap()[0];
+        assert_eq!(node.properties["database-settings"]["sync_enabled"], false);
+        assert_eq!(node.properties["database-settings"]["auth_status"], "local");
+
+        // Enabling sync flips only sync_enabled; auth_status is preserved.
+        service.set_sync_enabled(true).await.unwrap();
+        let node = &service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap()[0];
+        assert_eq!(node.properties["database-settings"]["sync_enabled"], true);
+        assert_eq!(node.properties["database-settings"]["auth_status"], "local");
+
+        // Advancing auth_status preserves sync_enabled.
+        service.set_auth_status("connected").await.unwrap();
+        let node = &service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap()[0];
+        assert_eq!(
+            node.properties["database-settings"]["auth_status"],
+            "connected"
+        );
+        assert_eq!(node.properties["database-settings"]["sync_enabled"], true);
+
+        // A later tenant binding does not clobber the sync state (cross-field merge).
+        service
+            .set_bound_tenant("tenant_public", COLL)
+            .await
+            .unwrap();
+        let node = &service
+            .query_nodes_by_type("database-settings", None)
+            .await
+            .unwrap()[0];
+        assert_eq!(node.properties["database-settings"]["sync_enabled"], true);
+        assert_eq!(
+            node.properties["database-settings"]["auth_status"],
+            "connected"
+        );
+
+        // And enabling sync again preserves the tenant binding.
+        service.set_sync_enabled(true).await.unwrap();
+        assert_eq!(
+            service.get_bound_tenant().await.unwrap(),
+            Some(("tenant_public".to_string(), COLL.to_string()))
+        );
     }
 
     #[tokio::test]

--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -39,6 +39,12 @@ service CloudSyncService {
   // the orchestrator loop then reports AUTH_REQUIRED. Idempotent.
   rpc SignOut (SignOutRequest) returns (SignOutResponse);
 
+  // Enable per-database cloud sync after the user's first-Pro consent. Flips
+  // the active database's DatabaseSettingsNode sync_enabled to true — the field
+  // the registry-driven Pro UI gates its collaboration surfaces on — so the UI
+  // can advance from the enable prompt to sign-in. Idempotent.
+  rpc EnableSync (EnableSyncRequest) returns (EnableSyncResponse);
+
   // --- Team membership (M5, #147). Thin adapters over the cloud
   // membership RPCs; the daemon forwards the signed-in user's JWT, so
   // the same admin / last-admin / open-vs-restricted gates apply
@@ -152,6 +158,9 @@ message TriggerSyncResponse {}
 
 message SignOutRequest {}
 message SignOutResponse {}
+
+message EnableSyncRequest {}
+message EnableSyncResponse {}
 
 // --- Team membership (M5, #147) ----------------------------------
 // permission is "admin" | "modify" | "readOnly". collection_id / person_id are

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -12,10 +12,10 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::services::pro_client::pb::cloud_sync_service_client::CloudSyncServiceClient;
 use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{
-    AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, GetIdentityRequest,
-    InitiateOAuthRequest, JoinCollectionRequest, LeaveCollectionRequest, ListInvitesRequest,
-    ListJoinableCollectionsRequest, ListMembersRequest, ListRequestsRequest, RemoveMemberRequest,
-    RequestJoinRequest, RevokeInviteRequest, SetMemberRequest, SignOutRequest,
+    AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, EnableSyncRequest,
+    GetIdentityRequest, InitiateOAuthRequest, JoinCollectionRequest, LeaveCollectionRequest,
+    ListInvitesRequest, ListJoinableCollectionsRequest, ListMembersRequest, ListRequestsRequest,
+    RemoveMemberRequest, RequestJoinRequest, RevokeInviteRequest, SetMemberRequest, SignOutRequest,
     WatchSyncStatusRequest,
 };
 use crate::services::{ProClient, ProTier};
@@ -184,6 +184,25 @@ pub async fn pro_signout(app: AppHandle) -> Result<(), String> {
         .await
         .map_err(|e| format!("SignOut failed: {e}"))?;
     tracing::info!("Pro: SignOut");
+    Ok(())
+}
+
+/// Enable per-database cloud sync after the user's first-Pro consent. Tells the
+/// daemon to flip the active database's `sync_enabled` flag, which unlocks the
+/// collaboration UI and lets the Pro-UI variant advance from the enable prompt
+/// to sign-in. No-ops in community mode (no `ProClient`), matching the other Pro
+/// commands' side-effect-free contract.
+#[tauri::command]
+pub async fn pro_enable_sync(app: AppHandle) -> Result<(), String> {
+    let Some(pro) = app.try_state::<ProClient>() else {
+        return Ok(());
+    };
+    let mut client = pro.client().await;
+    client
+        .enable_sync(EnableSyncRequest {})
+        .await
+        .map_err(|e| format!("EnableSync failed: {e}"))?;
+    tracing::info!("Pro: EnableSync");
     Ok(())
 }
 

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -440,6 +440,7 @@ pub fn run() {
             commands::pro_sync::pro_subscribe_sync_status,
             commands::pro_sync::pro_initiate_oauth,
             commands::pro_sync::pro_signout,
+            commands::pro_sync::pro_enable_sync,
             commands::pro_sync::pro_set_member,
             commands::pro_sync::pro_remove_member,
             commands::pro_sync::pro_leave_collection,

--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
@@ -9,7 +9,13 @@
   signature (surfaced as a data attribute for debugging).
 -->
 <script lang="ts">
+  import { proSync } from '$lib/stores/pro-sync.svelte';
+
   let { nodeId }: { nodeId: string } = $props();
+
+  function openConsent() {
+    proSync.consentPromptOpen = true;
+  }
 </script>
 
 <div class="collab-locked" data-collection-id={nodeId}>
@@ -19,6 +25,7 @@
     Enable cloud sync for this database to invite people, manage roles, and share
     collections.
   </p>
+  <button class="enable-btn" type="button" onclick={openConsent}> Enable sync </button>
 </div>
 
 <style>
@@ -49,5 +56,21 @@
     max-width: 360px;
     font-size: 13px;
     line-height: 1.5;
+  }
+
+  .enable-btn {
+    margin-top: 8px;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 6px;
+    background-color: #2563eb;
+    color: #ffffff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .enable-btn:hover {
+    background-color: #1d4ed8;
   }
 </style>

--- a/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
@@ -2,38 +2,20 @@
   Enable-sync prompt.
 
   Rendered in the app-shell overlay slot for the `enable-prompt` variant — a Pro
-  daemon whose active database has `sync_enabled: false`. Offers to turn cloud sync
-  on for this database.
+  daemon whose active database has `sync_enabled: false`. Clicking opens the
+  first-Pro data-sharing consent modal (rendered by `first-pro-consent-slot` in
+  the app-shell modal slot for the same variant), which is where the user makes
+  the informed, irreversible choice to merge into the public workspace. Nothing
+  leaves the device until they opt in there.
 
-  The concrete "turn sync on" action available today is starting the interactive
-  sign-in (`pro_initiate_oauth`): a Pro user opts a database into sync by signing
-  in to the cloud, after which the daemon binds the tenant and flips
-  `sync_enabled` / `auth_status` on the DatabaseSettingsNode, advancing the variant.
-  (A dedicated per-database "enable sync" intent command is backend follow-up.)
-
-  Never rendered in the community build (that resolves to `teaser`), so invoking a
-  Pro command here is safe.
+  Never rendered in the community build (that resolves to `teaser`), so touching
+  Pro state here is safe.
 -->
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
-  import { createLogger } from '$lib/utils/logger';
+  import { proSync } from '$lib/stores/pro-sync.svelte';
 
-  const log = createLogger('EnableSyncPill');
-
-  let pending = $state(false);
-
-  async function enableSync() {
-    if (pending) return;
-    pending = true;
-    try {
-      // Starting sign-in is how a Pro user enables sync for a database today.
-      await invoke('pro_initiate_oauth');
-      log.info('enable-sync: sign-in started');
-    } catch (e) {
-      log.warn('enable-sync: pro_initiate_oauth failed', { error: e });
-    } finally {
-      pending = false;
-    }
+  function openConsent() {
+    proSync.consentPromptOpen = true;
   }
 </script>
 
@@ -42,11 +24,10 @@
   type="button"
   title="Turn on cloud sync for this database"
   aria-label="Enable cloud sync for this database"
-  disabled={pending}
-  onclick={enableSync}
+  onclick={openConsent}
 >
   <span class="dot" aria-hidden="true"></span>
-  <span class="label">{pending ? 'Enabling…' : 'Enable sync'}</span>
+  <span class="label">Enable sync</span>
 </button>
 
 <style>
@@ -65,13 +46,8 @@
     cursor: pointer;
   }
 
-  .enable-sync-pill:hover:not(:disabled) {
+  .enable-sync-pill:hover {
     background: hsl(var(--muted));
-  }
-
-  .enable-sync-pill:disabled {
-    cursor: default;
-    opacity: 0.85;
   }
 
   .dot {

--- a/packages/desktop-app/src/lib/components/first-pro-consent-modal.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-modal.svelte
@@ -1,0 +1,187 @@
+<!--
+  First-Pro data-sharing consent modal.
+
+  Presentational only: the slot wrapper (`first-pro-consent-slot`) owns visibility
+  and the actions. This is the gate that keeps local data from reaching the shared
+  public workspace without an explicit, informed, irreversible choice.
+
+  - "Merge into public workspace" is disabled until the user ticks the
+    acknowledgement checkbox (and is never the default-focused control).
+  - "Keep this database local-only" — and Escape / overlay click — dismiss without
+    sharing anything.
+-->
+<script lang="ts">
+  import { focusTrap } from '$lib/actions/focus-trap';
+
+  interface Props {
+    /** Whether the modal is visible. */
+    open?: boolean;
+    /** True while the enable-sync / sign-in calls are in flight — disables the buttons. */
+    pending?: boolean;
+    /** Opt in: merge this database into the public workspace (irreversible). */
+    onMerge: () => void;
+    /** Decline: keep this database local-only, share nothing. */
+    onKeepLocal: () => void;
+  }
+
+  let { open = false, pending = false, onMerge, onKeepLocal }: Props = $props();
+
+  let acknowledged = $state(false);
+
+  function handleMerge() {
+    if (!acknowledged || pending) return;
+    acknowledged = false;
+    onMerge();
+  }
+
+  function handleKeepLocal() {
+    acknowledged = false;
+    onKeepLocal();
+  }
+</script>
+
+{#if open}
+  <div class="consent-overlay" onclick={handleKeepLocal} role="presentation" tabindex="-1">
+    <div
+      class="consent-content"
+      use:focusTrap={{ onEscape: handleKeepLocal }}
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-labelledby="consent-title"
+      aria-describedby="consent-body"
+      aria-modal="true"
+      tabindex="0"
+    >
+      <h2 id="consent-title">Share this database with the public workspace?</h2>
+      <div id="consent-body" class="consent-body">
+        <p>
+          Merging adds every note in this database to the shared
+          <strong>public workspace</strong>, where other people using NodeSpace can
+          <strong>read</strong> them. Editing and deleting stay yours alone.
+        </p>
+        <p class="consent-warning">
+          This cannot be undone. Once your notes are in the public workspace, others may already have
+          read or copied them, so they can never be un-shared.
+        </p>
+      </div>
+
+      <label class="consent-ack">
+        <input type="checkbox" bind:checked={acknowledged} disabled={pending} />
+        <span>I understand this is permanent and cannot be undone.</span>
+      </label>
+
+      <div class="consent-actions">
+        <button class="btn btn-secondary" type="button" onclick={handleKeepLocal} disabled={pending}>
+          Keep this database local-only
+        </button>
+        <button
+          class="btn btn-danger"
+          type="button"
+          onclick={handleMerge}
+          disabled={pending || !acknowledged}
+        >
+          {pending ? 'Merging…' : 'Merge into public workspace'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .consent-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .consent-content {
+    background: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
+    border-radius: 8px;
+    padding: 24px;
+    width: min(480px, calc(100vw - 48px));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .consent-content h2 {
+    margin: 0 0 12px 0;
+    font-size: 20px;
+  }
+
+  .consent-body {
+    font-size: 14px;
+    line-height: 1.5;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .consent-body p {
+    margin: 0 0 10px 0;
+  }
+
+  .consent-warning {
+    padding: 10px 12px;
+    background: hsl(var(--destructive) / 0.12);
+    border: 1px solid hsl(var(--destructive) / 0.4);
+    border-radius: 6px;
+    color: hsl(var(--foreground));
+    font-weight: 500;
+  }
+
+  .consent-ack {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 16px;
+    font-size: 14px;
+    color: hsl(var(--foreground));
+    cursor: pointer;
+  }
+
+  .consent-ack input {
+    margin-top: 2px;
+  }
+
+  .consent-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: 24px;
+  }
+
+  .btn {
+    padding: 10px 18px;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .btn:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  .btn-secondary {
+    background-color: hsl(var(--muted));
+    color: hsl(var(--foreground));
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background-color: hsl(var(--muted) / 0.7);
+  }
+
+  .btn-danger {
+    background-color: hsl(var(--destructive));
+    color: #ffffff;
+  }
+
+  .btn-danger:hover:not(:disabled) {
+    filter: brightness(0.92);
+  }
+</style>

--- a/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
@@ -1,0 +1,50 @@
+<!--
+  First-Pro consent slot.
+
+  Registry wrapper contributed to the `app-shell-modal` slot for the
+  `enable-prompt` variant (a Pro daemon whose active database has sync disabled).
+  Owns the enable-sync / sign-in orchestration and mounts the presentational
+  `FirstProConsentModal`. Visibility is driven off `proSync.consentPromptOpen`,
+  which the enable-sync pill (and the locked Collaboration placeholder) set.
+
+  Never rendered in the community build (that resolves to `teaser`), so invoking
+  Pro commands here is safe.
+-->
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import FirstProConsentModal from '$lib/components/first-pro-consent-modal.svelte';
+  import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { createLogger } from '$lib/utils/logger';
+
+  const log = createLogger('FirstProConsentSlot');
+
+  let pending = $state(false);
+
+  const open = $derived(proSync.isPro && proSync.consentPromptOpen);
+
+  async function handleMerge() {
+    if (pending) return;
+    pending = true;
+    try {
+      // Record the merge consent first (flips sync_enabled for this database),
+      // then start sign-in so the daemon can bind the tenant and push. The daemon
+      // only pushes once sync is enabled, so nothing has left the device before
+      // this point.
+      await invoke('pro_enable_sync');
+      await invoke('pro_initiate_oauth');
+    } catch (e) {
+      log.warn('first-pro consent: enabling sync failed', { error: e });
+    } finally {
+      pending = false;
+      proSync.consentPromptOpen = false;
+    }
+  }
+
+  function handleKeepLocal() {
+    // Decline: leave sync disabled, share nothing. The pill remains, so the user
+    // can revisit this choice later.
+    proSync.consentPromptOpen = false;
+  }
+</script>
+
+<FirstProConsentModal {open} {pending} onMerge={handleMerge} onKeepLocal={handleKeepLocal} />

--- a/packages/desktop-app/src/lib/plugins/pro-plugin.ts
+++ b/packages/desktop-app/src/lib/plugins/pro-plugin.ts
@@ -9,7 +9,7 @@
  *   | variant        | overlay pill              | modal              | collection tab              |
  *   |----------------|---------------------------|--------------------|-----------------------------|
  *   | teaser         | pro-teaser-pill (upsell)  | —                  | — (none)                    |
- *   | enable-prompt  | enable-sync-pill          | —                  | collaboration-locked        |
+ *   | enable-prompt  | enable-sync-pill          | first-pro-consent  | collaboration-locked        |
  *   | sign-in        | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
  *   | connected      | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
  *
@@ -53,6 +53,15 @@ export const proSyncUiExtension: UiExtensionDefinition = {
       slot: 'app-shell-overlay',
       variant: 'connected',
       lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
+    },
+    // First-Pro data-sharing consent modal — shown for a Pro daemon whose active
+    // database has sync disabled, when the user opts to enable it. The gate that
+    // keeps local data from reaching the public workspace without an explicit,
+    // irreversible choice.
+    {
+      slot: 'app-shell-modal',
+      variant: 'enable-prompt',
+      lazyLoad: () => import('$lib/components/first-pro-consent-slot.svelte')
     },
     // Re-login modal — only meaningful once sync is enabled for the database; the
     // wrapper itself only shows the modal on an AUTH_REQUIRED transition.

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -101,6 +101,15 @@ class ProSyncStore {
   signedInEpisode = $state(0);
 
   /**
+   * Whether the first-Pro data-sharing consent modal is open. Set true when the
+   * user clicks the enable-sync affordance; the consent slot renders the modal
+   * off this flag and clears it on either choice. Held here (rather than inside a
+   * component) so the enable-sync pill and the modal slot — separate registry
+   * contributions — share one source of truth.
+   */
+  consentPromptOpen = $state(false);
+
+  /**
    * Axis 1 only: "this daemon binary CAN sync" (the capability probe found
    * a Pro daemon). This is NOT "sync is active" — whether sync is enabled and
    * authenticated for the *active database* is axis 2, held on that database's

--- a/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
@@ -1,9 +1,9 @@
 /**
  * enable-sync-pill component.
  *
- * Rendered only for a Pro daemon whose active database has sync disabled. Clicking
- * starts the interactive sign-in — the concrete "turn sync on" action available
- * today (a dedicated per-database enable command is backend follow-up).
+ * Rendered only for a Pro daemon whose active database has sync disabled.
+ * Clicking opens the first-Pro data-sharing consent modal (which owns the
+ * irreversible merge choice) rather than pushing anything itself.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/svelte';
@@ -11,18 +11,15 @@ import { render, fireEvent, cleanup } from '@testing-library/svelte';
 vi.mock('$lib/utils/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 }));
-
-const mockInvoke = vi.fn();
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: (...args: unknown[]) => mockInvoke(...args)
-}));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
 
 import EnableSyncPill from '$lib/components/enable-sync-pill.svelte';
+import { proSync } from '$lib/stores/pro-sync.svelte';
 
 describe('EnableSyncPill', () => {
   beforeEach(() => {
-    mockInvoke.mockReset();
-    mockInvoke.mockResolvedValue('attempt-1');
+    proSync.consentPromptOpen = false;
   });
 
   afterEach(() => {
@@ -36,9 +33,10 @@ describe('EnableSyncPill', () => {
     expect(getByRole('button', { name: /enable cloud sync/i })).toBeTruthy();
   });
 
-  it('starts sign-in on click via pro_initiate_oauth', async () => {
+  it('opens the consent modal on click (does not push anything itself)', async () => {
     const { getByRole } = render(EnableSyncPill);
+    expect(proSync.consentPromptOpen).toBe(false);
     await fireEvent.click(getByRole('button', { name: /enable cloud sync/i }));
-    expect(mockInvoke).toHaveBeenCalledWith('pro_initiate_oauth');
+    expect(proSync.consentPromptOpen).toBe(true);
   });
 });

--- a/packages/desktop-app/src/tests/components/first-pro-consent-modal.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-modal.test.ts
@@ -1,0 +1,57 @@
+/**
+ * first-pro-consent-modal component (presentational).
+ *
+ * The gate that keeps local data from reaching the public workspace without an
+ * explicit, informed, irreversible choice. Merge is disabled until the user
+ * acknowledges permanence; declining shares nothing.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+import FirstProConsentModal from '$lib/components/first-pro-consent-modal.svelte';
+
+describe('FirstProConsentModal', () => {
+  afterEach(() => cleanup());
+
+  it('renders nothing when closed', () => {
+    const { queryByRole } = render(FirstProConsentModal, {
+      props: { open: false, onMerge: vi.fn(), onKeepLocal: vi.fn() }
+    });
+    expect(queryByRole('dialog')).toBeNull();
+  });
+
+  it('shows the irreversible warning when open', () => {
+    const { getByText } = render(FirstProConsentModal, {
+      props: { open: true, onMerge: vi.fn(), onKeepLocal: vi.fn() }
+    });
+    expect(getByText(/once your notes are in the public workspace/i)).toBeTruthy();
+  });
+
+  it('gates Merge behind the acknowledgement checkbox', async () => {
+    const onMerge = vi.fn();
+    const { getByRole } = render(FirstProConsentModal, {
+      props: { open: true, onMerge, onKeepLocal: vi.fn() }
+    });
+    const mergeBtn = getByRole('button', { name: /merge into public workspace/i });
+
+    // Disabled until acknowledged; clicking does nothing.
+    expect(mergeBtn.hasAttribute('disabled')).toBe(true);
+    await fireEvent.click(mergeBtn);
+    expect(onMerge).not.toHaveBeenCalled();
+
+    // Acknowledge → enabled → merges.
+    await fireEvent.click(getByRole('checkbox'));
+    expect(mergeBtn.hasAttribute('disabled')).toBe(false);
+    await fireEvent.click(mergeBtn);
+    expect(onMerge).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the database local-only without acknowledgement', async () => {
+    const onKeepLocal = vi.fn();
+    const { getByRole } = render(FirstProConsentModal, {
+      props: { open: true, onMerge: vi.fn(), onKeepLocal }
+    });
+    await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
+    expect(onKeepLocal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
@@ -1,0 +1,58 @@
+/**
+ * first-pro-consent-slot component.
+ *
+ * Registry wrapper for the consent modal. On merge it records the consent
+ * (pro_enable_sync → flips sync_enabled) and then starts sign-in; on decline it
+ * closes and shares nothing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => mockInvoke(...args) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+import FirstProConsentSlot from '$lib/components/first-pro-consent-slot.svelte';
+import { proSync } from '$lib/stores/pro-sync.svelte';
+
+describe('FirstProConsentSlot', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue(undefined);
+    proSync.tier = 'pro';
+    proSync.consentPromptOpen = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    proSync.tier = 'unknown';
+    proSync.consentPromptOpen = false;
+  });
+
+  it('merges: enables sync, then starts sign-in, then closes', async () => {
+    const { getByRole, findByRole } = render(FirstProConsentSlot);
+    await findByRole('dialog');
+
+    await fireEvent.click(getByRole('checkbox'));
+    await fireEvent.click(getByRole('button', { name: /merge into public workspace/i }));
+
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'pro_enable_sync');
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'pro_initiate_oauth');
+    await waitFor(() => expect(proSync.consentPromptOpen).toBe(false));
+  });
+
+  it('keep-local closes without any daemon call', async () => {
+    const { getByRole, findByRole } = render(FirstProConsentSlot);
+    await findByRole('dialog');
+
+    await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(proSync.consentPromptOpen).toBe(false);
+  });
+});

--- a/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
+++ b/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
@@ -60,9 +60,9 @@ describe('UI-extension registry', () => {
   describe('registry registration', () => {
     it('registers the built-in pro-sync extension with all contributions', () => {
       expect(uiExtensionRegistry.has('pro-sync')).toBe(true);
-      // 4 overlay pill variants + 2 modal (sign-in/connected).
+      // 4 overlay pill variants + 3 modal (enable-prompt consent / sign-in / connected).
       expect(uiExtensionRegistry.chromeFor('app-shell-overlay')).toHaveLength(4);
-      expect(uiExtensionRegistry.chromeFor('app-shell-modal')).toHaveLength(2);
+      expect(uiExtensionRegistry.chromeFor('app-shell-modal')).toHaveLength(3);
       // 3 collaboration viewer extensions (enable-prompt/sign-in/connected).
       expect(uiExtensionRegistry.viewersFor('collection')).toHaveLength(3);
       expect(uiExtensionRegistry.viewersFor('text')).toEqual([]);
@@ -125,13 +125,15 @@ describe('UI-extension registry', () => {
       expect(getActiveViewerExtensions('collection')).toEqual([]);
     });
 
-    it('enable-prompt: enable-sync pill + a locked collab tab, no modal', () => {
+    it('enable-prompt: enable-sync pill + the consent modal + a locked collab tab', () => {
       proSync.tier = 'pro';
       seedSettings({ sync_enabled: false, auth_status: 'local' });
       const overlay = getActiveChromeContributions('app-shell-overlay');
       expect(overlay).toHaveLength(1);
       expect(overlay[0].variant).toBe('enable-prompt');
-      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
+      const modal = getActiveChromeContributions('app-shell-modal');
+      expect(modal).toHaveLength(1);
+      expect(modal[0].variant).toBe('enable-prompt');
       const viewers = getActiveViewerExtensions('collection');
       expect(viewers).toHaveLength(1);
       expect(viewers[0].variant).toBe('enable-prompt');


### PR DESCRIPTION
## Problem

The registry-driven Pro UI gates its collaboration surfaces on the active database's `DatabaseSettingsNode` `sync_enabled` / `auth_status`, but **no production code ever wrote those fields** (#1645), so the admin/collaboration UI was permanently locked at the enable prompt. And there was no consent gate before local data could reach the shared public workspace (#1654).

This is the **core half** of a cross-repo feature. The Pro daemon `EnableSync` handler and the `auth_status → connected` mirror land in a follow-up nodespace-sync PR that pins the core rev this adds; the two `closes` when both land + the Monday two-user isolation check passes.

## What this adds

**Backend (core)**
- `NodeService::set_sync_enabled` / `set_auth_status` — merge single fields into the `database-settings` singleton, preserving siblings (shared merge helper). These are the authoritative writers the Pro UI's variant machine needs.

**Bridge (desktop-app src-tauri)**
- New `nodespace.pro.v1` `EnableSync` RPC (client copy) + `pro_enable_sync` Tauri command, modelled on `pro_signout` (no-op in community mode).

**Frontend consent flow (Pro-gated; community build unchanged)**
- First-Pro **consent modal**: *merge into the shared public workspace* — with a required, checkbox-gated **irreversible** warning, and the confirm button is never the default focus — vs *keep this database local-only*. Merge records consent via `pro_enable_sync` (flips `sync_enabled`), then starts sign-in; **nothing leaves the device before the opt-in**. Declining shares nothing.
- The enable-sync pill and the previously dead-end locked-Collaboration placeholder now open the modal; registered as the `enable-prompt` app-shell modal contribution.

## Consent sequencing

Consent-first: the modal is opened from the enable-sync affordance and the merge choice happens *before* sign-in / any cloud contact — strictly safer than prompting after sign-in, and it needs no "first-signed-in" detection. Re-clicking the pill re-opens it, so there's no auto-prompt to suppress.

## Tests
- NodeService roundtrip: `sync_enabled` / `auth_status` merge preserves the tenant binding.
- Modal gating + irreversible warning; slot merge → `pro_enable_sync` → sign-in; pill opens the modal; updated ui-extensions contribution counts.
- Full frontend suite (4037) + `clippy --all-targets -D warnings` + pre-push gate (`test:all` + build + `test:e2e`) green locally.

Part of #1645, #1654.