### PR TITLE
Idempotent markdown re-import with --replace, plus stripped collection member titles (S3/S4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6043,6 +6043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7629,6 +7635,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.0", features = ["v4", "serde"] }
+uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 thiserror = "1.0"
 async-trait = "0.1"
 libsql = "0.6"

--- a/packages/cli/src/commands/import.rs
+++ b/packages/cli/src/commands/import.rs
@@ -34,6 +34,12 @@ pub struct ImportFileArgs {
     /// Route files to collections based on directory structure.
     #[arg(long)]
     pub auto_collection_routing: bool,
+
+    /// Refresh an already-imported document in place: replace its child subtree
+    /// from the fresh parse, keeping the root node so inbound links survive.
+    /// Without this, an already-imported document is left untouched.
+    #[arg(long)]
+    pub replace: bool,
 }
 
 #[derive(Args, Debug)]
@@ -56,6 +62,13 @@ pub struct ImportDirArgs {
     /// Directory names to exclude (repeatable, e.g. --exclude node_modules).
     #[arg(long = "exclude")]
     pub exclude_patterns: Vec<String>,
+
+    /// Refresh already-imported documents in place: replace each existing
+    /// document's child subtree from the fresh parse, keeping its root node so
+    /// inbound links survive. Without this, already-imported documents are
+    /// skipped (a plain re-import never duplicates).
+    #[arg(long)]
+    pub replace: bool,
 }
 
 pub async fn run(client: &mut ImportClient, action: ImportAction, json: bool) -> Result<()> {
@@ -91,6 +104,7 @@ async fn run_file(client: &mut ImportClient, args: ImportFileArgs, json: bool) -
         auto_collection_routing: args.auto_collection_routing,
         exclude_patterns: vec![],
         base_directory: String::new(),
+        replace: args.replace,
     };
 
     let mut stream = client
@@ -152,6 +166,7 @@ async fn run_dir(client: &mut ImportClient, args: ImportDirArgs, json: bool) -> 
         auto_collection_routing: args.auto_collection_routing,
         exclude_patterns: args.exclude_patterns,
         base_directory: args.directory,
+        replace: args.replace,
     };
 
     let mut stream = client
@@ -174,13 +189,13 @@ async fn run_dir(client: &mut ImportClient, args: ImportDirArgs, json: bool) -> 
         } else {
             eprintln!("[{}/9] {}: {}", event.step, event.step_name, event.message);
             if event.step == 9 {
-                let successful = event.results.iter().filter(|r| r.success).count();
-                let failed = event.results.len().saturating_sub(successful);
-                println!("Imported {}/{} files", successful, event.results.len());
-                if failed > 0 {
-                    for r in event.results.iter().filter(|r| !r.success) {
-                        println!("  ✗ {}: {}", r.file_path, r.error);
-                    }
+                // The daemon's summary is the source of truth — it distinguishes
+                // newly imported, refreshed (--replace), and already-present
+                // (skipped) documents, so a plain re-import reads honestly
+                // instead of claiming to have re-imported everything.
+                println!("{}", event.message);
+                for r in event.results.iter().filter(|r| !r.success) {
+                    println!("  ✗ {}: {}", r.file_path, r.error);
                 }
             }
         }

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -174,26 +174,33 @@ impl SqliteStore {
             return Ok(HashMap::new());
         }
 
-        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
-        let sql = format!(
-            "SELECT * FROM node WHERE id IN ({})",
-            placeholders.join(", ")
-        );
-
-        let params: Vec<libsql::Value> = ids
-            .iter()
-            .map(|id| libsql::Value::Text(id.clone()))
-            .collect();
-        let mut rows = self
-            .db
-            .query(&sql, params)
-            .await
-            .context("Failed to batch query nodes")?;
-
+        // Chunk under SQLite's ~999 bound-parameter ceiling; a large `IN (...)`
+        // would otherwise fail outright (a directory import can list thousands
+        // of files). Mirrors the chunking in the other bulk store queries.
+        const ID_CHUNK: usize = 900;
         let mut result = HashMap::new();
-        while let Some(row) = rows.next().await? {
-            let node = Self::row_to_node(&row)?;
-            result.insert(node.id.clone(), node);
+        for chunk in ids.chunks(ID_CHUNK) {
+            let placeholders: Vec<String> =
+                (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            let sql = format!(
+                "SELECT * FROM node WHERE id IN ({})",
+                placeholders.join(", ")
+            );
+
+            let params: Vec<libsql::Value> = chunk
+                .iter()
+                .map(|id| libsql::Value::Text(id.clone()))
+                .collect();
+            let mut rows = self
+                .db
+                .query(&sql, params)
+                .await
+                .context("Failed to batch query nodes")?;
+
+            while let Some(row) = rows.next().await? {
+                let node = Self::row_to_node(&row)?;
+                result.insert(node.id.clone(), node);
+            }
         }
         Ok(result)
     }
@@ -642,6 +649,33 @@ impl SqliteStore {
             )
             .await
             .context("Failed to delete children subtree")?;
+        Ok(())
+    }
+
+    /// Delete exactly the given node ids (and, via FK CASCADE, their
+    /// relationship/embedding rows). No OCC check — for internal system
+    /// operations. Used to prune a document's *previous* subtree during an
+    /// idempotent re-import only after the fresh subtree has been inserted, so
+    /// a failed insert never destroys the old content.
+    pub async fn delete_nodes_by_ids_unchecked(&self, ids: &[String]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        // Chunk under SQLite's ~999 bound-parameter ceiling.
+        const ID_CHUNK: usize = 900;
+        for chunk in ids.chunks(ID_CHUNK) {
+            let placeholders: Vec<String> =
+                (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            let sql = format!("DELETE FROM node WHERE id IN ({})", placeholders.join(", "));
+            let params: Vec<libsql::Value> = chunk
+                .iter()
+                .map(|id| libsql::Value::Text(id.clone()))
+                .collect();
+            self.db
+                .execute(&sql, params)
+                .await
+                .context("Failed to delete nodes by id")?;
+        }
         Ok(())
     }
 

--- a/packages/core/tests/reimport_store_primitives_test.rs
+++ b/packages/core/tests/reimport_store_primitives_test.rs
@@ -1,0 +1,88 @@
+//! Store primitives that back idempotent markdown re-import.
+//!
+//! - `get_nodes_by_ids` must chunk under SQLite's bound-parameter ceiling so a
+//!   large directory import (thousands of files) can check which roots already
+//!   exist without the `IN (...)` query blowing the ~999-parameter limit.
+//! - `delete_nodes_by_ids_unchecked` must delete exactly the ids it is given
+//!   (and cascade their relationships), leaving every other node untouched —
+//!   this is what lets a `--replace` prune the OLD subtree only after the fresh
+//!   one is inserted.
+
+use nodespace_core::db::SqliteStore;
+use nodespace_core::models::Node;
+use serde_json::json;
+use tempfile::TempDir;
+
+async fn create_test_db() -> (SqliteStore, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let store = SqliteStore::new(temp_dir.path().join("test.db"))
+        .await
+        .unwrap();
+    (store, temp_dir)
+}
+
+fn make_node(id: &str, node_type: &str, content: &str) -> Node {
+    Node::new_with_id(
+        id.to_string(),
+        node_type.to_string(),
+        content.to_string(),
+        json!({}),
+    )
+}
+
+/// Querying more ids than SQLite's bound-parameter ceiling must succeed and
+/// return every matching node — the query is chunked, not truncated or errored.
+#[tokio::test]
+async fn get_nodes_by_ids_chunks_past_the_sqlite_parameter_ceiling() {
+    let (store, _tmp) = create_test_db().await;
+
+    // Well over the ~999 bound-parameter limit / 900-row chunk size.
+    let ids: Vec<String> = (0..1500).map(|i| format!("node-{i:04}")).collect();
+    for id in &ids {
+        store
+            .create_node(make_node(id, "text", "x"), None, None)
+            .await
+            .unwrap();
+    }
+
+    let found = store.get_nodes_by_ids(&ids).await.unwrap();
+    assert_eq!(found.len(), ids.len(), "every id must be returned");
+    assert!(ids.iter().all(|id| found.contains_key(id)));
+}
+
+/// `delete_nodes_by_ids_unchecked` removes exactly the listed nodes and nothing
+/// else — the property that lets a `--replace` prune an old subtree by id while
+/// leaving the kept root and every unrelated document intact.
+#[tokio::test]
+async fn delete_nodes_by_ids_unchecked_removes_only_the_listed_ids() {
+    let (store, _tmp) = create_test_db().await;
+
+    for id in ["root", "old-0", "old-1", "old-2", "keep"] {
+        store
+            .create_node(make_node(id, "text", id), None, None)
+            .await
+            .unwrap();
+    }
+
+    // Prune two of the three "old" nodes.
+    store
+        .delete_nodes_by_ids_unchecked(&["old-0".to_string(), "old-1".to_string()])
+        .await
+        .unwrap();
+
+    assert!(store.get_node("old-0").await.unwrap().is_none());
+    assert!(store.get_node("old-1").await.unwrap().is_none());
+    assert!(
+        store.get_node("old-2").await.unwrap().is_some(),
+        "unlisted node kept"
+    );
+    assert!(store.get_node("root").await.unwrap().is_some(), "root kept");
+    assert!(
+        store.get_node("keep").await.unwrap().is_some(),
+        "unrelated node kept"
+    );
+
+    // An empty id list is a no-op, not an error.
+    store.delete_nodes_by_ids_unchecked(&[]).await.unwrap();
+    assert!(store.get_node("old-2").await.unwrap().is_some());
+}

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -513,7 +513,6 @@ async fn run_batch_import(
     // ========================================================================
 
     let unique_collections_count = unique_collections.len();
-    let successful_files_count = prepared_files.len();
     let all_mentions_count = all_mentions.len();
     let replace = opts.replace;
     let store = Arc::clone(node_service.store());
@@ -578,8 +577,20 @@ async fn run_batch_import(
         let mut collection_assignments: Vec<(String, String)> = Vec::new();
         let mut replaced_roots: Vec<String> = Vec::new();
         let mut skipped_roots: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut new_docs: usize = 0;
+        // Old child ids of replaced docs, pruned only AFTER the fresh subtree is
+        // inserted so a failed insert never destroys the previous content (the
+        // bulk insert is not transactional). See the prune step below.
+        let mut prune_after_insert: Vec<String> = Vec::new();
+        // Same deterministic root id can appear twice in one batch (a duplicated
+        // or symlinked file); handle each document once so we never double-insert
+        // or double-prune.
+        let mut seen_roots: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for prepared in &prepared_files {
+            if !seen_roots.insert(prepared.root_id.clone()) {
+                continue;
+            }
             let exists = existing_roots.contains(&prepared.root_id);
 
             if exists && !replace {
@@ -589,17 +600,9 @@ async fn run_batch_import(
                 // doc that lost its edge in a prior partial import self-heals.
                 skipped_roots.insert(prepared.root_id.clone());
             } else if exists && replace {
-                // Refresh in place: drop the stale child subtree, then keep and
-                // update the root node so inbound links/mentions survive. The
-                // fresh children are (re)created via the bulk insert below.
-                if let Err(e) = store
-                    .delete_children_subtree_unchecked(&prepared.root_id)
-                    .await
-                {
-                    tracing::error!("Failed to clear subtree for {}: {:?}", prepared.root_id, e);
-                    phase2_error
-                        .get_or_insert_with(|| format!("Subtree replace failed: {e}"));
-                }
+                // Refresh in place. Update the root now (non-destructive) so its
+                // id and inbound links/mentions survive, and capture its current
+                // children to prune only after the fresh subtree is inserted.
                 let update = nodespace_core::NodeUpdate::new()
                     .with_content(prepared.root_content.clone());
                 if let Err(e) = store
@@ -607,6 +610,18 @@ async fn run_batch_import(
                     .await
                 {
                     tracing::warn!("Failed to refresh root {}: {}", prepared.root_id, e);
+                }
+                match node_service_clone.get_descendants(&prepared.root_id).await {
+                    Ok(desc) => prune_after_insert.extend(desc.into_iter().map(|n| n.id)),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to read existing subtree for {}: {:?}",
+                            prepared.root_id,
+                            e
+                        );
+                        phase2_error
+                            .get_or_insert_with(|| format!("Subtree replace failed: {e}"));
+                    }
                 }
                 replaced_roots.push(prepared.root_id.clone());
             } else {
@@ -623,6 +638,7 @@ async fn run_batch_import(
                     1.0,
                     root_props,
                 ));
+                new_docs += 1;
             }
 
             // Children are (re)created for new and replaced roots. Skipped roots
@@ -743,6 +759,21 @@ async fn run_batch_import(
             }
         }
 
+        // Now that the fresh subtrees are inserted, prune each replaced doc's
+        // OLD children. Deferring the delete to here (rather than before the
+        // insert) means a failed bulk insert leaves the previous content intact
+        // instead of truncating it — re-import is never destructive on error.
+        if !bulk_insert_failed && !prune_after_insert.is_empty() {
+            if let Err(e) = store.delete_nodes_by_ids_unchecked(&prune_after_insert).await {
+                tracing::error!(
+                    "Failed to prune {} stale node(s) after replace: {}",
+                    prune_after_insert.len(),
+                    e
+                );
+                phase2_error.get_or_insert_with(|| format!("Stale subtree prune failed: {e}"));
+            }
+        }
+
         // A replaced root keeps its id but gets a fresh child subtree, so its
         // content effectively changed — re-mark it stale so it re-embeds. New
         // roots already get their markers inside bulk_create_hierarchy_trusted.
@@ -779,9 +810,7 @@ async fn run_batch_import(
         let message = match &phase2_error {
             Some(err) => format!("Import completed with errors: {err}"),
             None => {
-                let new_files =
-                    successful_files_count - replaced_roots.len() - skipped_roots.len();
-                let mut summary = format!("Imported {new_files} files ({nodes_written} nodes)");
+                let mut summary = format!("Imported {new_docs} files ({nodes_written} nodes)");
                 if !replaced_roots.is_empty() {
                     summary.push_str(&format!(", {} refreshed", replaced_roots.len()));
                 }
@@ -1153,20 +1182,25 @@ async fn import_markdown_content(
 
     let mut nodes_created = 0;
 
+    // Old child ids captured before insert; pruned only after the fresh subtree
+    // lands, so a failed insert leaves the previous content intact.
+    let mut prune_after_insert: Vec<String> = Vec::new();
+
     if exists {
-        // Refresh in place: drop the stale child subtree, keep + update the root
-        // so inbound links/mentions survive.
-        node_service
-            .store()
-            .delete_children_subtree_unchecked(root_id)
-            .await
-            .map_err(|e| format!("Failed to clear existing subtree: {}", e))?;
+        // Refresh in place: keep + update the root (non-destructive) so inbound
+        // links/mentions survive, and capture its current children to prune only
+        // after the fresh subtree is inserted below.
         let update = nodespace_core::NodeUpdate::new().with_content(clean_title);
         node_service
             .store()
             .update_node(root_id, update, Some("import".to_string()))
             .await
             .map_err(|e| format!("Failed to refresh root node: {}", e))?;
+        let descendants = node_service
+            .get_descendants(root_id)
+            .await
+            .map_err(|e| format!("Failed to read existing subtree: {}", e))?;
+        prune_after_insert.extend(descendants.into_iter().map(|n| n.id));
     } else {
         let mut properties = serde_json::json!({});
         if is_archived {
@@ -1231,9 +1265,14 @@ async fn import_markdown_content(
         nodes_created += created_ids.len();
     }
 
-    // On replace, the root kept its id but got a fresh subtree — re-mark it
-    // stale so it re-embeds with the new content.
+    // On replace, prune the OLD children now that the fresh subtree is in place,
+    // and re-mark the (kept) root stale so it re-embeds with the new content.
     if exists {
+        node_service
+            .store()
+            .delete_nodes_by_ids_unchecked(&prune_after_insert)
+            .await
+            .map_err(|e| format!("Failed to prune stale subtree: {}", e))?;
         if let Err(e) = node_service
             .store()
             .create_stale_embedding_markers_bulk(&[root_id.to_string()])

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -28,6 +28,22 @@ use crate::services::database_manager::DatabaseManager;
 
 const CHANNEL_BUFFER: usize = 64;
 
+/// Stable namespace for deriving deterministic import root ids from a document's
+/// identity key (its base-directory-relative path). Re-importing the same file
+/// therefore addresses the same root node, which is what makes re-import
+/// idempotent (no duplicate documents, no orphan "ghost" roots). This UUID is
+/// arbitrary but MUST stay fixed — changing it re-keys every imported document.
+const IMPORT_ROOT_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x9a, 0x1d, 0x2b, 0x7c, 0x4e, 0x63, 0x5f, 0x81, 0xa2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29,
+]);
+
+/// Derive a document's root node id deterministically from its identity key.
+/// The key is the file's base-directory-relative path, so the same file yields
+/// the same root id across imports regardless of the absolute checkout path.
+fn deterministic_root_id(key: &str) -> String {
+    uuid::Uuid::new_v5(&IMPORT_ROOT_NAMESPACE, key.as_bytes()).to_string()
+}
+
 #[derive(Clone)]
 pub struct ImportServiceImpl {
     node_service: Arc<CoreNodeService>,
@@ -206,7 +222,29 @@ async fn import_single_file(
             .unwrap_or_else(|| "Untitled".to_string())
     };
 
-    match import_markdown_content(node_service, &title, &content, is_archived).await {
+    // Deterministic root id from the file's identity key (base-dir-relative
+    // path when a base is set, else the file path), so a re-import addresses
+    // the same document root.
+    let import_key = if opts.base_directory.is_empty() {
+        path.to_string_lossy().to_string()
+    } else {
+        path.strip_prefix(&opts.base_directory)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string()
+    };
+    let root_id = deterministic_root_id(&import_key);
+
+    match import_markdown_content(
+        node_service,
+        &root_id,
+        &title,
+        &content,
+        is_archived,
+        opts.replace,
+    )
+    .await
+    {
         Ok((root_id, nodes_created)) => {
             if let Some(ref coll) = collection {
                 let collection_service = CollectionService::new(node_service.store(), node_service);
@@ -381,7 +419,7 @@ async fn run_batch_import(
                 .unwrap_or_else(|| "Untitled".to_string())
         };
 
-        let root_id = uuid::Uuid::new_v4().to_string();
+        let root_id = deterministic_root_id(&file_read.relative_path);
 
         let root_content = if title.starts_with('#') {
             title.clone()
@@ -476,8 +514,8 @@ async fn run_batch_import(
 
     let unique_collections_count = unique_collections.len();
     let successful_files_count = prepared_files.len();
-    let total_nodes_count: usize = prepared_files.iter().map(|f| 1 + f.children.len()).sum();
     let all_mentions_count = all_mentions.len();
+    let replace = opts.replace;
     let store = Arc::clone(node_service.store());
     let node_service_clone = (*node_service).clone();
     let tx_bg = tx.clone();
@@ -514,6 +552,21 @@ async fn run_batch_import(
             }
         };
 
+        // Idempotent re-import: a document's root id is deterministic, so a
+        // matching id already in the store means this file was imported before.
+        // `--replace` refreshes it in place; without it, the existing document
+        // is left untouched (skipped) so a plain re-import never duplicates.
+        let root_ids: Vec<String> = prepared_files.iter().map(|p| p.root_id.clone()).collect();
+        let existing_roots: std::collections::HashSet<String> =
+            match store.get_nodes_by_ids(&root_ids).await {
+                Ok(map) => map.into_keys().collect(),
+                Err(e) => {
+                    tracing::error!("Failed to check for existing roots: {:?}", e);
+                    phase2_error.get_or_insert_with(|| format!("Existing-root check failed: {e}"));
+                    std::collections::HashSet::new()
+                }
+            };
+
         let mut all_nodes: Vec<(
             String,
             String,
@@ -523,36 +576,77 @@ async fn run_batch_import(
             serde_json::Value,
         )> = Vec::new();
         let mut collection_assignments: Vec<(String, String)> = Vec::new();
+        let mut replaced_roots: Vec<String> = Vec::new();
+        let mut skipped_roots: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for prepared in &prepared_files {
-            let mut root_props = serde_json::json!({});
-            if prepared.is_archived {
-                root_props["lifecycle_status"] = serde_json::json!("archived");
-            }
-            all_nodes.push((
-                prepared.root_id.clone(),
-                "header".to_string(),
-                prepared.root_content.clone(),
-                None,
-                1.0,
-                root_props,
-            ));
+            let exists = existing_roots.contains(&prepared.root_id);
 
-            for child in &prepared.children {
-                let parent = child
-                    .parent_id
-                    .clone()
-                    .or_else(|| Some(prepared.root_id.clone()));
+            if exists && !replace {
+                // Already imported and not refreshing: skip creating anything.
+                // The root stays a valid link target for other docs; only its
+                // (idempotent) collection membership is re-asserted below so a
+                // doc that lost its edge in a prior partial import self-heals.
+                skipped_roots.insert(prepared.root_id.clone());
+            } else if exists && replace {
+                // Refresh in place: drop the stale child subtree, then keep and
+                // update the root node so inbound links/mentions survive. The
+                // fresh children are (re)created via the bulk insert below.
+                if let Err(e) = store
+                    .delete_children_subtree_unchecked(&prepared.root_id)
+                    .await
+                {
+                    tracing::error!("Failed to clear subtree for {}: {:?}", prepared.root_id, e);
+                    phase2_error
+                        .get_or_insert_with(|| format!("Subtree replace failed: {e}"));
+                }
+                let update = nodespace_core::NodeUpdate::new()
+                    .with_content(prepared.root_content.clone());
+                if let Err(e) = store
+                    .update_node(&prepared.root_id, update, Some("import".to_string()))
+                    .await
+                {
+                    tracing::warn!("Failed to refresh root {}: {}", prepared.root_id, e);
+                }
+                replaced_roots.push(prepared.root_id.clone());
+            } else {
+                // New document: create the root node.
+                let mut root_props = serde_json::json!({});
+                if prepared.is_archived {
+                    root_props["lifecycle_status"] = serde_json::json!("archived");
+                }
                 all_nodes.push((
-                    child.id.clone(),
-                    child.node_type.clone(),
-                    child.content.clone(),
-                    parent,
-                    child.order,
-                    child.properties.clone(),
+                    prepared.root_id.clone(),
+                    "header".to_string(),
+                    prepared.root_content.clone(),
+                    None,
+                    1.0,
+                    root_props,
                 ));
             }
 
+            // Children are (re)created for new and replaced roots. Skipped roots
+            // keep their existing subtree, so contribute no children here.
+            if !(exists && !replace) {
+                for child in &prepared.children {
+                    let parent = child
+                        .parent_id
+                        .clone()
+                        .or_else(|| Some(prepared.root_id.clone()));
+                    all_nodes.push((
+                        child.id.clone(),
+                        child.node_type.clone(),
+                        child.content.clone(),
+                        parent,
+                        child.order,
+                        child.properties.clone(),
+                    ));
+                }
+            }
+
+            // Collection membership is idempotent (existing edges are skipped),
+            // so re-asserting it for every file — new, replaced, or skipped —
+            // both wires up new docs and repairs any that lost their edge.
             if let Some(ref coll_path) = prepared.collection_path {
                 if let Some(coll_id) = collection_map.get(coll_path) {
                     collection_assignments.push((prepared.root_id.clone(), coll_id.clone()));
@@ -571,6 +665,7 @@ async fn run_batch_import(
         )
         .await;
 
+        let nodes_written = all_nodes.len();
         let bulk_insert_failed = match node_service_clone
             .bulk_create_hierarchy_trusted(all_nodes)
             .await
@@ -648,6 +743,29 @@ async fn run_batch_import(
             }
         }
 
+        // A replaced root keeps its id but gets a fresh child subtree, so its
+        // content effectively changed — re-mark it stale so it re-embeds. New
+        // roots already get their markers inside bulk_create_hierarchy_trusted.
+        if !bulk_insert_failed && !replaced_roots.is_empty() {
+            if let Err(e) = store.create_stale_embedding_markers_bulk(&replaced_roots).await {
+                tracing::warn!(
+                    "Failed to re-mark {} replaced root(s) stale: {}",
+                    replaced_roots.len(),
+                    e
+                );
+            }
+        }
+
+        // Skipped documents (already present, no --replace) created no nodes.
+        // Reflect that in their per-file result so the count is honest.
+        for r in phase1_results.iter_mut() {
+            if let Some(ref rid) = r.root_id {
+                if skipped_roots.contains(rid) {
+                    r.nodes_created = 0;
+                }
+            }
+        }
+
         // Fold any phase-2 failure into the per-file results so the caller sees a
         // non-success outcome instead of a false "complete" — the disease behind
         // "nodes land with zero member_of edges while the CLI reports success".
@@ -660,10 +778,18 @@ async fn run_batch_import(
 
         let message = match &phase2_error {
             Some(err) => format!("Import completed with errors: {err}"),
-            None => format!(
-                "Imported {} files ({} nodes)",
-                successful_files_count, total_nodes_count
-            ),
+            None => {
+                let new_files =
+                    successful_files_count - replaced_roots.len() - skipped_roots.len();
+                let mut summary = format!("Imported {new_files} files ({nodes_written} nodes)");
+                if !replaced_roots.is_empty() {
+                    summary.push_str(&format!(", {} refreshed", replaced_roots.len()));
+                }
+                if !skipped_roots.is_empty() {
+                    summary.push_str(&format!(", {} already present", skipped_roots.len()));
+                }
+                summary
+            }
         };
         send_progress(
             &tx_bg,
@@ -984,16 +1110,18 @@ impl LocalFileImportResult {
 
 async fn import_markdown_content(
     node_service: &CoreNodeService,
+    root_id: &str,
     title: &str,
     content: &str,
     is_archived: bool,
+    replace: bool,
 ) -> Result<(String, usize), String> {
     use nodespace_core::services::CreateNodeParams;
 
-    let (_, clean_title) = if title.starts_with('#') {
-        ("header", title.to_string())
+    let clean_title = if title.starts_with('#') {
+        title.to_string()
     } else {
-        ("header", format!("# {}", title))
+        format!("# {}", title)
     };
 
     let content_for_children = {
@@ -1010,27 +1138,58 @@ async fn import_markdown_content(
     let prepared_nodes = prepare_nodes_from_markdown(&content_for_children, None)
         .map_err(|e| format!("Failed to parse markdown: {:?}", e))?;
 
-    let mut properties = serde_json::json!({});
-    if is_archived {
-        properties["lifecycle_status"] = serde_json::json!("archived");
+    // Idempotent re-import: the root id is deterministic, so an existing node
+    // means this document was imported before. `--replace` refreshes it;
+    // otherwise leave it untouched so a plain re-import never duplicates.
+    let exists = node_service
+        .get_node(root_id)
+        .await
+        .map_err(|e| format!("Failed to check existing document: {}", e))?
+        .is_some();
+
+    if exists && !replace {
+        return Ok((root_id.to_string(), 0));
     }
 
-    let root_id = node_service
-        .create_node_with_parent(CreateNodeParams {
-            id: None,
-            node_type: "header".to_string(),
-            content: clean_title,
-            parent_id: None,
-            position: nodespace_core::services::InsertPositionOwned::End,
-            properties,
-        })
-        .await
-        .map_err(|e| format!("Failed to create root node: {}", e))?;
+    let mut nodes_created = 0;
+
+    if exists {
+        // Refresh in place: drop the stale child subtree, keep + update the root
+        // so inbound links/mentions survive.
+        node_service
+            .store()
+            .delete_children_subtree_unchecked(root_id)
+            .await
+            .map_err(|e| format!("Failed to clear existing subtree: {}", e))?;
+        let update = nodespace_core::NodeUpdate::new().with_content(clean_title);
+        node_service
+            .store()
+            .update_node(root_id, update, Some("import".to_string()))
+            .await
+            .map_err(|e| format!("Failed to refresh root node: {}", e))?;
+    } else {
+        let mut properties = serde_json::json!({});
+        if is_archived {
+            properties["lifecycle_status"] = serde_json::json!("archived");
+        }
+        node_service
+            .create_node_with_parent(CreateNodeParams {
+                id: Some(root_id.to_string()),
+                node_type: "header".to_string(),
+                content: clean_title,
+                parent_id: None,
+                position: nodespace_core::services::InsertPositionOwned::End,
+                properties,
+            })
+            .await
+            .map_err(|e| format!("Failed to create root node: {}", e))?;
+        nodes_created += 1;
+    }
 
     if is_archived {
         if let Err(e) = node_service
             .store()
-            .update_lifecycle_status(&root_id, "archived")
+            .update_lifecycle_status(root_id, "archived")
             .await
         {
             tracing::warn!(
@@ -1040,8 +1199,6 @@ async fn import_markdown_content(
             );
         }
     }
-
-    let mut nodes_created = 1;
 
     if !prepared_nodes.is_empty() {
         let nodes_for_bulk: Vec<(
@@ -1054,7 +1211,7 @@ async fn import_markdown_content(
         )> = prepared_nodes
             .iter()
             .map(|n| {
-                let parent = n.parent_id.clone().or_else(|| Some(root_id.clone()));
+                let parent = n.parent_id.clone().or_else(|| Some(root_id.to_string()));
                 (
                     n.id.clone(),
                     n.node_type.clone(),
@@ -1074,7 +1231,19 @@ async fn import_markdown_content(
         nodes_created += created_ids.len();
     }
 
-    Ok((root_id, nodes_created))
+    // On replace, the root kept its id but got a fresh subtree — re-mark it
+    // stale so it re-embeds with the new content.
+    if exists {
+        if let Err(e) = node_service
+            .store()
+            .create_stale_embedding_markers_bulk(&[root_id.to_string()])
+            .await
+        {
+            tracing::warn!("Failed to re-mark replaced root {} stale: {}", root_id, e);
+        }
+    }
+
+    Ok((root_id.to_string(), nodes_created))
 }
 
 #[cfg(test)]
@@ -1083,8 +1252,37 @@ mod tests {
     use crate::services::SharedContext;
     use nodespace_agent::pty::PtySessionManager;
     use nodespace_core::services::EmbeddingScheduler;
+    use nodespace_core::SqliteStore;
     use nodespace_nlp_engine::EmbeddingService;
     use tokio::sync::watch;
+
+    /// Build a bare `NodeService` over a fresh on-disk store. The returned
+    /// `TempDir` owns the database file and must be kept alive for the test.
+    async fn new_service_and_dir() -> (CoreNodeService, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Arc::new(SqliteStore::new(dir.path().join("db")).await.unwrap());
+        let node_service = CoreNodeService::new(&mut store).await.unwrap();
+        (node_service, dir)
+    }
+
+    /// Drive `run_batch_import` to completion, draining its progress stream
+    /// until the terminal step-9 event (which the daemon sends only after every
+    /// phase-2 DB write has committed).
+    async fn run_batch_and_wait(
+        node_service: Arc<CoreNodeService>,
+        files: Vec<String>,
+        opts: ImportOptions,
+    ) {
+        let (tx, mut rx) = mpsc::channel::<Result<ImportProgressEvent, Status>>(CHANNEL_BUFFER);
+        run_batch_import(node_service, files, opts, tx).await;
+        while let Some(event) = rx.recv().await {
+            if let Ok(e) = event {
+                if e.step == 9 {
+                    break;
+                }
+            }
+        }
+    }
 
     fn test_context() -> SharedContext {
         let (_tx, model) = watch::channel::<Option<Arc<EmbeddingService>>>(None);
@@ -1159,6 +1357,157 @@ mod tests {
         assert_eq!(
             svc.import_markdown(req).await.unwrap_err().code(),
             tonic::Code::NotFound
+        );
+    }
+
+    /// A document's root id is a pure function of its base-directory-relative
+    /// path: the same path always yields the same (valid) id, different paths
+    /// yield different ids. This determinism is what makes re-import idempotent.
+    #[test]
+    fn deterministic_root_id_is_stable_and_path_sensitive() {
+        assert_eq!(
+            deterministic_root_id("architecture/system-overview.md"),
+            deterministic_root_id("architecture/system-overview.md"),
+        );
+        assert_ne!(
+            deterministic_root_id("architecture/system-overview.md"),
+            deterministic_root_id("architecture/data-layer.md"),
+        );
+        assert!(uuid::Uuid::parse_str(&deterministic_root_id("any/path.md")).is_ok());
+    }
+
+    /// Single-file path: a plain re-import of an unchanged file is a no-op (the
+    /// deterministic root id resolves to the same document, nothing is created,
+    /// nothing duplicates); `--replace` keeps that root id while refreshing its
+    /// child subtree from the fresh parse.
+    #[tokio::test]
+    async fn reimport_single_file_is_idempotent_and_replace_refreshes() {
+        let (ns, dir) = new_service_and_dir().await;
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        let path = src.join("guide.md");
+        std::fs::write(&path, "# Guide\n\nAlpha.\n\n## Section\n\nBeta.\n").unwrap();
+
+        let opts = ImportOptions {
+            base_directory: src.to_str().unwrap().to_string(),
+            ..Default::default()
+        };
+
+        // First import creates the document.
+        let r1 = import_single_file(&ns, &path, &opts).await;
+        assert!(r1.success, "first import failed: {:?}", r1.error);
+        assert!(r1.nodes_created > 0);
+        let root_id = r1.root_id.clone().expect("root id");
+        let headers_after_first = ns.store().count_nodes_by_type("header").await.unwrap();
+        let subtree_after_first = ns.get_descendants(&root_id).await.unwrap().len();
+        assert!(subtree_after_first > 0);
+
+        // Plain re-import: same root id, nothing created, no duplication.
+        let r2 = import_single_file(&ns, &path, &opts).await;
+        assert!(r2.success);
+        assert_eq!(r2.nodes_created, 0, "a plain re-import must create nothing");
+        assert_eq!(r2.root_id.as_deref(), Some(root_id.as_str()));
+        assert_eq!(
+            ns.store().count_nodes_by_type("header").await.unwrap(),
+            headers_after_first,
+            "a plain re-import must not duplicate any node",
+        );
+
+        // Edit the file (drop the section), re-import with --replace: the root
+        // id is kept (inbound links survive) and the subtree is refreshed.
+        std::fs::write(&path, "# Guide\n\nAlpha revised.\n").unwrap();
+        let opts_replace = ImportOptions {
+            replace: true,
+            ..opts.clone()
+        };
+        let r3 = import_single_file(&ns, &path, &opts_replace).await;
+        assert!(r3.success, "replace import failed: {:?}", r3.error);
+        assert_eq!(
+            r3.root_id.as_deref(),
+            Some(root_id.as_str()),
+            "replace keeps the root id",
+        );
+        assert!(
+            ns.get_node(&root_id).await.unwrap().is_some(),
+            "root node survives replace",
+        );
+        let subtree_after_replace = ns.get_descendants(&root_id).await.unwrap().len();
+        assert!(
+            subtree_after_replace < subtree_after_first,
+            "replace pruned the removed section (was {subtree_after_first}, now {subtree_after_replace})",
+        );
+        assert!(
+            ns.store().count_nodes_by_type("header").await.unwrap() <= headers_after_first,
+            "replace refreshes in place — it must never grow the document set",
+        );
+    }
+
+    /// Batch path (the `import dir` pipeline used for the docs corpus): a plain
+    /// re-import never duplicates, and `--replace` keeps each document's root id
+    /// (so an inbound `[[link]]` survives) and its collection membership.
+    #[tokio::test]
+    async fn batch_reimport_does_not_duplicate_and_replace_keeps_roots() {
+        let (ns, dir) = new_service_and_dir().await;
+        let ns = Arc::new(ns);
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.md"), "# Doc A\n\nSee [[Doc B]] for more.\n").unwrap();
+        std::fs::write(src.join("b.md"), "# Doc B\n\nBody of B.\n").unwrap();
+        let files = vec![
+            src.join("a.md").to_str().unwrap().to_string(),
+            src.join("b.md").to_str().unwrap().to_string(),
+        ];
+        let opts = ImportOptions {
+            base_directory: src.to_str().unwrap().to_string(),
+            auto_collection_routing: true,
+            ..Default::default()
+        };
+
+        // First import: both roots exist and are assigned to a collection.
+        run_batch_and_wait(Arc::clone(&ns), files.clone(), opts.clone()).await;
+        let id_a = deterministic_root_id("a.md");
+        let id_b = deterministic_root_id("b.md");
+        assert!(ns.get_node(&id_a).await.unwrap().is_some(), "Doc A created");
+        assert!(ns.get_node(&id_b).await.unwrap().is_some(), "Doc B created");
+        let headers_after_first = ns.store().count_nodes_by_type("header").await.unwrap();
+        assert!(
+            !ns.store().get_node_memberships(&id_a).await.unwrap().is_empty(),
+            "Doc A is assigned to a collection",
+        );
+
+        // Plain batch re-import: no duplication.
+        run_batch_and_wait(Arc::clone(&ns), files.clone(), opts.clone()).await;
+        assert_eq!(
+            ns.store().count_nodes_by_type("header").await.unwrap(),
+            headers_after_first,
+            "a plain batch re-import must not duplicate",
+        );
+        assert!(ns.get_node(&id_a).await.unwrap().is_some());
+        assert!(ns.get_node(&id_b).await.unwrap().is_some());
+
+        // Batch re-import with --replace: roots keep their ids, still no
+        // duplication, membership intact.
+        let opts_replace = ImportOptions {
+            replace: true,
+            ..opts.clone()
+        };
+        run_batch_and_wait(Arc::clone(&ns), files.clone(), opts_replace).await;
+        assert_eq!(
+            ns.store().count_nodes_by_type("header").await.unwrap(),
+            headers_after_first,
+            "replacing unchanged docs must keep the node count stable",
+        );
+        assert!(
+            ns.get_node(&id_a).await.unwrap().is_some(),
+            "Doc A root kept across replace",
+        );
+        assert!(
+            ns.get_node(&id_b).await.unwrap().is_some(),
+            "Doc B root kept across replace",
+        );
+        assert!(
+            !ns.store().get_node_memberships(&id_a).await.unwrap().is_empty(),
+            "collection membership survives replace",
         );
     }
 }

--- a/packages/daemon/tests/import_round_trip.rs
+++ b/packages/daemon/tests/import_round_trip.rs
@@ -109,6 +109,7 @@ async fn import_markdown_single_file_streams_progress_and_succeeds() {
                 auto_collection_routing: false,
                 exclude_patterns: vec![],
                 base_directory: String::new(),
+                replace: false,
             }),
         })
         .await
@@ -174,6 +175,7 @@ async fn import_markdown_files_batch_reports_all_results() {
                 auto_collection_routing: false,
                 exclude_patterns: vec![],
                 base_directory: tempdir.path().to_str().unwrap().to_string(),
+                replace: false,
             }),
         })
         .await

--- a/packages/desktop-app/src-tauri/src/commands/import.rs
+++ b/packages/desktop-app/src-tauri/src/commands/import.rs
@@ -26,6 +26,8 @@ pub struct ImportOptions {
     #[serde(default)]
     pub exclude_patterns: Vec<String>,
     pub base_directory: Option<String>,
+    #[serde(default)]
+    pub replace: bool,
 }
 
 impl ImportOptions {
@@ -36,6 +38,7 @@ impl ImportOptions {
             auto_collection_routing: self.auto_collection_routing,
             exclude_patterns: self.exclude_patterns,
             base_directory: self.base_directory.unwrap_or_default(),
+            replace: self.replace,
         }
     }
 }

--- a/packages/desktop-app/src/lib/stores/collections.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/collections.svelte.ts
@@ -2,6 +2,7 @@ import { collectionService, type CollectionInfo } from '$lib/services/collection
 import type { Node } from '$lib/types';
 import { createLogger } from '$lib/utils/logger';
 import { onDaemonReconnect } from '$lib/services/daemon-status';
+import { stripMarkdown } from '$lib/services/markdown-utils';
 
 const log = createLogger('CollectionsStore');
 
@@ -211,8 +212,10 @@ class CollectionsStore {
           .filter((node) => node.nodeType !== 'collection')
           .map((node) => ({
             id: node.id,
-            // Prefer title field (cleaned text without markdown) over raw content
-            name: node.title || node.content,
+            // Prefer the cleaned title; fall back to the node content with its
+            // markdown stripped so an imported header root shows "ACP Integration
+            // Architecture", not the raw "# ACP Integration Architecture".
+            name: node.title || stripMarkdown(node.content),
             nodeType: node.nodeType,
           }))
       );

--- a/packages/desktop-app/src/tests/stores/collections.test.ts
+++ b/packages/desktop-app/src/tests/stores/collections.test.ts
@@ -123,6 +123,35 @@ describe('Collections Store', () => {
       expect(members[0].name).toBe('AI-Powered Note Taking');
     });
 
+    it('strips the markdown heading marker from an untitled member (imported doc root)', () => {
+      // Imported header roots carry their heading in `content` ("# ACP...") and
+      // have no separate `title`, so the member list must strip the marker.
+      const untitledMembers = new Map<string, Node[]>([
+        [
+          'col-1',
+          [
+            {
+              id: 'imported-root',
+              content: '# ACP Integration Architecture',
+              title: '',
+              nodeType: 'header',
+              createdAt: new Date().toISOString(),
+              modifiedAt: new Date().toISOString(),
+              version: 1,
+              properties: {}
+            }
+          ]
+        ]
+      ]);
+      collectionsData._setTestData(flattenCollections(mockCollections), untitledMembers);
+
+      collectionsState.selectCollection('col-1');
+
+      const members = collectionsState.selectedCollectionMembers;
+      expect(members).toHaveLength(1);
+      expect(members[0].name).toBe('ACP Integration Architecture');
+    });
+
     it('selecting a different collection replaces the selection', () => {
       // Set up test data
       collectionsData._setTestData(flattenCollections(mockCollections), createTestMembers());

--- a/packages/proto/proto/import_service.proto
+++ b/packages/proto/proto/import_service.proto
@@ -37,6 +37,13 @@ message ImportOptions {
   // Base directory for relative path calculation in auto-routing.
   // Empty string = use the import directory.
   string base_directory = 5;
+  // Re-import behavior. Each document's root id is derived deterministically
+  // from its base-directory-relative path, so a re-import addresses the same
+  // root. When true, an already-imported document has its child subtree
+  // replaced from the fresh parse while the root node is kept, so inbound
+  // links/mentions to the doc root survive and nothing is duplicated. When
+  // false (default), an already-imported document is left untouched (skipped).
+  bool replace = 6;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the remaining work on the readable-docs import pipeline: **S3 idempotent re-import** and **S4 title polish**. With S1 (phase-2 failure surfacing) and the S2 mermaid-label fix already merged, this makes refreshing the docs corpus a safe, repeatable, one-command operation.

## S3 — Idempotent re-import

Each imported document's root node id is now **deterministic** — a UUIDv5 of the file's base-directory-relative path — so a re-import addresses the *same* root instead of minting a new one. Phase 2 detects roots that already exist:

- **Plain re-import** leaves an already-imported document untouched (skipped) — no duplicate documents, no orphan "ghost" roots.
- **`--replace`** drops the stale child subtree and **keeps the root node** (so inbound `[[links]]`/mentions to the doc root survive), recreates children from the fresh parse, and re-marks the root's embedding stale.
- Collection membership is re-asserted idempotently on every run, so a doc that lost its `member_of` edge in a prior partial import self-heals.

The `replace` option is threaded through the proto, the CLI (`nodespace import dir --replace`), the Tauri import command (so the desktop/Pro path gets it too), and both the batch and single-file daemon paths. The `import dir` summary now reports the honest daemon result (new / refreshed / already-present) instead of always claiming to have re-imported everything.

## S4 — Title polish

Collection member lists rendered imported header roots as raw markdown (`# ACP Integration Architecture`) because those nodes carry the heading in `content` with no separate `title`. The member list now falls back to the content with its markdown stripped. (Tab titles already strip the marker via `formatTabTitle`.)

## S2 — Render smoke

The mermaid-label fix is already merged and is directly guarded by hermetic unit tests (`mermaid-render.test.ts`: `<foreignObject>` stripped, native `<text>`/label text preserved, `htmlLabels:false` on flowchart + class). A corpus-walking E2E test was intentionally **not** added — it would depend on a non-hermetic sibling docs checkout and duplicate coverage the unit tests already lock.

## Testing

- **New Rust tests** (`import_service.rs`): deterministic id is stable & path-sensitive; single-file re-import is a no-op and `--replace` refreshes in place; batch re-import never duplicates and `--replace` keeps every root id + collection membership.
- **New frontend test** (`collections.test.ts`): an untitled imported doc root renders with the heading marker stripped.
- **Live smoke on the real `nodespaced` + `nodespace` binaries** against the actual architecture docs (29 files): fresh import → 29 roots / 2976 nodes; plain re-import → **exactly** 29 / 2976 (zero duplication — the original defect created ~2805 ghost nodes); `--replace` → 29 / 2976 with membership intact.
- Local: frontend `4050/4050`, `cargo test` for core + daemon + cli green, full pre-push gate green.

Closes #1651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
