### PR TITLE
Degrade the database store gracefully under dev:browser (closes #1652)

### DIFF
--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -37,6 +37,34 @@ interface DatabaseListing {
 }
 
 /**
+ * Whether the Tauri IPC bridge is present. Absent under `dev:browser`, where the
+ * app runs in a plain browser against the dev-proxy — which forwards NodeService
+ * but has no DatabaseService, so calling the `list_databases` invoke throws
+ * `Cannot read properties of undefined (reading 'invoke')`. Same probe the model,
+ * agent, and external-link surfaces use.
+ */
+function isTauriBridgePresent(): boolean {
+  return (
+    typeof window !== 'undefined' && ('__TAURI__' in window || '__TAURI_INTERNALS__' in window)
+  );
+}
+
+/**
+ * The single implicit database presented in browser dev mode: the dev-proxy is
+ * bound to one daemon/database and exposes no registry, so the switcher shows one
+ * concrete, non-switchable entry instead of erroring at boot.
+ */
+const IMPLICIT_BROWSER_DATABASE: DatabaseInfo = {
+  id: 'default',
+  name: 'Default',
+  path: '',
+  isDefault: true,
+  status: 'open',
+  createdAt: '',
+  lastOpenedAt: null
+};
+
+/**
  * Manages the daemon's registry of local databases and the desktop-local
  * "which database am I viewing" selection.
  *
@@ -77,6 +105,22 @@ class DatabaseStore {
   async load(): Promise<void> {
     this.loading = true;
     this.error = null;
+
+    // Browser dev mode (dev:browser): no Tauri bridge, so there is no database
+    // registry to query. Present a single implicit database rather than logging a
+    // boot error and rendering the switcher's failure fallback. The Tauri app,
+    // where the bridge is present, is unaffected.
+    if (!isTauriBridgePresent()) {
+      this.databases = [IMPLICIT_BROWSER_DATABASE];
+      this.defaultDatabaseId = IMPLICIT_BROWSER_DATABASE.id;
+      if (this.activeDatabaseId === null) {
+        this.activeDatabaseId = IMPLICIT_BROWSER_DATABASE.id;
+        this.hydrateDatabaseSettings();
+      }
+      this.loading = false;
+      return;
+    }
+
     try {
       const listing = await invoke<DatabaseListing>('list_databases');
       this.databases = listing.databases;
@@ -85,8 +129,7 @@ class DatabaseStore {
       if (this.activeDatabaseId === null) {
         // Prefer the daemon default; fall back to the first registered database
         // so the switcher always shows a concrete selection.
-        this.activeDatabaseId =
-          this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
+        this.activeDatabaseId = this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
         // Hydrate the active database's DatabaseSettingsNode so the Pro-sync
         // variant machine can read sync_enabled/auth_status.
         this.hydrateDatabaseSettings();
@@ -177,9 +220,7 @@ class DatabaseStore {
    * Returns the new entry so callers can switch to it.
    */
   async create(name: string, path?: string): Promise<DatabaseInfo | null> {
-    return this.mutate(() =>
-      invoke<DatabaseInfo>('create_database', { name, path: path ?? null })
-    );
+    return this.mutate(() => invoke<DatabaseInfo>('create_database', { name, path: path ?? null }));
   }
 
   /** Register an existing database file already on disk, then refresh the list. */
@@ -221,9 +262,7 @@ class DatabaseStore {
   }
 
   /** Run a registry mutation, refresh the list, and return the mutation result. */
-  private async mutate(
-    op: () => Promise<DatabaseInfo>
-  ): Promise<DatabaseInfo | null> {
+  private async mutate(op: () => Promise<DatabaseInfo>): Promise<DatabaseInfo | null> {
     this.error = null;
     try {
       const result = await op();

--- a/packages/desktop-app/src/tests/stores/database.test.ts
+++ b/packages/desktop-app/src/tests/stores/database.test.ts
@@ -77,6 +77,9 @@ function db(id: string, overrides: Partial<DatabaseInfo> = {}): DatabaseInfo {
 describe('Database Store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The store gates `load()` on the Tauri bridge; present it so these tests
+    // exercise the invoke path. The browser-mode describe removes it.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
     databaseStore.databases = [];
     databaseStore.activeDatabaseId = null;
     databaseStore.defaultDatabaseId = null;
@@ -125,6 +128,23 @@ describe('Database Store', () => {
       mockInvoke.mockRejectedValueOnce(new Error('boom'));
       await databaseStore.load();
       expect(databaseStore.error).toContain('boom');
+    });
+  });
+
+  describe('load in browser dev mode (no Tauri bridge)', () => {
+    beforeEach(() => {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    });
+
+    it('presents a single implicit database without erroring or invoking', async () => {
+      await databaseStore.load();
+
+      // No registry query is attempted (the bridge, hence DatabaseService, is absent).
+      expect(mockInvoke).not.toHaveBeenCalledWith('list_databases');
+      expect(databaseStore.error).toBeNull();
+      expect(databaseStore.databases).toHaveLength(1);
+      expect(databaseStore.activeDatabaseId).toBe(databaseStore.databases[0].id);
+      expect(databaseStore.activeDatabase).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Problem

In `dev:browser`, `DatabaseStore.load()` called the Tauri `list_databases` invoke unconditionally. The Tauri bridge is absent there and the dev-proxy exposes no DatabaseService, so it threw `Cannot read properties of undefined (reading 'invoke')` at boot and the switcher rendered its failure fallback — blocking multi-database debugging in the officially supported dev loop (and the WKWebView debug target).

## Fix

Gate `load()` on the Tauri bridge (`__TAURI__` / `__TAURI_INTERNALS__` in window — the same probe the model, agent, and external-link surfaces already use). When it's absent, present a single implicit **Default** database instead of erroring: the dev-proxy binds to one daemon/database, so one concrete, non-switchable entry is accurate. The Tauri app, where the bridge is present, is unchanged.

## Tests

`load()` with no bridge yields one implicit database, no error, and no `list_databases` invoke. Existing `load` tests set the bridge present so they still exercise the invoke path. Full frontend suite + pre-push gate green locally.