### PR TITLE
Disable mermaid HTML labels so diagram labels survive SVG sanitization (closes #1650)

### DIFF
--- a/packages/desktop-app/src/lib/services/mermaid-render.ts
+++ b/packages/desktop-app/src/lib/services/mermaid-render.ts
@@ -106,7 +106,9 @@ function getDOMPurify() {
   // executing in any modern webview — revisit if that CSP is ever relaxed.
   purify.addHook('uponSanitizeAttribute', (_node, data) => {
     if (data.attrName === 'style') {
-      data.attrValue = data.attrValue.replace(/(?:javascript|vbscript):/gi, '').replace(/expression\s*\(/gi, '');
+      data.attrValue = data.attrValue
+        .replace(/(?:javascript|vbscript):/gi, '')
+        .replace(/expression\s*\(/gi, '');
     }
   });
   return purify;
@@ -130,7 +132,15 @@ export async function renderMermaid(
         startOnLoad: false,
         securityLevel: 'strict',
         theme: 'base',
-        themeVariables: buildThemeVariables(isDark)
+        themeVariables: buildThemeVariables(isDark),
+        // Emit node labels as native SVG <text>, not HTML inside <foreignObject>.
+        // sanitizeSvg() runs DOMPurify's `svg` profile, which drops <foreignObject>
+        // (it can host arbitrary HTML) — so with mermaid's default htmlLabels:true
+        // every label is stripped and diagrams render as empty, wordless boxes.
+        // flowchart and class are the diagram types that use foreignObject labels;
+        // sequence/state/er emit <text> natively and need no flag.
+        flowchart: { htmlLabels: false },
+        class: { htmlLabels: false }
       });
       lastThemeKey = themeKey;
     }

--- a/packages/desktop-app/src/tests/services/mermaid-render.test.ts
+++ b/packages/desktop-app/src/tests/services/mermaid-render.test.ts
@@ -70,7 +70,8 @@ describe('sanitizeSvg', () => {
   });
 
   it('preserves legitimate SVG content', () => {
-    const svg = '<svg viewBox="0 0 100 100"><rect x="10" y="10" width="80" height="80"/><text>Hello</text></svg>';
+    const svg =
+      '<svg viewBox="0 0 100 100"><rect x="10" y="10" width="80" height="80"/><text>Hello</text></svg>';
     const result = sanitizeSvg(svg);
     expect(result).toContain('<rect');
     expect(result).toContain('<text>');
@@ -90,14 +91,29 @@ describe('sanitizeSvg', () => {
     expect(result).toContain('cy="50"');
     expect(result).toContain('r="40"');
   });
+
+  it('strips foreignObject HTML labels but preserves native <text> labels', () => {
+    // Root cause of the wordless-diagram bug: mermaid's default htmlLabels:true
+    // wraps every node label in <foreignObject> (arbitrary HTML), which the SVG
+    // profile removes — so the labels vanish. Native <text> labels (emitted when
+    // htmlLabels:false) must survive sanitization. This is why renderMermaid
+    // initializes with flowchart/class htmlLabels disabled.
+    const withForeignObject =
+      '<svg><g class="node"><foreignObject width="80" height="20"><div xmlns="http://www.w3.org/1999/xhtml">Label A</div></foreignObject></g></svg>';
+    const foResult = sanitizeSvg(withForeignObject);
+    expect(foResult).not.toContain('foreignObject');
+
+    const withText = '<svg><g class="node"><text>Label A</text></g></svg>';
+    const textResult = sanitizeSvg(withText);
+    expect(textResult).toContain('<text>');
+    expect(textResult).toContain('Label A');
+  });
 });
 
 describe('renderMermaid', () => {
   it('returns null on render failure', async () => {
     const { default: mermaid } = await import('mermaid');
-    (mermaid.render as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new Error('Invalid syntax')
-    );
+    (mermaid.render as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Invalid syntax'));
 
     const { renderMermaid } = await import('../../lib/services/mermaid-render.js');
     const result = await renderMermaid('invalid mermaid syntax %%%', 'test-id');
@@ -115,5 +131,27 @@ describe('renderMermaid', () => {
     expect(result).not.toBeNull();
     expect(result).toContain('<svg>');
     expect(result).toContain('flowchart');
+  });
+
+  it('initializes mermaid with HTML labels disabled (labels survive sanitization)', async () => {
+    const { default: mermaid } = await import('mermaid');
+    (mermaid.initialize as ReturnType<typeof vi.fn>).mockClear();
+    (mermaid.render as ReturnType<typeof vi.fn>).mockResolvedValue({
+      svg: '<svg><text>x</text></svg>'
+    });
+
+    const { renderMermaid } = await import('../../lib/services/mermaid-render.js');
+    // Toggle the theme across two renders so an initialize() call is guaranteed
+    // regardless of the module-level theme cache's prior state.
+    await renderMermaid('graph TD; A-->B;', 'init-light', false);
+    await renderMermaid('graph TD; A-->B;', 'init-dark', true);
+
+    expect(mermaid.initialize).toHaveBeenCalled();
+    const cfg = (mermaid.initialize as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
+      flowchart?: { htmlLabels?: boolean };
+      class?: { htmlLabels?: boolean };
+    };
+    expect(cfg.flowchart?.htmlLabels).toBe(false);
+    expect(cfg.class?.htmlLabels).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Every mermaid diagram in imported docs rendered as bare boxes with **no text** — the single biggest readability loss in the docs. DOM inspection showed 0 `<text>` and 0 `<foreignObject>` elements: the labels were gone, not hidden.

## Root cause

Mermaid's default `htmlLabels: true` emits node labels as HTML wrapped in `<foreignObject>`. `sanitizeSvg()` runs DOMPurify's `svg` profile, which **drops `<foreignObject>`** (it can host arbitrary HTML) — so every label is stripped. The existing sanitizer tests never asserted that label text survives, which is how this shipped.

## Fix

Initialize mermaid with `flowchart: { htmlLabels: false }` and `class: { htmlLabels: false }` so labels are emitted as native SVG `<text>`, which the sanitizer preserves. **The sanitizer is unchanged** — no relaxation of the XSS defense. sequence/state/er diagrams already emit `<text>` natively and need no flag.

## Tests

- `sanitizeSvg` strips `<foreignObject>` HTML labels but preserves native `<text>` labels (documents the root cause).
- `renderMermaid` initializes with `htmlLabels` disabled on flowchart + class.
- Full frontend suite + `cargo build --bin nodespaced` + `test:e2e` pre-push gate green locally.