### PR TITLE
Re-hydrate the Pro signed-in state on webview reload (closes #1647)

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -46,6 +46,32 @@ pub async fn pro_tier(app: AppHandle) -> Result<ProTier, String> {
     }
 }
 
+/// The daemon's most recent sync status (state, detail, signed-in email), cached
+/// from the `WatchSyncStatus` stream. Lets the frontend re-hydrate the signed-in
+/// state on demand — on a webview reload the one-shot `pro:tier-detected` event
+/// (which carries the initial status) does not re-fire, and `sync:status` only
+/// pushes on change, so without this a signed-in Pro user appears signed out.
+/// `None` in community mode or before any status is known.
+#[tauri::command]
+pub async fn pro_current_status(app: AppHandle) -> Result<Option<SyncStatusSnapshot>, String> {
+    let Some(pro) = app.try_state::<ProClient>() else {
+        return Ok(None);
+    };
+    Ok(pro.last_status().await.map(|s| SyncStatusSnapshot {
+        state: s.state,
+        detail: s.detail,
+        user_email: s.user_email,
+    }))
+}
+
+/// Serializable snapshot of `SyncStatusEvent` for [`pro_current_status`].
+#[derive(serde::Serialize)]
+pub struct SyncStatusSnapshot {
+    pub state: i32,
+    pub detail: String,
+    pub user_email: String,
+}
+
 /// Start a long-lived `WatchSyncStatus` subscription on the daemon
 /// and forward each event to the frontend as a Tauri event named
 /// `sync:status`.
@@ -68,6 +94,9 @@ pub async fn pro_subscribe_sync_status(app: AppHandle) -> Result<(), String> {
     // connection alive for the stream's lifetime — no explicit
     // keep-alive binding is required.
     let mut client = pro.client().await;
+    // Owned handle (Arc-backed) so the forwarding task can keep the cached
+    // status current for `pro_current_status` re-hydration on reload.
+    let pro_client = pro.inner().clone();
     let app_handle = app.clone();
 
     tokio::spawn(async move {
@@ -86,6 +115,9 @@ pub async fn pro_subscribe_sync_status(app: AppHandle) -> Result<(), String> {
         while let Some(item) = stream.next().await {
             match item {
                 Ok(evt) => {
+                    // Cache the latest status so a reloaded webview can re-hydrate
+                    // deterministically instead of appearing signed out.
+                    pro_client.set_last_status(evt.clone()).await;
                     let payload = serde_json::json!({
                         "state": evt.state,
                         "detail": evt.detail,

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -437,6 +437,7 @@ pub fn run() {
             frontend_log,
             check_daemon_status,
             commands::pro_sync::pro_tier,
+            commands::pro_sync::pro_current_status,
             commands::pro_sync::pro_subscribe_sync_status,
             commands::pro_sync::pro_initiate_oauth,
             commands::pro_sync::pro_signout,

--- a/packages/desktop-app/src-tauri/src/services/pro_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/pro_client.rs
@@ -81,6 +81,14 @@ impl ProClient {
         self.inner.read().await.last_status.clone()
     }
 
+    /// Cache the daemon's most recent status. Called from the `WatchSyncStatus`
+    /// forwarding task so `last_status` tracks the live state rather than only
+    /// the probe-time snapshot — this is what lets the frontend re-hydrate the
+    /// signed-in state after a webview reload (the daemon only pushes on change).
+    pub async fn set_last_status(&self, status: SyncStatusEvent) {
+        self.inner.write().await.last_status = Some(status);
+    }
+
     pub async fn client(&self) -> CloudSyncServiceClient<Channel> {
         self.inner.read().await.client.clone()
     }

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -187,6 +187,26 @@ class ProSyncStore {
       log.warn('pro_tier invoke failed', { error: e });
     }
 
+    // Re-hydrate the current status snapshot. On a webview reload the one-shot
+    // `pro:tier-detected` event (which carries the initial status) does not
+    // re-fire, and `sync:status` only pushes on change — so without this a
+    // signed-in Pro user would appear signed out until the next daemon
+    // transition. The daemon session is intact; this reflects it deterministically.
+    try {
+      const snapshot = await invoke<{
+        state: number;
+        detail: string;
+        user_email?: string;
+      } | null>('pro_current_status');
+      if (snapshot) {
+        this.setState(decodeState(snapshot.state));
+        this.detail = snapshot.detail;
+        this.setUserEmail(snapshot.user_email ?? '');
+      }
+    } catch (e) {
+      log.warn('pro_current_status invoke failed', { error: e });
+    }
+
     this.unlistenTier = await listen<{
       tier: ProTier;
       initial_status: { state: number; detail: string; user_email?: string } | null;

--- a/packages/desktop-app/src/tests/stores/pro-sync.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync.test.ts
@@ -207,3 +207,48 @@ describe('ProSync store — onProConfirmed (#1566)', () => {
     expect(() => unregister()).not.toThrow();
   });
 });
+
+describe('ProSync store — reload re-hydration (#1647)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the idempotent-start latch so start() re-runs its hydration, as it
+    // does on a fresh page load / webview reload. Clear carry-over identity from
+    // earlier tests (proSync is a module singleton).
+    proSync.stop();
+    proSync.userEmail = '';
+    proSync.state = 'unspecified';
+  });
+
+  it('re-hydrates signed-in identity from the current-status snapshot on start', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'pro_tier') return 'pro';
+      if (cmd === 'pro_current_status') {
+        return { state: 6, detail: 'live', user_email: 'mayank@nodespace.dev' };
+      }
+      return undefined;
+    });
+
+    await proSync.start();
+
+    // The reload path: neither `pro:tier-detected` nor `sync:status` fires, yet
+    // the signed-in state is restored deterministically from the snapshot.
+    expect(mockInvoke).toHaveBeenCalledWith('pro_current_status');
+    expect(proSync.tier).toBe('pro');
+    expect(proSync.state).toBe('connected');
+    expect(proSync.userEmail).toBe('mayank@nodespace.dev');
+  });
+
+  it('leaves the snapshot alone when the daemon has no status yet (null)', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'pro_tier') return 'pro';
+      if (cmd === 'pro_current_status') return null;
+      return undefined;
+    });
+
+    await proSync.start();
+
+    expect(proSync.tier).toBe('pro');
+    // No snapshot → userEmail is not populated (stays signed-out).
+    expect(proSync.userEmail).toBe('');
+  });
+});


### PR DESCRIPTION
## Problem

On a webview reload a signed-in Pro user appears signed out. Two mechanisms conspire:

- `pro:tier-detected` is a one-shot event carrying the initial status — it does **not** re-fire on reload.
- `sync:status` only pushes on a *change*, so a steady signed-in session emits nothing after reload.

The daemon session is fully intact; only the frontend's view of it is lost until the next daemon transition (which may be minutes away, or never while idle).

## Fix

A pull-based snapshot to complement the two push channels:

- **`pro_client.rs`** — `ProClientInner` already caches `last_status` from the capability probe. Added `set_last_status()` so the `WatchSyncStatus` forwarding task keeps it current (the probe snapshot alone goes stale immediately).
- **`commands/pro_sync.rs`** — the stream-forwarding task now calls `pro_client.set_last_status(evt.clone())` per event; added a `pro_current_status` command returning a `SyncStatusSnapshot { state, detail, user_email }` (or `null` if the daemon hasn't emitted yet).
- **`pro-sync.svelte.ts`** — `start()` invokes `pro_current_status` after `pro_tier` and hydrates `state`/`detail`/`userEmail` from the snapshot. Deterministic: neither event needs to fire for the signed-in state to be restored.

Community mode is unchanged — no `ProClient` in managed state → the command returns `null` and the store stays signed-out.

## Tests

- `pro-sync.test.ts` — new `reload re-hydration (#1647)` describe: re-hydrates identity from the snapshot on `start()`; leaves the store signed-out when the daemon has no status yet (`null`).
- Full frontend suite green locally; `cargo build --bin nodespaced` + `test:e2e` pre-push gate passed.