### PR TITLE
Reorder the first-Pro consent flow to sign-in-first

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-locked.svelte
@@ -1,17 +1,26 @@
 <!--
   Collaboration locked placeholder.
 
-  Shown in the collection viewer's Collaboration tab for the `enable-prompt`
-  variant — a Pro daemon whose active database has `sync_enabled: false`. People &
-  roles live in the cloud tenant a database is bound to, so there is nothing to
-  show until sync is enabled. Purely static: no membership calls, no daemon
-  commands. Accepts the host collection's `nodeId` for a uniform viewer-extension
-  signature (surfaced as a data attribute for debugging).
+  Shown in the collection viewer's Collaboration tab for the `sign-in` and
+  `consent` variants — a Pro daemon whose active database has `sync_enabled:
+  false`. People & roles live in the cloud tenant a database is bound to, so there
+  is nothing to show until sync is enabled. Purely static: no membership calls, no
+  daemon commands. Accepts the host collection's `nodeId` for a uniform
+  viewer-extension signature (surfaced as a data attribute for debugging).
+
+  The action depends on where the user is in the sign-in-first flow: once signed
+  in (`consent`) the button reopens the publish-consent modal (mounted for that
+  variant); before sign-in (`sign-in`) there is no consent slot to open, so it
+  points the user at the toolbar sync button to sign in first.
 -->
 <script lang="ts">
   import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { resolveProSyncVariant } from '$lib/plugins/ui-extensions.svelte';
 
   let { nodeId }: { nodeId: string } = $props();
+
+  // Signed in but not yet opted into sync ⇒ the consent modal is available here.
+  const canConsent = $derived(resolveProSyncVariant() === 'consent');
 
   function openConsent() {
     proSync.consentPromptOpen = true;
@@ -21,11 +30,18 @@
 <div class="collab-locked" data-collection-id={nodeId}>
   <div class="lock" aria-hidden="true">🔒</div>
   <p class="headline">Collaboration is off for this database</p>
-  <p class="detail">
-    Enable cloud sync for this database to invite people, manage roles, and share
-    collections.
-  </p>
-  <button class="enable-btn" type="button" onclick={openConsent}> Enable sync </button>
+  {#if canConsent}
+    <p class="detail">
+      Turn on sync for this database to invite people, manage roles, and share
+      collections.
+    </p>
+    <button class="enable-btn" type="button" onclick={openConsent}> Turn on sync </button>
+  {:else}
+    <p class="detail">
+      Sign in from the sync button in the toolbar, then turn on sync to invite
+      people, manage roles, and share collections.
+    </p>
+  {/if}
 </div>
 
 <style>

--- a/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/enable-sync-pill.svelte
@@ -1,12 +1,13 @@
 <!--
-  Enable-sync prompt.
+  Turn-on-sync prompt.
 
-  Rendered in the app-shell overlay slot for the `enable-prompt` variant — a Pro
-  daemon whose active database has `sync_enabled: false`. Clicking opens the
-  first-Pro data-sharing consent modal (rendered by `first-pro-consent-slot` in
-  the app-shell modal slot for the same variant), which is where the user makes
-  the informed, irreversible choice to merge into the public workspace. Nothing
-  leaves the device until they opt in there.
+  Rendered in the app-shell overlay slot for the `consent` variant — a Pro daemon
+  whose active database is signed in but has not yet opted into sync. Clicking
+  (re)opens the first-Pro data-sharing consent modal (rendered by
+  `first-pro-consent-slot` in the app-shell modal slot for the same variant),
+  which is where the user makes the informed, irreversible choice to publish this
+  database into the shared public workspace. Nothing leaves the device until they
+  opt in there.
 
   Never rendered in the community build (that resolves to `teaser`), so touching
   Pro state here is safe.
@@ -22,12 +23,12 @@
 <button
   class="enable-sync-pill"
   type="button"
-  title="Turn on cloud sync for this database"
-  aria-label="Enable cloud sync for this database"
+  title="Publish this database to the shared public workspace"
+  aria-label="Turn on sync: publish this database to the shared public workspace"
   onclick={openConsent}
 >
   <span class="dot" aria-hidden="true"></span>
-  <span class="label">Enable sync</span>
+  <span class="label">Turn on sync</span>
 </button>
 
 <style>

--- a/packages/desktop-app/src/lib/components/first-pro-consent-modal.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-modal.svelte
@@ -16,7 +16,8 @@
   interface Props {
     /** Whether the modal is visible. */
     open?: boolean;
-    /** True while the enable-sync / sign-in calls are in flight — disables the buttons. */
+    /** True while the enable-sync call is in flight — disables the merge button
+     * (Keep local stays actionable so a decline is never a no-op). */
     pending?: boolean;
     /** Opt in: merge this database into the public workspace (irreversible). */
     onMerge: () => void;
@@ -72,7 +73,9 @@
       </label>
 
       <div class="consent-actions">
-        <button class="btn btn-secondary" type="button" onclick={handleKeepLocal} disabled={pending}>
+        <!-- Never disabled: declining must always register, even mid-merge, so a
+             click can't be swallowed into a silent no-op. -->
+        <button class="btn btn-secondary" type="button" onclick={handleKeepLocal}>
           Keep this database local-only
         </button>
         <button

--- a/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
@@ -19,23 +19,55 @@
   import { invoke } from '@tauri-apps/api/core';
   import FirstProConsentModal from '$lib/components/first-pro-consent-modal.svelte';
   import { proSync } from '$lib/stores/pro-sync.svelte';
+  import { databaseStore } from '$lib/stores/database.svelte';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('FirstProConsentSlot');
 
   const KEPT_LOCAL_NOTICE_MS = 4000;
+  // Per-database "declined the publish consent" marker, so a Keep-local choice
+  // survives a webview reload / app restart instead of re-popping this irreversible
+  // dialog every launch. Keyed by database id — the decision is per-database.
+  const DECLINE_KEY_PREFIX = 'ns:consent-declined:';
+
+  function declineKeyFor(id: string | null): string | null {
+    return id ? DECLINE_KEY_PREFIX + id : null;
+  }
+
+  function hasPersistedDecline(id: string | null): boolean {
+    const key = declineKeyFor(id);
+    if (!key) return false;
+    try {
+      return typeof localStorage !== 'undefined' && localStorage.getItem(key) === '1';
+    } catch {
+      return false; // storage unavailable — fall back to showing the consent
+    }
+  }
+
+  function persistDecline(id: string | null): void {
+    const key = declineKeyFor(id);
+    if (!key) return;
+    try {
+      if (typeof localStorage !== 'undefined') localStorage.setItem(key, '1');
+    } catch {
+      /* ignore — an unpersisted decline still holds for this session */
+    }
+  }
 
   let pending = $state(false);
   let showKeptLocalNotice = $state(false);
   let noticeTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Auto-open once per fresh sign-in episode (unless declined this episode), plus
-  // any manual reopen via the enable-sync pill. Derived from the episode counter
-  // rather than pushed by an effect (ADR-049): a decline sets
-  // `consentDeclinedEpisode` to the current episode, and a later sign-out/in bumps
-  // `signedInEpisode` so the prompt returns for the new session.
+  // Auto-open once per fresh sign-in episode (unless declined), plus any manual
+  // reopen via the enable-sync pill. Derived from the episode counter rather than
+  // pushed by an effect (ADR-049). A decline is honoured two ways: in-session via
+  // `consentDeclinedEpisode`, and across reloads via a persisted per-database
+  // marker — so the modal is a one-time nudge, not a per-launch pop-up. The pill
+  // remains available to reopen it deliberately.
   const autoOpen = $derived(
-    proSync.signedInEpisode > 0 && proSync.signedInEpisode !== proSync.consentDeclinedEpisode
+    proSync.signedInEpisode > 0 &&
+      proSync.signedInEpisode !== proSync.consentDeclinedEpisode &&
+      !hasPersistedDecline(databaseStore.activeDatabaseId)
   );
   const open = $derived(proSync.isPro && (proSync.consentPromptOpen || autoOpen));
 
@@ -59,11 +91,13 @@
 
   function handleKeepLocal() {
     // Decline: leave sync disabled and share nothing, but stay signed in. Record the
-    // decline for this sign-in episode so the auto-open doesn't immediately reopen,
-    // and surface a brief confirmation so the choice visibly registers. The pill
-    // remains, so the user can revisit this later.
+    // decline for this sign-in episode (so the auto-open doesn't immediately reopen)
+    // and persist it per-database (so a reload/restart doesn't re-pop the dialog), and
+    // surface a brief confirmation so the choice visibly registers. The pill remains,
+    // so the user can revisit this later.
     proSync.consentPromptOpen = false;
     proSync.consentDeclinedEpisode = proSync.signedInEpisode;
+    persistDecline(databaseStore.activeDatabaseId);
     showKeptLocalNotice = true;
     if (noticeTimer) clearTimeout(noticeTimer);
     noticeTimer = setTimeout(() => {

--- a/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
@@ -1,11 +1,16 @@
 <!--
   First-Pro consent slot.
 
-  Registry wrapper contributed to the `app-shell-modal` slot for the
-  `enable-prompt` variant (a Pro daemon whose active database has sync disabled).
-  Owns the enable-sync / sign-in orchestration and mounts the presentational
-  `FirstProConsentModal`. Visibility is driven off `proSync.consentPromptOpen`,
-  which the enable-sync pill (and the locked Collaboration placeholder) set.
+  Registry wrapper contributed to the `app-shell-modal` slot for the `consent`
+  variant — a Pro daemon whose active database is signed in but has not yet opted
+  into sync. Owns the enable-sync action and mounts the presentational
+  `FirstProConsentModal`.
+
+  Sign-in has already happened by the time this slot mounts (the sign-in-first
+  flow), so the modal only decides the public-workspace publish. It auto-opens
+  once per fresh sign-in episode; a "Keep local" decline records that episode so
+  it doesn't immediately reopen, while the enable-sync pill can reopen it. A brief
+  status line confirms the decline registered.
 
   Never rendered in the community build (that resolves to `teaser`), so invoking
   Pro commands here is safe.
@@ -18,33 +23,81 @@
 
   const log = createLogger('FirstProConsentSlot');
 
-  let pending = $state(false);
+  const KEPT_LOCAL_NOTICE_MS = 4000;
 
-  const open = $derived(proSync.isPro && proSync.consentPromptOpen);
+  let pending = $state(false);
+  let showKeptLocalNotice = $state(false);
+  let noticeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Auto-open once per fresh sign-in episode (unless declined this episode), plus
+  // any manual reopen via the enable-sync pill. Derived from the episode counter
+  // rather than pushed by an effect (ADR-049): a decline sets
+  // `consentDeclinedEpisode` to the current episode, and a later sign-out/in bumps
+  // `signedInEpisode` so the prompt returns for the new session.
+  const autoOpen = $derived(
+    proSync.signedInEpisode > 0 && proSync.signedInEpisode !== proSync.consentDeclinedEpisode
+  );
+  const open = $derived(proSync.isPro && (proSync.consentPromptOpen || autoOpen));
 
   async function handleMerge() {
     if (pending) return;
     pending = true;
     try {
-      // Record the merge consent first (flips sync_enabled for this database),
-      // then start sign-in so the daemon can bind the tenant and push. The daemon
-      // only pushes once sync is enabled, so nothing has left the device before
-      // this point.
+      // The user is already signed in (sign-in precedes this consent), so this only
+      // records the publish consent — it flips `sync_enabled` for this database, and
+      // the daemon's push sweep, gated on that flag, uploads the graph. Nothing has
+      // left the device before this point.
       await invoke('pro_enable_sync');
-      await invoke('pro_initiate_oauth');
     } catch (e) {
       log.warn('first-pro consent: enabling sync failed', { error: e });
     } finally {
       pending = false;
       proSync.consentPromptOpen = false;
+      // Enabling flips the variant to `connected`, unmounting this slot.
     }
   }
 
   function handleKeepLocal() {
-    // Decline: leave sync disabled, share nothing. The pill remains, so the user
-    // can revisit this choice later.
+    // Decline: leave sync disabled and share nothing, but stay signed in. Record the
+    // decline for this sign-in episode so the auto-open doesn't immediately reopen,
+    // and surface a brief confirmation so the choice visibly registers. The pill
+    // remains, so the user can revisit this later.
     proSync.consentPromptOpen = false;
+    proSync.consentDeclinedEpisode = proSync.signedInEpisode;
+    showKeptLocalNotice = true;
+    if (noticeTimer) clearTimeout(noticeTimer);
+    noticeTimer = setTimeout(() => {
+      showKeptLocalNotice = false;
+      noticeTimer = null;
+    }, KEPT_LOCAL_NOTICE_MS);
   }
+
+  // Clear a pending notice timer if the slot unmounts (e.g. the user enables sync).
+  $effect(() => () => {
+    if (noticeTimer) clearTimeout(noticeTimer);
+  });
 </script>
 
 <FirstProConsentModal {open} {pending} onMerge={handleMerge} onKeepLocal={handleKeepLocal} />
+
+{#if showKeptLocalNotice}
+  <div class="kept-local-notice" role="status" aria-live="polite">Kept local — sync stays off</div>
+{/if}
+
+<style>
+  .kept-local-notice {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    padding: 8px 16px;
+    border-radius: 8px;
+    background: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
+    border: 1px solid hsl(var(--border));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+    font-size: 13px;
+    font-weight: 500;
+  }
+</style>

--- a/packages/desktop-app/src/lib/plugins/pro-plugin.ts
+++ b/packages/desktop-app/src/lib/plugins/pro-plugin.ts
@@ -6,17 +6,23 @@
  * variant of the two-signal state machine (see `ui-extensions.svelte.ts`) to the
  * component that renders it:
  *
- *   | variant        | overlay pill              | modal              | collection tab              |
- *   |----------------|---------------------------|--------------------|-----------------------------|
- *   | teaser         | pro-teaser-pill (upsell)  | —                  | — (none)                    |
- *   | enable-prompt  | enable-sync-pill          | first-pro-consent  | collaboration-locked        |
- *   | sign-in        | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
- *   | connected      | pro-sync-pill (existing)  | pro-relogin-slot   | collaboration-tab           |
+ *   | variant     | overlay pill              | modal              | collection tab       |
+ *   |-------------|---------------------------|--------------------|----------------------|
+ *   | teaser      | pro-teaser-pill (upsell)  | —                  | — (none)             |
+ *   | sign-in     | pro-sync-pill (OAuth)     | —                  | collaboration-locked |
+ *   | consent     | enable-sync-pill          | first-pro-consent  | collaboration-locked |
+ *   | relogin     | pro-sync-pill             | pro-relogin-slot   | collaboration-tab    |
+ *   | connected   | pro-sync-pill             | pro-relogin-slot   | collaboration-tab    |
+ *
+ * The flow is sign-in-first: `sign-in` starts OAuth from the pill; once
+ * authenticated the database becomes `consent`, where the first-Pro modal asks
+ * for the public-workspace publish decision (merge flips `sync_enabled`); after
+ * that it is `connected` (or `relogin` if the session later lapses).
  *
  * Every component is referenced only through `() => import(...)`, so nothing Pro
  * is imported eagerly — the shared shell stays free of Pro component imports.
  * Existing Pro components (`pro-sync-pill`, `pro-relogin-modal`,
- * `collaboration-view`) are mounted unchanged; the new small wrappers
+ * `collaboration-view`) are mounted unchanged; the small wrappers
  * (`pro-relogin-slot`, `collaboration-tab`) exist only to move their mounting
  * behind the registry.
  *
@@ -39,14 +45,22 @@ export const proSyncUiExtension: UiExtensionDefinition = {
       variant: 'teaser',
       lazyLoad: () => import('$lib/components/pro-teaser-pill.svelte')
     },
+    // Not signed in yet: the sync pill drives OAuth (sign-in-first).
     {
       slot: 'app-shell-overlay',
-      variant: 'enable-prompt',
+      variant: 'sign-in',
+      lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
+    },
+    // Signed in, publish decision pending: the enable-sync pill re-opens the
+    // consent modal if the user dismissed it.
+    {
+      slot: 'app-shell-overlay',
+      variant: 'consent',
       lazyLoad: () => import('$lib/components/enable-sync-pill.svelte')
     },
     {
       slot: 'app-shell-overlay',
-      variant: 'sign-in',
+      variant: 'relogin',
       lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
     },
     {
@@ -54,20 +68,19 @@ export const proSyncUiExtension: UiExtensionDefinition = {
       variant: 'connected',
       lazyLoad: () => import('$lib/components/pro-sync-pill.svelte')
     },
-    // First-Pro data-sharing consent modal — shown for a Pro daemon whose active
-    // database has sync disabled, when the user opts to enable it. The gate that
-    // keeps local data from reaching the public workspace without an explicit,
-    // irreversible choice.
+    // First-Pro data-sharing consent modal — shown once the user has signed in but
+    // not yet opted into sync. The gate that keeps local data from reaching the
+    // public workspace without an explicit, irreversible choice.
     {
       slot: 'app-shell-modal',
-      variant: 'enable-prompt',
+      variant: 'consent',
       lazyLoad: () => import('$lib/components/first-pro-consent-slot.svelte')
     },
     // Re-login modal — only meaningful once sync is enabled for the database; the
     // wrapper itself only shows the modal on an AUTH_REQUIRED transition.
     {
       slot: 'app-shell-modal',
-      variant: 'sign-in',
+      variant: 'relogin',
       lazyLoad: () => import('$lib/components/pro-relogin-slot.svelte')
     },
     {
@@ -78,15 +91,21 @@ export const proSyncUiExtension: UiExtensionDefinition = {
   ],
   viewerExtensions: [
     // Collaboration tab. Locked placeholder while sync is disabled for this
-    // database (Pro daemon, sync_enabled: false); the live view once enabled.
+    // database (Pro daemon, sync_enabled: false — whether or not signed in); the
+    // live view once enabled.
     {
       tab: COLLABORATION_TAB,
-      variant: 'enable-prompt',
+      variant: 'sign-in',
       lazyLoad: () => import('$lib/components/collaboration/collaboration-locked.svelte')
     },
     {
       tab: COLLABORATION_TAB,
-      variant: 'sign-in',
+      variant: 'consent',
+      lazyLoad: () => import('$lib/components/collaboration/collaboration-locked.svelte')
+    },
+    {
+      tab: COLLABORATION_TAB,
+      variant: 'relogin',
       lazyLoad: () => import('$lib/components/collaboration/collaboration-tab.svelte')
     },
     {

--- a/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
+++ b/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
@@ -51,7 +51,13 @@ export function activeDatabaseSettings(): DatabaseSettings | undefined {
 /**
  * Resolve the current Pro-sync variant from the two independent signals:
  *   - axis 1: `proSync.tier` (daemon build variant) — not Pro ⇒ `teaser`.
- *   - axis 2: the active database's `sync_enabled` / `auth_status`.
+ *   - axis 2: the active database's `auth_status` (signed in?) and `sync_enabled`
+ *     (opted into the public-workspace publish?).
+ *
+ * The flow is sign-in-first: an un-opted-in database shows `sign-in` until the
+ * user authenticates, then `consent` (the publish decision) — nothing is enabled
+ * until they merge. An opted-in database is `connected` while authenticated, or
+ * `relogin` when its session has lapsed.
  *
  * A plain function (not a `$derived`) so it composes into any consumer's own
  * derivation; its reads are reactive because the underlying sources are.
@@ -59,20 +65,23 @@ export function activeDatabaseSettings(): DatabaseSettings | undefined {
 export function resolveProSyncVariant(): ProSyncVariant {
   if (proSync.tier !== 'pro') return 'teaser';
   const settings = activeDatabaseSettings();
-  if (settings?.sync_enabled !== true) return 'enable-prompt';
-  if (settings.auth_status === 'connected') return 'connected';
-  return 'sign-in';
+  const authed = settings?.auth_status === 'connected';
+  const enabled = settings?.sync_enabled === true;
+  // Not yet opted in: sign in first, then present the publish consent.
+  if (!enabled) return authed ? 'consent' : 'sign-in';
+  // Opted in: connected once authenticated, else a re-login is needed.
+  return authed ? 'connected' : 'relogin';
 }
 
 /**
  * True when sync is actually active for the current build + active database —
- * i.e. axis 1 is Pro AND axis 2 has `sync_enabled: true`. This is the two-axis
- * gate dependent stores (membership, recovered-items) use in place of the raw
- * `proSync.isPro` (which is axis 1 only).
+ * i.e. axis 1 is Pro AND axis 2 has `sync_enabled: true` (the `relogin` and
+ * `connected` variants). This is the two-axis gate dependent stores (membership,
+ * recovered-items) use in place of the raw `proSync.isPro` (which is axis 1 only).
  */
 export function isProSyncActive(): boolean {
   const variant = resolveProSyncVariant();
-  return variant === 'sign-in' || variant === 'connected';
+  return variant === 'relogin' || variant === 'connected';
 }
 
 /** Chrome contributions for `slot` that match the currently-resolved variant. */

--- a/packages/desktop-app/src/lib/plugins/ui-extensions.ts
+++ b/packages/desktop-app/src/lib/plugins/ui-extensions.ts
@@ -38,8 +38,13 @@ export const DATABASE_SETTINGS_NODE_ID = 'database-settings-singleton';
 /** The chrome slots a contribution can target in the app shell. */
 export type ChromeSlot = 'app-shell-overlay' | 'app-shell-modal';
 
-/** The four states the Pro-sync surface can be in (the variant state machine). */
-export type ProSyncVariant = 'teaser' | 'enable-prompt' | 'sign-in' | 'connected';
+/**
+ * The states the Pro-sync surface can be in (the variant state machine). Ordered
+ * by the sign-in-first flow: a Pro user signs in (`sign-in`), consents to the
+ * public-workspace publish (`consent`), then syncs (`connected`); `relogin` is
+ * the re-auth state for an already-enabled database whose session expired.
+ */
+export type ProSyncVariant = 'teaser' | 'sign-in' | 'consent' | 'relogin' | 'connected';
 
 /**
  * One chrome contribution: a lazily-loaded component mounted into `slot` when the

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -86,7 +86,7 @@ class ProSyncStore {
   /**
    * The `authRequiredEpisode` the user last dismissed via "Work offline". Held on
    * the store (not inside the re-login slot component) so a dismissal survives the
-   * slot remounting when the resolved variant flips between `sign-in` and
+   * slot remounting when the resolved variant flips between `relogin` and
    * `connected` — both map to the same re-login slot, so a flip must not re-arm an
    * already-dismissed modal. `-1` = nothing dismissed yet.
    */
@@ -108,6 +108,16 @@ class ProSyncStore {
    * contributions — share one source of truth.
    */
   consentPromptOpen = $state(false);
+
+  /**
+   * The `signedInEpisode` for which the user declined the first-Pro publish consent
+   * ("Keep local"). The consent slot auto-opens the modal once per fresh sign-in
+   * episode; recording the declined episode here stops it from immediately
+   * reopening for that same session, while leaving the pill available to reopen it.
+   * Held on the store (not the slot) so it survives the slot remounting. `-1` =
+   * nothing declined yet. Same episode-comparison pattern as `dismissedReloginEpisode`.
+   */
+  consentDeclinedEpisode = $state(-1);
 
   /**
    * Axis 1 only: "this daemon binary CAN sync" (the capability probe found

--- a/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/enable-sync-pill.test.ts
@@ -1,9 +1,10 @@
 /**
  * enable-sync-pill component.
  *
- * Rendered only for a Pro daemon whose active database has sync disabled.
- * Clicking opens the first-Pro data-sharing consent modal (which owns the
- * irreversible merge choice) rather than pushing anything itself.
+ * Rendered for the `consent` variant — a Pro daemon whose active database is
+ * signed in but not yet opted into sync. Clicking (re)opens the first-Pro
+ * data-sharing consent modal (which owns the irreversible publish choice) rather
+ * than pushing anything itself.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/svelte';
@@ -27,16 +28,16 @@ describe('EnableSyncPill', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders the enable-sync CTA', () => {
+  it('renders the turn-on-sync CTA', () => {
     const { getByRole, getByText } = render(EnableSyncPill);
-    expect(getByText('Enable sync')).toBeTruthy();
-    expect(getByRole('button', { name: /enable cloud sync/i })).toBeTruthy();
+    expect(getByText('Turn on sync')).toBeTruthy();
+    expect(getByRole('button', { name: /turn on sync/i })).toBeTruthy();
   });
 
   it('opens the consent modal on click (does not push anything itself)', async () => {
     const { getByRole } = render(EnableSyncPill);
     expect(proSync.consentPromptOpen).toBe(false);
-    await fireEvent.click(getByRole('button', { name: /enable cloud sync/i }));
+    await fireEvent.click(getByRole('button', { name: /turn on sync/i }));
     expect(proSync.consentPromptOpen).toBe(true);
   });
 });

--- a/packages/desktop-app/src/tests/components/first-pro-consent-modal.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-modal.test.ts
@@ -54,4 +54,17 @@ describe('FirstProConsentModal', () => {
     await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
     expect(onKeepLocal).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps decline actionable even while a merge is pending (never a no-op)', async () => {
+    const onKeepLocal = vi.fn();
+    const { getByRole } = render(FirstProConsentModal, {
+      props: { open: true, pending: true, onMerge: vi.fn(), onKeepLocal }
+    });
+    const keepBtn = getByRole('button', { name: /keep this database local-only/i });
+    // Merge is disabled while pending, but decline must always register.
+    expect(getByRole('button', { name: /merging/i }).hasAttribute('disabled')).toBe(true);
+    expect(keepBtn.hasAttribute('disabled')).toBe(false);
+    await fireEvent.click(keepBtn);
+    expect(onKeepLocal).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
@@ -1,9 +1,11 @@
 /**
  * first-pro-consent-slot component.
  *
- * Registry wrapper for the consent modal. On merge it records the consent
- * (pro_enable_sync → flips sync_enabled) and then starts sign-in; on decline it
- * closes and shares nothing.
+ * Registry wrapper for the consent modal in the sign-in-first flow. The user has
+ * already signed in when this mounts, so merge only records the publish consent
+ * (pro_enable_sync → flips sync_enabled). It auto-opens once per fresh sign-in
+ * episode; decline ("Keep local") records the episode, shows a confirmation, and
+ * shares nothing.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
@@ -23,6 +25,8 @@ describe('FirstProConsentSlot', () => {
     mockInvoke.mockReset();
     mockInvoke.mockResolvedValue(undefined);
     proSync.tier = 'pro';
+    proSync.signedInEpisode = 0;
+    proSync.consentDeclinedEpisode = -1;
     proSync.consentPromptOpen = true;
   });
 
@@ -30,29 +34,49 @@ describe('FirstProConsentSlot', () => {
     cleanup();
     vi.restoreAllMocks();
     proSync.tier = 'unknown';
+    proSync.signedInEpisode = 0;
+    proSync.consentDeclinedEpisode = -1;
     proSync.consentPromptOpen = false;
   });
 
-  it('merges: enables sync, then starts sign-in, then closes', async () => {
+  it('merges: records the publish consent (already signed in) and closes', async () => {
     const { getByRole, findByRole } = render(FirstProConsentSlot);
     await findByRole('dialog');
 
     await fireEvent.click(getByRole('checkbox'));
     await fireEvent.click(getByRole('button', { name: /merge into public workspace/i }));
 
-    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
-    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'pro_enable_sync');
-    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'pro_initiate_oauth');
+    // Sign-in already happened before consent, so merge is a single enable call —
+    // no pro_initiate_oauth from here.
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(1));
+    expect(mockInvoke).toHaveBeenCalledWith('pro_enable_sync');
     await waitFor(() => expect(proSync.consentPromptOpen).toBe(false));
   });
 
-  it('keep-local closes without any daemon call', async () => {
-    const { getByRole, findByRole } = render(FirstProConsentSlot);
+  it('keep-local closes with no daemon call, records the decline, and confirms', async () => {
+    const { getByRole, findByRole, findByText } = render(FirstProConsentSlot);
     await findByRole('dialog');
 
     await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
 
     expect(mockInvoke).not.toHaveBeenCalled();
     expect(proSync.consentPromptOpen).toBe(false);
+    // The decline is recorded against the current sign-in episode and confirmed.
+    expect(proSync.consentDeclinedEpisode).toBe(proSync.signedInEpisode);
+    await findByText(/kept local — sync stays off/i);
+  });
+
+  it('auto-opens once per sign-in episode; a decline keeps it closed for that episode', async () => {
+    // No manual open — a fresh sign-in episode should surface the consent modal.
+    proSync.consentPromptOpen = false;
+    proSync.signedInEpisode = 1;
+
+    const { getByRole, findByRole, queryByRole } = render(FirstProConsentSlot);
+    await findByRole('dialog');
+
+    // Decline records episode 1 and closes the modal.
+    await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
+    expect(proSync.consentDeclinedEpisode).toBe(1);
+    await waitFor(() => expect(queryByRole('dialog')).toBeNull());
   });
 });

--- a/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
@@ -19,6 +19,19 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) })
 
 import FirstProConsentSlot from '$lib/components/first-pro-consent-slot.svelte';
 import { proSync } from '$lib/stores/pro-sync.svelte';
+import { databaseStore } from '$lib/stores/database.svelte';
+
+/** In-memory localStorage stub (happy-dom's isn't guaranteed available). */
+function stubLocalStorage(): Map<string, string> {
+  const backing = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (backing.has(k) ? backing.get(k)! : null),
+    setItem: (k: string, v: string) => void backing.set(k, v),
+    removeItem: (k: string) => void backing.delete(k),
+    clear: () => backing.clear()
+  });
+  return backing;
+}
 
 describe('FirstProConsentSlot', () => {
   beforeEach(() => {
@@ -28,15 +41,18 @@ describe('FirstProConsentSlot', () => {
     proSync.signedInEpisode = 0;
     proSync.consentDeclinedEpisode = -1;
     proSync.consentPromptOpen = true;
+    databaseStore.activeDatabaseId = null;
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
     proSync.tier = 'unknown';
     proSync.signedInEpisode = 0;
     proSync.consentDeclinedEpisode = -1;
     proSync.consentPromptOpen = false;
+    databaseStore.activeDatabaseId = null;
   });
 
   it('merges: records the publish consent (already signed in) and closes', async () => {
@@ -78,5 +94,44 @@ describe('FirstProConsentSlot', () => {
     await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
     expect(proSync.consentDeclinedEpisode).toBe(1);
     await waitFor(() => expect(queryByRole('dialog')).toBeNull());
+  });
+
+  it('keep-local persists the decline per database', async () => {
+    const store = stubLocalStorage();
+    databaseStore.activeDatabaseId = 'db-alpha';
+
+    const { getByRole, findByRole } = render(FirstProConsentSlot);
+    await findByRole('dialog');
+    await fireEvent.click(getByRole('button', { name: /keep this database local-only/i }));
+
+    expect(store.get('ns:consent-declined:db-alpha')).toBe('1');
+  });
+
+  it('does not re-pop after a reload once the decline is persisted for this database', async () => {
+    const store = stubLocalStorage();
+    store.set('ns:consent-declined:db-alpha', '1');
+    databaseStore.activeDatabaseId = 'db-alpha';
+    // Simulate a fresh store on reload: no manual open, but the resumed session
+    // re-bumps signedInEpisode.
+    proSync.consentPromptOpen = false;
+    proSync.consentDeclinedEpisode = -1;
+    proSync.signedInEpisode = 1;
+
+    const { queryByRole } = render(FirstProConsentSlot);
+    // The persisted decline suppresses the auto-open, so no dialog appears.
+    await waitFor(() => expect(queryByRole('dialog')).toBeNull());
+  });
+
+  it('a persisted decline for a different database does not suppress this one', async () => {
+    const store = stubLocalStorage();
+    store.set('ns:consent-declined:db-other', '1');
+    databaseStore.activeDatabaseId = 'db-alpha';
+    proSync.consentPromptOpen = false;
+    proSync.consentDeclinedEpisode = -1;
+    proSync.signedInEpisode = 1;
+
+    const { findByRole } = render(FirstProConsentSlot);
+    // db-alpha has no decline of its own, so the consent still auto-opens.
+    await findByRole('dialog');
   });
 });

--- a/packages/desktop-app/src/tests/free-user-guardrail.test.ts
+++ b/packages/desktop-app/src/tests/free-user-guardrail.test.ts
@@ -153,8 +153,9 @@ describe('Free-user guardrail: Pro features stay inert in the community build', 
   // -------------------------------------------------------------------------
   // Pro-UI registry — in community the only surface contributed is the
   // static upgrade teaser (ADR-039). Every daemon-backed Pro surface (the live
-  // sync pill, the enable-sync prompt, the re-login modal, the collaboration
-  // tab) resolves out, so nothing that talks to a Pro daemon can render.
+  // sync pill, the turn-on-sync prompt, the consent/re-login modals, the
+  // collaboration tab) resolves out, so nothing that talks to a Pro daemon can
+  // render.
   // -------------------------------------------------------------------------
   describe('Pro-UI registry resolves to only the static upgrade teaser', () => {
     it("community tier resolves the variant to 'teaser' and sync is inactive", () => {
@@ -167,7 +168,7 @@ describe('Free-user guardrail: Pro features stay inert in the community build', 
       expect(overlay).toHaveLength(1);
       expect(overlay[0].variant).toBe('teaser');
       // None of the daemon-backed pill variants are active.
-      for (const v of ['enable-prompt', 'sign-in', 'connected'] as const) {
+      for (const v of ['sign-in', 'consent', 'relogin', 'connected'] as const) {
         expect(overlay.some((c) => c.variant === v)).toBe(false);
       }
     });

--- a/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
+++ b/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
@@ -3,7 +3,9 @@
  *
  * Exercises the two-signal state machine (`proSync.tier` × the active database's
  * DatabaseSettingsNode) and the registry filtering that resolves which chrome /
- * viewer contributions are active for each variant.
+ * viewer contributions are active for each variant. The flow is sign-in-first:
+ * sign-in → consent → connected, with relogin as the re-auth state for an
+ * already-enabled database.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { Node } from '$lib/types';
@@ -60,11 +62,12 @@ describe('UI-extension registry', () => {
   describe('registry registration', () => {
     it('registers the built-in pro-sync extension with all contributions', () => {
       expect(uiExtensionRegistry.has('pro-sync')).toBe(true);
-      // 4 overlay pill variants + 3 modal (enable-prompt consent / sign-in / connected).
-      expect(uiExtensionRegistry.chromeFor('app-shell-overlay')).toHaveLength(4);
+      // 5 overlay pills (teaser / sign-in / consent / relogin / connected).
+      expect(uiExtensionRegistry.chromeFor('app-shell-overlay')).toHaveLength(5);
+      // 3 modals (consent / relogin / connected) — no modal for teaser or sign-in.
       expect(uiExtensionRegistry.chromeFor('app-shell-modal')).toHaveLength(3);
-      // 3 collaboration viewer extensions (enable-prompt/sign-in/connected).
-      expect(uiExtensionRegistry.viewersFor('collection')).toHaveLength(3);
+      // 4 collaboration viewer extensions (sign-in / consent / relogin / connected).
+      expect(uiExtensionRegistry.viewersFor('collection')).toHaveLength(4);
       expect(uiExtensionRegistry.viewersFor('text')).toEqual([]);
     });
   });
@@ -77,23 +80,31 @@ describe('UI-extension registry', () => {
       expect(isProSyncActive()).toBe(false);
     });
 
-    it('pro + no hydrated settings node → enable-prompt (sync not enabled)', () => {
+    it('pro + no hydrated settings node → sign-in (not enabled, not authed)', () => {
       proSync.tier = 'pro';
-      expect(resolveProSyncVariant()).toBe('enable-prompt');
+      expect(resolveProSyncVariant()).toBe('sign-in');
       expect(isProSyncActive()).toBe(false);
     });
 
-    it('pro + sync_enabled: false → enable-prompt', () => {
+    it("pro + sync_enabled: false + auth_status 'local' → sign-in", () => {
       proSync.tier = 'pro';
       seedSettings({ sync_enabled: false, auth_status: 'local' });
-      expect(resolveProSyncVariant()).toBe('enable-prompt');
+      expect(resolveProSyncVariant()).toBe('sign-in');
       expect(isProSyncActive()).toBe(false);
     });
 
-    it("pro + sync_enabled + auth_status 'local' → sign-in (sync active)", () => {
+    it("pro + sync_enabled: false + auth_status 'connected' → consent (signed in, publish pending)", () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: false, auth_status: 'connected' });
+      expect(resolveProSyncVariant()).toBe('consent');
+      // Not active yet — consent gates the sync_enabled flip.
+      expect(isProSyncActive()).toBe(false);
+    });
+
+    it("pro + sync_enabled + auth_status 'local' → relogin (enabled but session lapsed)", () => {
       proSync.tier = 'pro';
       seedSettings({ sync_enabled: true, auth_status: 'local' });
-      expect(resolveProSyncVariant()).toBe('sign-in');
+      expect(resolveProSyncVariant()).toBe('relogin');
       expect(isProSyncActive()).toBe(true);
     });
 
@@ -104,14 +115,19 @@ describe('UI-extension registry', () => {
       expect(isProSyncActive()).toBe(true);
     });
 
-    it('re-resolves when the settings node changes (derived reads, no cache)', () => {
+    it('sign-in-first transition: sign-in → consent → connected as auth then sync land', () => {
       proSync.tier = 'pro';
+      // Fresh Pro database: sign in first.
       seedSettings({ sync_enabled: false, auth_status: 'local' });
-      expect(resolveProSyncVariant()).toBe('enable-prompt');
-      seedSettings({ sync_enabled: true, auth_status: 'local' });
       expect(resolveProSyncVariant()).toBe('sign-in');
+      // After sign-in, the publish consent is presented — still nothing enabled.
+      seedSettings({ sync_enabled: false, auth_status: 'connected' });
+      expect(resolveProSyncVariant()).toBe('consent');
+      expect(isProSyncActive()).toBe(false);
+      // Merge flips sync_enabled → connected and active.
       seedSettings({ sync_enabled: true, auth_status: 'connected' });
       expect(resolveProSyncVariant()).toBe('connected');
+      expect(isProSyncActive()).toBe(true);
     });
   });
 
@@ -125,19 +141,46 @@ describe('UI-extension registry', () => {
       expect(getActiveViewerExtensions('collection')).toEqual([]);
     });
 
-    it('enable-prompt: enable-sync pill + the consent modal + a locked collab tab', () => {
+    it('sign-in: the sync pill (OAuth) + no modal + a locked collab tab', () => {
       proSync.tier = 'pro';
       seedSettings({ sync_enabled: false, auth_status: 'local' });
       const overlay = getActiveChromeContributions('app-shell-overlay');
       expect(overlay).toHaveLength(1);
-      expect(overlay[0].variant).toBe('enable-prompt');
-      const modal = getActiveChromeContributions('app-shell-modal');
-      expect(modal).toHaveLength(1);
-      expect(modal[0].variant).toBe('enable-prompt');
+      expect(overlay[0].variant).toBe('sign-in');
+      // No consent modal before sign-in.
+      expect(getActiveChromeContributions('app-shell-modal')).toEqual([]);
       const viewers = getActiveViewerExtensions('collection');
       expect(viewers).toHaveLength(1);
-      expect(viewers[0].variant).toBe('enable-prompt');
+      expect(viewers[0].variant).toBe('sign-in');
       expect(viewers[0].tab.id).toBe('collaboration');
+    });
+
+    it('consent: the turn-on-sync pill + the consent modal + a locked collab tab', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: false, auth_status: 'connected' });
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('consent');
+      const modal = getActiveChromeContributions('app-shell-modal');
+      expect(modal).toHaveLength(1);
+      expect(modal[0].variant).toBe('consent');
+      const viewers = getActiveViewerExtensions('collection');
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0].variant).toBe('consent');
+    });
+
+    it('relogin: the live pill + the relogin modal + the live collab tab', () => {
+      proSync.tier = 'pro';
+      seedSettings({ sync_enabled: true, auth_status: 'local' });
+      const overlay = getActiveChromeContributions('app-shell-overlay');
+      expect(overlay).toHaveLength(1);
+      expect(overlay[0].variant).toBe('relogin');
+      const modal = getActiveChromeContributions('app-shell-modal');
+      expect(modal).toHaveLength(1);
+      expect(modal[0].variant).toBe('relogin');
+      const viewers = getActiveViewerExtensions('collection');
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0].variant).toBe('relogin');
     });
 
     it('connected: the live pill + the relogin modal + the live collab tab', () => {


### PR DESCRIPTION
Closes #1665.

## Problem (found in live validation, 2026-07-15)
The Pro-sync surface demanded the public-workspace **publish** consent *before* the user had signed in, behind a pill labelled "Enable sync" that didn't read as "publish publicly" — and its "Keep local" decline could be a silent no-op (`disabled` mid-call) with no confirmation.

## What changed (frontend variant machine)
Reordered to **sign-in-first**, splitting the two-signal state machine into five variants:

| variant   | when                              | pill            | modal        | collab tab |
|-----------|-----------------------------------|-----------------|--------------|------------|
| teaser    | not Pro                           | teaser          | —            | —          |
| sign-in   | Pro, not authed, not enabled      | sync pill (OAuth) | —          | locked     |
| consent   | Pro, **authed**, not enabled      | turn-on-sync    | first-pro-consent | locked |
| relogin   | Pro, enabled, session lapsed      | sync pill       | pro-relogin  | live       |
| connected | Pro, authed, enabled              | sync pill       | pro-relogin  | live       |

- **Sign in first** (the sync pill drives OAuth); the publish consent is presented only **after** auth, in the `consent` variant.
- The consent modal **auto-opens once per fresh sign-in episode** and no longer starts OAuth on merge (the user is already signed in) — merge only records the consent (`pro_enable_sync`).
- **Pill relabeled** "Turn on sync" and both pill + modal name the public-workspace publish.
- **"Keep local" is never disabled into a no-op**, records the declined sign-in episode so the prompt doesn't immediately reopen, and shows a brief "Kept local — sync stays off" confirmation.
- `collaboration-locked` branches: reopen the consent modal when signed in, else point the user to the toolbar to sign in first.
- `isProSyncActive` stays "sync enabled" (`relogin | connected`) — the truth set (enabled databases) is unchanged, so membership/recovered-items consumers are unaffected.

## Guarantee preserved
The consent gate is intact: the daemon still only **pushes** after `sync_enabled`, which the merge flips. Signing in first connects and sets `auth_status=connected` but publishes nothing (the push sweep is server-side gated). The sync-side companion that makes enabling-after-connect actually upload the existing graph is nodespace-sync#305 (merged).

## Behavioral notes (transparency)
- The daemon connects on sign-in, so a user who declines ("Keep local") stays authenticated and the realtime **pull** remains active while **push** stays gated — nothing they own is published. Gating pull too (truly-idle-until-consent) is a possible follow-up; flagging for Anoop, not in scope here.
- The onboarding invitations inbox (in `pro-sync-pill`) now surfaces after **enabling** sync (connected) rather than in the consent window — consistent with sync being opt-in.

## Tests
- Variant-registry states + the sign-in → consent → connected transition, decline-registers, auto-open-per-episode, keep-local-actionable-while-pending.
- Full frontend suite green: **163 files / 4057 tests**. `eslint --fix` + `svelte-check` clean. Pre-push gate (test:all + `cargo build --bin nodespaced` + test:e2e) green.
