### PR TITLE
Demo hardening: CLI auto-discovers the daemon socket; collection page reachable from the sidebar

### DIFF
--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -163,9 +163,32 @@ pub fn resolve_socket_path(override_: Option<&str>) -> std::path::PathBuf {
         return std::path::PathBuf::from(p);
     }
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    std::path::PathBuf::from(home)
-        .join(".nodespace")
-        .join("daemon.sock")
+    discover_socket_in(&std::path::PathBuf::from(home).join(".nodespace"))
+}
+
+/// Pick the daemon socket to dial when none is set explicitly. The daemon socket
+/// filename is scoped by the app's build variant (release/dev × community/Pro),
+/// so a running dev or Pro app does not listen on the canonical `daemon.sock`.
+/// Prefer the canonical path, but if it is absent, auto-discover a running
+/// daemon of another variant so the CLI works against whichever app is open
+/// without needing `NODESPACED_SOCKET`. When none exist, return the canonical
+/// path so the caller reports a clean "is the daemon running?" error.
+#[cfg(unix)]
+fn discover_socket_in(dir: &std::path::Path) -> std::path::PathBuf {
+    // Order = preference: canonical first, then the other build variants.
+    const VARIANTS: [&str; 4] = [
+        "daemon.sock",         // release community (canonical / CLI default)
+        "daemon-pro.sock",     // release Pro
+        "daemon-dev.sock",     // dev community
+        "daemon-dev-pro.sock", // dev Pro
+    ];
+    for name in VARIANTS {
+        let candidate = dir.join(name);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    dir.join(VARIANTS[0])
 }
 
 /// Build a tonic `Channel` connected over a Unix Domain Socket.
@@ -360,5 +383,31 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::database::run(&mut client, action, json).await
         }
         Command::Uninstall(args) => commands::uninstall::run(args),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::discover_socket_in;
+
+    /// With no socket set, the CLI dials the canonical `daemon.sock` when it
+    /// exists, otherwise auto-discovers whichever build-variant daemon is
+    /// actually running, and falls back to the canonical path (for a clean
+    /// error) when none exist.
+    #[test]
+    fn discover_socket_prefers_canonical_then_falls_back_to_a_variant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        // Nothing running → canonical default (so the connect error is clean).
+        assert_eq!(discover_socket_in(dir), dir.join("daemon.sock"));
+
+        // Only a dev-Pro daemon is up → discover it without NODESPACED_SOCKET.
+        std::fs::write(dir.join("daemon-dev-pro.sock"), b"").unwrap();
+        assert_eq!(discover_socket_in(dir), dir.join("daemon-dev-pro.sock"));
+
+        // Canonical present → always preferred over the variants.
+        std::fs::write(dir.join("daemon.sock"), b"").unwrap();
+        assert_eq!(discover_socket_in(dir), dir.join("daemon.sock"));
     }
 }

--- a/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
+++ b/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
@@ -15,9 +15,11 @@
     members: CollectionMember[];
     onClose: () => void;
     onNodeClick: (_nodeId: string, _nodeType: string) => void;
+    /** Open the collection's own page (Contents / Collaboration tabs). */
+    onOpenCollection: () => void;
   }
 
-  let { open, collectionName, members, onClose, onNodeClick }: Props = $props();
+  let { open, collectionName, members, onClose, onNodeClick, onOpenCollection }: Props = $props();
 
   function getNodeIcon(nodeType: string): 'calendar' | 'circle' | 'text' {
     const iconMap: Record<string, 'calendar' | 'circle' | 'text'> = {
@@ -31,7 +33,14 @@
 
 <div class="sub-panel" class:open>
   <div class="sub-panel-header">
-    <span class="sub-panel-title">{collectionName}</span>
+    <button
+      class="sub-panel-title"
+      onclick={onOpenCollection}
+      title="Open collection (manage members & collaboration)"
+    >
+      <span class="sub-panel-title-text">{collectionName}</span>
+      <Icon name="chevronRight" size={14} />
+    </button>
     <button class="close-btn" onclick={onClose} aria-label="Close panel">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M18 6L6 18M6 6l12 12" />
@@ -91,9 +100,27 @@
   }
 
   .sub-panel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
     font-size: 0.875rem;
     font-weight: 600;
     color: hsl(var(--foreground));
+    background: none;
+    border: none;
+    padding: 0.125rem 0.25rem;
+    margin: -0.125rem -0.25rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .sub-panel-title:hover {
+    background: hsl(var(--border));
+  }
+
+  .sub-panel-title-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -580,6 +580,9 @@
       members={collectionMembers}
       onClose={handleCloseSubPanel}
       onNodeClick={handleNodeClick}
+      onOpenCollection={() => {
+        if (collectionForPanel) handleNodeClick(collectionForPanel.id, 'collection');
+      }}
     />
   </div>
 

--- a/packages/desktop-app/src/tests/components/collection-sub-panel.test.ts
+++ b/packages/desktop-app/src/tests/components/collection-sub-panel.test.ts
@@ -1,0 +1,47 @@
+/**
+ * collection-sub-panel component.
+ *
+ * The fly-out that previews a collection's members. Clicking the panel title
+ * opens the collection's own page (Contents / Collaboration tabs) — the
+ * reachable path to the collaboration/admin UI — while clicking a member row
+ * opens that member node.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+import CollectionSubPanel from '$lib/components/layout/collection-sub-panel.svelte';
+
+function baseProps() {
+  return {
+    open: true,
+    collectionName: 'Architecture',
+    members: [{ id: 'm1', name: 'System Overview', nodeType: 'header' }],
+    onClose: vi.fn(),
+    onNodeClick: vi.fn(),
+    onOpenCollection: vi.fn()
+  };
+}
+
+describe('CollectionSubPanel', () => {
+  afterEach(() => cleanup());
+
+  it('opens the collection page when the title is clicked', async () => {
+    const props = baseProps();
+    const { getByRole } = render(CollectionSubPanel, { props });
+
+    await fireEvent.click(getByRole('button', { name: /Architecture/i }));
+
+    expect(props.onOpenCollection).toHaveBeenCalledTimes(1);
+    expect(props.onNodeClick).not.toHaveBeenCalled();
+  });
+
+  it('opens a member node when its row is clicked', async () => {
+    const props = baseProps();
+    const { getByRole } = render(CollectionSubPanel, { props });
+
+    await fireEvent.click(getByRole('button', { name: /System Overview/i }));
+
+    expect(props.onNodeClick).toHaveBeenCalledWith('m1', 'header');
+    expect(props.onOpenCollection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two small UX fixes that remove real friction when driving NodeSpace from the CLI + desktop app together (surfaced while writing a demo runbook).

## 1. CLI auto-discovers the daemon socket

The daemon socket filename is scoped by the app's build variant — `daemon.sock` (release community), `daemon-pro.sock`, `daemon-dev.sock`, `daemon-dev-pro.sock` (`src-tauri/src/daemon_setup.rs:64-76`). The CLI only ever dialed the canonical `daemon.sock`, so against a **dev** or **Pro** app it failed to connect unless you set `NODESPACED_SOCKET` by hand — which meant a `nodespace import …` wouldn't show up in a running dev/Pro GUI.

`resolve_socket_path` now prefers the canonical path but, when it's absent, discovers whichever variant socket actually exists, so the CLI just works against whichever app is open. Falls back to the canonical path (for a clean "is the daemon running?" error) when none exist. Unit-tested.

## 2. The collaboration/admin page is reachable again

Clicking a collection in the sidebar opened only a members-preview fly-out, with no way to reach the collection's **own page** — where the **Contents** and **Collaboration** (membership/admin) tabs live. Collection nodes aren't returned by semantic search either, so that page was effectively unreachable from the UI.

The fly-out title is now a button that opens the collection page (reusing the existing node-open path with the `collection` node type). Component-tested (title opens the page; member rows still open member nodes).

## Testing
- New Rust test: socket discovery prefers canonical, falls back to a running variant, else the canonical default.
- New frontend test: fly-out title opens the collection page; member rows still open member nodes.
- Full pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
