### PR TITLE
Remove GitHub issue-number references from code comments

### DIFF
--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -9,8 +9,6 @@
 //! not use these constants — they get all tool/capability guidance from
 //! `packages/skill/SKILL.md`, the CLI-vocabulary companion doc, not from this
 //! module's tool-call-vocabulary prose.
-//!
-//! Issue #1089.
 
 /// Schema creation guidance.
 ///
@@ -18,8 +16,7 @@
 /// `create_node`, and how custom types relate to built-in types. More detailed
 /// `title_template` token / field alignment guidance currently lives in
 /// `skill_pipeline.rs` (used only by the skill-based schema-creation path) and
-/// should be consolidated here when that path is unified — tracked separately
-/// from #1089.
+/// should be consolidated here when that path is unified.
 pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in RELEVANT ENTITY TYPES.\n\
     \"DATABASE\" = SCHEMA: When the user says \"create a database\", \"set up a tracker\", or \"track X\", call create_schema IMMEDIATELY — no confirmation, no search_skills, no planning text. The entity name is the schema (\"a contacts database\" → call create_schema with name=\"Contact\").\n\
     INSTANCE vs TYPE: \"Add an invoice for $500\", \"add a contact named Jane Doe\", \"log a project called X\" — these ask for a specific INSTANCE of an existing type. Call search_skills(query=\"add contact\") then call create_node(node_type=\"contact\", ...). Never ask for confirmation — just execute.\n\

--- a/packages/agent/src/lib.rs
+++ b/packages/agent/src/lib.rs
@@ -12,7 +12,7 @@ pub use agent_types::*;
 pub mod local_agent;
 
 // Shared agent guidance rules: single source of truth for tool strategy,
-// schema creation, and node reference guidance (issue #1089). Consumed by
+// schema creation, and node reference guidance. Consumed by
 // `prompt_assembler` (local Ollama agent) and by ADR-032 context-file
 // writers in `acp`.
 pub mod agent_guidance;
@@ -22,7 +22,7 @@ pub mod prompt_assembler;
 
 // Skill seeding templates: default skill nodes inserted on first run.
 // Skill discovery itself is LLM-orchestrated via the `search_skills` tool
-// (issue #1130) — there is no longer a pre-turn intent pipeline.
+// there is no longer a pre-turn intent pipeline.
 pub mod skill_pipeline;
 
 // Shared source of truth for core-type rules referenced by both

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -3,8 +3,6 @@
 //! Orchestrates the conversation cycle: build prompts, call inference,
 //! parse tool calls, execute tools, feed results back, and repeat until
 //! the model produces a final response or hits iteration limits.
-//!
-//! Issue #1006
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -1848,7 +1846,7 @@ mod tests {
             assert_eq!(tc.name, "search_nodes");
         }
 
-        // The fallback response must encode the invariant from issue #1092:
+        // The fallback response must encode the invariant:
         // no raw tool identifier reaches the UI.
         assert!(
             !result.response.contains("search_nodes"),
@@ -2328,8 +2326,8 @@ mod tests {
         assert_eq!(result.response, "Here is your answer.");
     }
 
-    /// A model whose effective context window was reduced to fit memory (issue
-    /// #1638) must summarize when history exceeds *that* window — not the old
+    /// A model whose effective context window was reduced to fit memory must
+    /// summarize when history exceeds *that* window — not the old
     /// hardcoded 32K budget. Here history is ~10K tokens: comfortably under the
     /// former 32K constant, but well over a 4096-token effective window. Before
     /// budgeting against the effective window, this history would sail past the
@@ -2963,7 +2961,7 @@ mod tests {
 
     // -- search_skills as a regular tool ---------------------------------
 
-    /// Issue #1130: the model decides when to search for skills by calling
+    /// The model decides when to search for skills by calling
     /// the `search_skills` tool, then invokes a matching skill (if any) like
     /// any other tool. There's no pre-LLM dispatch — the loop always runs the
     /// full tool set against the model.
@@ -3075,7 +3073,7 @@ mod tests {
         assert!(result.usage.prompt_tokens > 0);
     }
 
-    /// Multi-skill turn from issue #1130 AC: the model calls `search_skills`
+    /// Multi-skill turn: the model calls `search_skills`
     /// for each sub-task, then invokes the matched skill's tool. This test
     /// exercises a full chain — search_skills (notes) → search_semantic →
     /// search_skills (task) → create_node — not just two back-to-back
@@ -3231,7 +3229,7 @@ mod tests {
     /// Empty `search_skills` matches → model judges and produces a contextual
     /// clarification (referencing what it searched), rather than the prior
     /// hardcoded `CLARIFYING_QUESTION` string. This is the "no relevant skill"
-    /// path from issue #1130 AC.
+    /// path.
     #[tokio::test]
     async fn empty_search_skills_matches_let_model_clarify_with_context() {
         let engine = Arc::new(MockEngine::new(vec![
@@ -3580,7 +3578,7 @@ mod tests {
         );
     }
 
-    /// Per #1130: an empty response with no tool calls is an inference bug
+    /// An empty response with no tool calls is an inference bug
     /// (model should always produce text or a tool call), not a UX surface.
     /// Surface as an error so it lands in logs/metrics rather than being
     /// silently masked.
@@ -3602,7 +3600,7 @@ mod tests {
         }
     }
 
-    // -- Silent-failure guard regression tests (#1531) -----------------------
+    // -- Silent-failure guard regression tests -----------------------
 
     /// Scenario B: the model prints a tool call as plain text instead of using
     /// the structured tool_calls field. `tool_calls == 0`, so the tool-failure

--- a/packages/agent/src/local_agent/composite_model_manager.rs
+++ b/packages/agent/src/local_agent/composite_model_manager.rs
@@ -3,8 +3,6 @@
 //! Implements the [`ModelManager`] trait by delegating to either the GGUF model manager
 //! (for local GGUF models) or the Ollama model manager (for models served by a local
 //! Ollama daemon). Models are distinguished by the "ollama:" prefix on the model ID.
-//!
-//! Issue #1058
 
 use std::sync::Arc;
 
@@ -247,7 +245,7 @@ mod tests {
         );
     }
 
-    // -- Ollama progress callback de-prefixing (issue #1471 re-review) ------
+    // -- Ollama progress callback de-prefixing ------
     //
     // `download()` strips the "ollama:" prefix before delegating to the
     // underlying OllamaModelManager, which keys its progress callbacks and

--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -4,8 +4,6 @@
 //! Implements the [`ModelManager`] trait from `agent_types` for managing local
 //! GGUF model files on disk. Models are downloaded from HuggingFace with HTTP
 //! range-request resume support and verified via streaming SHA-256 hash.
-//!
-//! Issue #1000
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -172,8 +170,8 @@ const GEMMA_4_E4B: CatalogEntry = CatalogEntry {
 };
 
 /// Gemma 4 31B -- Google's larger dense quality-tier option (24GB+ Apple
-/// Silicon, e.g. M3 Pro/Max, M4 Pro). Issue #1094 originally referenced "27B"
-/// but Gemma 4's dense large variant is 31B; 27B was a Gemma 2 size.
+/// Silicon, e.g. M3 Pro/Max, M4 Pro). This tier is 31B: Gemma 4's dense
+/// large variant is 31B, whereas 27B was a Gemma 2 size.
 const GEMMA_4_31B: CatalogEntry = CatalogEntry {
     id: "gemma-4-31b-q4km",
     family: ModelFamily::Gemma4,
@@ -353,8 +351,8 @@ impl GgufModelManager {
     /// Returns Gemma 4 E4B as the primary llama.cpp default, per ADR-056.
     /// Unlike [`Self::recommended_model_id_for`]'s general three-tier Gemma4
     /// behavior, this always recommends E4B regardless of RAM: the 12B and
-    /// 31B tiers remain parked per ADR-046 (unresolved tool-call defects,
-    /// #1346 / #1365 / #1348) and must not become the default recommendation
+    /// 31B tiers remain parked per ADR-046 (unresolved tool-call defects)
+    /// and must not become the default recommendation
     /// on higher-RAM machines. Callers that want the full RAM-tiered
     /// within-family recommendation should use
     /// [`Self::recommended_model_id_for`] directly.
@@ -1760,7 +1758,7 @@ mod tests {
         check_disk_space(tmp.path(), 1).unwrap();
     }
 
-    // -- Progress callback lifecycle (issue #1471) --------------------------
+    // -- Progress callback lifecycle --------------------------
     //
     // A download's gRPC response stream is backed by an mpsc channel whose
     // sender is cloned into the progress callback. If that callback is never

--- a/packages/agent/src/local_agent/ollama_model_manager.rs
+++ b/packages/agent/src/local_agent/ollama_model_manager.rs
@@ -3,8 +3,6 @@
 //! Implements the [`ModelManager`] trait for models served by a local Ollama instance.
 //! Models are managed entirely by Ollama (download, caching, loading); this implementation
 //! acts as a client to the Ollama HTTP API.
-//!
-//! Issue #1058
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/packages/agent/src/local_agent/otlp_tracer.rs
+++ b/packages/agent/src/local_agent/otlp_tracer.rs
@@ -6,8 +6,6 @@
 //!
 //! MLflow 3.x includes a native OTLP HTTP receiver at `/v1/traces`. Point it at
 //! `http://localhost:5000`. See `scripts/mlflow-dev.md`.
-//!
-//! Issue #1341
 
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::trace::SdkTracerProvider;

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -1616,7 +1616,7 @@ impl GraphToolExecutor {
 impl AgentToolExecutor for GraphToolExecutor {
     /// Return typed `ToolDefinition`s generated from tool nodes in the graph.
     ///
-    /// Reads `node_type='tool'` nodes seeded at startup (issue #1353), builds a
+    /// Reads `node_type='tool'` nodes seeded at startup, builds a
     /// `ToolDefinition` from each enabled node whose handler key is present in
     /// the deterministic registry, then preserves the canonical registry ordering.
     /// Falls back to the hardcoded list when the node service is unavailable or
@@ -2235,7 +2235,7 @@ mod tests {
 
     #[test]
     fn search_skills_description_mentions_empty_signal() {
-        // Per #1130, the description must teach the model that an empty
+        // The description must teach the model that an empty
         // `matches` array is a meaningful signal, not an error. This wording
         // is load-bearing — without it, a small model tends to retry the
         // tool with rephrased queries instead of judging "no skill applies".
@@ -2291,7 +2291,7 @@ mod tests {
         assert!(names.contains(&"create_nodes_from_markdown"));
     }
 
-    // -- Embedding handle is read live (race fix, #1328) --
+    // -- Embedding handle is read live (race fix) --
 
     /// The executor must read the embedding service through the shared handle on
     /// every call, not capture a snapshot at construction. This is what closes
@@ -2428,7 +2428,7 @@ mod tests {
         }
     }
 
-    // -- Scope passthrough test (issue #1085 acceptance criterion) --
+    // -- Scope passthrough test (acceptance criterion) --
 
     /// Verifies that scope="conversations" is correctly parsed from JSON params
     /// and would be forwarded to SearchSemanticInput by exec_search_semantic.

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -5,7 +5,7 @@
 //! If no prompt nodes are found (corrupted/empty database), falls back to a
 //! minimal emergency prompt and logs a warning.
 //!
-//! Issue #1049, ADR-030 Phase 2.
+//! ADR-030 Phase 2.
 
 use std::sync::Arc;
 

--- a/packages/agent/src/props.rs
+++ b/packages/agent/src/props.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn get_prop_namespace_overrides_stale_flat() {
-        // Regression test for #1080: skill seeded with flat {"max_iterations": 2},
+        // Regression test: skill seeded with flat {"max_iterations": 2},
         // then MCP update normalizes to {"skill": {"max_iterations": 4}}.
         // Both coexist until the node is re-seeded; namespace must win.
         let props = json!({"max_iterations": 2, "skill": {"max_iterations": 4}});

--- a/packages/agent/src/pty/detection.rs
+++ b/packages/agent/src/pty/detection.rs
@@ -1,4 +1,4 @@
-//! Binary and auth detection for PTY agent CLIs (Issue #1124).
+//! Binary and auth detection for PTY agent CLIs.
 //!
 //! `detect_all_agents()` iterates the static AGENT_CATALOG and checks two
 //! things per agent: (1) the binary is reachable on an augmented PATH, and

--- a/packages/agent/src/pty/session.rs
+++ b/packages/agent/src/pty/session.rs
@@ -786,7 +786,7 @@ mod tests {
         session.terminate().await.expect("terminate cat");
     }
 
-    // ---- Regression: env allowlist (issue #1521) ------------------------
+    // ---- Regression: env allowlist ------------------------
 
     /// A secret-shaped var present in the daemon's own environment must NOT
     /// reach the PTY child — only `BASE_ENV_ALLOWLIST` entries and explicitly

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -6,14 +6,14 @@
 //! template into a flat list of `PreparedNode`s before inserting them via
 //! `NodeService::bulk_create_hierarchy`.
 //!
-//! Issue #1130: The previous push-based [`SkillPipeline`] (pre-LLM intent
+//! The previous push-based [`SkillPipeline`] (pre-LLM intent
 //! routing with confidence thresholds + tool whitelist scoping) has been
 //! removed. Skill discovery is now LLM-orchestrated through the
 //! `search_skills` tool exposed by [`crate::local_agent::tools`], so the
 //! agent loop no longer needs a pipeline object — only the seeded skill
 //! nodes themselves remain.
 //!
-//! Issue #1353: Tool nodes (`node_type='tool'`) bridge graph storage to
+//! Tool nodes (`node_type='tool'`) bridge graph storage to
 //! deterministic Rust handlers. Each tool is seeded as a node carrying its
 //! handler key, typed parameter schema, description, and `source` provenance.
 
@@ -397,7 +397,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
     ]
 }
 
-/// Default tool node templates seeded on first run (issue #1353).
+/// Default tool node templates seeded on first run.
 ///
 /// Each template produces one `node_type='tool'` node bridging graph storage to
 /// a deterministic Rust handler. Properties:
@@ -553,7 +553,7 @@ mod tests {
         );
     }
 
-    // -- Tool node seeding tests (issue #1353) --------------------------------
+    // -- Tool node seeding tests --------------------------------
 
     #[test]
     fn seed_tool_nodes_covers_all_registered_tools() {

--- a/packages/agent/tests/ollama_integration.rs
+++ b/packages/agent/tests/ollama_integration.rs
@@ -340,7 +340,7 @@ async fn test_ollama_inference_with_production_prompt() {
 
     // Build the full production system prompt (~7KB) using the same assembler
     // the live app uses. This mirrors the exact request shape that produced
-    // prompt_tokens=4095, completion_tokens=1 in the num_ctx bug (issue #1443).
+    // prompt_tokens=4095, completion_tokens=1 in the num_ctx bug.
     let system_prompt =
         nodespace_agent::prompt_assembler::PromptAssembler::assemble_static("", None);
     eprintln!(
@@ -470,7 +470,7 @@ async fn test_ollama_model_info() {
 }
 
 // ===========================================================================
-// Skill Pipeline Real Model E2E Tests (Issue #1057)
+// Skill Pipeline Real Model E2E Tests
 // ===========================================================================
 //
 // Each test resolves an inference engine using this fallback chain:

--- a/packages/agent/tests/search_skills_latency.rs
+++ b/packages/agent/tests/search_skills_latency.rs
@@ -7,7 +7,7 @@
 //!      without schema_metadata from search_skills response)
 //!   3. Multi-skill turn — cross-type request spanning search and creation
 //!
-//! Architecture note (#1283): entity types are no longer injected into the
+//! Architecture note: entity types are no longer injected into the
 //! system prompt. The model discovers type metadata on-demand via `search_skills`,
 //! which returns `schema_metadata` (type IDs, field names, enum values) per match.
 //!
@@ -27,8 +27,6 @@
 //!
 //! Gracefully skips if no inference backend is available (Ollama not running and
 //! no local GGUF model downloaded).
-//!
-//! Issues #1152, #1283
 
 use async_trait::async_trait;
 use nodespace_agent::agent_types::{
@@ -228,7 +226,7 @@ impl AgentToolExecutor for BenchToolExecutor {
             "search_skills" => {
                 // Return realistic schema metadata for the matched skill so the model
                 // can construct correct create_node / search_nodes calls without a
-                // global entity-type list in the system prompt (#1283).
+                // global entity-type list in the system prompt.
                 let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
                 if query.to_lowercase().contains("invoice")
                     || query.to_lowercase().contains("overdue")
@@ -769,7 +767,7 @@ async fn bench_search_skills_e2e_latency() {
 }
 
 // ---------------------------------------------------------------------------
-// Schema metadata infrastructure check (#1283)
+// Schema metadata infrastructure check
 //
 // Verifies that `BenchToolExecutor` returns `schema_metadata` in search_skills
 // responses — confirming the on-demand discovery pattern works correctly.

--- a/packages/core/benches/performance.rs
+++ b/packages/core/benches/performance.rs
@@ -441,7 +441,7 @@ fn bench_batch_update(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark BM25 root-walk latency at realistic corpus sizes (Issue #951)
+/// Benchmark BM25 root-walk latency at realistic corpus sizes
 ///
 /// Measures: BM25 `@@` query + iterative parent-walk to resolve roots.
 /// Run at 100, 500, and 1000 nodes with 3-level nesting (root→child→grandchild).

--- a/packages/core/src/agent_params.rs
+++ b/packages/core/src/agent_params.rs
@@ -62,7 +62,7 @@ pub struct SearchSemanticParams {
     #[serde(default)]
     pub include_archived: Option<bool>,
 
-    /// Search scope - controls which node types are included (Issue #1018).
+    /// Search scope - controls which node types are included.
     /// Values: "knowledge" (default), "conversations", "everything".
     #[serde(default)]
     pub scope: Option<String>,

--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -256,7 +256,7 @@ pub trait NodeBehavior: Send + Sync {
     /// let behavior = TaskNodeBehavior;
     /// let defaults = behavior.default_metadata();
     /// // Task defaults use nested format: properties.task.status
-    /// // Status values use lowercase format (Issue #670)
+    /// // Status values use lowercase format
     /// assert_eq!(defaults["task"]["status"], "open");
     /// ```
     fn default_metadata(&self) -> serde_json::Value {
@@ -306,7 +306,7 @@ pub trait NodeBehavior: Send + Sync {
         }
     }
 
-    /// Phase 2: Optional async — aggregated content from related nodes (Issue #1018)
+    /// Phase 2: Optional async — aggregated content from related nodes
     ///
     /// Called by the embedding service after `get_embeddable_content()` returns `Some`.
     /// Enables tree-walking types (text, header) to fetch children via `NodeAccessor`
@@ -435,10 +435,10 @@ impl NodeBehavior for TextNodeBehavior {
     }
 
     fn validate(&self, _node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #479 Phase 1: Allow blank text nodes
+        // Phase 1: Allow blank text nodes
         // Changed behavior: Backend now accepts blank text nodes
         //
-        // Architecture Change (Issue #479):
+        // Architecture Change:
         // - Frontend: Persists blank nodes immediately (with 500ms debounce)
         // - Backend: Accepts blank text nodes (user responsible for managing them)
         // - User Experience: Users can create blank nodes via Enter key, burden is on user to maintain or delete
@@ -448,7 +448,7 @@ impl NodeBehavior for TextNodeBehavior {
         // 2. Prevents UNIQUE constraint violations when indenting blank nodes
         // 3. Simplifies frontend persistence logic (Phase 2 will remove deferred update queue)
         //
-        // Previous behavior (before Issue #479):
+        // Previous behavior (before blank content was allowed):
         // - Backend rejected blank nodes with validation error
         // - Frontend had to manage ephemeral nodes until content was added
         // - Caused database constraint issues during indent operations
@@ -473,7 +473,7 @@ impl NodeBehavior for TextNodeBehavior {
         })
     }
 
-    /// Text nodes aggregate children's content for embedding (Issue #1018)
+    /// Text nodes aggregate children's content for embedding
     fn get_aggregated_content<'a>(
         &'a self,
         node: &'a Node,
@@ -514,7 +514,7 @@ impl NodeBehavior for HeaderNodeBehavior {
     }
 
     fn validate(&self, _node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #484: Allow blank header nodes (e.g., "##" with no content)
+        // Allow blank header nodes (e.g., "##" with no content)
         // Similar to text nodes, headers can be created blank and filled in later
         // Frontend manages the UX of blank headers (e.g., showing placeholder text)
         Ok(())
@@ -535,7 +535,7 @@ impl NodeBehavior for HeaderNodeBehavior {
         })
     }
 
-    /// Header nodes aggregate children's content for embedding (Issue #1018)
+    /// Header nodes aggregate children's content for embedding
     fn get_aggregated_content<'a>(
         &'a self,
         node: &'a Node,
@@ -555,7 +555,7 @@ impl NodeBehavior for HeaderNodeBehavior {
 /// # Valid Status Values (Schema-Defined)
 ///
 /// Status values are defined in the task schema and validated dynamically.
-/// All values use lowercase format for consistency across layers (Issue #670).
+/// All values use lowercase format for consistency across layers.
 ///
 /// Core values (protected, cannot be removed):
 /// - "open" - Not started (default)
@@ -565,7 +565,7 @@ impl NodeBehavior for HeaderNodeBehavior {
 ///
 /// User-extensible values can be added via schema.
 ///
-/// # Strongly-Typed Validation (Issue #673)
+/// # Strongly-Typed Validation
 ///
 /// This behavior supports both generic Node validation (via `validate()`) and
 /// strongly-typed TaskNode validation (via `validate_task_node()`). The generic
@@ -589,7 +589,7 @@ impl NodeBehavior for HeaderNodeBehavior {
 pub struct TaskNodeBehavior;
 
 impl TaskNodeBehavior {
-    /// Validate a strongly-typed TaskNode directly (Issue #673)
+    /// Validate a strongly-typed TaskNode directly
     ///
     /// This method provides compile-time type safety by validating TaskNode
     /// fields directly rather than parsing from JSON properties. Use this
@@ -640,7 +640,7 @@ impl NodeBehavior for TaskNodeBehavior {
     }
 
     fn validate(&self, node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #673: Convert to strongly-typed TaskNode and validate
+        // Convert to strongly-typed TaskNode and validate
         // This provides type-safe validation with direct field access
         match TaskNode::from_node(node.clone()) {
             Ok(task) => self.validate_task_node(&task),
@@ -652,7 +652,7 @@ impl NodeBehavior for TaskNodeBehavior {
                     e
                 );
 
-                // Type-namespaced property validation (Issue #397)
+                // Type-namespaced property validation
                 // Properties are stored under type-specific namespaces: properties.task.*
                 // This allows preserving properties when converting between types
                 //
@@ -700,7 +700,7 @@ impl NodeBehavior for TaskNodeBehavior {
     }
 
     fn default_metadata(&self) -> serde_json::Value {
-        // Uses lowercase canonical values for consistency across all layers (Issue #670)
+        // Uses lowercase canonical values for consistency across all layers
         serde_json::json!({
             "task": {
                 "status": "open",
@@ -756,7 +756,7 @@ impl NodeBehavior for CodeBlockNodeBehavior {
     }
 
     fn validate(&self, _node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #484: Allow blank code blocks (e.g., "```language" with no code)
+        // Allow blank code blocks (e.g., "```language" with no code)
         // Users can create blank code blocks and fill in code later
         // Frontend manages the UX of blank code blocks (e.g., showing placeholder text)
         Ok(())
@@ -805,7 +805,7 @@ impl NodeBehavior for QuoteBlockNodeBehavior {
     }
 
     fn validate(&self, _node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #484: Allow blank quote blocks (e.g., ">" with no content)
+        // Allow blank quote blocks (e.g., ">" with no content)
         // Users can create blank quote blocks and fill in quoted text later
         // Frontend manages the UX of blank quote blocks (e.g., showing placeholder text)
         Ok(())
@@ -854,7 +854,7 @@ impl NodeBehavior for OrderedListNodeBehavior {
     }
 
     fn validate(&self, _node: &Node) -> Result<(), NodeValidationError> {
-        // Issue #484: Allow blank ordered list nodes (consistent with headers, quotes, etc.)
+        // Allow blank ordered list nodes (consistent with headers, quotes, etc.)
         //
         // ARCHITECTURAL DECISION: Blank ordered lists are semantically valid:
         //
@@ -873,7 +873,7 @@ impl NodeBehavior for OrderedListNodeBehavior {
         //    - User expects immediate persistence without requiring content first
         //    - Backend should accept what frontend naturally generates
         //
-        // 4. Consistency with other node types (Issue #484)
+        // 4. Consistency with other node types
         //    - Headers allow blank content after "##"
         //    - Quote blocks allow blank content after ">"
         //    - Code blocks allow blank content after "```"
@@ -986,7 +986,7 @@ impl NodeBehavior for TableNodeBehavior {
 /// # ID Format
 ///
 /// Date nodes must have IDs matching `YYYY-MM-DD` (e.g., "2025-01-03").
-/// Per Issue #670, the content field can be any custom content (no longer
+/// The content field can be any custom content (no longer
 /// required to match the date ID).
 ///
 /// # Examples
@@ -1026,7 +1026,7 @@ impl NodeBehavior for DateNodeBehavior {
             NodeValidationError::InvalidId(format!("Invalid date format: {}", node.id))
         })?;
 
-        // NOTE: Per Issue #670, date nodes can have custom content (not required to match ID).
+        // NOTE: Date nodes can have custom content (not required to match ID).
         // The ID is always in YYYY-MM-DD format, but content can be anything (e.g., "Custom Date Content").
 
         Ok(())
@@ -2395,12 +2395,12 @@ mod tests {
         let valid_node = Node::new("text".to_string(), "Hello world".to_string(), json!({}));
         assert!(behavior.validate(&valid_node).is_ok());
 
-        // Issue #479: Blank text nodes are now allowed (frontend manages persistence)
+        // Blank text nodes are now allowed (frontend manages persistence)
         let mut empty_node = valid_node.clone();
         empty_node.content = "".to_string();
         assert!(behavior.validate(&empty_node).is_ok());
 
-        // Issue #479: Whitespace-only content is also allowed
+        // Whitespace-only content is also allowed
         let mut whitespace_node = valid_node.clone();
         whitespace_node.content = "   ".to_string();
         assert!(behavior.validate(&whitespace_node).is_ok());
@@ -2411,7 +2411,7 @@ mod tests {
         let behavior = TextNodeBehavior;
         let base_node = Node::new("text".to_string(), "Valid".to_string(), json!({}));
 
-        // Issue #479: All whitespace (including Unicode) is now allowed
+        // All whitespace (including Unicode) is now allowed
         // Backend no longer validates content - frontend manages blank node persistence
 
         // Zero-width space (U+200B) - now allowed
@@ -2510,7 +2510,7 @@ mod tests {
         );
         assert!(behavior.validate(&valid_node).is_ok());
 
-        // Issue #484: Blank headers are now allowed (e.g., "##" with no content)
+        // Blank headers are now allowed (e.g., "##" with no content)
         let mut blank_node = valid_node.clone();
         blank_node.content = "".to_string();
         assert!(
@@ -2518,7 +2518,7 @@ mod tests {
             "Blank header nodes should be allowed per Issue #484"
         );
 
-        // Issue #484: Whitespace-only headers are allowed
+        // Whitespace-only headers are allowed
         let mut whitespace_node = valid_node.clone();
         whitespace_node.content = "   ".to_string();
         assert!(
@@ -2539,7 +2539,7 @@ mod tests {
         );
         assert!(behavior.validate(&valid_node).is_ok());
 
-        // Issue #484: Blank code blocks are now allowed
+        // Blank code blocks are now allowed
         let mut blank_node = valid_node.clone();
         blank_node.content = "".to_string();
         assert!(
@@ -2547,7 +2547,7 @@ mod tests {
             "Blank code blocks should be allowed per Issue #484"
         );
 
-        // Issue #484: Whitespace-only code blocks are allowed
+        // Whitespace-only code blocks are allowed
         let mut whitespace_node = valid_node.clone();
         whitespace_node.content = "   ".to_string();
         assert!(
@@ -2568,7 +2568,7 @@ mod tests {
         );
         assert!(behavior.validate(&valid_node).is_ok());
 
-        // Issue #484: Blank quote blocks are now allowed (e.g., ">" with no content)
+        // Blank quote blocks are now allowed (e.g., ">" with no content)
         let mut blank_node = valid_node.clone();
         blank_node.content = "".to_string();
         assert!(
@@ -2576,7 +2576,7 @@ mod tests {
             "Blank quote blocks should be allowed per Issue #484"
         );
 
-        // Issue #484: Quote with just prefix and whitespace
+        // Quote with just prefix and whitespace
         let mut prefix_only_node = valid_node.clone();
         prefix_only_node.content = ">".to_string();
         assert!(
@@ -2584,7 +2584,7 @@ mod tests {
             "Quote blocks with just '>' should be allowed per Issue #484"
         );
 
-        // Issue #484: Quote with prefix and space
+        // Quote with prefix and space
         let mut prefix_space_node = valid_node.clone();
         prefix_space_node.content = "> ".to_string();
         assert!(
@@ -2605,7 +2605,7 @@ mod tests {
         );
         assert!(behavior.validate(&valid_node).is_ok());
 
-        // Issue #484: Blank ordered lists are now allowed (consistent with headers, quotes, etc.)
+        // Blank ordered lists are now allowed (consistent with headers, quotes, etc.)
         let mut blank_node = valid_node.clone();
         blank_node.content = "".to_string();
         assert!(
@@ -2613,7 +2613,7 @@ mod tests {
             "Blank ordered list nodes should be allowed per Issue #484"
         );
 
-        // Issue #484: Ordered list with just prefix
+        // Ordered list with just prefix
         let mut prefix_only_node = valid_node.clone();
         prefix_only_node.content = "1. ".to_string();
         assert!(
@@ -2621,7 +2621,7 @@ mod tests {
             "Ordered lists with just '1. ' should be allowed per Issue #484"
         );
 
-        // Issue #484: Whitespace-only ordered lists are allowed
+        // Whitespace-only ordered lists are allowed
         let mut whitespace_node = valid_node.clone();
         whitespace_node.content = "   ".to_string();
         assert!(
@@ -2704,7 +2704,7 @@ mod tests {
         let behavior = TaskNodeBehavior;
 
         // Valid task with status (old flat format - backward compatibility)
-        // Status values use lowercase format (Issue #670)
+        // Status values use lowercase format
         let valid_node_old_format = Node::new(
             "task".to_string(),
             "Implement feature".to_string(),
@@ -2712,7 +2712,7 @@ mod tests {
         );
         assert!(behavior.validate(&valid_node_old_format).is_ok());
 
-        // Valid task with status (new nested format - Issue #397)
+        // Valid task with status (new nested format)
         let valid_node_new_format = Node::new(
             "task".to_string(),
             "Implement feature".to_string(),
@@ -2812,8 +2812,8 @@ mod tests {
         let behavior = TaskNodeBehavior;
         let metadata = behavior.default_metadata();
 
-        // Properties are now nested under "task" namespace (Issue #397)
-        // Status/priority values use lowercase format (Issue #670)
+        // Properties are now nested under "task" namespace
+        // Status/priority values use lowercase format
         assert_eq!(metadata["task"]["status"], "open");
         assert_eq!(metadata["task"]["priority"], "medium");
         assert!(metadata["task"]["due_date"].is_null());
@@ -2822,13 +2822,13 @@ mod tests {
 
     #[test]
     fn test_type_conversion_preserves_properties() {
-        // Core value proposition of Issue #397: Properties should be preserved
+        // Core value proposition: Properties should be preserved
         // when converting between node types (e.g., task → text → task)
 
         let behavior = TaskNodeBehavior;
 
         // Create a task node with properties in the new nested format
-        // Status/priority values use lowercase format (Issue #670)
+        // Status/priority values use lowercase format
         let mut task_node = Node::new(
             "task".to_string(),
             "Important task".to_string(),
@@ -2892,7 +2892,7 @@ mod tests {
         invalid_date.id = "2025-13-45".to_string();
         assert!(behavior.validate(&invalid_date).is_err());
 
-        // Valid: Per Issue #670, content can be different from ID
+        // Valid: content can be different from ID
         let mut custom_content = valid_node.clone();
         custom_content.content = "Custom Daily Notes".to_string();
         assert!(behavior.validate(&custom_content).is_ok());
@@ -2976,7 +2976,7 @@ mod tests {
         let text_node = Node::new("text".to_string(), "Hello".to_string(), json!({}));
         assert!(registry.validate_node(&text_node).is_ok());
 
-        // Valid task node (status uses lowercase format per Issue #670)
+        // Valid task node (status uses lowercase format)
         let task_node = Node::new(
             "task".to_string(),
             "Do something".to_string(),
@@ -3065,7 +3065,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Two-Level Embeddability Tests (Issue #573)
+    // Two-Level Embeddability Tests
     // =========================================================================
 
     #[test]
@@ -3123,7 +3123,7 @@ mod tests {
         let behavior = TaskNodeBehavior;
 
         // Task node should NOT be embeddable as root
-        // Status uses lowercase format (Issue #670)
+        // Status uses lowercase format
         let node = Node::new(
             "task".to_string(),
             "Buy groceries".to_string(),
@@ -3241,7 +3241,7 @@ mod tests {
         let text_behavior = registry.get("text").unwrap();
         assert!(text_behavior.get_embeddable_content(&text_node).is_some());
 
-        // Task node - not embeddable (status uses lowercase format per Issue #670)
+        // Task node - not embeddable (status uses lowercase format)
         let task_node = Node::new(
             "task".to_string(),
             "Task content".to_string(),
@@ -3674,7 +3674,7 @@ mod tests {
     }
 
     // =========================================================================
-    // title_template Validation Tests (Issue #824)
+    // title_template Validation Tests
     // =========================================================================
 
     #[test]
@@ -3927,7 +3927,7 @@ mod tests {
     fn test_task_node_from_node_nested_format() {
         use crate::models::{TaskNode, TaskPriority};
 
-        // Test that TaskNode::from_node handles nested format (Issue #397)
+        // Test that TaskNode::from_node handles nested format
         // Priority now uses string enum format
         let nested_node = Node::new(
             "task".to_string(),
@@ -4334,7 +4334,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Comprehensive: Every behavior's get_embeddable_content() (Issue #1018)
+    // Comprehensive: Every behavior's get_embeddable_content()
     // =========================================================================
 
     /// Verify the embeddable content decision for every registered behavior type.
@@ -4574,7 +4574,7 @@ mod tests {
         );
     }
 
-    // ToolNodeBehavior tests (issue #1353) ------------------------------------
+    // ToolNodeBehavior tests ------------------------------------
 
     fn tool_node_with_props(props: serde_json::Value) -> Node {
         Node::new("tool".to_string(), "search_nodes".to_string(), props)

--- a/packages/core/src/db/events.rs
+++ b/packages/core/src/db/events.rs
@@ -17,7 +17,7 @@
 //! 3. All subscribers receive the event asynchronously
 //! 4. LiveQueryService (Tauri layer) listens to events and forwards to frontend
 //!
-//! # Unified Relationship Event System (Issue #811)
+//! # Unified Relationship Event System
 //!
 //! All relationships (`has_child`, `member_of`, `mentions`, and custom types)
 //! use a generic `RelationshipEvent` struct with `relationship_type` for discrimination.
@@ -26,7 +26,7 @@
 use crate::models::Node;
 use serde::{Deserialize, Serialize};
 
-/// Unified relationship event for all relationship types (Issue #811)
+/// Unified relationship event for all relationship types
 ///
 /// This generic structure supports all relationship types: `has_child`, `member_of`, `mentions`,
 /// and any future custom relationship types. It replaces the enum-based approach
@@ -100,7 +100,7 @@ pub(crate) fn node_thing(id: &str) -> String {
     }
 }
 
-/// Describes a single property change for playbook trigger matching (Issue #995)
+/// Describes a single property change for playbook trigger matching
 ///
 /// Computed by diffing pre-mutation and post-mutation node properties.
 /// Used by the playbook engine for fine-grained `property_changed` triggers.
@@ -114,7 +114,7 @@ pub struct PropertyChange {
     pub new_value: Option<serde_json::Value>,
 }
 
-/// Playbook execution context carried on events for cycle detection (Issue #995)
+/// Playbook execution context carried on events for cycle detection
 ///
 /// When the playbook engine executes actions that mutate the graph, the resulting
 /// events carry this context so the engine can track chain depth and attribution.
@@ -128,7 +128,7 @@ pub struct PlaybookExecutionContext {
     pub source_playbook_id: String,
 }
 
-/// Metadata for cross-cutting concerns on domain events (Issue #995)
+/// Metadata for cross-cutting concerns on domain events
 ///
 /// Wraps `DomainEvent` in an envelope so metadata like `source_client_id` lives
 /// in one place instead of being duplicated across every event variant.
@@ -140,7 +140,7 @@ pub struct EventMetadata {
     pub playbook_context: Option<PlaybookExecutionContext>,
 }
 
-/// Envelope wrapping DomainEvent with metadata (Issue #995)
+/// Envelope wrapping DomainEvent with metadata
 ///
 /// Carried on the broadcast channel. All subscribers receive envelopes.
 /// `source_client_id` has been moved from individual event variants into
@@ -159,7 +159,7 @@ pub struct EventEnvelope {
 /// They represent domain-level changes, not database operations.
 ///
 /// Source client identification is carried in `EventMetadata` (on the
-/// `EventEnvelope` wrapper), not on individual variants (Issue #995).
+/// `EventEnvelope` wrapper), not on individual variants.
 ///
 #[derive(Debug, Clone, PartialEq)]
 pub enum DomainEvent {
@@ -186,7 +186,7 @@ pub enum DomainEvent {
     },
 
     // ============================================================================
-    // Unified Relationship Events (Issue #811)
+    // Unified Relationship Events
     // All relationship types (has_child, member_of, mentions, custom) use these
     // generic events. No backward compatibility - old EdgeCreated/etc removed.
     // ============================================================================
@@ -252,7 +252,7 @@ mod tests {
         assert_eq!(rel.to_id, "node:def");
     }
 
-    /// Contract test: Documents and enforces the exact JSON format for RelationshipEvent (Issue #811)
+    /// Contract test: Documents and enforces the exact JSON format for RelationshipEvent
     ///
     /// IMPORTANT: The frontend TypeScript types MUST match this format.
     /// This is the unified format that supports all relationship types.

--- a/packages/core/src/db/migrations/v002_embedding_origin.rs
+++ b/packages/core/src/db/migrations/v002_embedding_origin.rs
@@ -1,4 +1,4 @@
-//! Adds `embedding.origin` (#182/#183): 'local' = generated on this device,
+//! Adds `embedding.origin`: 'local' = generated on this device,
 //! 'remote' = pulled from another device via cloud sync. The cloud-push sweep
 //! reads only 'local' rows, so a pulled vector never gets re-pushed (no
 //! cross-device re-push loop / write amplification). Rebuilds `idx_emb_modified`

--- a/packages/core/src/db/sqlite_store/embeddings.rs
+++ b/packages/core/src/db/sqlite_store/embeddings.rs
@@ -15,7 +15,7 @@ impl SqliteStore {
     }
 
     /// Replace a node's embeddings with vectors PULLED from another device
-    /// (`origin = 'remote'`, #182/#183). Identical to `upsert_embeddings` except
+    /// (`origin = 'remote'`). Identical to `upsert_embeddings` except
     /// for the provenance tag, which keeps the push sweep from re-pushing a vector
     /// this device merely received (no cross-device re-push loop).
     pub async fn apply_remote_embeddings(
@@ -216,7 +216,7 @@ impl SqliteStore {
     }
 
     /// Read all locally-stored embedding records for a node (one per chunk),
-    /// ordered by chunk index. Used by the Pro daemon's cloud push (#97) to
+    /// ordered by chunk index. Used by the Pro daemon's cloud push to
     /// mirror a node's vectors into Supabase pgvector.
     pub async fn get_embeddings(&self, node_id: &str) -> Result<Vec<crate::models::Embedding>> {
         let mut rows = self
@@ -240,11 +240,11 @@ impl SqliteStore {
 
     /// Read **locally-generated** (`origin = 'local'`) embedding records modified
     /// at or after `since`, across all nodes, ordered by `modified_at`. Drives the
-    /// Pro daemon's cloud-push sweep (#97): the daemon keeps a cursor over
+    /// Pro daemon's cloud-push sweep: the daemon keeps a cursor over
     /// `modified_at` and pushes newly (re)computed vectors. Stale rows are
     /// included — the caller decides whether to skip them.
     ///
-    /// The `origin = 'local'` filter (#182/#183) excludes vectors PULLED from
+    /// The `origin = 'local'` filter excludes vectors PULLED from
     /// other devices, so a received vector is never re-pushed — without it, a
     /// pull's `modified_at = now` would re-arm this sweep and bounce the vector
     /// back to cloud, amplifying writes and (on heterogeneous devices) looping.

--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -189,7 +189,7 @@ impl SqliteStore {
         Ok(())
     }
 
-    /// One-time FTS5 backfill (#1428). The external-content `node_fts` triggers
+    /// One-time FTS5 backfill. The external-content `node_fts` triggers
     /// only index FUTURE writes, so any node predating the FTS table (user DBs are
     /// never reset — same reason the migration runner exists) is absent from
     /// the index and never returned by `bm25_search_roots`. Rebuild the index from
@@ -381,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_collection_members_recursive_includes_subcollection_members() -> Result<()> {
-        // #1426: members of a SUB-collection must be returned for the parent.
+        // members of a SUB-collection must be returned for the parent.
         // member_of stores in_node = member/child, out_node = collection/parent;
         // add_to_collection(member, collection) creates that edge.
         let (store, _t) = create_test_store().await?;
@@ -420,7 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_create_mentions_skips_dangling_links() -> Result<()> {
-        // #1462: a `[[link]]` to a node that wasn't imported (or a typo) is an FK
+        // a `[[link]]` to a node that wasn't imported (or a typo) is an FK
         // violation (relationship.out_node REFERENCES node(id), foreign_keys ON).
         // The whole-batch transaction used to roll back on the first dangling link
         // — losing EVERY mention. Now dangling pairs are skipped and the valid ones
@@ -469,7 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_member_of_cycle_is_rejected() -> Result<()> {
-        // #1427: collection hierarchy is a DAG. With `B member_of A`, adding
+        // collection hierarchy is a DAG. With `B member_of A`, adding
         // `A member_of B` would close a cycle and must be rejected.
         let (store, _t) = create_test_store().await?;
 
@@ -509,7 +509,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_fts_reindexes_unindexed_nodes() -> Result<()> {
-        // #1428: a node present in `node` but missing from `node_fts` (the pre-FTS
+        // a node present in `node` but missing from `node_fts` (the pre-FTS
         // corpus) must be re-indexed by the one-time backfill.
         let (store, _t) = create_test_store().await?;
 
@@ -568,7 +568,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_order_uses_negative_sibling_not_default() -> Result<()> {
-        // #1431: appending after a sibling whose order is <= 0 must compute from
+        // appending after a sibling whose order is <= 0 must compute from
         // that real max, not fall back to the first-item default. A sibling at
         // -1.0 (a legitimate prepend result) → next order 0.0 (= -1.0 + 1.0), NOT
         // the buggy 1.0 the `last_order > 0.0` sentinel produced.
@@ -601,7 +601,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_persisted_version_distinguishes_missing_from_present() -> Result<()> {
-        // #1432: the primitive that disambiguates a no-op version-checked update —
+        // the primitive that disambiguates a no-op version-checked update —
         // a real row reports Some(version); a missing row (incl. a date-format id
         // that get_node would virtualize) reports None, NOT a phantom version.
         let (store, _t) = create_test_store().await?;
@@ -619,7 +619,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_delete_removes_all_in_one_transaction() -> Result<()> {
-        // #1433: bulk_delete deletes every existing target (all-or-nothing) and
+        // bulk_delete deletes every existing target (all-or-nothing) and
         // returns the deleted nodes; a missing id is simply skipped.
         let (store, _t) = create_test_store().await?;
 
@@ -686,7 +686,7 @@ mod tests {
         Ok(())
     }
 
-    // ---- sqlite-vec (#1221) ----
+    // ---- sqlite-vec ----
 
     /// One 768-dim embedding whose only nonzero component is `axis` (a unit vector).
     /// Two such vectors are identical iff they share an axis (cosine sim 1.0) and
@@ -723,7 +723,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_embeddings_roundtrip_and_modified_since() -> Result<()> {
-        // #97 read-API: vectors must round-trip out of the le-f32 blob, both
+        // read-API: vectors must round-trip out of the le-f32 blob, both
         // chunks come back in order, and the modified-since cursor filters.
         let (store, _tmp) = create_test_store().await?;
         let node = store
@@ -757,7 +757,7 @@ mod tests {
         let future = Utc::now() + chrono::Duration::days(1);
         assert!(store.embeddings_modified_since(future).await?.is_empty());
 
-        // Provenance (#182/#183): a node's REMOTE (pulled) embedding must NOT show
+        // Provenance: a node's REMOTE (pulled) embedding must NOT show
         // up in the push sweep, so a received vector is never re-pushed.
         let other = store
             .create_node(
@@ -779,7 +779,7 @@ mod tests {
         );
 
         // The recurring sweep must ride idx_emb_modified, not full-scan + filesort
-        // (the #1416 review concern): assert the query plan uses the index and the
+        // (review concern): assert the query plan uses the index and the
         // ORDER BY is index-covered.
         let mut plan = store
             .db
@@ -919,7 +919,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_embeddings_batches_across_chunk_boundary() -> Result<()> {
-        // #1524: embedding/vec_embeddings inserts are now batched into multi-row
+        // embedding/vec_embeddings inserts are now batched into multi-row
         // statements chunked under SQLite's bound-parameter ceiling. Exercise a
         // chunk count large enough to span more than one batch statement.
         let (store, _tmp) = create_test_store().await?;
@@ -953,7 +953,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_stale_embedding_markers_bulk_across_chunk_boundary() -> Result<()> {
-        // #1524: marker inserts are now batched multi-row statements. Exercise a
+        // marker inserts are now batched multi-row statements. Exercise a
         // node count large enough to span more than one batch (ID_CHUNK = 180),
         // plus a duplicate node_id to confirm INSERT OR IGNORE still dedupes via
         // idx_emb_unique(node_id, model_name, chunk_index).
@@ -1111,7 +1111,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_move_node_cross_parent_leaves_exactly_one_edge() -> Result<()> {
-        // #1429: the cross-parent move deletes the old has_child edge and inserts
+        // the cross-parent move deletes the old has_child edge and inserts
         // the new one in ONE transaction. After a successful move the node must
         // have EXACTLY ONE has_child edge, pointing at the new parent — never zero
         // (orphaned root, the bug when a non-transactional INSERT failed after the
@@ -1210,7 +1210,7 @@ mod tests {
         Ok(())
     }
 
-    /// #1483: two `SqliteStore`s opened against the same file (simulating a dev +
+    /// two `SqliteStore`s opened against the same file (simulating a dev +
     /// production daemon both holding the DB) must not surface SQLITE_BUSY as a
     /// hard error on the loser of a write race. `busy_timeout` (set by migration 1,
     /// applied per-connection in `initialize_schema`) makes the second writer retry

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -81,7 +81,7 @@ impl SqliteStore {
             libsql::params![parent_id.to_string()],
         ).await.context("Failed to get last child order")?;
 
-        // #1431: distinguish "no siblings" from "a sibling at order <= 0".
+        // distinguish "no siblings" from "a sibling at order <= 0".
         // Fractional ordering legitimately yields orders <= 0 (a prepend gives
         // 0.0, then -1.0…), and `unwrap_or(0.0)` maps a NULL order to 0.0. The old
         // `last_order > 0.0` sentinel misread a lone child at 0.0 as "no children",
@@ -328,7 +328,7 @@ impl SqliteStore {
     /// Version of the REAL persisted `node` row, or `None` if no such row exists.
     /// Unlike `get_node`, this does NOT virtualize a date-page node — so a
     /// concurrently-deleted date page reports `None`, not a phantom version 1.
-    /// Used to disambiguate a no-op version-checked update (#1432).
+    /// Used to disambiguate a no-op version-checked update.
     pub async fn persisted_version(&self, id: &str) -> Result<Option<i64>> {
         let mut rows = self
             .db
@@ -446,7 +446,7 @@ impl SqliteStore {
         })
     }
 
-    /// Atomically delete multiple nodes in a SINGLE transaction (#1433). Either
+    /// Atomically delete multiple nodes in a SINGLE transaction. Either
     /// every existing target row is removed or none are — a mid-batch failure rolls
     /// the whole thing back, so a caller that gets `Err` can rely on nothing having
     /// been deleted. FK CASCADE removes each node's relationships + embeddings (same
@@ -768,7 +768,7 @@ impl SqliteStore {
             bind_values.push(libsql::Value::Text(nt.clone()));
         }
 
-        // #1430: id-scoping (e.g. a collection's members). Build `id IN (…)` and
+        // id-scoping (e.g. a collection's members). Build `id IN (…)` and
         // CHUNK it under SQLite's bound-parameter ceiling so a large member set
         // can't overflow the limit. Each chunk also carries the title/node_type
         // conditions already collected. The caller (NodeService::query_nodes)
@@ -1110,11 +1110,11 @@ impl SqliteStore {
         Ok(())
     }
 
-    /// Cycle guard for collection-hierarchy `member_of` edges (#1427). The
+    /// Cycle guard for collection-hierarchy `member_of` edges. The
     /// `has_child` tree has `validate_no_cycle`, but collection hierarchy is built
     /// from `member_of` (a sub-collection is a member_of its parent) and had no
     /// equivalent — so `a member_of b` + `b member_of a` produced a cycle in the
-    /// supposed DAG, which (post-#1426) makes the recursive members walk loop.
+    /// supposed DAG, which now makes the recursive members walk loop.
     ///
     /// `member_of` stores in_node = child/member, out_node = parent/collection.
     /// Adding `source member_of target` makes `target` an ancestor of `source`;

--- a/packages/core/src/db/sqlite_store/relationships.rs
+++ b/packages/core/src/db/sqlite_store/relationships.rs
@@ -191,7 +191,7 @@ impl SqliteStore {
             .await
             .context("Failed to get last order for relationship")?;
 
-        // #1431: presence-not-sign — append after the max sibling even when its
+        // presence-not-sign — append after the max sibling even when its
         // order is <= 0 (a `> 0.0` sentinel misreads a lone child at 0.0 as none).
         let last_order: Option<f64> = if let Some(row) = rows.next().await? {
             Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
@@ -243,7 +243,7 @@ impl SqliteStore {
             .await
             .context("Failed to get last member order")?;
 
-        // #1431: presence-not-sign — append after the max member even at order <= 0.
+        // presence-not-sign — append after the max member even at order <= 0.
         let last_order: Option<f64> = if let Some(row) = order_rows.next().await? {
             Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
         } else {
@@ -392,7 +392,7 @@ impl SqliteStore {
     ) -> Result<Vec<String>> {
         // Get all collections in the subtree using WITH RECURSIVE.
         //
-        // #1426: collection hierarchy is built from `member_of` edges (a
+        // collection hierarchy is built from `member_of` edges (a
         // sub-collection is a member_of its parent), NOT `has_child` — the old
         // recursive arm followed `has_child` and so matched nothing, leaving
         // `coll_subtree` as just the seed and silently dropping every
@@ -400,7 +400,7 @@ impl SqliteStore {
         // out_node = collection/parent, so we descend parent→child by joining on
         // `r.out_node = cs.node_id` and taking `r.in_node`, restricted to
         // collection children (a content member isn't a sub-collection). A depth
-        // cap bounds traversal in case a cycle slips in (see #1427).
+        // cap bounds traversal in case a cycle slips in.
         let mut rows = self
             .db
             .query(
@@ -577,7 +577,7 @@ impl SqliteStore {
             return Ok(0);
         }
 
-        // #1462: a mention edge is FK-constrained — `relationship.in_node` /
+        // a mention edge is FK-constrained — `relationship.in_node` /
         // `out_node` are `NOT NULL REFERENCES node(id)` with `PRAGMA foreign_keys
         // = ON` — so a mention to a NON-EXISTENT node (a dangling `[[link]]` to a
         // doc that wasn't imported, a typo, or an external ref) is an FK violation

--- a/packages/core/src/markdown/markdown_test.rs
+++ b/packages/core/src/markdown/markdown_test.rs
@@ -92,7 +92,7 @@ Text under second H2"#;
     async fn test_same_level_headers_are_siblings() {
         let (node_service, _temp_dir) = setup_test_service().await;
 
-        // Test case from issue #350: Multiple H2s should be siblings, not nested
+        // Multiple H2s should be siblings, not nested
         let markdown = r#"# Main Title
 ## First H2
 Some content under first H2
@@ -1292,7 +1292,7 @@ Text under section 1
     async fn test_bullet_with_link() {
         let (node_service, _temp_dir) = setup_test_service().await;
 
-        // Issue #871: Bullet items containing links should have "- " stripped
+        // Bullet items containing links should have "- " stripped
         // The link IS the bullet content, not a special case to exclude
         let markdown = r#"Text paragraph
 - [Click here](https://example.com)
@@ -1740,7 +1740,7 @@ Regular text after code."#;
         );
     }
 
-    // Issue #760: Test async mode (default) returns immediately with minimal response
+    // Test async mode (default) returns immediately with minimal response
     #[tokio::test]
     async fn test_async_import_returns_immediately() {
         let (node_service, _temp_dir) = setup_test_service().await;
@@ -1772,7 +1772,7 @@ Content under section 2"#;
         );
     }
 
-    // Issue #760: Test that async mode actually creates nodes in background
+    // Test that async mode actually creates nodes in background
     #[tokio::test]
     async fn test_async_import_creates_nodes_in_background() {
         let (node_service, _temp_dir) = setup_test_service().await;
@@ -1829,7 +1829,7 @@ More nested content"#;
         );
     }
 
-    // Issue #760: Test that sync mode (for tests) returns full response
+    // Test that sync mode (for tests) returns full response
     #[tokio::test]
     async fn test_sync_import_for_tests() {
         let (node_service, _temp_dir) = setup_test_service().await;
@@ -1857,12 +1857,12 @@ Some content"#;
         assert!(result["duration_ms"].is_number());
     }
 
-    // Issue #855: Test multi-paragraph quote blocks with empty continuation lines
+    // Test multi-paragraph quote blocks with empty continuation lines
     #[tokio::test]
     async fn test_quote_block_with_empty_continuation_lines() {
         let (node_service, _temp_dir) = setup_test_service().await;
 
-        // Test case from issue #855: Multi-line quote with empty continuation line
+        // Multi-line quote with empty continuation line
         let markdown = r#"> **First line of quote**
 >
 > **Second line of quote**
@@ -1917,7 +1917,7 @@ Some content"#;
         );
     }
 
-    // Issue #855: Test quote block starting with empty continuation line (edge case)
+    // Test quote block starting with empty continuation line (edge case)
     #[tokio::test]
     async fn test_quote_block_starting_with_empty_line() {
         let (node_service, _temp_dir) = setup_test_service().await;
@@ -1957,7 +1957,7 @@ Some content"#;
         );
     }
 
-    // Issue #855: Test production example from testing guide
+    // Test production example from testing guide
     #[tokio::test]
     async fn test_quote_block_production_example() {
         let (node_service, _temp_dir) = setup_test_service().await;
@@ -1989,7 +1989,7 @@ Some content"#;
         assert_eq!(nodes[1]["node_type"], "quote-block");
     }
 
-    // Issue #855: Test quote block via update path (handle_update_root_from_markdown)
+    // Test quote block via update path (handle_update_root_from_markdown)
     // This ensures the parse_markdown function (used for updates) also handles empty continuations
     #[tokio::test]
     async fn test_update_root_with_quote_block_empty_continuation() {
@@ -2006,7 +2006,7 @@ Some content"#;
             .unwrap();
         let root_id = create_result["root_id"].as_str().unwrap();
 
-        // Update with multi-line quote containing empty continuation (issue #855 pattern)
+        // Update with multi-line quote containing empty continuation
         let update_params = json!({
             "root_id": root_id,
             "markdown": "> Line 1\n>\n> Line 2"
@@ -2036,7 +2036,7 @@ Some content"#;
         assert_eq!(lines[2], "> Line 2");
     }
 
-    // Issue #914: Verify parse_markdown id_map handles 3+ level deep hierarchy
+    // Verify parse_markdown id_map handles 3+ level deep hierarchy
     // prepare_nodes_from_markdown generates temporary UUIDs; parse_markdown must map
     // grandparent → parent → child IDs correctly through the id_map
     #[tokio::test]
@@ -2112,7 +2112,7 @@ Some content"#;
         assert!(h3_text_nodes[0].content.contains("Top-level text"));
     }
 
-    // Issue #914: Verify create_nodes_from_markdown and update_root_from_markdown
+    // Verify create_nodes_from_markdown and update_root_from_markdown
     // produce identical node structures for the same markdown input.
     // Both paths now share prepare_nodes_from_markdown for detection logic.
     #[tokio::test]
@@ -2212,7 +2212,7 @@ Some content"#;
     }
 }
 
-/// Tests for link transformation (Issue #854)
+/// Tests for link transformation
 ///
 /// These tests verify that inter-file links are correctly transformed
 /// during bulk import operations.
@@ -2479,7 +2479,7 @@ mod link_transformation_tests {
     }
 }
 
-/// Tests for mention collection during link transformation (Issue #868)
+/// Tests for mention collection during link transformation
 ///
 /// These tests verify that mention relationships are correctly collected
 /// when inter-file links are transformed to nodespace:// format.
@@ -2943,7 +2943,7 @@ ___
     async fn test_horizontal_rule_placed_at_root_level_inside_heading() {
         let (node_service, _temp_dir) = setup_test_service().await;
 
-        // Regression test for issue #948: HR inside a heading section should be
+        // Regression test: HR inside a heading section should be
         // placed as a direct child of root, not nested under the heading.
         let markdown = r#"# Section One
 
@@ -3015,7 +3015,7 @@ Some text here.
 }
 
 // ============================================================================
-// NodeTemplate / prepare_nodes_from_template unit tests (Issue #1056)
+// NodeTemplate / prepare_nodes_from_template unit tests
 // ============================================================================
 
 #[cfg(test)]

--- a/packages/core/src/markdown/mod.rs
+++ b/packages/core/src/markdown/mod.rs
@@ -4,7 +4,7 @@
 //! Preserves heading hierarchy and list indentation as parent-child relationships.
 //! Consumed as a library by `nodespace-agent` and `nodespace-daemon`.
 //!
-//! As of Issue #676, all handlers use NodeService directly instead of NodeOperations.
+//! All handlers use NodeService directly instead of NodeOperations.
 //!
 //! # Examples
 //!
@@ -59,7 +59,7 @@ const MAX_NODES_PER_IMPORT: usize = 1000;
 const MAX_BULLET_CONTENT_LENGTH: usize = 100;
 
 // ============================================================================
-// Two-Phase Batch Creation (Issue #737)
+// Two-Phase Batch Creation
 // ============================================================================
 
 /// A node prepared for bulk insertion with pre-calculated hierarchy
@@ -160,14 +160,14 @@ impl PrepareContext {
 }
 
 // ============================================================================
-// Link Transformation (Issue #854, #868)
+// Link Transformation
 // ============================================================================
 
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-/// Result of link transformation containing collected mentions (Issue #868)
+/// Result of link transformation containing collected mentions
 ///
 /// During link transformation, we collect (source_node_id, target_node_id) pairs
 /// for creating mention relationships after nodes are inserted into the database.
@@ -218,7 +218,7 @@ pub fn transform_links_in_nodes(
     let _ = transform_links_in_nodes_with_mentions(nodes, file_to_root_id, current_file_path, "");
 }
 
-/// Transform inter-file markdown links and collect mention relationships (Issue #868)
+/// Transform inter-file markdown links and collect mention relationships
 ///
 /// Same as `transform_links_in_nodes` but also returns a `LinkTransformResult`
 /// containing (source_node_id, target_node_id) pairs for creating mention relationships.
@@ -267,7 +267,7 @@ pub fn transform_links_in_nodes_with_mentions(
     result
 }
 
-/// Transform links in a single content string and collect target IDs (Issue #868)
+/// Transform links in a single content string and collect target IDs
 fn transform_links_in_content_with_mentions(
     content: &str,
     file_to_root_id: &HashMap<PathBuf, String>,
@@ -301,7 +301,7 @@ fn transform_links_in_content_with_mentions(
     (transformed, target_ids)
 }
 
-/// Transform a single link and return the target ID if it resolves to a nodespace link (Issue #868)
+/// Transform a single link and return the target ID if it resolves to a nodespace link
 ///
 /// Returns a tuple of (transformed_link, Option<target_id>)
 /// - For existing nodespace:// links: returns the link and extracts the target ID
@@ -910,7 +910,7 @@ pub async fn handle_create_nodes_from_markdown(
     };
 
     // ============================================================================
-    // Two-Phase Batch Creation (Issue #737)
+    // Two-Phase Batch Creation
     // Phase 1: Create container/root node (single node, uses existing path)
     // Phase 2: Batch create all children in a single transaction
     // ============================================================================
@@ -1246,7 +1246,7 @@ pub async fn handle_create_nodes_from_markdown(
 }
 
 // ============================================================================
-// Node Template (Issue #1056)
+// Node Template
 // ============================================================================
 //
 // Allows callers to define a hierarchy using markdown content while overriding

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -292,7 +292,7 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             modified_at: now,
             is_core: true,
             schema_version: 1,
-            // ADR-037 #1372: opt-in restriction. A Core-protected boolean; the Pro
+            // ADR-037: opt-in restriction. A Core-protected boolean; the Pro
             // RLS layer reads `properties->>'restrictedToMembers'` to gate access.
             // Default/absent = false = open (organizational). member_of edge
             // `permission` (admin/modify/readOnly) is a free-form edge property the
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_collection_has_restricted_to_members_field() {
-        // ADR-037 #1372: opt-in restriction is a Core-protected boolean on collection.
+        // ADR-037: opt-in restriction is a Core-protected boolean on collection.
         let schemas = get_core_schemas();
         let collection = schemas.iter().find(|s| s.id == "collection").unwrap();
         let field = collection

--- a/packages/core/src/models/node.rs
+++ b/packages/core/src/models/node.rs
@@ -23,7 +23,7 @@
 //!     json!({}),
 //! );
 //!
-//! // Create a task node with properties (status uses lowercase format per Issue #670)
+//! // Create a task node with properties (status uses lowercase format)
 //! let task_node = Node::new(
 //!     "task".to_string(),
 //!     "Implement Pure JSON schema".to_string(),
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_node_validation_accepts_blank_content() {
-        // Issue #484: Blank content is now allowed (supports ephemeral node elimination from #479)
+        // Blank content is now allowed (supports ephemeral node elimination)
         let mut node = Node::new("text".to_string(), "Valid content".to_string(), json!({}));
         node.content = String::new();
 
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_task_node_with_properties() {
-        // Status/priority values use lowercase format (Issue #670)
+        // Status/priority values use lowercase format
         let task = Node::new(
             "task".to_string(),
             "Implement feature".to_string(),
@@ -714,7 +714,7 @@ mod tests {
         assert_eq!(task.properties["priority"], "high");
     }
 
-    // Lifecycle Status Tests (Issue #755)
+    // Lifecycle Status Tests
 
     #[test]
     fn test_node_lifecycle_status_default() {

--- a/packages/core/src/models/schema_node.rs
+++ b/packages/core/src/models/schema_node.rs
@@ -3,7 +3,7 @@
 //! Provides compile-time type safety for schema nodes using Universal Graph Architecture.
 //! Schema properties (fields, relationships) are stored in node.properties.
 //!
-//! # Architecture (Universal Graph - Issue #783)
+//! # Architecture (Universal Graph)
 //!
 //! **Query Pattern:**
 //! Note: Column aliases use camelCase to match serde's `#[serde(rename_all = "camelCase")]`.
@@ -23,7 +23,7 @@
 //! FROM node:`task` WHERE node_type = 'schema';
 //! ```
 //!
-//! ## Description Storage (Issue #1351)
+//! ## Description Storage
 //!
 //! Schema descriptions are stored as a **child node subtree** (markdown parsed into text/header
 //! nodes), not as `properties.description`. This enables:

--- a/packages/core/src/models/task_node.rs
+++ b/packages/core/src/models/task_node.rs
@@ -1,7 +1,7 @@
 //! Strongly-Typed TaskNode
 //!
 //! Provides compile-time type safety for task nodes with strongly-typed status,
-//! priority, and date fields. Uses Universal Graph Architecture (Issue #783).
+//! priority, and date fields. Uses Universal Graph Architecture.
 //!
 //! # Architecture
 //!
@@ -97,7 +97,7 @@ mod flexible_date {
 /// Task status enumeration
 ///
 /// Represents the lifecycle states of a task node.
-/// Values use lowercase format for consistency across all layers (Issue #670):
+/// Values use lowercase format for consistency across all layers:
 /// - "open" - Not started (default)
 /// - "in_progress" - Currently being worked on
 /// - "done" - Finished
@@ -869,7 +869,7 @@ mod tests {
 /// the two directions disagree on a property key — the field is silently dropped
 /// on the next write. This proptest turns that silent drop into a test failure by
 /// asserting `from_node(task.into_node())` recovers every typed field: the
-/// domain→storage→domain round trip issue #1502 asks for.
+/// domain→storage→domain round trip.
 #[cfg(test)]
 mod roundtrip_proptests {
     use super::*;

--- a/packages/core/src/models/task_node_test.rs
+++ b/packages/core/src/models/task_node_test.rs
@@ -31,7 +31,7 @@ mod tests {
     fn test_status_getter_default() {
         let node = Node::new("task".to_string(), "Test".to_string(), json!({}));
         let task = TaskNode::from_node(node).unwrap();
-        // Default status is Open (Issue #670)
+        // Default status is Open
         assert_eq!(task.status(), TaskStatus::Open);
     }
 
@@ -59,7 +59,7 @@ mod tests {
         assert_eq!(task.status(), TaskStatus::Done);
         // Direct field access now
         assert_eq!(task.status, TaskStatus::Done);
-        // Status value uses lowercase format (Issue #670)
+        // Status value uses lowercase format
         assert_eq!(task.as_node().properties["status"], "done");
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_as_node_reference() {
-        // Status uses lowercase format (Issue #670)
+        // Status uses lowercase format
         let node = Node::new(
             "task".to_string(),
             "Test".to_string(),
@@ -234,7 +234,7 @@ mod tests {
 
         assert_eq!(task.content, "Implement feature");
         assert_eq!(task.as_node().node_type, "task");
-        // Default status is Open (Issue #670)
+        // Default status is Open
         assert_eq!(task.status(), TaskStatus::Open);
         // Default priority is Medium
         assert_eq!(task.get_priority(), TaskPriority::Medium);
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_task_status_from_str() {
-        // Status values use lowercase format (Issue #670)
+        // Status values use lowercase format
         assert_eq!("open".parse::<TaskStatus>().unwrap(), TaskStatus::Open);
         assert_eq!(
             "in_progress".parse::<TaskStatus>().unwrap(),
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_task_status_as_str() {
-        // Status values use lowercase format (Issue #670)
+        // Status values use lowercase format
         assert_eq!(TaskStatus::Open.as_str(), "open");
         assert_eq!(TaskStatus::InProgress.as_str(), "in_progress");
         assert_eq!(TaskStatus::Done.as_str(), "done");
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_all_status_values() {
-        // Updated status values per Issue #670
+        // Updated status values
         let statuses = vec![
             TaskStatus::Open,
             TaskStatus::InProgress,

--- a/packages/core/src/ops/context_ops.rs
+++ b/packages/core/src/ops/context_ops.rs
@@ -6,9 +6,9 @@
 //!
 //! Entity types are no longer included here by default — the model discovers
 //! type metadata on-demand via `search_skills` which returns `schema_metadata`
-//! per match (#1283). When a query + embedding service are provided, schemas
+//! per match. When a query + embedding service are provided, schemas
 //! semantically relevant to the query are injected to cover implicit references
-//! (e.g. "track my clients" → `customer` schema) (#1300).
+//! (e.g. "track my clients" → `customer` schema).
 
 use crate::models::SchemaNode;
 use crate::services::{CollectionService, NodeEmbeddingService, NodeService};
@@ -60,7 +60,7 @@ const MAX_SEMANTIC_SCHEMAS: usize = 5;
 /// When `embedding_service` and `query` are both provided, schema nodes
 /// semantically similar to the query are retrieved and injected into the
 /// context. Falls back to schema-free context when the embedding service is
-/// unavailable or the query is empty (#1300).
+/// unavailable or the query is empty.
 pub async fn build_workspace_context(
     node_service: &Arc<NodeService>,
     embedding_service: Option<&Arc<NodeEmbeddingService>>,
@@ -93,7 +93,7 @@ pub async fn build_workspace_context(
         })
         .collect();
 
-    // Semantic schema retrieval (#1300): find schemas relevant to the query.
+    // Semantic schema retrieval: find schemas relevant to the query.
     // Only runs when both an embedding service and a non-empty query are present.
     let relevant_schemas = match (embedding_service, query.filter(|q| !q.trim().is_empty())) {
         (Some(emb), Some(q)) => {
@@ -143,8 +143,8 @@ impl WorkspaceContext {
     ///
     /// Semantically-relevant schemas are injected when present (retrieved via
     /// vector similarity by `build_workspace_context` — covers implicit type
-    /// references like "clients" → `customer` schema, #1300). All other entity
-    /// types remain on-demand via `search_skills` (#1283).
+    /// references like "clients" → `customer` schema). All other entity
+    /// types remain on-demand via `search_skills`.
     ///
     /// `max_chars` is a rough character budget for the combined output.
     pub fn format_for_prompt(&self, max_chars: usize) -> String {
@@ -158,7 +158,7 @@ impl WorkspaceContext {
             }
         }
 
-        // Relevant schemas section (query-matched via semantic retrieval, #1300)
+        // Relevant schemas section (query-matched via semantic retrieval)
         if !self.relevant_schemas.is_empty() {
             let header = "\nRELEVANT ENTITY TYPES:\n";
             if out.len() + header.len() <= max_chars {

--- a/packages/core/src/ops/mod.rs
+++ b/packages/core/src/ops/mod.rs
@@ -58,7 +58,7 @@ impl From<NodeServiceError> for OpsError {
                 actual: actual_version,
                 // task_node path: get_node() is not called before this conversion, so
                 // current_node is unavailable here. The frontend falls back to
-                // resyncNodeFromServer for task-node conflicts (see #1268 follow-up).
+                // resyncNodeFromServer for task-node conflicts.
                 current_node: None,
             },
             NodeServiceError::ValidationFailed(e) => OpsError::ValidationFailed(e.to_string()),

--- a/packages/core/src/ops/node_ops.rs
+++ b/packages/core/src/ops/node_ops.rs
@@ -416,7 +416,7 @@ pub async fn query_nodes(
         );
     }
 
-    // #1430: pagination differs for a collection-scoped query. Pushing offset/limit
+    // pagination differs for a collection-scoped query. Pushing offset/limit
     // to SQL paginated the WRONG set (membership is filtered after the query), and
     // the old fixed 1000 over-fetch silently dropped any member outside the newest
     // 1000 rows. Instead SCOPE the SQL to the collection's members via `with_ids` —
@@ -489,7 +489,7 @@ pub async fn query_nodes(
         .await
         .map_err(|e| OpsError::Internal(format!("Failed to query nodes: {}", e)))?;
 
-    // Paginate IN MEMORY (#1430). The SQL is already id-scoped to members (the
+    // Paginate IN MEMORY. The SQL is already id-scoped to members (the
     // `id IN (…)` from `with_ids`), so this `member_ids.contains` is a genuine
     // defensive double-check, not the thing producing correctness. Apply offset +
     // limit over the membership set (CreatedDesc-ordered) so `offset>0` and `limit`

--- a/packages/core/src/ops/skill_ops.rs
+++ b/packages/core/src/ops/skill_ops.rs
@@ -2,8 +2,6 @@
 //!
 //! Shared logic for skill search used by the local agent's `search_skills`
 //! tool and the MCP `find_skills` handler exposed to external agents.
-//!
-//! Issues #1051, #1130, #1283, #1356, #1392.
 
 use crate::models::Node;
 use crate::services::{NodeEmbeddingService, NodeService, SearchNodeFilters};
@@ -19,8 +17,8 @@ use super::OpsError;
 /// similarity, including weak ones, and decides for itself which (if any)
 /// skill is relevant. The underlying store filter is `composite_score >
 /// $threshold`, so a zero match (orthogonal vector) is still excluded — but
-/// that's the cosine noise floor, not a confidence judgment call. Issue
-/// #1130 explicitly removed server-side bucketing in favour of letting the
+/// that's the cosine noise floor, not a confidence judgment call.
+/// Server-side bucketing was explicitly removed in favour of letting the
 /// LLM judge confidence from the raw score; a non-zero floor here would
 /// partially undo that by silently hiding the long tail.
 const SKILL_SEARCH_THRESHOLD: f32 = 0.0;
@@ -109,9 +107,9 @@ fn render_subtree_dfs(
 /// Returns up to `limit` matches (default 3) with `id`, `name`, `description`,
 /// `confidence`, `tools`, `schema_metadata`, and `instructions`. The `instructions`
 /// field is the skill's child subtree rendered to markdown — the actual procedure
-/// the model must follow (#1356). The `schema_metadata` field contains type IDs,
+/// the model must follow. The `schema_metadata` field contains type IDs,
 /// field names, and enum values for entity types associated with the skill's
-/// `tool_whitelist` scope (#1283).
+/// `tool_whitelist` scope.
 ///
 /// No filtering or bucketing — the caller (model or MCP client) inspects the
 /// raw confidence score and decides how to act. An empty `skills` array is a

--- a/packages/core/src/ops/skill_updater.rs
+++ b/packages/core/src/ops/skill_updater.rs
@@ -15,8 +15,6 @@
 //! 3. Updates the "Node Creation" skill node's `description` property.
 //! 4. The embedding pipeline then re-embeds the skill automatically (triggered by
 //!    the `NodeUpdated` event the update emits).
-//!
-//! Issue #1061.
 
 use crate::db::events::{DomainEvent, EventEnvelope};
 use crate::models::{NodeQuery, NodeUpdate};

--- a/packages/core/src/playbook/cel.rs
+++ b/packages/core/src/playbook/cel.rs
@@ -11,7 +11,7 @@
 //! directly from `node.properties` (the raw DB format), not via
 //! `flatten_properties_for_api`.
 //!
-//! # Graph Traversal (#1010)
+//! # Graph Traversal
 //!
 //! Dot-path relationship walking (e.g., `node.story.epic.status`) is resolved
 //! before evaluation by the `GraphResolver`. The path extractor parses CEL ASTs

--- a/packages/core/src/playbook/engine.rs
+++ b/packages/core/src/playbook/engine.rs
@@ -588,7 +588,7 @@ pub(crate) async fn rule_processor_loop(
                 rule_ref.rule.name, rule_ref.playbook_id, rule_ref.rule_index,
             );
 
-            // Phase 3 + #1010: Evaluate CEL conditions with graph resolver
+            // Phase 3: Evaluate CEL conditions with graph resolver
             let mut resolver =
                 crate::playbook::graph_resolver::GraphResolver::new(Arc::clone(&node_service));
             let condition_result = crate::playbook::cel::evaluate_conditions(

--- a/packages/core/src/playbook/lifecycle.rs
+++ b/packages/core/src/playbook/lifecycle.rs
@@ -152,7 +152,7 @@ impl PlaybookLifecycleManager {
     /// affected schema's node_type (either directly as a trigger or via dot-path
     /// traversal in conditions) and need to be disabled.
     ///
-    /// Uses path extraction (#1010) to find playbooks whose conditions traverse
+    /// Uses path extraction to find playbooks whose conditions traverse
     /// through the changed schema, not just those that trigger on it directly.
     ///
     /// Returns the list of playbook IDs that were disabled due to schema drift.
@@ -378,14 +378,14 @@ pub fn trigger_keys_for_event(event: &crate::db::events::DomainEvent) -> Vec<Tri
             vec![]
         }
         DomainEvent::RelationshipCreated { .. } => {
-            // TODO(#995-phase2): Relationship events don't carry source_node_type.
+            // TODO(phase2): Relationship events don't carry source_node_type.
             // The EventSubscriber will need to fetch the source node to determine its
             // type, then perform TriggerKey::RelationshipEvent lookup. Until then,
             // relationship_added/relationship_removed triggers are indexed but not matched.
             vec![]
         }
         DomainEvent::RelationshipUpdated { .. } => vec![], // No playbook triggers for updates
-        DomainEvent::RelationshipDeleted { .. } => vec![], // TODO(#995-phase2): same as RelationshipCreated above
+        DomainEvent::RelationshipDeleted { .. } => vec![], // TODO(phase2): same as RelationshipCreated above
     }
 }
 
@@ -532,7 +532,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // handle_schema_update — path-aware drift detection (#1010)
+    // handle_schema_update — path-aware drift detection
     // -----------------------------------------------------------------------
 
     #[test]

--- a/packages/core/src/playbook/types.rs
+++ b/packages/core/src/playbook/types.rs
@@ -39,7 +39,7 @@ pub enum RelEventType {
     RelationshipRemoved,
 }
 
-/// Key for O(1) rule lookup in the TriggerIndex (Issue #995).
+/// Key for O(1) rule lookup in the TriggerIndex.
 ///
 /// An enum — not a flat tuple — because relationship triggers have no
 /// `property_key` dimension. The `RelationshipEvent` variant intentionally

--- a/packages/core/src/playbook/validation.rs
+++ b/packages/core/src/playbook/validation.rs
@@ -184,7 +184,7 @@ pub async fn validate_playbook(
         for (cond_idx, condition) in rule.conditions.iter().enumerate() {
             let location = format!("rule[{}].condition[{}]", rule_idx, cond_idx);
 
-            // Schema-aware path validation (#1010): extract dot-paths and
+            // Schema-aware path validation: extract dot-paths and
             // verify each segment resolves to a field or relationship on the schema graph
             if let Some(nt) = &trigger_node_type {
                 if let Ok(extraction) = path_extractor::extract_paths(&condition.source) {
@@ -528,7 +528,7 @@ async fn validate_relationship_action(
 }
 
 // ---------------------------------------------------------------------------
-// Schema Change Impact Analysis (Issue #1012 Phase 2)
+// Schema Change Impact Analysis (Phase 2)
 // ---------------------------------------------------------------------------
 
 /// A playbook affected by a schema change, with the specific broken paths.
@@ -1242,7 +1242,7 @@ mod tests {
             assert!(result.is_ok());
         }
 
-        // -- Schema-aware path validation tests (#1010) --
+        // -- Schema-aware path validation tests --
 
         #[tokio::test]
         async fn test_valid_multi_hop_path_passes() {
@@ -1377,7 +1377,7 @@ mod tests {
         }
 
         // ---------------------------------------------------------------
-        // check_schema_change_impact tests (Issue #1012 Phase 2)
+        // check_schema_change_impact tests (Phase 2)
         // ---------------------------------------------------------------
 
         /// Helper: create a playbook node in the database.
@@ -1507,7 +1507,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // NodeService synchronous validation gate tests (Issue #1012 Phase 1)
+    // NodeService synchronous validation gate tests (Phase 1)
     // ---------------------------------------------------------------
 
     mod sync_gate_tests {

--- a/packages/core/src/schema/mod.rs
+++ b/packages/core/src/schema/mod.rs
@@ -535,7 +535,7 @@ pub async fn handle_update_schema(
         }
     }
 
-    // Issue #1012: Check if any active playbooks would be affected by this schema change.
+    // Check if any active playbooks would be affected by this schema change.
     // Done before any mutations so a blocked rename doesn't partially execute.
     let affected =
         crate::playbook::validation::check_schema_change_impact(&params.schema_id, node_service)

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -506,7 +506,7 @@ async fn test_rename_field_migrates_node_data() {
 }
 
 // ============================================================================
-// Issue #1351: Description subtree tests
+// Description subtree tests
 // ============================================================================
 
 #[tokio::test]

--- a/packages/core/src/services/collection_service.rs
+++ b/packages/core/src/services/collection_service.rs
@@ -306,7 +306,7 @@ impl ResolvedPath {
 /// queries. It delegates to `NodeService` for relationship operations to ensure
 /// proper event emission.
 ///
-/// # Event Emission (Issue #813)
+/// # Event Emission
 ///
 /// Per service-layer-architecture.md, event emission happens in NodeService.
 /// CollectionService delegates `member_of` operations to NodeService, which
@@ -335,7 +335,7 @@ impl<'a> CollectionService<'a> {
     /// This method parses the path, finds or creates each segment in order,
     /// and establishes hierarchy relationships between them using `member_of` edges.
     ///
-    /// # Collection Hierarchy (Issue #808)
+    /// # Collection Hierarchy
     ///
     /// Collections form a DAG (Directed Acyclic Graph) where:
     /// - Path `hr:policy:vacation` creates hierarchy using `member_of` edges
@@ -381,7 +381,7 @@ impl<'a> CollectionService<'a> {
         let mut collections = Vec::with_capacity(parsed.segments.len());
         let mut previous_collection_id: Option<String> = None;
 
-        // Issue #808: Collections form a hierarchical DAG structure.
+        // Collections form a hierarchical DAG structure.
         // Each segment in the path is a member of the previous segment (its parent).
         // Collection names are globally unique, so the same collection can
         // appear in multiple paths (e.g., "hr:policy:vacation:berlin" and
@@ -401,7 +401,7 @@ impl<'a> CollectionService<'a> {
             // Create hierarchy relationship: current collection is member_of parent collection
             // Direction: child -> member_of -> parent (same as nodes belonging to collections)
             // This is idempotent - if the relationship already exists, nothing happens
-            // Issue #813: Delegate to NodeService for event emission
+            // Delegate to NodeService for event emission
             if let Some(parent_id) = &previous_collection_id {
                 self.node_service
                     .create_relationship(&node.id, "member_of", parent_id, json!({}))
@@ -452,7 +452,7 @@ impl<'a> CollectionService<'a> {
     ///
     /// * `name` - The collection name (will be validated, must be globally unique)
     ///
-    /// # Issue #813
+    /// # Event Emission
     ///
     /// Uses NodeService.create_node() to ensure NodeCreated event emission.
     /// The pattern is "read from store, write through NodeService".
@@ -463,7 +463,7 @@ impl<'a> CollectionService<'a> {
         let node = Node::new("collection".to_string(), validated_name, json!({}));
         let node_id = node.id.clone();
 
-        // Issue #813: Use NodeService for node creation (emits NodeCreated event)
+        // Use NodeService for node creation (emits NodeCreated event)
         self.node_service.create_node(node).await?;
 
         // Fetch and return the created node
@@ -489,7 +489,7 @@ impl<'a> CollectionService<'a> {
     ) -> Result<ResolvedPath, NodeServiceError> {
         let resolved = self.resolve_path(collection_path).await?;
 
-        // Issue #813, #825: Delegate to NodeService for event emission (unified method)
+        // Delegate to NodeService for event emission (unified method)
         self.node_service
             .create_relationship(node_id, "member_of", &resolved.leaf.id, json!({}))
             .await?;
@@ -534,7 +534,7 @@ impl<'a> CollectionService<'a> {
             )));
         }
 
-        // Issue #813, #825: Delegate to NodeService for event emission (unified method)
+        // Delegate to NodeService for event emission (unified method)
         self.node_service
             .create_relationship(node_id, "member_of", collection_id, json!({}))
             .await?;
@@ -553,7 +553,7 @@ impl<'a> CollectionService<'a> {
         node_id: &str,
         collection_id: &str,
     ) -> Result<(), NodeServiceError> {
-        // Issue #813, #825: Delegate to NodeService for event emission (unified method)
+        // Delegate to NodeService for event emission (unified method)
         self.node_service
             .delete_relationship(node_id, "member_of", collection_id)
             .await?;
@@ -656,7 +656,7 @@ impl<'a> CollectionService<'a> {
     /// 3. Creates missing collections in hierarchy order
     /// 4. Returns a map from path → leaf collection ID
     ///
-    /// # Performance (Issue #854)
+    /// # Performance
     ///
     /// For 100 files with paths like "Architecture:Core", "Architecture:Components":
     /// - Before: 100 separate resolve_path calls, each querying for "Architecture"

--- a/packages/core/src/services/embedding_processor.rs
+++ b/packages/core/src/services/embedding_processor.rs
@@ -1,4 +1,4 @@
-//! Background Embedding Processor (Issue #729)
+//! Background Embedding Processor
 //!
 //! Provides event-driven background processing of stale root-aggregate embeddings:
 //! - Purely event-driven: only wakes when nodes change
@@ -240,7 +240,7 @@ impl EmbeddingProcessor {
     /// Unlike polling, this approach has zero overhead when idle. The processor
     /// only runs when there's actual work to do.
     ///
-    /// ## Root-Aggregate Model (Issue #729)
+    /// ## Root-Aggregate Model
     ///
     /// Uses `process_stale_embeddings()` which:
     /// 1. Queries the `embedding` table for stale entries

--- a/packages/core/src/services/embedding_service.rs
+++ b/packages/core/src/services/embedding_service.rs
@@ -1,4 +1,4 @@
-//! Root-Aggregate Embedding Service (Issue #729, refactored in Issue #1018)
+//! Root-Aggregate Embedding Service
 //!
 //! ## Overview
 //!
@@ -8,7 +8,7 @@
 //! - Uses the dedicated `embedding` table (not node.embedding_vector)
 //! - Supports chunking for content > 512 tokens
 //!
-//! ## Behavior-Driven Embeddability (Issue #1018)
+//! ## Behavior-Driven Embeddability
 //!
 //! Whether a node is embeddable is determined by its `NodeBehavior::get_embeddable_content()`.
 //! No hardcoded type list. Content extraction uses a two-phase approach:
@@ -41,7 +41,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 50;
 /// Maximum depth for parent chain traversal (safety limit to prevent infinite loops)
 pub const MAX_PARENT_CHAIN_DEPTH: usize = 100;
 
-/// Title keyword boost added to composite score when any query term matches the node title (Issue #936)
+/// Title keyword boost added to composite score when any query term matches the node title
 ///
 /// Applied as an additive bonus: `composite_score + TITLE_BOOST` when a match is found.
 /// Start at 0.1; tune against benchmark if needed.
@@ -52,7 +52,7 @@ pub const MAX_PARENT_CHAIN_DEPTH: usize = 100;
 /// the node is fetched — so the boost must be Rust-side, not SQL-side.
 pub const TITLE_BOOST: f64 = 0.1;
 
-/// Root-aggregate embedding service (Issue #1018: behavior-driven)
+/// Root-aggregate embedding service (behavior-driven)
 ///
 /// Manages semantic embeddings using the root-aggregate model where only
 /// root nodes get embedded. Whether a node is embeddable is decided by its
@@ -75,7 +75,7 @@ pub struct NodeEmbeddingService {
 }
 
 impl NodeEmbeddingService {
-    /// Create a new NodeEmbeddingService with behavior-driven content extraction (Issue #1018)
+    /// Create a new NodeEmbeddingService with behavior-driven content extraction
     ///
     /// # Arguments
     /// * `nlp_engine` - The NLP engine for generating embeddings
@@ -182,7 +182,7 @@ impl NodeEmbeddingService {
     }
 
     // =========================================================================
-    // Behavior-Driven Content Extraction (Issue #1018)
+    // Behavior-Driven Content Extraction
     // =========================================================================
 
     /// Extract full embeddable content for a root node using its behavior.
@@ -191,7 +191,7 @@ impl NodeEmbeddingService {
     /// 1. `behavior.get_embeddable_content(node)` — sync, the node's own content
     /// 2. `behavior.get_aggregated_content(node, accessor)` — async, child aggregation
     ///
-    /// Also prepends the node title if present (Issue #936 title boost).
+    /// Also prepends the node title if present (title boost).
     ///
     /// Returns `None` if the behavior says this node is not embeddable.
     async fn extract_content_for_embedding(
@@ -214,7 +214,7 @@ impl NodeEmbeddingService {
         // Build full content: title + own + aggregated
         let mut parts = Vec::new();
 
-        // Prepend title so it is included in the embedding (Issue #936)
+        // Prepend title so it is included in the embedding
         if let Some(ref title) = node.title {
             if !title.trim().is_empty() {
                 parts.push(title.clone());
@@ -360,7 +360,7 @@ impl NodeEmbeddingService {
     /// Generate and store embeddings for a root node
     ///
     /// This is the main entry point for embedding a root node's content.
-    /// Uses behavior-driven content extraction (Issue #1018):
+    /// Uses behavior-driven content extraction:
     /// 1. `behavior.get_embeddable_content()` determines if node is embeddable
     /// 2. `behavior.get_aggregated_content()` gathers child content
     /// 3. Chunks, generates vectors, and stores in the embedding table
@@ -540,7 +540,7 @@ impl NodeEmbeddingService {
     ///
     /// If the node is a root of an embeddable type, marks its embedding as stale.
     /// If the node is a child, finds its root and marks that as stale.
-    /// Embeddability is determined by `NodeBehavior::get_embeddable_content()` (Issue #1018).
+    /// Embeddability is determined by `NodeBehavior::get_embeddable_content()`.
     pub async fn queue_for_embedding(&self, node_id: &str) -> Result<(), NodeServiceError> {
         // Find the root of this node's tree
         let root_id = self.find_root_id(node_id).await?;
@@ -632,7 +632,7 @@ impl NodeEmbeddingService {
     // Search
     // =========================================================================
 
-    /// Search for nodes using hybrid BM25 + KNN scoring (Issue #951)
+    /// Search for nodes using hybrid BM25 + KNN scoring
     ///
     /// Runs BM25 full-text search and KNN vector search in parallel, then tiers results:
     /// - **Tier 1** (highest confidence): roots in BOTH BM25 and KNN results
@@ -665,7 +665,7 @@ impl NodeEmbeddingService {
         })?;
         let embed_time = embed_start.elapsed();
 
-        // Run BM25 and KNN searches in parallel (Issue #951)
+        // Run BM25 and KNN searches in parallel
         // BM25 is O(log n) via inverted index — sub-millisecond
         // KNN is ~50-100ms via HNSW — total latency = max(bm25, knn) ≈ same as before
         let search_start = std::time::Instant::now();
@@ -685,7 +685,7 @@ impl NodeEmbeddingService {
         let bm25_roots = bm25_roots
             .map_err(|e| NodeServiceError::query_failed(format!("BM25 search failed: {}", e)))?;
 
-        // Apply title keyword boost (Issue #936) to KNN results
+        // Apply title keyword boost to KNN results
         // Punctuation is stripped from tokens so queries like "persistence?" still match.
         let query_terms: Vec<String> = query
             .split_whitespace()
@@ -709,7 +709,7 @@ impl NodeEmbeddingService {
             }
         }
 
-        // Tier results by intersection signal (Issue #951)
+        // Tier results by intersection signal
         //
         // Tier 1: roots present in BOTH KNN and BM25 → highest confidence
         // Tier 2: roots in KNN only → semantic relevance alone
@@ -799,7 +799,7 @@ impl NodeEmbeddingService {
     /// Search and return full nodes
     ///
     /// Convenience method that fetches the full Node objects for search results.
-    /// Search with scope filtering (Issue #1018)
+    /// Search with scope filtering
     ///
     /// Wraps `semantic_search` and applies post-result filtering based on the
     /// `SearchScope`. The scope determines which node types are included in
@@ -862,7 +862,7 @@ impl NodeEmbeddingService {
     /// a SQL join, eliminating N+1 query overhead.
     ///
     /// Accepts an optional [`SearchNodeFilters`] to restrict results by node type
-    /// and/or property values (Issue #1059). When filters are active, the fetch
+    /// and/or property values. When filters are active, the fetch
     /// is inflated by 3× to compensate for post-filter attrition, then truncated
     /// to `limit`. Passing `None` preserves the original unfiltered behavior.
     pub async fn semantic_search_nodes(
@@ -1205,7 +1205,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Behavior-Driven Embedding Decision Tests (Issue #1018)
+    // Behavior-Driven Embedding Decision Tests
     // =========================================================================
 
     /// Mock NodeAccessor for testing extract_content_for_embedding without a database.

--- a/packages/core/src/services/migration_registry.rs
+++ b/packages/core/src/services/migration_registry.rs
@@ -23,7 +23,7 @@
 //! let mut registry = MigrationRegistry::new();
 //!
 //! // Register a migration transform
-//! // Issue #794: Properties are namespaced under properties[node_type]
+//! // Properties are namespaced under properties[node_type]
 //! registry.register_migration(
 //!     "task",    // schema ID
 //!     1,         // from version
@@ -31,7 +31,7 @@
 //!     |node| {
 //!         // Transform the node (e.g., add new field with default value)
 //!         let mut node = node.clone();
-//!         // Issue #794: Write to namespaced format
+//!         // Write to namespaced format
 //!         if let Some(task_ns) = node
 //!             .properties
 //!             .as_object_mut()
@@ -46,7 +46,7 @@
 //! );
 //!
 //! // Apply migrations to upgrade a node
-//! // Issue #794: Properties are namespaced under properties[node_type]
+//! // Properties are namespaced under properties[node_type]
 //! let mut old_node = Node::new("task".to_string(), "Test".to_string(), json!({"task": {"_schema_version": 1}}));
 //!
 //! let upgraded = registry.apply_migrations(&old_node, 2)?;
@@ -75,7 +75,7 @@ pub type MigrationTransform = fn(&Node) -> Result<Node, NodeServiceError>;
 
 /// Helper function to get _schema_version from a node's properties.
 ///
-/// Issue #794: Properties are now namespaced under properties[node_type][field_name].
+/// Properties are now namespaced under properties[node_type][field_name].
 /// This function reads _schema_version from the namespaced location.
 ///
 /// # Arguments
@@ -86,7 +86,7 @@ pub type MigrationTransform = fn(&Node) -> Result<Node, NodeServiceError>;
 ///
 /// The schema version as u32, or None if not found
 fn get_schema_version(node: &Node) -> Option<u32> {
-    // Issue #794: Read from namespaced format: properties[node_type]._schema_version
+    // Read from namespaced format: properties[node_type]._schema_version
     node.properties
         .get(&node.node_type)
         .and_then(|type_props| type_props.get("_schema_version"))
@@ -202,7 +202,7 @@ impl MigrationRegistry {
         node: &Node,
         target_version: u32,
     ) -> Result<Node, NodeServiceError> {
-        // Get current version from node properties (Issue #794: namespaced format)
+        // Get current version from node properties (namespaced format)
         let current_version = get_schema_version(node).ok_or_else(|| {
             NodeServiceError::SerializationError(
                 "Node missing _schema_version property".to_string(),
@@ -238,7 +238,7 @@ impl MigrationRegistry {
             // Apply transform
             migrated_node = transform(&migrated_node)?;
 
-            // Verify version was updated (Issue #794: namespaced format)
+            // Verify version was updated (namespaced format)
             let new_version = get_schema_version(&migrated_node).ok_or_else(|| {
                 NodeServiceError::SerializationError(format!(
                     "Migration {} v{}→v{} did not set _schema_version",
@@ -307,7 +307,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    // Helper to create a test node with version (Issue #794: namespaced format)
+    // Helper to create a test node with version (namespaced format)
     fn create_node_with_version(version: u32) -> Node {
         Node::new(
             "task".to_string(),
@@ -321,7 +321,7 @@ mod tests {
         )
     }
 
-    // Migration v1→v2: Add priority field (Issue #794: namespaced format)
+    // Migration v1→v2: Add priority field (namespaced format)
     fn task_v1_to_v2(node: &Node) -> Result<Node, NodeServiceError> {
         let mut node = node.clone();
         if let Some(task_ns) = node
@@ -336,7 +336,7 @@ mod tests {
         Ok(node)
     }
 
-    // Migration v2→v3: Add assignee field (Issue #794: namespaced format)
+    // Migration v2→v3: Add assignee field (namespaced format)
     fn task_v2_to_v3(node: &Node) -> Result<Node, NodeServiceError> {
         let mut node = node.clone();
         if let Some(task_ns) = node
@@ -351,7 +351,7 @@ mod tests {
         Ok(node)
     }
 
-    // Migration v3→v4: Rename status values (Issue #794: namespaced format)
+    // Migration v3→v4: Rename status values (namespaced format)
     fn task_v3_to_v4(node: &Node) -> Result<Node, NodeServiceError> {
         let mut node = node.clone();
         if let Some(task_ns) = node
@@ -388,7 +388,7 @@ mod tests {
         let node = create_node_with_version(1);
         let migrated = registry.apply_migrations(&node, 2).unwrap();
 
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         assert_eq!(migrated.properties["task"]["_schema_version"], 2);
         assert_eq!(migrated.properties["task"]["priority"], 0);
         assert_eq!(migrated.properties["task"]["status"], "OPEN"); // Original field preserved
@@ -403,7 +403,7 @@ mod tests {
         let migrated = registry.apply_migrations(&node, 2).unwrap();
 
         // Should return clone without changes
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         assert_eq!(migrated.properties["task"]["_schema_version"], 2);
         assert!(migrated.properties["task"].get("priority").is_none()); // v2 field not added
     }
@@ -417,7 +417,7 @@ mod tests {
         let migrated = registry.apply_migrations(&node, 2).unwrap();
 
         // Should return clone without downgrading
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         assert_eq!(migrated.properties["task"]["_schema_version"], 3);
     }
 
@@ -432,7 +432,7 @@ mod tests {
         let migrated = registry.apply_migrations(&node, 4).unwrap();
 
         // All migrations should be applied
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         assert_eq!(migrated.properties["task"]["_schema_version"], 4);
         assert_eq!(migrated.properties["task"]["priority"], 0); // Added in v1→v2
         assert_eq!(migrated.properties["task"]["assignee"], json!(null)); // Added in v2→v3
@@ -450,7 +450,7 @@ mod tests {
         let node = create_node_with_version(2);
         let migrated = registry.apply_migrations(&node, 4).unwrap();
 
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         assert_eq!(migrated.properties["task"]["_schema_version"], 4);
         assert!(migrated.properties["task"].get("priority").is_none()); // Not added (started at v2)
         assert_eq!(migrated.properties["task"]["assignee"], json!(null)); // Added in v2→v3
@@ -502,7 +502,7 @@ mod tests {
         let mut registry = MigrationRegistry::new();
         registry.register_migration("task", 1, 2, task_v1_to_v2);
 
-        // Issue #794: Properties are namespaced under properties[node_type]
+        // Properties are namespaced under properties[node_type]
         let node = Node::new(
             "task".to_string(),
             "Test task".to_string(),
@@ -520,10 +520,10 @@ mod tests {
 
         let migrated = registry.apply_migrations(&node, 2).unwrap();
 
-        // New field added (Issue #794: namespaced)
+        // New field added (namespaced)
         assert_eq!(migrated.properties["task"]["priority"], 0);
 
-        // All original fields preserved (Issue #794: namespaced)
+        // All original fields preserved (namespaced)
         assert_eq!(migrated.properties["task"]["status"], "OPEN");
         assert_eq!(migrated.properties["task"]["custom_field"], "custom_value");
         assert_eq!(migrated.properties["task"]["nested"]["deep"], "value");

--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -5,13 +5,13 @@
 //! - `NodeService` - CRUD operations and hierarchy management
 //! - `NodeEmbeddingService` - Embedding generation and semantic search (`nlp` feature)
 //! - `EmbeddingProcessor` - Background task for processing stale root embeddings (`nlp` feature)
-//! - `NodeAccessor` - Read-only trait for behavior-driven node access (Issue #1018)
+//! - `NodeAccessor` - Read-only trait for behavior-driven node access
 //! - `MigrationRegistry` - Schema migration infrastructure (for future use)
 //! - `InboundRelationshipCache` - Fast NLP discovery of inbound relationships
-//! - `QueryService` - Query execution with SQL translation (Issue #440)
-//! - `CollectionService` - Collection path parsing and membership management (Issue #756)
+//! - `QueryService` - Query execution with SQL translation
+//! - `CollectionService` - Collection path parsing and membership management
 //!
-//! Schema nodes are managed via generic NodeService CRUD operations (Issue #690).
+//! Schema nodes are managed via generic NodeService CRUD operations.
 //! Validation is handled by SchemaNodeBehavior.
 //!
 //! Services coordinate between the database layer and application logic,
@@ -32,7 +32,7 @@ pub mod node_service;
 pub mod query_service;
 pub mod relationship_cache;
 
-/// Read-only node accessor for behavior-driven content extraction (Issue #1018)
+/// Read-only node accessor for behavior-driven content extraction
 ///
 /// This trait provides a minimal, read-only interface for `NodeBehavior` implementations
 /// to access related nodes during content aggregation (e.g., fetching children for
@@ -65,7 +65,7 @@ pub trait NodeAccessor: Send + Sync {
     async fn get_nodes(&self, ids: &[&str]) -> Result<Vec<Node>, error::NodeServiceError>;
 }
 
-/// Scope for semantic search queries (Issue #1018)
+/// Scope for semantic search queries
 ///
 /// Controls which node types are included in search results. Replaces the
 /// previous `exclude_types` parameter approach — callers don't need to know
@@ -85,7 +85,7 @@ pub enum SearchScope {
     },
 }
 
-/// Service-layer filters for semantic search queries (Issue #1059).
+/// Service-layer filters for semantic search queries.
 ///
 /// Allows callers to narrow `semantic_search_nodes` results by node type and/or
 /// property values without duplicating filter logic in every caller.
@@ -202,7 +202,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    // Unit tests for SearchNodeFilters (Issue #1059)
+    // Unit tests for SearchNodeFilters
 
     #[test]
     fn test_default_is_empty() {

--- a/packages/core/src/services/node_service/bulk.rs
+++ b/packages/core/src/services/node_service/bulk.rs
@@ -64,13 +64,13 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // NOTE: NodeCreated events are now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeCreated events are now automatically emitted by store notifier
 
         // Extract IDs for return (maintaining backward compatibility)
         Ok(created_nodes.into_iter().map(|n| n.id).collect())
     }
 
-    /// Bulk create nodes with hierarchy in a single transaction (Issue #737)
+    /// Bulk create nodes with hierarchy in a single transaction
     ///
     /// Creates multiple nodes with parent-child relationships atomically.
     /// This method is optimized for markdown import where all node data
@@ -104,7 +104,7 @@ impl NodeService {
             return Ok(Vec::new());
         }
 
-        // Performance optimization (Issue #760): Cache schema lookups by node_type
+        // Performance optimization: Cache schema lookups by node_type
         // Instead of querying the database for each node, we query once per unique type
         let unique_types: std::collections::HashSet<&str> = nodes
             .iter()
@@ -129,7 +129,7 @@ impl NodeService {
             }
         }
 
-        // Issue #854: Normalize flat properties to namespaced format before validation
+        // Normalize flat properties to namespaced format before validation
         // Parser emits: { "status": "open" }
         // Storage expects: { "task": { "status": "open" } }
         let nodes_normalized: Vec<_> = nodes
@@ -174,7 +174,7 @@ impl NodeService {
         }
 
         // Find the root ID once - all nodes in a bulk import share the same root
-        // Performance optimization (Issue #760): Single DB query instead of N queries
+        // Performance optimization: Single DB query instead of N queries
         let root_id = if let Some((_, _, _, Some(first_parent), _, _)) = nodes_normalized.first() {
             self.get_root_id(first_parent).await.ok()
         } else {
@@ -188,7 +188,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Queue root for embedding regeneration once (Issue #729, #760)
+        // Queue root for embedding regeneration once
         // All nodes share the same root, so we only need one queue operation
         #[cfg(feature = "nlp")]
         if let Some(root_id) = root_id {
@@ -218,7 +218,7 @@ impl NodeService {
             return Ok(Vec::new());
         }
 
-        // Performance optimization (Issue #760): Cache schema lookups by node_type
+        // Performance optimization: Cache schema lookups by node_type
         let unique_types: std::collections::HashSet<&str> = nodes
             .iter()
             .map(|(_, node_type, _, _, _, _)| node_type.as_str())
@@ -242,7 +242,7 @@ impl NodeService {
             }
         }
 
-        // Issue #854: Normalize flat properties to namespaced format before validation
+        // Normalize flat properties to namespaced format before validation
         // Parser emits: { "status": "open" }
         // Storage expects: { "task": { "status": "open" } }
         let nodes_normalized: Vec<_> = nodes
@@ -310,12 +310,12 @@ impl NodeService {
     ///
     /// Optimized for import paths where the source is trusted (like markdown parser).
     /// This method:
-    /// - Normalizes flat properties to namespaced format (Issue #854)
+    /// - Normalizes flat properties to namespaced format
     /// - Skips schema DB queries (no lookup overhead)
     /// - Skips schema validation (parser output is trusted)
     /// - Still validates via behaviors (type-specific rules)
     ///
-    /// # Issue #854: Import Pipeline Optimization
+    /// # Import Pipeline Optimization
     ///
     /// The markdown parser only creates known node types with correct properties:
     /// - Task nodes get `{"status": "open"}`
@@ -346,7 +346,7 @@ impl NodeService {
             return Ok(Vec::new());
         }
 
-        // Issue #854: Normalize flat properties to namespaced format
+        // Normalize flat properties to namespaced format
         // Parser emits: { "status": "open" }
         // Storage expects: { "task": { "status": "open" } }
         // No schema fields needed - import properties are always simple values
@@ -395,7 +395,7 @@ impl NodeService {
             })
             .collect();
 
-        // Coalesce per-node Created events into one per root node (Issue #1311).
+        // Coalesce per-node Created events into one per root node.
         // Without the guard, bulk_create_hierarchy fires one store notification per
         // inserted node, flooding WatchNodes subscribers on large imports.
         let _batch = self.begin_batch_emit();
@@ -477,7 +477,7 @@ impl NodeService {
             return Ok(());
         }
 
-        // Step 1: Batch-fetch all nodes in a single query (Issue #143)
+        // Step 1: Batch-fetch all nodes in a single query
         // This replaces the N+1 pattern where we called get_node() for each update
         let ids: Vec<String> = updates.iter().map(|(id, _)| id.clone()).collect();
         let existing_nodes = self.store.get_nodes_by_ids(&ids).await.map_err(|e| {
@@ -490,7 +490,7 @@ impl NodeService {
         // Step 2: Build the MERGED update candidate for each node, validate it, and
         // record the property-change set for the event.
         //
-        // #1434: previously bulk_update wholesale-REPLACED properties with the raw
+        // Previously bulk_update wholesale-REPLACED properties with the raw
         // client value (`updated.properties = properties.clone()`) and emitted an
         // empty `changed_properties`. That diverged from the single-update path
         // (which normalizes flat client props → deep-merges into the existing
@@ -588,9 +588,9 @@ impl NodeService {
             ))
         })?;
 
-        // Issue #1306: emit one NodeUpdated event per node (store.bulk_update runs a
+        // Emit one NodeUpdated event per node (store.bulk_update runs a
         // single SQL transaction with no per-row notify), now carrying the real
-        // changed_properties so property-change automation fires (#1434).
+        // changed_properties so property-change automation fires.
         for (id, node, changed_properties) in pending_events {
             self.emit_event(DomainEvent::NodeUpdated {
                 node_id: id,
@@ -637,11 +637,11 @@ impl NodeService {
             return Ok(());
         }
 
-        // #1433: delete in ONE transaction so the documented all-or-nothing contract
+        // Delete in ONE transaction so the documented all-or-nothing contract
         // actually holds. The old loop called store.delete_node per id (each its own
         // autocommit), so a failure on the Nth left the first N-1 committed while the
         // caller got Err and reasonably assumed nothing was deleted → orphaned state /
-        // double-delete on retry. Coalesce the Deleted events: one per node (#1306).
+        // double-delete on retry. Coalesce the Deleted events: one per node.
         let _batch = self.begin_batch_emit();
         self.store
             .bulk_delete(&ids, self.client_id.clone())

--- a/packages/core/src/services/node_service/crud.rs
+++ b/packages/core/src/services/node_service/crud.rs
@@ -52,7 +52,7 @@ impl NodeService {
 
         // Auto-detect date nodes by ID format (YYYY-MM-DD) to ensure correct node_type.
         // This maintains data integrity regardless of caller mistakes.
-        // NOTE: Per Issue #670, date nodes can have custom content (not required to match ID).
+        // NOTE: Date nodes can have custom content (not required to match ID).
         // We only enforce the node_type, not the content.
         if is_date_node_id(&node.id) {
             node.node_type = "date".to_string();
@@ -109,7 +109,7 @@ impl NodeService {
                     if let Ok(fields) = serde_json::from_value::<Vec<crate::models::SchemaField>>(
                         fields_json.clone(),
                     ) {
-                        // Issue #838: Normalize flat properties to namespaced format before processing
+                        // Normalize flat properties to namespaced format before processing
                         // Clients send: { "status": "open" }
                         // Storage format: { "task": { "status": "open" } }
                         node.properties = Self::normalize_flat_properties_to_namespace(
@@ -124,7 +124,7 @@ impl NodeService {
                         // Validate with the same fields
                         self.validate_node_with_fields(&node, &fields)?;
 
-                        // Add schema version if schema has fields (Issue #794)
+                        // Add schema version if schema has fields
                         // Using the already-fetched schema instead of fetching again
                         if !fields.is_empty() {
                             if let Some(version) =
@@ -164,8 +164,8 @@ impl NodeService {
 
         // NOTE: root_id filtering removed - hierarchy now managed via relationships
 
-        // Issue #821: Populate title for @mention search
-        // Issue #824: Schema-driven title_template support
+        // Populate title for @mention search
+        // Schema-driven title_template support
         // Only set title if not already set (create_node_with_parent may have set it for root nodes)
         if node.title.is_none() {
             // For task/collection we know they're always titled; for others we need to check
@@ -173,7 +173,7 @@ impl NodeService {
             node.title = self.compute_title(&node, None).await?;
         }
 
-        // Issue #1012: Synchronous playbook validation gate — reject invalid playbooks before persist
+        // Synchronous playbook validation gate — reject invalid playbooks before persist
         if node.node_type == "playbook" {
             self.validate_playbook_rules(&node.properties).await?;
         }
@@ -193,7 +193,7 @@ impl NodeService {
             db_start.elapsed().as_millis()
         );
 
-        // NOTE: NodeCreated event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeCreated event is now automatically emitted by store notifier
 
         tracing::debug!(
             node_id = %node.id,
@@ -356,8 +356,8 @@ impl NodeService {
         // Save node_type before moving into Node (needed for embedding check)
         let node_type = params.node_type.clone();
 
-        // Issue #821: Determine title for @mention search
-        // Issue #824: Schema-driven title_template support
+        // Determine title for @mention search
+        // Schema-driven title_template support
         // Normalize properties to namespaced format so compute_title can find fields correctly.
         // (create_node will normalize again, but the result is idempotent)
         let title = {
@@ -420,12 +420,12 @@ impl NodeService {
 
             // Step 7a: Child node created - queue root for embedding regeneration
             // The new child's content should be included in the root's aggregate embedding
-            // (Issue #729 - root-aggregate model)
+            // (root-aggregate model)
             #[cfg(feature = "nlp")]
             self.queue_root_for_embedding(&created_id).await;
         } else {
             // Step 7b: Root node created - queue for embedding if embeddable type
-            // (Issue #729 - root-aggregate model)
+            // (root-aggregate model)
             // Stale markers are written unconditionally (even without the `nlp` feature) so
             // that a build re-enabled with NLP picks up existing roots without a manual resync.
             if self.is_embeddable_type(&node_type) {
@@ -642,7 +642,7 @@ impl NodeService {
 
         if let Some(properties) = update.properties {
             properties_changed = true;
-            // Issue #838: Normalize flat client properties to namespaced format before merging
+            // Normalize flat client properties to namespaced format before merging
             // Skip for schema nodes - they use a special non-namespaced format
             if updated.node_type == "schema" {
                 // Schema nodes use flat properties format (relationships, fields, etc.)
@@ -655,7 +655,7 @@ impl NodeService {
                     &properties,
                     None, // Schema fields are fetched later if needed
                 );
-                // Deep-merge namespaced properties (Issue #794)
+                // Deep-merge namespaced properties
                 Self::deep_merge_namespaced_properties(
                     &mut updated.properties,
                     normalized_properties,
@@ -690,8 +690,8 @@ impl NodeService {
             self.validate_node_against_schema(&updated).await?;
         }
 
-        // Issue #821: Sync title when content, node_type, or properties change
-        // Issue #824: Schema-driven title_template — also trigger on properties_changed
+        // Sync title when content, node_type, or properties change
+        // Schema-driven title_template — also trigger on properties_changed
         let title_update = if content_changed || node_type_changed || properties_changed {
             let new_title = self.compute_title(&updated, None).await?;
             Some(new_title)
@@ -714,7 +714,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // NOTE: NodeUpdated event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeUpdated event is now automatically emitted by store notifier
 
         // Sync mentions if content changed
         if content_changed {
@@ -774,7 +774,7 @@ impl NodeService {
 
         if let Some(properties) = update.properties {
             properties_changed = true;
-            // Issue #838: Normalize flat client properties to namespaced format before merging
+            // Normalize flat client properties to namespaced format before merging
             // Skip for schema nodes - they use a special non-namespaced format
             if updated.node_type == "schema" {
                 // Schema nodes use flat properties format (relationships, fields, etc.)
@@ -785,7 +785,7 @@ impl NodeService {
                     &properties,
                     None,
                 );
-                // Deep-merge namespaced properties (Issue #794)
+                // Deep-merge namespaced properties
                 Self::deep_merge_namespaced_properties(
                     &mut updated.properties,
                     normalized_properties,
@@ -804,13 +804,13 @@ impl NodeService {
             self.validate_node_against_schema(&updated).await?;
         }
 
-        // Issue #1012: Synchronous playbook validation gate — reject invalid rule changes before persist
+        // Synchronous playbook validation gate — reject invalid rule changes before persist
         if updated.node_type == "playbook" && properties_changed {
             self.validate_playbook_rules(&updated.properties).await?;
         }
 
-        // Issue #821: Sync title when content, node_type, or properties change
-        // Issue #824: Schema-driven title_template — also trigger on properties_changed
+        // Sync title when content, node_type, or properties change
+        // Schema-driven title_template — also trigger on properties_changed
         let title_update = if content_changed || node_type_changed || properties_changed {
             let new_title = self.compute_title(&updated, None).await?;
             Some(new_title)
@@ -819,7 +819,7 @@ impl NodeService {
         };
 
         // Create node update
-        // Issue #828, #770: Pass through lifecycle_status if provided
+        // Pass through lifecycle_status if provided
         let node_update = crate::models::NodeUpdate {
             node_type: Some(updated.node_type.clone()),
             content: Some(updated.content.clone()),
@@ -848,9 +848,9 @@ impl NodeService {
             None => return Ok(None),
         };
 
-        // NOTE: NodeUpdated event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeUpdated event is now automatically emitted by store notifier
 
-        // Queue root for embedding regeneration if content changed (Issue #729 - root-aggregate model)
+        // Queue root for embedding regeneration if content changed (root-aggregate model)
         // Fire-and-forget: don't block the update response on embedding queue operations
         #[cfg(feature = "nlp")]
         if content_changed {
@@ -949,7 +949,7 @@ impl NodeService {
         {
             Some(updated_node) => Ok(updated_node),
             None => {
-                // #1432: the version-gated UPDATE matched no row for one of two
+                // The version-gated UPDATE matched no row for one of two
                 // reasons — the node was concurrently DELETED, or its version
                 // moved. Disambiguate against the REAL persisted row: `get_node`
                 // virtualizes a date page, so it would report a phantom version 1
@@ -1014,7 +1014,7 @@ impl NodeService {
                 }
             }
 
-            // Auto-create date nodes when mentioned (Issue #814 fix).
+            // Auto-create date nodes when mentioned.
             // Date nodes are lazily created, but we need them to exist for the
             // "Mentioned by" panel to work. This ensures the relationship can be created.
             if is_date_node_id(mentioned_id) {
@@ -1105,7 +1105,7 @@ impl NodeService {
                 })
             })?;
 
-        // NOTE: NodeDeleted event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeDeleted event is now automatically emitted by store notifier
 
         // Idempotent delete: return success even if node doesn't exist
         Ok(result)
@@ -1162,7 +1162,7 @@ impl NodeService {
                 ))
             })?;
 
-        // NOTE: NodeDeleted event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeDeleted event is now automatically emitted by store notifier
 
         Ok(rows_affected)
     }
@@ -1180,7 +1180,7 @@ impl NodeService {
         node_id: &str,
         expected_version: i64,
     ) -> Result<crate::models::DeleteResult, NodeServiceError> {
-        // Capture root before deletion for embedding queue (Issue #729).
+        // Capture root before deletion for embedding queue.
         let root_id_for_embedding = self.get_root_id(node_id).await.ok();
 
         let (existed, deleted_nodes) = self
@@ -1276,7 +1276,7 @@ impl NodeService {
             ))
         })?;
 
-        // NOTE: NodeUpdated event is now automatically emitted by store notifier (Issue #718)
+        // NOTE: NodeUpdated event is now automatically emitted by store notifier
 
         Ok(updated_node)
     }
@@ -1331,7 +1331,7 @@ impl NodeService {
                     NodeServiceError::query_failed(format!("Failed to create parent node: {}", e))
                 })?;
 
-            // NOTE: NodeCreated event is now automatically emitted by store notifier (Issue #718)
+            // NOTE: NodeCreated event is now automatically emitted by store notifier
         }
 
         // Enforce container rule: the (now-existent) parent must accept children
@@ -1372,7 +1372,7 @@ impl NodeService {
                     NodeServiceError::query_failed(format!("Failed to update node: {}", e))
                 })?;
 
-            // NOTE: NodeUpdated event is now automatically emitted by store notifier (Issue #718)
+            // NOTE: NodeUpdated event is now automatically emitted by store notifier
 
             // Update parent relationship via edge (handles sibling ordering)
             let actual_order = self
@@ -1383,7 +1383,7 @@ impl NodeService {
                     NodeServiceError::query_failed(format!("Failed to update parent: {}", e))
                 })?;
 
-            // Emit RelationshipUpdated event (Issue #811: unified relationship events)
+            // Emit RelationshipUpdated event (unified relationship events)
             self.emit_event(DomainEvent::RelationshipUpdated {
                 relationship: crate::db::events::RelationshipEvent::new(
                     format!("relationship:{}:{}", parent_id, node_id),
@@ -1415,7 +1415,7 @@ impl NodeService {
                     NodeServiceError::query_failed(format!("Failed to create node: {}", e))
                 })?;
 
-            // NOTE: NodeCreated event is now automatically emitted by store notifier (Issue #718)
+            // NOTE: NodeCreated event is now automatically emitted by store notifier
 
             // Create parent relationship via edge (handles sibling ordering)
             let actual_order = self
@@ -1426,7 +1426,7 @@ impl NodeService {
                     NodeServiceError::query_failed(format!("Failed to set parent: {}", e))
                 })?;
 
-            // Emit RelationshipCreated event (Issue #811: unified relationship events)
+            // Emit RelationshipCreated event (unified relationship events)
             self.emit_event(DomainEvent::RelationshipCreated {
                 relationship: crate::db::events::RelationshipEvent::new(
                     format!("relationship:{}:{}", parent_id, node_id),
@@ -1471,7 +1471,7 @@ impl NodeService {
         self.validate_node_with_fields(node, &fields)
     }
 
-    /// Validate playbook rules before persisting (Issue #1012).
+    /// Validate playbook rules before persisting.
     pub(crate) async fn validate_playbook_rules(
         &self,
         properties: &serde_json::Value,
@@ -1525,7 +1525,7 @@ impl NodeService {
         // Get mutable reference to properties object
         let props_obj = node.properties.as_object_mut().unwrap();
 
-        // Get or create the type namespace (Issue #794)
+        // Get or create the type namespace
         // Properties are stored under properties[node_type][field_name]
         let type_namespace = props_obj
             .entry(&node.node_type)
@@ -1552,7 +1552,7 @@ impl NodeService {
         Ok(())
     }
 
-    /// Deep-merge namespaced properties for Issue #794
+    /// Deep-merge namespaced properties
     pub(crate) fn deep_merge_namespaced_properties(
         existing: &mut serde_json::Value,
         new: serde_json::Value,
@@ -1579,7 +1579,7 @@ impl NodeService {
         }
     }
 
-    /// Normalize flat properties input into namespaced storage format (Issue #838)
+    /// Normalize flat properties input into namespaced storage format
     pub(crate) fn normalize_flat_properties_to_namespace(
         node_type: &str,
         properties: &serde_json::Value,
@@ -1642,7 +1642,7 @@ impl NodeService {
         node: &Node,
         fields: &[crate::models::SchemaField],
     ) -> Result<(), NodeServiceError> {
-        // Get properties for this node type from the type namespace (Issue #794)
+        // Get properties for this node type from the type namespace
         // Properties are stored under properties[node_type][field_name]
         let node_props = node
             .properties
@@ -1709,7 +1709,7 @@ impl NodeService {
         &self,
         node: &mut Node,
     ) -> Result<(), NodeServiceError> {
-        // Only backfill for types that have schema fields (Issue #794)
+        // Only backfill for types that have schema fields
         let schema = match self.get_schema_for_type(&node.node_type).await? {
             Some(s) => s,
             None => return Ok(()), // No schema = no version needed
@@ -1726,7 +1726,7 @@ impl NodeService {
             return Ok(()); // Empty schema = no version needed
         }
 
-        // Check if _schema_version exists in the type namespace (Issue #794)
+        // Check if _schema_version exists in the type namespace
         let has_version = node
             .properties
             .get(&node.node_type)
@@ -1800,7 +1800,7 @@ impl NodeService {
         &self,
         node: &mut Node,
     ) -> Result<(), NodeServiceError> {
-        // Get current version from type namespace (Issue #794)
+        // Get current version from type namespace
         let current_version = node
             .properties
             .get(&node.node_type)
@@ -1895,7 +1895,7 @@ impl NodeService {
         Ok(())
     }
 
-    /// Compute the indexed title for a node (Issue #824).
+    /// Compute the indexed title for a node.
     pub(crate) async fn compute_title(
         &self,
         node: &Node,

--- a/packages/core/src/services/node_service/embedding.rs
+++ b/packages/core/src/services/node_service/embedding.rs
@@ -8,7 +8,7 @@ impl NodeService {
     /// Read-only and **independent of the `nlp` feature**: it queries the
     /// persisted `embedding` table, which exists whether or not embedding
     /// *generation* (llama-cpp) is compiled in. The Pro daemon uses this to
-    /// mirror a node's vectors into Supabase pgvector (#97).
+    /// mirror a node's vectors into Supabase pgvector.
     pub async fn get_embeddings(
         &self,
         node_id: &str,
@@ -19,7 +19,7 @@ impl NodeService {
     }
 
     /// Read embedding records modified at or after `since`, across all nodes,
-    /// ordered by `modified_at`. Drives the Pro daemon's cloud-push sweep (#97):
+    /// ordered by `modified_at`. Drives the Pro daemon's cloud-push sweep:
     /// it advances a cursor over `modified_at` and pushes newly (re)computed
     /// vectors. Also independent of the `nlp` feature.
     pub async fn embeddings_modified_since(
@@ -54,8 +54,8 @@ impl NodeService {
             })
     }
 
-    /// Apply embeddings PULLED from another device (`origin = 'remote'`,
-    /// #182/#183). The Pro daemon's cloud pull uses this instead of
+    /// Apply embeddings PULLED from another device (`origin = 'remote'`).
+    /// The Pro daemon's cloud pull uses this instead of
     /// [`Self::upsert_embeddings`] so the push sweep won't re-push a vector this
     /// device merely received. Also independent of the `nlp` feature.
     pub async fn apply_remote_embeddings(
@@ -72,7 +72,7 @@ impl NodeService {
     }
 
     /// Delete all of a node's embeddings. Used by the Pro daemon's cloud pull to
-    /// apply a remote embeddings delete (#97). Also independent of the `nlp` feature.
+    /// apply a remote embeddings delete. Also independent of the `nlp` feature.
     pub async fn delete_embeddings(&self, node_id: &str) -> Result<(), NodeServiceError> {
         self.store.delete_embeddings(node_id).await.map_err(|e| {
             NodeServiceError::query_failed(format!("Failed to delete embeddings: {}", e))
@@ -231,7 +231,7 @@ impl NodeService {
             }
         };
 
-        // Only queue if root is an embeddable type (Issue #1018: behavior-driven)
+        // Only queue if root is an embeddable type (behavior-driven)
         let behavior: std::sync::Arc<dyn crate::behaviors::NodeBehavior> =
             behaviors.get(&root_type).unwrap_or_else(|| {
                 std::sync::Arc::new(crate::behaviors::CustomNodeBehavior::new(&root_type))

--- a/packages/core/src/services/node_service/hierarchy.rs
+++ b/packages/core/src/services/node_service/hierarchy.rs
@@ -143,7 +143,7 @@ impl NodeService {
         }
 
         // Create adjacency list: parent_id → Vec of child_ids (sorted by order)
-        // Issue #788: RelationshipRecord now stores order in properties, accessed via order() method
+        // RelationshipRecord now stores order in properties, accessed via order() method
         let mut adjacency_with_order: HashMap<String, Vec<(String, f64)>> = HashMap::new();
         for rel in relationships {
             adjacency_with_order
@@ -334,7 +334,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Emit RelationshipUpdated event (Issue #811: unified relationship events)
+        // Emit RelationshipUpdated event (unified relationship events)
         if let Some(parent_id) = new_parent {
             self.emit_event(DomainEvent::RelationshipUpdated {
                 relationship: crate::db::events::RelationshipEvent::new(
@@ -446,7 +446,7 @@ impl NodeService {
         }
 
         // Capture the OLD parent before the move so we can surface its edge removal
-        // (sync-epic nodespace-sync#162 / S3): the store deletes the old has_child
+        // (sync-epic S3): the store deletes the old has_child
         // edge but, historically, only a RelationshipUpdated for the NEW parent was
         // emitted (gated on Some). A move-to-root (new_parent = None) therefore
         // emitted no relationship event at all, so the detach never propagated to
@@ -463,7 +463,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Emit RelationshipUpdated event (Issue #811: unified relationship events).
+        // Emit RelationshipUpdated event (unified relationship events).
         // Emit the NEW-parent edge first so a consumer that inserts-then-deletes
         // never sees the node parentless mid-move.
         if let Some(parent_id) = new_parent {
@@ -754,7 +754,7 @@ impl NodeService {
             "create_parent_edge: START"
         );
 
-        // Idempotency guard for nodespace-sync#77 (alice-side echo) — if
+        // Idempotency guard for the alice-side echo — if
         // `child_id` is already a child of `parent_id` AND the position is
         // End (no explicit reorder hint), treat this call as a no-op.
         // `Beginning` and `After(_)` still trigger a real reorder.
@@ -786,7 +786,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Emit RelationshipCreated event (Issue #811: unified relationship events)
+        // Emit RelationshipCreated event (unified relationship events)
         self.emit_event(DomainEvent::RelationshipCreated {
             relationship: crate::db::events::RelationshipEvent::new(
                 format!("relationship:{}:{}", parent_id, child_id),
@@ -866,7 +866,7 @@ impl NodeService {
             .await
             .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
 
-        // Emit RelationshipUpdated event (Issue #811: unified relationship events)
+        // Emit RelationshipUpdated event (unified relationship events)
         // Reordering updates the hierarchy edge's order field
         if let Some(ref parent_id) = parent_id {
             self.emit_event(DomainEvent::RelationshipUpdated {

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -4,7 +4,7 @@
 //! - The `NodeService` struct definition and `Clone` impl
 //! - Construction (`new`, `seed_*`) and accessors (`store`, `behaviors`, `with_client`,
 //!   `subscribe_to_events`)
-//! - Hierarchy methods (Phase 4 — kept here until #1237 lands; will move to `hierarchy.rs`)
+//! - Hierarchy methods (Phase 4 — kept here for now; will move to `hierarchy.rs`)
 //! - `NodeAccessor` trait impl
 //! - Module declarations for the focused sub-modules:
 //!   `crud`, `relationship`, `schema`, `bulk`, `query`, `embedding`
@@ -50,7 +50,7 @@ pub(crate) mod schema;
 /// key off this constant so the node is deterministic and created at most once.
 pub(crate) const DATABASE_SETTINGS_NODE_ID: &str = "database-settings-singleton";
 
-/// Compute property changes between pre-mutation and post-mutation node properties (Issue #995)
+/// Compute property changes between pre-mutation and post-mutation node properties
 ///
 /// Diffs the top-level keys within each namespace. For namespaced properties
 /// (e.g., `{"task": {"status": "done"}}`), diffs within each namespace object,
@@ -737,7 +737,7 @@ pub struct NodeService {
     pub(crate) migration_registry: Arc<MigrationRegistry>,
 
     /// Broadcast channel for domain events (128 subscriber capacity)
-    /// Issue #995: Changed from DomainEvent to EventEnvelope
+    /// Changed from DomainEvent to EventEnvelope
     pub(crate) event_tx: broadcast::Sender<crate::db::events::EventEnvelope>,
 
     /// Shared batch state for coalescing events during bulk operations.
@@ -747,7 +747,7 @@ pub struct NodeService {
     /// returns a `BatchEmitGuard` that flushes on drop.
     pub(crate) batch_state: Arc<Mutex<BatchState>>,
 
-    /// Optional client identifier for event source tracking (Issue #665)
+    /// Optional client identifier for event source tracking
     ///
     /// When set, all emitted events will include this client_id as source_client_id
     /// in the EventEnvelope metadata.
@@ -755,13 +755,13 @@ pub struct NodeService {
     /// Use `with_client()` to create a new NodeService instance with client_id set.
     pub(crate) client_id: Option<String>,
 
-    /// Optional playbook execution context for cycle detection (Issue #995)
+    /// Optional playbook execution context for cycle detection
     ///
     /// When set, emitted events carry this context in EventEnvelope metadata.
     /// Use `scoped_for_playbook()` to create a scoped instance.
     pub(crate) execution_context: Option<crate::db::events::PlaybookExecutionContext>,
 
-    /// Optional waker to trigger embedding processor (Issue #729)
+    /// Optional waker to trigger embedding processor
     ///
     /// When set, `queue_root_for_embedding()` will wake the processor after
     /// creating stale markers. This enables event-driven embedding processing
@@ -815,7 +815,7 @@ impl NodeService {
     /// # }
     /// ```
     ///
-    /// # Cache Population (Issue #704)
+    /// # Cache Population
     ///
     /// Takes `&mut Arc<SqliteStore>` to enable cache updates during schema seeding:
     /// - On first launch: Seeds schemas and updates caches incrementally via `Arc::get_mut()`
@@ -825,26 +825,26 @@ impl NodeService {
         // Infrastructure exists for future schema evolution post-deployment
         let migration_registry = MigrationRegistry::new();
 
-        // Initialize broadcast channel for domain events (Issue #995: EventEnvelope)
+        // Initialize broadcast channel for domain events (EventEnvelope)
         let (event_tx, _) = broadcast::channel(DOMAIN_EVENT_CHANNEL_CAPACITY);
 
         // Shared batch state — Immediate by default; swapped to Batching during bulk ops.
         let batch_state: Arc<Mutex<BatchState>> = Arc::new(Mutex::new(BatchState::Immediate));
 
-        // Register store-level notifier for automatic domain event emission (Issue #718)
+        // Register store-level notifier for automatic domain event emission
         // This callback converts StoreChange notifications to EventEnvelopes.
         // Must be set BEFORE seed_core_schemas so schema seeding also emits events.
         //
-        // Issue #724: Events now send only node_id (not full payload) for efficiency.
-        // Issue #995: Events wrapped in EventEnvelope with metadata.
-        // Issue #1306: Batch mode coalesces events per node during bulk operations.
+        // Events now send only node_id (not full payload) for efficiency.
+        // Events wrapped in EventEnvelope with metadata.
+        // Batch mode coalesces events per node during bulk operations.
         {
             let tx = event_tx.clone();
             let batch_state_ref = Arc::clone(&batch_state);
             let notifier = Arc::new(move |change: StoreChange| {
                 use crate::db::events::{EventEnvelope, EventMetadata};
 
-                // Compute changed properties for updates (Issue #995)
+                // Compute changed properties for updates
                 let changed_properties = if change.operation == StoreOperation::Updated {
                     if let Some(ref prev) = change.previous_node {
                         compute_property_changes(&prev.properties, &change.node.properties)
@@ -873,7 +873,7 @@ impl NodeService {
                     },
                 };
 
-                // Wrap in EventEnvelope with metadata (Issue #995)
+                // Wrap in EventEnvelope with metadata
                 let envelope = EventEnvelope {
                     event,
                     metadata: EventMetadata {
@@ -882,7 +882,7 @@ impl NodeService {
                     },
                 };
 
-                // Issue #1306: In batch mode, accumulate last-write-wins per node.
+                // In batch mode, accumulate last-write-wins per node.
                 // In immediate mode (default), broadcast directly.
                 let mut state = batch_state_ref.lock().unwrap_or_else(|e| e.into_inner());
                 match &mut *state {
@@ -904,7 +904,7 @@ impl NodeService {
             store_mut.set_notifier(notifier);
         }
 
-        // Seed core schemas if needed (Issue #704)
+        // Seed core schemas if needed
         // This must happen BEFORE we clone the Arc into Self, so we can use Arc::get_mut()
         // to update schema caches incrementally during seeding.
         Self::seed_core_schemas_if_needed(store).await?;
@@ -921,11 +921,11 @@ impl NodeService {
             embedding_waker: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
 
-        // Issue #1351: backfill description subtrees for schemas that still have
+        // Backfill description subtrees for schemas that still have
         // properties.description but no child nodes (databases created before this change).
         service.backfill_schema_description_subtrees().await?;
 
-        // ADR-037 (#133): every install has exactly one local PersonNode (the user).
+        // ADR-037: every install has exactly one local PersonNode (the user).
         service.seed_local_person_if_needed().await?;
 
         // ADR-037: seed the DatabaseSettingsNode singleton and its owner has_role
@@ -935,14 +935,14 @@ impl NodeService {
         Ok(service)
     }
 
-    /// ADR-037 (#133): seed exactly one local PersonNode — the local user.
+    /// ADR-037: seed exactly one local PersonNode — the local user.
     /// Idempotent: skips when a person already exists, so an existing database
     /// is backfilled on next open too. Name/email stay absent until the user
     /// fills them in (PersonNodeBehavior allows it). On Pro upgrade this node
-    /// is bound to a Supabase identity (nodespace-sync#125) via a single
+    /// is bound to a Supabase identity via a single
     /// `auth_identities` row — not recreated.
     ///
-    /// Note: `auth_status` lives on DatabaseSettingsNode (#1398), not here.
+    /// Note: `auth_status` lives on DatabaseSettingsNode, not here.
     async fn seed_local_person_if_needed(&self) -> Result<(), NodeServiceError> {
         if !self.query_nodes_by_type("person", None).await?.is_empty() {
             return Ok(());
@@ -1265,7 +1265,7 @@ impl NodeService {
             }
         } // ← Arc clone dropped here, enabling Arc::get_mut() below
 
-        // Update schema caches incrementally (Issue #704)
+        // Update schema caches incrementally
         // We use Arc::get_mut() since we're the only owner at this point (before cloning into Self)
         let store_mut = Arc::get_mut(store).ok_or_else(|| {
             NodeServiceError::InitializationError(
@@ -1284,7 +1284,7 @@ impl NodeService {
         Ok(())
     }
 
-    /// Seed node hierarchies from pre-expanded template node lists (Issue #1056).
+    /// Seed node hierarchies from pre-expanded template node lists.
     ///
     /// Each element of `template_groups` is a flat `Vec<PreparedNode>` produced
     /// by [`crate::markdown::prepare_nodes_from_template`].
@@ -1386,8 +1386,7 @@ impl NodeService {
         Ok(())
     }
 
-    /// Backfill description child subtrees for schemas that still have `properties.description`
-    /// (Issue #1351).
+    /// Backfill description child subtrees for schemas that still have `properties.description`.
     ///
     /// Runs at every startup; idempotent because `properties.description` is removed from the
     /// schema node after a successful backfill. Schemas without that key are skipped in O(1).
@@ -1504,7 +1503,7 @@ impl NodeService {
         &self.store
     }
 
-    /// Get a reference to the behavior registry (Issue #1018)
+    /// Get a reference to the behavior registry
     pub fn behaviors(&self) -> &Arc<NodeBehaviorRegistry> {
         &self.behaviors
     }
@@ -1516,7 +1515,7 @@ impl NodeService {
             .unwrap_or_else(|| Arc::new(crate::behaviors::CustomNodeBehavior::new(node_type)))
     }
 
-    /// Check if a node type is embeddable according to its behavior (Issue #1018)
+    /// Check if a node type is embeddable according to its behavior
     ///
     /// Uses `NodeBehavior::get_embeddable_content()` on a probe node to determine
     /// if this node type can ever produce embeddable content. Types that unconditionally
@@ -1582,7 +1581,7 @@ impl NodeService {
     }
 
     /// Return a scoped `NodeService` that tags all emitted events with the given
-    /// playbook execution context (Issue #995).
+    /// playbook execution context.
     ///
     /// Events emitted through the returned instance carry `playbook_context` in
     /// `EventEnvelope.metadata` for cycle detection in the playbook engine.
@@ -1598,7 +1597,7 @@ impl NodeService {
         cloned
     }
 
-    /// Subscribe to domain events (Issue #995: returns EventEnvelope)
+    /// Subscribe to domain events (returns EventEnvelope)
     ///
     /// Returns a broadcast receiver that receives all domain events wrapped
     /// in `EventEnvelope` with metadata (source_client_id, playbook_context).
@@ -1606,7 +1605,7 @@ impl NodeService {
         self.event_tx.subscribe()
     }
 
-    /// Begin batched event emission for bulk operations (Issue #1306).
+    /// Begin batched event emission for bulk operations.
     ///
     /// While the returned `BatchEmitGuard` is live, domain events from the store
     /// notifier are coalesced per node (last-write-wins) instead of being broadcast
@@ -1634,7 +1633,7 @@ impl NodeService {
         }
     }
 
-    /// Emit a domain event to all subscribers (Issue #995: wraps in EventEnvelope)
+    /// Emit a domain event to all subscribers (wraps in EventEnvelope)
     ///
     /// Internal helper for emitting events after successful operations.
     /// Wraps the event in an EventEnvelope with this instance's client_id
@@ -1724,7 +1723,7 @@ fn build_node_tree_recursive(
     json
 }
 
-/// Issue #1018: NodeAccessor implementation for NodeService
+/// NodeAccessor implementation for NodeService
 ///
 /// Delegates to existing NodeService methods, ensuring all business rules
 /// (mentions, migrations, etc.) apply when behaviors fetch related nodes.
@@ -1787,7 +1786,7 @@ mod tests {
     async fn test_create_task_node() {
         let (service, _temp) = create_test_service().await;
 
-        // Issue #838: Client sends flat properties, backend normalizes to namespaced storage
+        // Client sends flat properties, backend normalizes to namespaced storage
         let node = Node::new(
             "task".to_string(),
             "Implement NodeService".to_string(),
@@ -1824,7 +1823,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_embedding_write_wrappers_upsert_read_delete() {
-        // #97 pull-apply path: the non-nlp NodeService write wrappers must
+        // Pull-apply path: the non-nlp NodeService write wrappers must
         // round-trip a received vector into the local store and clear it.
         let (service, _temp) = create_test_service().await;
         let id = service
@@ -2107,7 +2106,7 @@ mod tests {
         assert_eq!(after_type_update.node_type, "text");
 
         // Update only properties — content and node_type must be preserved.
-        // #1434: bulk_update now NORMALIZES + deep-MERGES properties exactly like the
+        // bulk_update now NORMALIZES + deep-MERGES properties exactly like the
         // single-node update_node path (it previously wholesale-replaced with the raw
         // client value, diverging from single-update and skipping normalization).
         service
@@ -2830,7 +2829,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // Atomic subtree cascade delete tests (Issue #220)
+    // Atomic subtree cascade delete tests
     // ---------------------------------------------------------------------------
 
     #[tokio::test]
@@ -2965,7 +2964,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Issue #1306: BatchEmitGuard — batched event emission tests
+    // BatchEmitGuard — batched event emission tests
     // =========================================================================
 
     /// Single `update_node` (non-bulk) must still emit immediately — no guard involved.
@@ -3124,8 +3123,8 @@ mod tests {
     }
 
     /// `bulk_create_hierarchy_trusted` must emit exactly one Created event per inserted
-    /// node with no duplicates, delivered in a single flush rather than one-at-a-time
-    /// (Issue #1311). The batch guard coalesces last-write-wins per node_id on drop.
+    /// node with no duplicates, delivered in a single flush rather than one-at-a-time.
+    /// The batch guard coalesces last-write-wins per node_id on drop.
     #[tokio::test]
     async fn bulk_create_hierarchy_trusted_coalesces_events_per_root() {
         let (service, _temp) = create_test_service().await;

--- a/packages/core/src/services/node_service/relationship.rs
+++ b/packages/core/src/services/node_service/relationship.rs
@@ -73,8 +73,8 @@ impl NodeService {
             ));
         }
 
-        // Issue #813: Store returns relationship ID, service emits event
-        // Issue #834: root_id no longer stored - computed dynamically via graph traversal
+        // Store returns relationship ID, service emits event
+        // root_id no longer stored - computed dynamically via graph traversal
         let relationship_id = self
             .store
             .create_mention(mentioning_node_id, mentioned_node_id)
@@ -130,7 +130,7 @@ impl NodeService {
         mentioning_node_id: &str,
         mentioned_node_id: &str,
     ) -> Result<(), NodeServiceError> {
-        // Issue #813: Store returns relationship ID, service emits event
+        // Store returns relationship ID, service emits event
         let relationship_id = self
             .store
             .delete_mention(mentioning_node_id, mentioned_node_id)
@@ -232,8 +232,8 @@ impl NodeService {
             }
         }
 
-        // Issue #813: Store returns relationship ID, service emits event
-        // Issue #834: root_id no longer stored - computed dynamically via graph traversal
+        // Store returns relationship ID, service emits event
+        // root_id no longer stored - computed dynamically via graph traversal
         let relationship_id = self
             .store
             .create_mention(source_id, target_id)
@@ -287,7 +287,7 @@ impl NodeService {
         source_id: &str,
         target_id: &str,
     ) -> Result<(), NodeServiceError> {
-        // Issue #813: Store returns relationship ID, service emits event
+        // Store returns relationship ID, service emits event
         let relationship_id = self
             .store
             .delete_mention(source_id, target_id)
@@ -417,7 +417,7 @@ impl NodeService {
     }
 
     // ========================================================================
-    // Relationship CRUD Operations (Issue #703 Phase 4)
+    // Relationship CRUD Operations (Phase 4)
     // ========================================================================
 
     /// Create a relationship between two nodes
@@ -426,7 +426,7 @@ impl NodeService {
     /// Validates that both nodes exist, enforces cardinality constraints, and supports
     /// edge field data.
     ///
-    /// # TODO(Issue #710): UI components needed for relationship interaction
+    /// # TODO: UI components needed for relationship interaction
     /// The backend API is complete, but users need UI components to:
     /// - Select nodes to relate (search/dropdown)
     /// - View existing relationships
@@ -480,7 +480,7 @@ impl NodeService {
         target_id: &str,
         edge_data: serde_json::Value,
     ) -> Result<(), NodeServiceError> {
-        // Issue #825: Unified relationship creation - ALL relationships use the `relationship` table
+        // Unified relationship creation - ALL relationships use the `relationship` table
         // The relationship_type field distinguishes between different relationship types
 
         // Built-in type validation
@@ -502,7 +502,7 @@ impl NodeService {
                         target.node_type
                     )));
                 }
-                // #1427: collection hierarchy (collection member_of collection) is a
+                // Collection hierarchy (collection member_of collection) is a
                 // DAG, but nothing enforced it — `a member_of b` + `b member_of a`
                 // created a cycle that makes the recursive members walk loop. Reject
                 // a hierarchy edge that would close a cycle. Only relevant when the
@@ -583,7 +583,7 @@ impl NodeService {
             }
         }
 
-        // Issue #865: For member_of relationships with auto-order, use the atomic
+        // For member_of relationships with auto-order, use the atomic
         // add_to_collection method to prevent race conditions. This ensures the
         // order calculation and relationship creation happen in a single query.
         if relationship_name == "member_of" {
@@ -640,7 +640,7 @@ impl NodeService {
             return Ok(());
         }
 
-        // Issue #839: Auto-calculate order for built-in ordered relationships if not provided
+        // Auto-calculate order for built-in ordered relationships if not provided
         let final_edge_data = if is_builtin {
             let mut data = edge_data.as_object().cloned().unwrap_or_default();
 
@@ -692,7 +692,7 @@ impl NodeService {
     ///
     /// Removes the edge between the source and target nodes for the specified relationship.
     ///
-    /// # TODO(Issue #710): UI components needed for relationship interaction
+    /// # TODO: UI components needed for relationship interaction
     ///
     /// # Arguments
     ///
@@ -731,7 +731,7 @@ impl NodeService {
         relationship_name: &str,
         target_id: &str,
     ) -> Result<(), NodeServiceError> {
-        // Issue #825: Unified relationship deletion - ALL relationships use the `relationship` table
+        // Unified relationship deletion - ALL relationships use the `relationship` table
         // The relationship_type field distinguishes between different relationship types
 
         let rel_id = self
@@ -769,7 +769,7 @@ impl NodeService {
     /// Queries the relationship table and returns all target nodes connected via the specified
     /// relationship. Supports both "out" and "in" directions.
     ///
-    /// # TODO(Issue #710): UI components needed for relationship interaction
+    /// # TODO: UI components needed for relationship interaction
     ///
     /// # Arguments
     ///

--- a/packages/core/src/services/node_service/schema.rs
+++ b/packages/core/src/services/node_service/schema.rs
@@ -232,7 +232,7 @@ impl NodeService {
         })
     }
 
-    /// Rename a field across all node instances and update the schema definition (Issue #1088).
+    /// Rename a field across all node instances and update the schema definition.
     pub async fn rename_schema_field(
         &self,
         type_id: &str,

--- a/packages/core/src/services/query_service/mod.rs
+++ b/packages/core/src/services/query_service/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! - **Unified Node Table**: All queries target the `node` table directly
 //! - **JSON Properties**: Type-specific properties stored in `properties` JSON column
-//! - **Universal Relationship Table**: All relationships in `relationship` table with `relationship_type` discriminator (Issue #788)
+//! - **Universal Relationship Table**: All relationships in `relationship` table with `relationship_type` discriminator
 //! - **No FETCH**: Single table queries, no record link resolution needed
 //!
 //! # Query Pattern Examples
@@ -217,7 +217,7 @@ impl QueryService {
         });
     }
 
-    /// Compare two nodes by a specific field (Issue #794: Namespaced property access)
+    /// Compare two nodes by a specific field (Namespaced property access)
     fn compare_nodes_by_field(&self, a: &Node, b: &Node, field: &str) -> std::cmp::Ordering {
         match field {
             // Metadata fields
@@ -275,7 +275,7 @@ impl QueryService {
     /// Builds queries against the unified node table with JSON properties.
     /// All node types use the same query pattern with properties stored inline.
     ///
-    /// Issue #794: Properties are now stored in namespaced format:
+    /// Properties are now stored in namespaced format:
     /// properties[node_type][field_name] instead of properties[field_name]
     fn build_query(&self, query: &QueryDefinition) -> Result<String> {
         let mut sql = String::from("SELECT * FROM node");
@@ -337,7 +337,7 @@ impl QueryService {
         Ok(sql)
     }
 
-    /// Resolve field name for SQLite queries (Issue #794: Namespaced property access)
+    /// Resolve field name for SQLite queries (Namespaced property access)
     ///
     /// Metadata fields accessed directly: created_at, modified_at, content, node_type
     /// Type-specific fields use json_extract: json_extract(properties, '$.task.status')
@@ -353,7 +353,7 @@ impl QueryService {
 
     // ========== Filter Builders ==========
 
-    /// Build property filter (Issue #794: Namespaced property access)
+    /// Build property filter (Namespaced property access)
     ///
     /// Uses SQLite json_extract for property access.
     fn build_property_filter(&self, filter: &QueryFilter, target_type: &str) -> Result<String> {

--- a/packages/core/src/services/query_service/query_service_test.rs
+++ b/packages/core/src/services/query_service/query_service_test.rs
@@ -83,7 +83,7 @@ mod tests {
     async fn test_property_filter_equals() {
         let (query_service, node_service, _temp) = create_test_services().await;
 
-        // Create task nodes with different statuses (Issue #794: namespaced properties)
+        // Create task nodes with different statuses (namespaced properties)
         let task1 = CreateNodeParams {
             id: None,
             node_type: "task".to_string(),
@@ -424,7 +424,7 @@ mod tests {
     async fn test_combined_filters() {
         let (query_service, node_service, _temp) = create_test_services().await;
 
-        // Create various task nodes (Issue #794: namespaced properties)
+        // Create various task nodes (namespaced properties)
         let tasks = vec![
             ("High priority open task", "open", "high"),
             ("Low priority open task", "open", "low"),
@@ -1250,7 +1250,7 @@ mod tests {
 
         let results = query_service.execute(&query).await.unwrap();
         assert_eq!(results.len(), 3);
-        // Sorted by status alphabetically: done, in_progress, open (Issue #794: namespaced properties)
+        // Sorted by status alphabetically: done, in_progress, open (namespaced properties)
         assert_eq!(results[0].properties["task"]["status"], "done");
         assert_eq!(results[1].properties["task"]["status"], "in_progress");
         assert_eq!(results[2].properties["task"]["status"], "open");

--- a/packages/core/tests/collection_membership_test.rs
+++ b/packages/core/tests/collection_membership_test.rs
@@ -1,4 +1,4 @@
-//! Collection Membership Tests (Issue #756)
+//! Collection Membership Tests
 //!
 //! Integration tests for the collection system's membership operations.
 //!
@@ -299,7 +299,7 @@ mod collection_service_tests {
     use tempfile::TempDir;
 
     /// Helper to create test database with SqliteStore and NodeService
-    /// Issue #813: CollectionService now requires both store and node_service
+    /// CollectionService now requires both store and node_service
     async fn create_test_services() -> Result<(Arc<SqliteStore>, NodeService, TempDir)> {
         let temp_dir = TempDir::new()?;
         let db_path = temp_dir.path().join("test.db");
@@ -747,7 +747,7 @@ mod collection_service_tests {
 
     #[tokio::test]
     async fn test_collection_hierarchy_via_member_of() -> Result<()> {
-        // Issue #808: Collection path resolution creates hierarchy between collections
+        // Collection path resolution creates hierarchy between collections
         // using member_of relationships in universal relationship table, not has_child edges.
         let (store, node_service, _temp_dir) = create_test_services().await?;
         let collection_service = CollectionService::new(&store, &node_service);
@@ -779,7 +779,7 @@ mod collection_service_tests {
             "Collections should NOT use has_child - 'parent' should have no has_child children"
         );
 
-        // Issue #808: Verify hierarchy exists via member_of relationships
+        // Verify hierarchy exists via member_of relationships
         // child should be a member_of parent
         let child_memberships = collection_service.get_node_collections(&child.id).await?;
         assert_eq!(
@@ -797,7 +797,7 @@ mod collection_service_tests {
 
     #[tokio::test]
     async fn test_collection_hierarchy_three_levels() -> Result<()> {
-        // Issue #808: Test deeper hierarchy creation
+        // Test deeper hierarchy creation
         let (store, node_service, _temp_dir) = create_test_services().await?;
         let collection_service = CollectionService::new(&store, &node_service);
 
@@ -844,7 +844,7 @@ mod collection_service_tests {
 
     #[tokio::test]
     async fn test_collection_multi_parent_dag() -> Result<()> {
-        // Issue #808: Collections can have multiple parents (DAG structure)
+        // Collections can have multiple parents (DAG structure)
         // Example: "berlin" can be reached via multiple paths
         let (store, node_service, _temp_dir) = create_test_services().await?;
         let collection_service = CollectionService::new(&store, &node_service);
@@ -898,7 +898,7 @@ mod collection_service_tests {
 
     #[tokio::test]
     async fn test_collection_hierarchy_idempotent() -> Result<()> {
-        // Issue #808: Resolving the same path multiple times should not create duplicate relationships
+        // Resolving the same path multiple times should not create duplicate relationships
         let (store, node_service, _temp_dir) = create_test_services().await?;
         let collection_service = CollectionService::new(&store, &node_service);
 
@@ -1000,7 +1000,7 @@ mod collection_service_tests {
 
     /// Test that collection membership operations emit unified relationship events
     ///
-    /// **Issue #813**: CollectionService now delegates to NodeService for event emission.
+    /// CollectionService now delegates to NodeService for event emission.
     /// This test verifies that events are properly emitted via NodeService.
     #[tokio::test]
     async fn test_collection_membership_events_emitted() -> Result<()> {
@@ -1010,7 +1010,7 @@ mod collection_service_tests {
         let (store, node_service, _temp_dir) = create_test_services().await?;
         let collection_service = CollectionService::new(&store, &node_service);
 
-        // Subscribe to NodeService events (Issue #813: events come from NodeService)
+        // Subscribe to NodeService events (events come from NodeService)
         let mut event_rx = node_service.subscribe_to_events();
 
         // Create a collection
@@ -1029,7 +1029,7 @@ mod collection_service_tests {
             .add_to_collection("event-doc", &collection_id)
             .await?;
 
-        // Check for RelationshipCreated event (unified format from NodeService, Issue #995: EventEnvelope)
+        // Check for RelationshipCreated event (unified format from NodeService, EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), event_rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
@@ -1048,7 +1048,7 @@ mod collection_service_tests {
             .remove_from_collection("event-doc", &collection_id)
             .await?;
 
-        // Check for RelationshipDeleted event (unified format from NodeService, Issue #995: EventEnvelope)
+        // Check for RelationshipDeleted event (unified format from NodeService, EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), event_rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
@@ -1067,7 +1067,7 @@ mod collection_service_tests {
 
     /// Test that collection membership operations work correctly end-to-end
     ///
-    /// Issue #813: This test verifies basic add/remove membership operations
+    /// This test verifies basic add/remove membership operations
     /// work through the CollectionService -> NodeService delegation pattern.
     #[tokio::test]
     async fn test_collection_membership_add_remove_operations() -> Result<()> {
@@ -1109,7 +1109,7 @@ mod collection_service_tests {
         Ok(())
     }
 
-    /// Test get_all_collections_with_member_counts (Issue #817)
+    /// Test get_all_collections_with_member_counts
     ///
     /// This test validates that the optimized single-query method for fetching
     /// all collections with their member counts works correctly.

--- a/packages/core/tests/embedding_service_test.rs
+++ b/packages/core/tests/embedding_service_test.rs
@@ -43,7 +43,7 @@ async fn create_unified_test_env(
     // Create NodeService first (it may set up schema)
     let node_service = NodeService::new(&mut store).await?;
 
-    // Create embedding service using the SAME store (Issue #1018: behavior-driven)
+    // Create embedding service using the SAME store (behavior-driven)
     let nlp_engine = create_test_nlp_engine();
     let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> =
         Arc::new(node_service.clone());
@@ -65,7 +65,7 @@ async fn create_unified_test_env_with_config(
     // Create NodeService first (it may set up schema)
     let node_service = NodeService::new(&mut store).await?;
 
-    // Create embedding service with custom config using the SAME store (Issue #1018)
+    // Create embedding service with custom config using the SAME store
     let nlp_engine = create_test_nlp_engine();
     let node_accessor: Arc<dyn nodespace_core::services::NodeAccessor> =
         Arc::new(node_service.clone());
@@ -174,7 +174,7 @@ async fn test_find_root_id_for_deep_child() -> Result<()> {
     Ok(())
 }
 
-/// Issue #1018: Behavior-driven embeddability test (replaces should_embed_root)
+/// Behavior-driven embeddability test (replaces should_embed_root)
 #[tokio::test]
 async fn test_behavior_driven_embeddable_types() -> Result<()> {
     use nodespace_core::behaviors::NodeBehaviorRegistry;
@@ -182,7 +182,7 @@ async fn test_behavior_driven_embeddable_types() -> Result<()> {
     let registry = NodeBehaviorRegistry::new();
 
     // Types whose behaviors return Some from get_embeddable_content for non-empty content
-    // Issue #1018: table is now correctly embeddable (was excluded from EMBEDDABLE_NODE_TYPES)
+    // table is now correctly embeddable (was excluded from EMBEDDABLE_NODE_TYPES)
     let embeddable_types = vec!["text", "header", "code-block", "schema", "table"];
     for node_type in embeddable_types {
         let behavior = registry.get(node_type).expect("behavior should exist");
@@ -196,7 +196,7 @@ async fn test_behavior_driven_embeddable_types() -> Result<()> {
     Ok(())
 }
 
-/// Issue #1018: Behavior-driven non-embeddability test (replaces should_embed_root)
+/// Behavior-driven non-embeddability test (replaces should_embed_root)
 #[tokio::test]
 async fn test_behavior_driven_non_embeddable_types() -> Result<()> {
     use nodespace_core::behaviors::NodeBehaviorRegistry;
@@ -218,7 +218,7 @@ async fn test_behavior_driven_non_embeddable_types() -> Result<()> {
 }
 
 // =========================================================================
-// Behavior-Driven Content Extraction Tests (Issue #1018)
+// Behavior-Driven Content Extraction Tests
 // =========================================================================
 
 /// Test: behavior.get_aggregated_content() collects children for text nodes
@@ -280,7 +280,7 @@ async fn test_behavior_task_not_embeddable() -> Result<()> {
     Ok(())
 }
 
-/// Test: table nodes are embeddable (bug fix from Issue #1018)
+/// Test: table nodes are embeddable (bug fix)
 #[tokio::test]
 async fn test_behavior_table_is_embeddable() -> Result<()> {
     use nodespace_core::behaviors::{NodeBehavior, TableNodeBehavior};
@@ -690,7 +690,7 @@ async fn test_knn_search_with_multiple_chunks() -> Result<()> {
     Ok(())
 }
 
-/// Test that match density ratio score formula is applied correctly (Issue #944)
+/// Test that match density ratio score formula is applied correctly
 ///
 /// Validates formula: score = max_similarity * (1.0 + 0.3 * (matching_chunks / total_chunks))
 ///
@@ -957,7 +957,7 @@ async fn test_partial_density_ranks_below_full_density() -> Result<()> {
     Ok(())
 }
 
-/// Test that threshold filters by composite score, not raw similarity (Issue #787)
+/// Test that threshold filters by composite score, not raw similarity
 ///
 /// This test verifies that the threshold parameter filters results based on the
 /// composite score (which includes breadth boost) rather than raw similarity.
@@ -1031,7 +1031,7 @@ async fn test_threshold_filters_by_composite_score_not_raw_similarity() -> Resul
         result.max_similarity, result.matching_chunks, result.score
     );
 
-    // Verify the composite score formula is applied correctly (Issue #944: density ratio)
+    // Verify the composite score formula is applied correctly (density ratio)
     // With 5 matching chunks out of 5 total: density = 1.0
     // composite = max_similarity * (1.0 + 0.3 * 1.0) = max_similarity * 1.30
     let density = result.matching_chunks as f64 / 5.0; // total_chunks=5
@@ -1043,7 +1043,7 @@ async fn test_threshold_filters_by_composite_score_not_raw_similarity() -> Resul
         result.score
     );
 
-    // KEY TEST (Issue #787): Find a threshold between raw_similarity and composite_score
+    // KEY TEST: Find a threshold between raw_similarity and composite_score
     // With 5/5 chunks, density = 1.0, density_factor = 1.30
     // If max_similarity = 0.68, composite = 0.68 * 1.30 ≈ 0.88
     // We choose a threshold between them
@@ -1073,7 +1073,7 @@ async fn test_threshold_filters_by_composite_score_not_raw_similarity() -> Resul
         .search_embeddings(&query_vec, 10, Some(threshold))
         .await?;
 
-    // The document SHOULD be returned (Issue #787 fix)
+    // The document SHOULD be returned
     // OLD behavior (bug): document NOT returned because raw_similarity < threshold
     // NEW behavior (fix): document IS returned because composite_score > threshold
     assert!(
@@ -1096,10 +1096,10 @@ async fn test_threshold_filters_by_composite_score_not_raw_similarity() -> Resul
 }
 
 // =========================================================================
-// Issue #936: Title inclusion in embeddings + title keyword boost tests
+// Title inclusion in embeddings + title keyword boost tests
 // =========================================================================
 
-/// Test that title keyword boost is applied when a query term matches the node title (Issue #936)
+/// Test that title keyword boost is applied when a query term matches the node title
 ///
 /// Uses mock embeddings to test Rust-side scoring logic without an NLP engine.
 /// The boost is applied in semantic_search(), which is tested here via search_embeddings()
@@ -1234,7 +1234,7 @@ async fn test_title_keyword_boost_applied() -> Result<()> {
 }
 
 // =========================================================================
-// Hybrid Search Tests (Issue #951)
+// Hybrid Search Tests
 // =========================================================================
 
 /// Test that BM25 search finds nodes containing query terms
@@ -1642,10 +1642,10 @@ async fn test_hybrid_conceptual_query_bm25_misses_knn_hits() -> Result<()> {
 }
 
 // =========================================================================
-// Issue #1018: NodeAccessor Implementation Tests
+// NodeAccessor Implementation Tests
 // =========================================================================
 
-/// Test: NodeAccessor implementation on NodeService works correctly (Issue #1018)
+/// Test: NodeAccessor implementation on NodeService works correctly
 #[tokio::test]
 async fn test_node_accessor_get_node() -> Result<()> {
     use nodespace_core::services::NodeAccessor;
@@ -1665,7 +1665,7 @@ async fn test_node_accessor_get_node() -> Result<()> {
     Ok(())
 }
 
-/// Test: NodeAccessor::get_children returns children sorted by order (Issue #1018)
+/// Test: NodeAccessor::get_children returns children sorted by order
 #[tokio::test]
 async fn test_node_accessor_get_children() -> Result<()> {
     use nodespace_core::services::NodeAccessor;
@@ -1680,7 +1680,7 @@ async fn test_node_accessor_get_children() -> Result<()> {
     Ok(())
 }
 
-/// Test: NodeAccessor::get_nodes batch fetch works (Issue #1018)
+/// Test: NodeAccessor::get_nodes batch fetch works
 #[tokio::test]
 async fn test_node_accessor_get_nodes_batch() -> Result<()> {
     use nodespace_core::services::NodeAccessor;

--- a/packages/core/tests/event_emission_test.rs
+++ b/packages/core/tests/event_emission_test.rs
@@ -1,9 +1,9 @@
-//! Event Emission Tests (Issue #643, updated for Issue #665, #995)
+//! Event Emission Tests
 //!
 //! Tests that verify correct event emission for all major operations.
-//! As of Issue #665, events are now emitted at the NodeService layer
+//! Events are now emitted at the NodeService layer
 //! (not SqliteStore) to support client filtering.
-//! As of Issue #995, events are wrapped in EventEnvelope with metadata.
+//! Events are wrapped in EventEnvelope with metadata.
 //!
 //! These tests verify:
 //! 1. Correct events are emitted for each operation type
@@ -69,14 +69,14 @@ mod event_emission_tests {
             .create_node(node)
             .await?;
 
-        // Receive the emitted event (Issue #995: EventEnvelope)
+        // Receive the emitted event (EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
             .expect("Should receive event");
 
         // Verify it's a NodeCreated event with correct client_id in envelope metadata
-        // (Issue #724: ID-only events, Issue #832: node_type, Issue #995: EventEnvelope)
+        // (ID-only events, node_type, EventEnvelope)
         match &envelope.event {
             DomainEvent::NodeCreated { node_id, node_type } => {
                 assert_eq!(node_id, &expected_id);
@@ -115,14 +115,14 @@ mod event_emission_tests {
             )
             .await?;
 
-        // Receive the emitted event (Issue #995: EventEnvelope)
+        // Receive the emitted event (EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
             .expect("Should receive event");
 
         // Verify it's a NodeUpdated event with correct client_id in envelope metadata
-        // (Issue #724: ID-only events, Issue #995: EventEnvelope + node_type + changed_properties)
+        // (ID-only events, EventEnvelope + node_type + changed_properties)
         match &envelope.event {
             DomainEvent::NodeUpdated {
                 node_id: updated_id,
@@ -142,7 +142,7 @@ mod event_emission_tests {
 
     #[tokio::test]
     async fn test_collection_query_paginates_members_not_global_set() -> Result<()> {
-        // #1430: offset/limit must paginate the COLLECTION'S members (in memory),
+        // offset/limit must paginate the COLLECTION'S members (in memory),
         // not the global unfiltered set, and non-members must be excluded.
         let (service, _temp_dir) = create_test_service().await?;
 
@@ -202,7 +202,7 @@ mod event_emission_tests {
 
     #[tokio::test]
     async fn test_collection_query_returns_members_despite_many_newer_nonmembers() -> Result<()> {
-        // #1430 regression guard: members must be returned even when MANY newer
+        // Regression guard: members must be returned even when MANY newer
         // non-member nodes exist. The SQL is id-scoped to the member set, so it can
         // never be crowded out. This FAILS under a capped-global-limit approach
         // (the newest N rows would all be non-members → 0 members) and under the
@@ -258,7 +258,7 @@ mod event_emission_tests {
 
     #[tokio::test]
     async fn test_bulk_update_emits_changed_properties_and_merges() -> Result<()> {
-        // #1434: bulk_update must emit a NON-empty changed_properties (so
+        // bulk_update must emit a NON-empty changed_properties (so
         // property-change automation fires) and MERGE properties (not wholesale
         // replace), matching the single-update path.
         let (service, _temp_dir) = create_test_service().await?;
@@ -342,7 +342,7 @@ mod event_emission_tests {
             .await?;
         assert!(result.existed);
 
-        // Receive the emitted event (Issue #995: EventEnvelope)
+        // Receive the emitted event (EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
@@ -395,7 +395,7 @@ mod event_emission_tests {
             )
             .await?;
 
-        // Receive the emitted event (Issue #811: unified relationship events, Issue #995: EventEnvelope)
+        // Receive the emitted event (unified relationship events, EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
@@ -438,7 +438,7 @@ mod event_emission_tests {
             .create_mention(&source_node.id, &target_node.id)
             .await?;
 
-        // Receive the emitted event (Issue #811: unified relationship events, Issue #995: EventEnvelope)
+        // Receive the emitted event (unified relationship events, EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
@@ -485,14 +485,14 @@ mod event_emission_tests {
             .remove_mention(&source_node.id, &target_node.id)
             .await?;
 
-        // Receive the emitted event (Issue #811: unified relationship events, Issue #995: EventEnvelope)
+        // Receive the emitted event (unified relationship events, EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")
             .expect("Should receive event");
 
         // Verify it's a RelationshipDeleted event with correct client_id in metadata
-        // Issue #813: Relationship IDs are now from universal `relationship` table
+        // Relationship IDs are now from universal `relationship` table
         match &envelope.event {
             DomainEvent::RelationshipDeleted {
                 id: _,
@@ -540,7 +540,7 @@ mod event_emission_tests {
             )
             .await?;
 
-        // Should receive exactly ONE event (Issue #995: EventEnvelope)
+        // Should receive exactly ONE event (EventEnvelope)
         let envelope1 = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Should receive event")
@@ -569,7 +569,7 @@ mod event_emission_tests {
         let node = Node::new("text".to_string(), "Test content".to_string(), json!({}));
         service.create_node(node).await?;
 
-        // Receive the emitted event (Issue #995: EventEnvelope)
+        // Receive the emitted event (EventEnvelope)
         let envelope = timeout(Duration::from_secs(1), rx.recv())
             .await
             .expect("Event should be emitted within 1 second")

--- a/packages/core/tests/move_node_ordering_test.rs
+++ b/packages/core/tests/move_node_ordering_test.rs
@@ -1,4 +1,4 @@
-//! C3a: move_node ordering contract tests (Issue #1259)
+//! C3a: move_node ordering contract tests
 //!
 //! Regression-locks the contract that the frontend depends on after removing
 //! client-side fractional order math:

--- a/packages/core/tests/person_seed_test.rs
+++ b/packages/core/tests/person_seed_test.rs
@@ -1,10 +1,10 @@
-//! Local PersonNode seeding tests (Issue #133, ADR-037)
+//! Local PersonNode seeding tests (ADR-037)
 //!
 //! ADR-037 mandates that every install — free included — seeds exactly one
 //! local PersonNode (the local user). On Pro upgrade this node is bound to a
-//! Supabase identity (nodespace-sync#125), not recreated. These tests verify:
+//! Supabase identity, not recreated. These tests verify:
 //! 1. Constructing a NodeService on a fresh database seeds exactly one person.
-//! 2. The seeded person has no auth_status (that lives on DatabaseSettingsNode, #1398).
+//! 2. The seeded person has no auth_status (that lives on DatabaseSettingsNode).
 //! 3. Re-opening the same database does NOT create a second person (idempotent).
 
 #[cfg(test)]
@@ -28,7 +28,7 @@ mod person_seed_tests {
             1,
             "a fresh install must seed exactly one local PersonNode"
         );
-        // auth_status lives on DatabaseSettingsNode (#1398), not on PersonNode
+        // auth_status lives on DatabaseSettingsNode, not on PersonNode
         assert!(
             people[0]
                 .properties

--- a/packages/core/tests/skill_updater_test.rs
+++ b/packages/core/tests/skill_updater_test.rs
@@ -1,4 +1,4 @@
-//! Integration tests for SkillUpdater (Issue #1061).
+//! Integration tests for SkillUpdater.
 //!
 //! Verifies that when schemas are created or deleted, the "Node Creation"
 //! skill node's description is updated to include the new type names,

--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -287,7 +287,7 @@ impl AgentSessionService for AgentSessionHandler {
                         // stream down — losing a render frame is preferable
                         // to losing the whole session view.
                         //
-                        // TODO(#1119 review): Lag is invisible to the client
+                        // TODO(review): Lag is invisible to the client
                         // today (only a server-side tracing::warn). Options
                         // for surfacing it: a sentinel OutputChunk with an
                         // in-band "[N bytes dropped]" notice, or a session-
@@ -330,7 +330,7 @@ impl AgentSessionService for AgentSessionHandler {
 
         // PtySession::write_input writes the entire buffer atomically and
         // flushes, so on success bytes_written always equals the input length.
-        // The proto field is int64 (widened from int32 during PR #1119 review)
+        // The proto field is int64 (widened from int32 during review)
         // so a 64-bit `usize` cannot truncate — fits the full `data.len()`
         // range on every realistic platform.
         Ok(Response::new(WriteInputResponse {
@@ -517,8 +517,8 @@ mod tests {
 
     #[test]
     fn parse_agent_type_rejects_snake_case() {
-        // Snake-case is the proto-comment form from the original #1111 spec
-        // but was dropped in the #1119 review per CLAUDE.md's no-backwards-
+        // Snake-case is the proto-comment form from the original spec
+        // but was dropped in review per CLAUDE.md's no-backwards-
         // compat directive. Pin the rejection so a future refactor can't
         // silently restore the dual-accept path.
         for snake in ["claude_code", "gemini_cli", "open_code"] {

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -562,7 +562,7 @@ impl GrpcNodeService for NodeServiceImpl {
                 &req.node_type,
                 &req.parent_id,
                 &req.root_id,
-                None, // before_sibling_id intentionally None per #616 fractional ordering
+                None, // before_sibling_id intentionally None for fractional ordering
             )
             .await
             .map_err(service_error_to_status)?;
@@ -1425,7 +1425,7 @@ impl GrpcNodeService for NodeServiceImpl {
         let req = request.into_inner();
         if !req.node_type.is_empty() || !req.root_id.is_empty() {
             // Filtering is intentionally out of scope for the initial implementation
-            // (issue #1114 lists it as a Non-Goal). Log so clients can see the
+            // (this filtering is a documented Non-Goal). Log so clients can see the
             // request was accepted but the filter is being ignored.
             tracing::debug!(
                 node_type = %req.node_type,
@@ -1527,7 +1527,7 @@ pub(crate) fn node_to_proto(node: Node) -> NodeData {
 /// Translate a core `DomainEvent` into a proto `NodeEvent`.
 ///
 /// Returns `None` for non-node events (relationships) — those are out of scope
-/// for `WatchNodes` (per issue #1114 Non-Goals: relationship streaming is a
+/// for `WatchNodes` (a documented Non-Goal: relationship streaming is a
 /// separate concern).
 ///
 /// For `NodeCreated` and `NodeUpdated`, fetches the current node payload so

--- a/packages/daemon/src/tray.rs
+++ b/packages/daemon/src/tray.rs
@@ -74,7 +74,7 @@ impl TrayController {
 
 /// Tray runtime state. Constructed inside the event loop's `Init` callback
 /// because creating the icon before the loop is actually running produces
-/// stale icons on macOS (upstream issue tauri-apps/tray-icon#90).
+/// stale icons on macOS (a known upstream tauri-apps/tray-icon bug).
 ///
 /// Not `Send` — `TrayIcon` holds platform handles (`NSStatusItem` on macOS,
 /// HWND on Windows) that are tied to the thread that created them.

--- a/packages/daemon/tests/grpc_round_trip.rs
+++ b/packages/daemon/tests/grpc_round_trip.rs
@@ -3,7 +3,7 @@
 //! Spins the tonic server up in-process against a tempdir-backed SQLite database,
 //! drives a `NodeServiceClient` against it, and verifies a CreateNode →
 //! GetNode round trip plus a few error-mapping paths. This validates the
-//! single acceptance criterion in #1112:
+//! single acceptance criterion:
 //!   > Integration test: start daemon, send GetNode via gRPC client,
 //!   > verify response.
 
@@ -323,7 +323,7 @@ async fn next_event_with_timeout(
         .expect("stream item was an error")
 }
 
-/// Acceptance criterion (#1114): mutate a node via gRPC, verify the watcher
+/// Acceptance criterion: mutate a node via gRPC, verify the watcher
 /// receives the corresponding event. Covers all three event kinds in one go.
 #[tokio::test]
 async fn watch_nodes_receives_create_update_delete_events() {
@@ -413,7 +413,7 @@ async fn watch_nodes_receives_create_update_delete_events() {
     let _ = shutdown.send(());
 }
 
-/// Acceptance criterion (#1114): multiple concurrent watchers supported
+/// Acceptance criterion: multiple concurrent watchers supported
 /// simultaneously. Both must receive the same event from a single mutation.
 #[tokio::test]
 async fn watch_nodes_supports_multiple_concurrent_watchers() {
@@ -663,7 +663,7 @@ async fn test_insert_position_beginning_and_after_proto_decoding() {
     let _ = shutdown.send(());
 }
 
-/// Parity test (AC #1241): create a node with a collection path and a non-default
+/// Parity test: create a node with a collection path and a non-default
 /// lifecycle status via the gRPC RPC. Verifies the daemon delegates to node_ops
 /// correctly — the node lands in the resolved collection and has the requested
 /// lifecycle status.
@@ -716,7 +716,7 @@ async fn create_node_with_collection_and_lifecycle_status() {
     let _ = shutdown.send(());
 }
 
-/// Parity test (AC #1241): update a node without supplying version — the
+/// Parity test: update a node without supplying version — the
 /// daemon delegates to node_ops, which auto-fetches the current version.
 #[tokio::test]
 async fn update_node_auto_fetches_version_when_omitted() {
@@ -760,7 +760,7 @@ async fn update_node_auto_fetches_version_when_omitted() {
     let _ = shutdown.send(());
 }
 
-/// Parity test (AC #1241): add then remove a collection membership via
+/// Parity test: add then remove a collection membership via
 /// update_node's add_to_collection / remove_from_collection fields.
 #[tokio::test]
 async fn update_node_add_then_remove_collection_membership() {

--- a/packages/desktop-app/src-tauri/src/commands/agent_session.rs
+++ b/packages/desktop-app/src-tauri/src/commands/agent_session.rs
@@ -1,4 +1,4 @@
-//! Tauri command proxies for `AgentSessionService` gRPC RPCs (Issue #1120).
+//! Tauri command proxies for `AgentSessionService` gRPC RPCs.
 //!
 //! Each command wraps one RPC. `launch_session` additionally spawns a
 //! background task that reads the `StreamOutput` server-streaming response

--- a/packages/desktop-app/src-tauri/src/commands/chat_models.rs
+++ b/packages/desktop-app/src-tauri/src/commands/chat_models.rs
@@ -3,8 +3,6 @@
 //! Thin gRPC proxy to `LocalAgentService` model management RPCs in the daemon.
 //! Download progress is forwarded through the `model://download-progress`
 //! Tauri event channel.
-//!
-//! Issue #1058, #1194
 
 use crate::agent_events;
 use crate::commands::nodes::CommandError;

--- a/packages/desktop-app/src-tauri/src/commands/collections.rs
+++ b/packages/desktop-app/src-tauri/src/commands/collections.rs
@@ -1,6 +1,6 @@
 //! Collection CRUD operation commands for collection browsing and management
 //!
-//! As of Issue #1113, all commands proxy through the in-process gRPC server
+//! All commands proxy through the in-process gRPC server
 //! (nodespace-daemon) instead of calling `packages/core` directly.
 
 use crate::types::Node;

--- a/packages/desktop-app/src-tauri/src/commands/embeddings.rs
+++ b/packages/desktop-app/src-tauri/src/commands/embeddings.rs
@@ -1,7 +1,7 @@
 //! Tauri Commands for Topic Embeddings
 //!
 //! Thin gRPC proxy: all operations are forwarded to the `EmbeddingsService`
-//! running in the in-process `nodespaced` server (Issue #1135).
+//! running in the in-process `nodespaced` server.
 
 use crate::commands::nodes::CommandError;
 use crate::services::GrpcClient;
@@ -210,7 +210,7 @@ pub async fn sync_embeddings(grpc: State<'_, GrpcClient>) -> Result<(), CommandE
 ///
 /// `Unimplemented` collapses to `Ok(0)`: the daemon serves no
 /// `EmbeddingsService` — `nodespaced-pro` omits the NLP/embedding stack
-/// (no llama-cpp, per nodespace-sync#10) and never registers it — so there
+/// (no llama-cpp) and never registers it — so there
 /// is no embedding queue and zero is the honest count.
 ///
 /// Note this arm intentionally collapses *any* `Unimplemented` for this
@@ -238,7 +238,7 @@ fn stale_count_from_result(
 ///
 /// Degrades gracefully when the daemon serves no `EmbeddingsService` (e.g.
 /// `nodespaced-pro`): the status bar polls this every 5s, so an
-/// `Unimplemented` must not flood the console (nodespace-sync#82). See
+/// `Unimplemented` must not flood the console. See
 /// [`stale_count_from_result`] for the mapping rationale.
 #[tauri::command]
 pub async fn get_stale_root_count(grpc: State<'_, GrpcClient>) -> Result<usize, CommandError> {
@@ -323,7 +323,7 @@ mod tests {
         assert!(params.exact.unwrap());
     }
 
-    /// Regression guard for nodespace-sync#82: a daemon with no
+    /// Regression guard: a daemon with no
     /// `EmbeddingsService` returns `Unimplemented`, which must collapse to
     /// a quiet `Ok(0)` rather than an error the 5s poll would flood.
     #[test]

--- a/packages/desktop-app/src-tauri/src/commands/nodes.rs
+++ b/packages/desktop-app/src-tauri/src/commands/nodes.rs
@@ -1,6 +1,6 @@
 //! Node CRUD operation commands for Text, Task, and Date nodes
 //!
-//! As of Issue #1113, all commands proxy through the in-process gRPC server
+//! All commands proxy through the in-process gRPC server
 //! (nodespace-daemon) instead of calling `packages/core` directly.
 
 use crate::types::{
@@ -218,7 +218,7 @@ async fn validate_node_type(
     }
 }
 
-/// Convert a Node to its strongly-typed JSON representation (Issue #673)
+/// Convert a Node to its strongly-typed JSON representation
 pub fn node_to_typed_value(node: Node) -> Result<Value, CommandError> {
     types_node_to_typed_value(node).map_err(|e| CommandError {
         message: e.clone(),
@@ -228,7 +228,7 @@ pub fn node_to_typed_value(node: Node) -> Result<Value, CommandError> {
     })
 }
 
-/// Convert a list of Nodes to their strongly-typed JSON representations (Issue #673)
+/// Convert a list of Nodes to their strongly-typed JSON representations
 pub fn nodes_to_typed_values(nodes: Vec<Node>) -> Result<Vec<Value>, CommandError> {
     types_nodes_to_typed_values(nodes).map_err(|e| CommandError {
         message: e.clone(),
@@ -259,7 +259,7 @@ pub struct SaveNodeWithParentInput {
     pub node_type: String,
     pub parent_id: String,
     pub root_id: String,
-    // before_sibling_id removed - backend uses fractional ordering on has_child edges (Issue #616)
+    // before_sibling_id removed - backend uses fractional ordering on has_child edges
 }
 
 /// Create a new node of any type with a registered schema
@@ -575,7 +575,7 @@ pub async fn get_nodes_by_root_id(
     root_id: String,
 ) -> Result<Vec<Value>, CommandError> {
     let mut c = client.client().await;
-    // Phase 5 (Issue #511): Redirect to get_children (graph-native)
+    // Phase 5: Redirect to get_children (graph-native)
     let resp = c
         .get_children(Request::new(GetChildrenRequest { node_id: root_id }))
         .await

--- a/packages/desktop-app/src-tauri/src/commands/onboarding.rs
+++ b/packages/desktop-app/src-tauri/src/commands/onboarding.rs
@@ -1,4 +1,4 @@
-//! Onboarding wizard Tauri commands (Issues #1180, #1199).
+//! Onboarding wizard Tauri commands.
 //!
 //! Handles first-launch setup: PATH configuration and NodeSpace skill
 //! installation. Completion state is persisted to `~/.nodespace/config.json`.

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -22,8 +22,8 @@ use crate::services::{ProClient, ProTier};
 use tonic::transport::Channel;
 
 /// Auth-Worker URL used for the OAuth flow — not client-configurable.
-/// Release builds hit the deployed canonical domain (`pro.nodespace.ai`,
-/// nodespace-cloud#21); debug builds hit the local `wrangler dev` worker
+/// Release builds hit the deployed canonical domain (`pro.nodespace.ai`);
+/// debug builds hit the local `wrangler dev` worker
 /// (`127.0.0.1:8787`, what `device-sync.sh` runs).
 #[cfg(debug_assertions)]
 const DEFAULT_WORKER_URL: &str = "http://127.0.0.1:8787";
@@ -200,7 +200,7 @@ pub async fn pro_initiate_oauth(
     Ok(resp.attempt_id)
 }
 
-/// Sign out of Pro (#199 S6). Tells the daemon to drop its session and wipe the
+/// Sign out of Pro. Tells the daemon to drop its session and wipe the
 /// persisted refresh token from the OS keychain, so a restart won't auto-resume.
 /// The resulting AUTH_REQUIRED transition flows back through the `sync:status`
 /// stream. No-ops in community mode (no `ProClient`), matching the other Pro
@@ -238,7 +238,7 @@ pub async fn pro_enable_sync(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-// --- Team membership commands (M5, #147) ----------------------------------
+// --- Team membership commands (M5) ----------------------------------
 //
 // Thin pass-throughs over the daemon's `CloudSyncService` membership RPCs. The
 // daemon forwards the signed-in user's JWT to the matching cloud RPC, so the
@@ -255,7 +255,7 @@ pub struct MemberDto {
     pub permission: String,
 }
 
-/// One pending invite returned by [`pro_list_invites`] (S2, #239).
+/// One pending invite returned by [`pro_list_invites`].
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct InviteDto {
     /// uuid — the handle [`pro_revoke_invite`] takes.
@@ -270,7 +270,7 @@ pub struct InviteDto {
     pub expires_at: String,
 }
 
-/// One pending join request returned by [`pro_list_requests`] (S2, #239).
+/// One pending join request returned by [`pro_list_requests`].
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RequestDto {
     /// uuid — the handle [`pro_approve_request`] / [`pro_revoke_invite`] take.
@@ -293,7 +293,7 @@ pub struct JoinableCollectionDto {
     pub restricted: bool,
 }
 
-/// The caller's own identity, returned by [`pro_current_person`] (#238/#239).
+/// The caller's own identity, returned by [`pro_current_person`].
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PersonDto {
     /// Bound PersonNode id; empty on an un-bound device ("role unknown").
@@ -490,7 +490,7 @@ pub async fn pro_approve_request(
     Ok(())
 }
 
-/// List a collection's pending invites (admin only, server-gated). #239.
+/// List a collection's pending invites (admin only, server-gated).
 #[tauri::command]
 pub async fn pro_list_invites(
     app: AppHandle,
@@ -515,7 +515,7 @@ pub async fn pro_list_invites(
         .collect())
 }
 
-/// List a collection's pending join requests (admin only, server-gated). #239.
+/// List a collection's pending join requests (admin only, server-gated).
 #[tauri::command]
 pub async fn pro_list_requests(
     app: AppHandle,
@@ -538,7 +538,7 @@ pub async fn pro_list_requests(
         .collect())
 }
 
-/// Revoke a pending invite or join request by id (admin only, server-gated). #239.
+/// Revoke a pending invite or join request by id (admin only, server-gated).
 #[tauri::command]
 pub async fn pro_revoke_invite(app: AppHandle, invite_id: String) -> Result<(), String> {
     let mut client = membership_client(&app).await?;
@@ -549,7 +549,7 @@ pub async fn pro_revoke_invite(app: AppHandle, invite_id: String) -> Result<(), 
     Ok(())
 }
 
-/// The caller's own identity — bound PersonNode id + signed-in email (#238/#239).
+/// The caller's own identity — bound PersonNode id + signed-in email.
 /// Lets the UI tell which roster row is "me" and gate admin controls on the
 /// caller's own per-collection role. `person_id` is empty on an un-bound device;
 /// the UI treats that as "role unknown" and hides admin controls.

--- a/packages/desktop-app/src-tauri/src/commands/recovered_items.rs
+++ b/packages/desktop-app/src-tauri/src/commands/recovered_items.rs
@@ -1,4 +1,4 @@
-//! Pro-tier "Recovered Items" commands (core#1303 viewer/restore half).
+//! Pro-tier "Recovered Items" commands (viewer/restore half).
 //!
 //! When a cloud last-writer-wins conflict overwrites a genuine local edit, the
 //! Pro daemon snapshots the superseded content to a per-user **local-only** log
@@ -96,7 +96,7 @@ pub async fn pro_list_recovered_items(app: AppHandle) -> Result<Vec<RecoveredIte
 /// between our read and rewrite, that entry is clobbered. Low-probability and the
 /// only loss is a recovery breadcrumb (the node content itself lives in the store
 /// and cloud); a proper fix is daemon-mediated mutation (or file locking), tracked
-/// as a follow-up. Acceptable for the viewer/restore slice (core#1303).
+/// as a follow-up. Acceptable for the viewer/restore slice.
 #[tauri::command]
 pub async fn pro_dismiss_recovered_item(app: AppHandle, node_id: String) -> Result<(), String> {
     if app.try_state::<ProClient>().is_none() {

--- a/packages/desktop-app/src-tauri/src/commands/schemas.rs
+++ b/packages/desktop-app/src-tauri/src/commands/schemas.rs
@@ -1,6 +1,6 @@
 //! Schema read commands for retrieving entity schemas
 //!
-//! As of Issue #1113, schema operations proxy through the in-process gRPC server
+//! Schema operations proxy through the in-process gRPC server
 //! (nodespace-daemon) instead of calling `packages/core` directly.
 //!
 //! This module provides read-only schema commands:

--- a/packages/desktop-app/src-tauri/src/daemon_setup.rs
+++ b/packages/desktop-app/src-tauri/src/daemon_setup.rs
@@ -34,7 +34,7 @@ const CLI_BINARY_NAME: &str = "nodespace";
 #[cfg(target_os = "linux")]
 const SYSTEMD_SERVICE_NAME: &str = "nodespace.service";
 
-// ── Pro edition, baked at compile time (#156) ───────────────────────────────
+// ── Pro edition, baked at compile time ───────────────────────────────
 // A Pro build sets these env vars when running `tauri build` (see
 // nodespace-sync/scripts/build-pro-dmg.sh); a community build leaves them unset.
 // When set, the app installs + launches the `nodespaced-pro` sync daemon with the

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -17,7 +17,7 @@ pub mod constants;
 // Background services
 pub mod services;
 
-// gRPC-backed node event watcher (#1114). Inert until activated by #1113 —
+// gRPC-backed node event watcher. Inert until activated —
 // see watcher.rs module docs for activation gating.
 pub mod watcher;
 
@@ -25,7 +25,7 @@ pub mod watcher;
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 pub mod daemon_setup;
 
-// First-launch skill installer (Issue #1199)
+// First-launch skill installer
 pub mod skill_setup;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -70,7 +70,7 @@ fn frontend_log(line: String) {
 /// Report the current daemon health to the frontend.
 ///
 /// Returns "healthy", "starting", or "not_running". The frontend uses this
-/// to decide whether to show an error state (Issue #1179).
+/// to decide whether to show an error state.
 #[tauri::command]
 async fn check_daemon_status() -> String {
     daemon_status_body().await
@@ -244,7 +244,7 @@ pub fn run() {
             // RPC). Previously `manage(GrpcClient)` ran only after the async connect
             // below, so a frontend command issued at startup (e.g. the date page's
             // `get_children_tree`) raced it and got a fatal "state not managed for
-            // field `client`", closing the view (nodespace-sync#162). With the client
+            // field `client`", closing the view. With the client
             // managed up front, an early call instead yields a retryable transport
             // error until the daemon is reachable.
             #[cfg(any(unix, windows))]
@@ -362,7 +362,7 @@ pub fn run() {
                     // otherwise leave the UI silently empty. After the probe has
                     // exercised the channel, confirm reachability with the same socket
                     // check `check_daemon_status` uses and emit `not_running` so
-                    // app-shell shows its error banner + retry (Issue #1179). `Starting`
+                    // app-shell shows its error banner + retry. `Starting`
                     // is transient — only `NotRunning` trips the banner.
                     {
                         use daemon_setup::{check_daemon_socket, DaemonStatus};
@@ -383,7 +383,7 @@ pub fn run() {
                 });
             }
 
-            // Streaming task registry for PTY session cancellation (Issue #1120)
+            // Streaming task registry for PTY session cancellation
             app.manage(commands::agent_session::StreamingTaskRegistry::default());
 
             Ok(())
@@ -487,7 +487,7 @@ pub fn run() {
             commands::nodes::get_mentioning_roots,
             commands::nodes::delete_node_mention,
             commands::nodes::update_task_node,
-            // Collection commands (Issue #757 - Collection browsing and management UI)
+            // Collection commands (browsing and management UI)
             commands::collections::get_all_collections,
             commands::collections::get_collection_members,
             commands::collections::get_collection_members_recursive,
@@ -500,7 +500,7 @@ pub fn run() {
             commands::collections::create_collection,
             commands::collections::rename_collection,
             commands::collections::delete_collection,
-            // Schema read commands (Issue #690 - mutation commands removed, not used by UI)
+            // Schema read commands (mutation commands removed, not used by UI)
             commands::schemas::get_all_schemas,
             commands::schemas::get_schema_definition,
             // File import commands for bulk markdown import
@@ -527,7 +527,7 @@ pub fn run() {
             commands::local_agent::local_agent_cancel_turn,
             commands::local_agent::ensure_model_ready,
             commands::local_agent::list_local_models,
-            // Chat model management commands (Issue #1008)
+            // Chat model management commands
             commands::chat_models::chat_model_list,
             commands::chat_models::chat_model_recommended,
             commands::chat_models::chat_model_download,
@@ -537,14 +537,14 @@ pub fn run() {
             commands::chat_models::chat_model_unload,
             commands::chat_models::ollama_available,
             commands::chat_models::get_system_ram_gb,
-            // PTY agent session commands (Issue #1120)
+            // PTY agent session commands
             commands::agent_session::launch_session,
             commands::agent_session::write_input,
             commands::agent_session::resize_terminal,
             commands::agent_session::terminate_session,
             commands::agent_session::list_sessions,
             commands::agent_session::check_agent_availability,
-            // First-launch onboarding wizard + Settings integrations panel (Issue #1180, #1181, #1199)
+            // First-launch onboarding wizard + Settings integrations panel
             commands::onboarding::check_onboarding_status,
             commands::onboarding::configure_path,
             commands::onboarding::remove_from_path,

--- a/packages/desktop-app/src-tauri/src/skill_setup.rs
+++ b/packages/desktop-app/src-tauri/src/skill_setup.rs
@@ -1,4 +1,4 @@
-//! First-launch skill installer (Issue #1199).
+//! First-launch skill installer.
 //!
 //! Invokes `npx @nodespaceai/skill install` to copy SKILL.md and agent shims
 //! into detected agents' directories. Persists completion state to

--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -29,7 +29,7 @@
 //! see that file's comment for why serializing matters here. Prefer `cargo
 //! test -p nodespace-app -- --test-threads=1` when iterating locally on more
 //! than one test in the same file to avoid the same daemon-spawn contention
-//! #1610 fixed in the gate.
+//! the gate serializes away.
 
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
@@ -48,7 +48,7 @@ use tauri::Manager;
 /// `tests/*.rs` binary `#[tokio::test]`s run concurrently by default, so
 /// several real daemon spawns can contend for the same cores at once —
 /// worse on a machine that also has an unrelated `cargo test` running
-/// elsewhere (see #1610). 30s was tuned for an unloaded machine and had no
+/// elsewhere. 30s was tuned for an unloaded machine and had no
 /// headroom for that; 60s gives slack without materially raising the
 /// wall-clock cost of a clean, unloaded run, since `wait_for_daemon` returns
 /// as soon as the socket is healthy rather than sleeping out the full

--- a/packages/desktop-app/src-tauri/tests/commits_per_edit_test.rs
+++ b/packages/desktop-app/src-tauri/tests/commits_per_edit_test.rs
@@ -1,5 +1,5 @@
 //! ADR-048 commits-per-edit assertion — validates the backend half of the
-//! #1492 fix (frontend serialization lives in
+//! write-coalescing fix (frontend serialization lives in
 //! `shared-node-store.svelte.ts`'s `SimplePersistenceCoordinator`; that half
 //! already has frontend coverage). What belongs at the Tauri seam is proof
 //! that the real `update_node` command, called the way a correctly
@@ -69,7 +69,7 @@ async fn one_coalesced_edit_produces_exactly_one_version_increment() {
 /// A correctly sequenced writer for a SECOND coalesced edit reads the
 /// version from the first edit's confirmed response (2), not from a stale
 /// pre-confirmation guess (1) — this is the "latest-wins serial writer that
-/// reads the version only after prior confirmation" #1492 mandates.
+/// reads the version only after prior confirmation" the fix mandates.
 /// Confirms that path also increments by exactly one, and that reusing the
 /// now-stale version 1 is rejected — proving self-conflict is structurally
 /// impossible only when the version is sourced correctly, not by accident.
@@ -117,7 +117,7 @@ async fn second_coalesced_edit_uses_the_confirmed_version_not_a_stale_guess() {
         "second coalesced edit must move the version by exactly one more"
     );
 
-    // The regression #1492 fixed: re-using the now-stale pre-confirmation
+    // The regression this guards against: re-using the now-stale pre-confirmation
     // version (1) for a write against a node already at version 3 must be
     // rejected by OCC, not silently accepted — this is what makes
     // self-conflict structurally impossible rather than accidental.

--- a/packages/desktop-app/src-tauri/tests/daemon_readiness_test.rs
+++ b/packages/desktop-app/src-tauri/tests/daemon_readiness_test.rs
@@ -1,4 +1,4 @@
-//! Integration test for #1525 — proves the daemon-readiness contract holds
+//! Integration test — proves the daemon-readiness contract holds
 //! against a REAL headless `nodespaced`, not a mock: a socket nothing is
 //! listening on reports NotRunning, a real daemon's bind is observed as
 //! Healthy once `wait_for_daemon` catches up to it, and both the raw

--- a/packages/desktop-app/src-tauri/tests/indent_outdent_rapid_ordering_test.rs
+++ b/packages/desktop-app/src-tauri/tests/indent_outdent_rapid_ordering_test.rs
@@ -151,9 +151,9 @@ async fn rapid_sibling_creation_preserves_insertion_order() {
 /// two nodes being reordered are distinct, so there's no version conflict
 /// between them). Does NOT assert the final sibling order matches both
 /// reorders: that assertion is `concurrent_reorders_produce_correct_final_order`
-/// below, `#[ignore]`d as a known-failing regression test for #1561 (a real,
+/// below, `#[ignore]`d as a known-failing regression test for a real,
 /// intermittent race in the fractional-order read-then-write window that
-/// this concurrent case can trigger).
+/// this concurrent case can trigger.
 #[tokio::test]
 async fn concurrent_reorders_of_distinct_nodes_all_succeed() {
     let daemon = SpawnedDaemon::spawn();
@@ -196,7 +196,7 @@ async fn concurrent_reorders_of_distinct_nodes_all_succeed() {
     r2.expect("reorder of ids[0] to End failed");
 }
 
-/// Regression test for #1561: concurrent reorders of distinct siblings to
+/// Regression test: concurrent reorders of distinct siblings to
 /// opposite boundary positions (Beginning / End) must produce a sibling
 /// order reflecting BOTH operations, not just that each RPC individually
 /// succeeded. `move_node`'s same-parent branch reads sibling order values
@@ -204,7 +204,7 @@ async fn concurrent_reorders_of_distinct_nodes_all_succeed() {
 /// (`packages/core/src/db/sqlite_store.rs`), so two concurrent reorders can
 /// read the same sibling snapshot and race. Reproduces intermittently
 /// (roughly 1 in 15 full-suite runs) — `#[ignore]`d so the flake doesn't
-/// block the suite; un-ignore once #1561 wraps the read+compute+write in a
+/// block the suite; un-ignore once the read+compute+write is wrapped in a
 /// transaction per parent.
 #[tokio::test]
 #[ignore = "known race — see #1561"]

--- a/packages/desktop-app/src/lib/actions/focus-trap.ts
+++ b/packages/desktop-app/src/lib/actions/focus-trap.ts
@@ -1,5 +1,5 @@
 /**
- * focusTrap - Svelte action for accessible modal dialogs (#1414)
+ * focusTrap - Svelte action for accessible modal dialogs
  *
  * The app's hand-rolled modals (overlay + content + `stopPropagation`) never
  * moved focus into the dialog on open and never trapped Tab, so under real

--- a/packages/desktop-app/src/lib/actions/position-cursor.ts
+++ b/packages/desktop-app/src/lib/actions/position-cursor.ts
@@ -33,7 +33,7 @@ export type CursorPositionType =
   | 'arrow-navigation'
   | 'line-column'
   | 'node-type-conversion'
-  | 'inherited-type'; // Issue #664: For nodes created via Enter key that inherit parent type
+  | 'inherited-type'; // For nodes created via Enter key that inherit parent type
 
 export interface CursorPositionDefault {
   type: 'default';
@@ -63,7 +63,7 @@ export interface CursorPositionNodeTypeConversion {
 }
 
 /**
- * Issue #664: For nodes created via Enter key that inherit parent type
+ * For nodes created via Enter key that inherit parent type
  * These nodes have a type-locked pattern state (cannot revert to text)
  */
 export interface CursorPositionInheritedType {
@@ -166,7 +166,7 @@ export function positionCursor(
           break;
 
         case 'inherited-type':
-          // Issue #664: Position cursor for inherited type nodes (Enter key on typed node)
+          // Position cursor for inherited type nodes (Enter key on typed node)
           // Same positioning as node-type-conversion, but controller will use 'inherited' source
           controller.focus();
           controller.setCursorPosition(data.position);

--- a/packages/desktop-app/src/lib/commands/keyboard/create-node.command.ts
+++ b/packages/desktop-app/src/lib/commands/keyboard/create-node.command.ts
@@ -185,7 +185,7 @@ export class CreateNodeCommand implements KeyboardCommand {
     // always at position 0, so the old unconditional `position <= 0` made every
     // Enter on an empty node insert *above* and keep focus on it
     // (`focusOriginalNode`) — blank nodes piled upward and focus never advanced,
-    // diverging across sync (#1421). For an empty node, fall through to normal
+    // diverging across sync. For an empty node, fall through to normal
     // "create below + advance focus" splitting.
     if (position <= 0) {
       return content.trim().length > 0;

--- a/packages/desktop-app/src/lib/components/autocomplete-modal.svelte
+++ b/packages/desktop-app/src/lib/components/autocomplete-modal.svelte
@@ -51,7 +51,7 @@
     hierarchy?: string[];
   }
 
-  // Stub interface - NodeReferenceService was deleted in #558
+  // Stub interface - NodeReferenceService was deleted
   // These methods are stubbed to prevent TypeScript errors
   // The autocomplete-modal needs refactoring to use a different service
   export interface NodeReferenceService {

--- a/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/collaboration-view.svelte
@@ -1,6 +1,6 @@
 <!--
-  CollaborationView — per-collection membership management (epic #237, slice S3
-  #240). Shows the roster (people + role) and, for admins, controls to change a
+  CollaborationView — per-collection membership management. Shows the roster
+  (people + role) and, for admins, controls to change a
   member's role, remove them (last-admin protected server-side), and add someone
   already in the workspace. Self-service "Leave" for the caller. Non-admins see a
   read-only roster.
@@ -39,7 +39,7 @@
 	let addRole = $state<Permission>('readOnly');
 	let adding = $state(false);
 
-	// --- Invites & requests (S4 #241), admin-only ---
+	// --- Invites & requests, admin-only ---
 	const TTL_PRESETS: { label: string; secs?: number }[] = [
 		{ label: '1 day', secs: 86400 },
 		{ label: '7 days', secs: 604800 },

--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -1,5 +1,5 @@
 <!--
-  InvitationsInbox — onboarding entry point (epic #237, slice S5 #242). A modal
+  InvitationsInbox — onboarding entry point. A modal
   opened from the Pro account menu (and once, on first sign-in). Lets a user
   redeem a share-code invite, browse the collections they can join, and join an
   open one directly / request a restricted one.
@@ -26,7 +26,7 @@
 		open?: boolean;
 		onClose: () => void;
 		// When provided, a signed-in user with no code/membership can log out from
-		// here — reverting to the free/signed-out state (#248). Omitted callers get
+		// here — reverting to the free/signed-out state. Omitted callers get
 		// the plain Close-only footer.
 		onLogout?: () => void | Promise<void>;
 	} = $props();

--- a/packages/desktop-app/src/lib/components/index.ts
+++ b/packages/desktop-app/src/lib/components/index.ts
@@ -12,7 +12,7 @@ export { default as BaseNodeReference } from './base-node-reference.svelte';
 export type { TreeNodeData } from '$lib/types/tree';
 
 // Export AutocompleteModal types - defined inline since they're UI-specific
-// Note: NodeReferenceService was deleted in #558, autocomplete modal needs refactoring
+// Note: NodeReferenceService was deleted, autocomplete modal needs refactoring
 export interface AutocompleteModalProps {
   visible: boolean;
   position: { x: number; y: number };

--- a/packages/desktop-app/src/lib/components/layout/app-shell.svelte
+++ b/packages/desktop-app/src/lib/components/layout/app-shell.svelte
@@ -41,7 +41,7 @@
   // Logger instance for AppShell component
   const log = createLogger('AppShell');
 
-  // Daemon connectivity state (Issue #1179, generalized in #1470). `connecting`
+  // Daemon connectivity state. `connecting`
   // covers the brief window before the first daemon-status event arrives (or
   // a short grace period elapses); `unreachable` reflects a terminal
   // `not_running` event.
@@ -50,10 +50,10 @@
   const daemonConnecting = $derived($daemonStatus.connecting);
   const daemonUnreachable = $derived($daemonStatus.unreachable);
 
-  // First-launch onboarding wizard (Issue #1180).
+  // First-launch onboarding wizard.
   let showOnboarding = $state(false);
 
-  // Recovered Items (core#1303): once the daemon's probe confirms Pro tier, load
+  // Recovered Items: once the daemon's probe confirms Pro tier, load
   // the local-only recovery log. If the daemon preserved any conflict "losers",
   // show a one-time snackbar on first open; the inline badge handles per-node
   // review/restore. Guarded one-shot so it loads exactly once per session; fully
@@ -252,18 +252,18 @@
         collectionsData.loadCollections();
       });
 
-      // Show a warning if the nodespace CLI is not on $PATH after skill install (Issue #1199).
+      // Show a warning if the nodespace CLI is not on $PATH after skill install.
       unlistenSkillCliMissing = listen<{ warning: string }>('skill:cli-missing', (event) => {
         log.warn('nodespace CLI not on PATH:', event.payload.warning);
         statusBar.error(event.payload.warning);
       });
 
-      // Start the shared daemon-status listener (Issue #1179, generalized in #1470).
+      // Start the shared daemon-status listener.
       // Drives daemonConnecting/daemonUnreachable above and fans out reconnect
       // events to any store registered via onDaemonReconnect.
       startDaemonStatusListener();
 
-      // Show first-launch onboarding wizard if setup has not been completed (Issue #1180).
+      // Show first-launch onboarding wizard if setup has not been completed.
       invoke<{ completed: boolean }>('check_onboarding_status')
         .then((status) => {
           if (!status.completed) {
@@ -640,10 +640,10 @@
       <StatusBar />
     </div>
 
-    <!-- First-launch onboarding wizard (Issue #1180) -->
+    <!-- First-launch onboarding wizard -->
     <OnboardingWizard open={showOnboarding} onClose={() => (showOnboarding = false)} />
 
-    <!-- Conflict resolution notifications (Issue #642) -->
+    <!-- Conflict resolution notifications -->
     <ConflictToast />
 
     <!-- Pro chrome modal slot (re-login prompt when the daemon's session can't be

--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -52,7 +52,7 @@
       const viewer = await pluginRegistry.getViewer(nodeType);
       // Always store a result (viewer or BaseNodeViewer fallback) so the guard
       // viewerComponents.has(nodeType) fires true on subsequent calls and prevents
-      // repeated load attempts that cause mount/unmount loops (issue #967).
+      // repeated load attempts that cause mount/unmount loops.
       viewerComponents = new Map(viewerComponents.set(nodeType, viewer ?? BaseNodeViewer));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error loading viewer';

--- a/packages/desktop-app/src/lib/components/node-tree.svelte
+++ b/packages/desktop-app/src/lib/components/node-tree.svelte
@@ -247,7 +247,7 @@
     }
   }
 
-  /* Header-level CSS variables - matches HeaderNode wrapper classes for perfect chevron alignment (Issue #311) */
+  /* Header-level CSS variables - matches HeaderNode wrapper classes for perfect chevron alignment */
   .ns-node-tree :global(.header-h1) {
     --font-size: 2rem;
     --line-height: 1.2;

--- a/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
+++ b/packages/desktop-app/src/lib/components/pro-relogin-modal.svelte
@@ -1,5 +1,5 @@
 <!--
-  Pro-tier re-login modal (T18, #1304).
+  Pro-tier re-login modal.
 
   Surfaced by the app shell when the Pro daemon reports `AUTH_REQUIRED`
   (`SyncStatusEvent.state` = 4) — i.e. the persisted refresh token could

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -63,7 +63,7 @@
   let menuOpen = $state(false);
   let signingOut = $state(false);
 
-  // Invitations inbox (onboarding, #199 S5). Opened from the account menu and,
+  // Invitations inbox (onboarding). Opened from the account menu and,
   // once per device, automatically on the first sign-in.
   //
   // `inboxOpenedManually` tracks explicit opens (account menu). The first-run
@@ -89,7 +89,7 @@
     }
   }
 
-  // Signed in = the daemon surfaced an identity (#199 S6). When set, clicking the
+  // Signed in = the daemon surfaced an identity. When set, clicking the
   // pill opens the account menu ("signed in as <email>" + Sign out) instead of
   // starting a new sign-in.
   let signedIn = $derived(proSync.userEmail !== '');
@@ -97,7 +97,7 @@
   // While the daemon catches up in the background (state 'syncing'), the app is
   // fully usable on the local cache — so the tooltip surfaces that progress even
   // when signed in, rather than only "Signed in as <email>". Never a blocking gate;
-  // the pill is purely a status indicator (#249).
+  // the pill is purely a status indicator.
   let pillTitle = $derived(
     signedIn
       ? proSync.state === 'syncing'
@@ -172,7 +172,7 @@
     try {
       await proSync.signOut();
       // Drop cached membership state so the next user doesn't inherit this
-      // session's roster/identity (#199 S5; identity is per-session).
+      // session's roster/identity (identity is per-session).
       membership.reset();
       log.info('signed out');
     } finally {
@@ -322,7 +322,7 @@
     box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.18);
   }
 
-  /* Account menu (#199 S6) — shown when signed in. */
+  /* Account menu — shown when signed in. */
   .menu-backdrop {
     position: fixed;
     inset: 0;

--- a/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
@@ -111,7 +111,7 @@
   });
 
   /**
-   * Get property value with backward compatibility (Issue #397)
+   * Get property value with backward compatibility
    *
    * Supports multiple formats:
    * - Strongly-typed nodes: top-level type-specific fields (e.g., task.status)
@@ -127,7 +127,7 @@
       return (node as unknown as Record<string, unknown>)[fieldName];
     }
 
-    // Issue #794: Properties are namespaced under properties[nodeType][fieldName]
+    // Properties are namespaced under properties[nodeType][fieldName]
     const typeNamespace = node.properties?.[nodeType];
     if (typeNamespace && typeof typeNamespace === 'object' && fieldName in typeNamespace) {
       return (typeNamespace as Record<string, unknown>)[fieldName];
@@ -200,7 +200,7 @@
   function updateProperty(fieldName: string, value: unknown) {
     if (!node || !schema) return;
 
-    // AUTO-MIGRATION (Issue #397): If this is the first write and node is still in old
+    // AUTO-MIGRATION: If this is the first write and node is still in old
     // flat format, migrate all existing properties to new nested format. This prevents
     // mixed-format properties within the same node and ensures clean data migration.
     const typeNamespace = node.properties?.[nodeType];
@@ -311,7 +311,7 @@
   }
 
   // Format enum value for display (convert snake_case to Title Case)
-  // Handles lowercase values like "in_progress" → "In Progress" (Issue #670)
+  // Handles lowercase values like "in_progress" → "In Progress"
   function formatEnumLabel(value: string): string {
     return value
       .split('_')

--- a/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/task-schema-form.svelte
@@ -1,5 +1,5 @@
 <!--
-  TaskSchemaForm - Type-Safe Task Property Form (Issue #709)
+  TaskSchemaForm - Type-Safe Task Property Form
 
   Hybrid approach:
   - Hardcoded UI for core task properties (status, priority, dueDate, assignee)
@@ -202,7 +202,7 @@
   // Update a user-defined field.
   //
   // WRITE uses the STORAGE shape: the backend stores type properties namespaced
-  // under `properties.task` (issue #838), so updates must re-nest the field there.
+  // under `properties.task`, so updates must re-nest the field there.
   // This leaves the local node in the nested shape until the backend echo
   // re-flattens it — getUserFieldValue above reads both forms to bridge the gap.
   function updateUserField(fieldName: string, value: unknown) {

--- a/packages/desktop-app/src/lib/components/schema/generic-schema-form.svelte
+++ b/packages/desktop-app/src/lib/components/schema/generic-schema-form.svelte
@@ -1,5 +1,5 @@
 <!--
-  GenericSchemaForm - Schema-driven property form for custom node types (Issue #965)
+  GenericSchemaForm - Schema-driven property form for custom node types
 
   Renders fields from a SchemaNode definition as appropriate inputs.
   Used by BaseNodeViewer when a node's nodeType is a UUID (custom schema type)

--- a/packages/desktop-app/src/lib/components/version-conflict-modal.svelte
+++ b/packages/desktop-app/src/lib/components/version-conflict-modal.svelte
@@ -2,7 +2,7 @@
   import { focusTrap } from '$lib/actions/focus-trap';
   import type { Node } from '$lib/types';
 
-  // ConflictResolution type moved inline (version-conflict-resolver deleted in #558)
+  // ConflictResolution type moved inline (version-conflict-resolver deleted)
   interface ConflictResolution {
     type: 'yours' | 'current' | 'merged';
     resolvedNode: Node;

--- a/packages/desktop-app/src/lib/components/viewers/ai-chat-pty-session.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/ai-chat-pty-session.svelte
@@ -152,7 +152,7 @@
 
   onMount(async () => {
     // Pre-select the agent chosen in the header AiChatModelSelector, when one
-    // was already stored on the node (issue #1450); otherwise keep the
+    // was already stored on the node; otherwise keep the
     // 'claude-code' default.
     const nodeModel = node?.properties?.model as string | undefined;
     if (nodeModel) {

--- a/packages/desktop-app/src/lib/components/viewers/date-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/date-node-viewer.svelte
@@ -21,7 +21,7 @@
 
   // Props using Svelte 5 runes mode - unified NodeViewerProps interface.
   // The tab title is never pushed from here — tab-system.svelte derives it directly
-  // from the tab's nodeId via computeTabTitle (see issue #1564).
+  // from the tab's nodeId via computeTabTitle.
   let {
     nodeId,
     onNodeIdChange

--- a/packages/desktop-app/src/lib/components/viewers/task-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/task-node-viewer.svelte
@@ -3,7 +3,7 @@
 
   Features:
   - Wraps BaseNodeViewer for node management
-  - BaseNodeViewer automatically loads TaskSchemaForm via plugin registry (Issue #709)
+  - BaseNodeViewer automatically loads TaskSchemaForm via plugin registry
   - Direct type-specific property binding (status, priority, dueDate, assignee)
   - Type-safe updates via updateTaskNode
   - Follows *NodeViewer pattern (like DateNodeViewer)

--- a/packages/desktop-app/src/lib/contexts/node-service-context.svelte
+++ b/packages/desktop-app/src/lib/contexts/node-service-context.svelte
@@ -117,7 +117,7 @@
     }
   });
 
-  // Cleanup subscriptions on unmount to prevent memory leaks (Issue #640)
+  // Cleanup subscriptions on unmount to prevent memory leaks
   onDestroy(() => {
     if (servicesContainer.services?.nodeManager) {
       servicesContainer.services.nodeManager.destroy();

--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -96,7 +96,7 @@
   let isPromoting = $state(false);
 
   // Stable placeholder ID - cached outside reactive system to avoid mutations during derived evaluation
-  // Issue #653: Eliminated $effect by using a non-reactive cache variable
+  // Eliminated $effect by using a non-reactive cache variable
   // The ID is created lazily when first needed and reset when placeholder is promoted
   let cachedPlaceholderId: string | null = null;
 
@@ -122,7 +122,7 @@
 
   // Viewer-local placeholder (not in sharedNodeStore until it gets content)
   // This placeholder is only visible to this viewer instance
-  // Issue #653: Now uses lazy ID generation instead of $effect-managed state
+  // Now uses lazy ID generation instead of $effect-managed state
   const viewerPlaceholder = $derived.by<Node | null>(() => {
     // Note: shouldShowPlaceholder is defined later in the file (forward reference is safe in Svelte 5)
     if (shouldShowPlaceholder) {
@@ -180,7 +180,7 @@
       depth: number,
       result: ViewerRenderNode[] = []
     ): ViewerRenderNode[] {
-      // TRANSITION PERIOD (Issue #580): Try reactive structure tree first, fall back to sharedNodeStore
+      // TRANSITION PERIOD: Try reactive structure tree first, fall back to sharedNodeStore
       // This supports gradual migration where reactive stores are being populated asynchronously.
       // Once all nodes are in reactive stores, remove fallback and use only reactiveStructureTree.
       let childIds = reactiveStructureTree.getChildren(parentId);
@@ -192,12 +192,12 @@
       }
 
       for (const id of childIds) {
-        // Issue #679: sharedNodeStore is now single source of truth (consolidated from nodeData)
+        // sharedNodeStore is now single source of truth (consolidated from nodeData)
         const node = sharedNodeStore.getNode(id);
         if (!node) continue;
 
         // Get children IDs for this node
-        // TRANSITION PERIOD (Issue #580): Same fallback pattern as above
+        // TRANSITION PERIOD: Same fallback pattern as above
         let children = reactiveStructureTree.getChildren(node.id);
         if (children.length === 0) {
           const cachedChildren = sharedNodeStore.getNodesForParent(node.id);
@@ -297,7 +297,7 @@
           return;
         }
 
-        // Issue #679: No longer need viewedNodeCache workaround
+        // No longer need viewedNodeCache workaround
         // sharedNodeStore.nodes is now $state, so currentViewedNode $derived updates automatically
         // Header content derived from currentViewedNode - no manual assignment needed
 
@@ -309,16 +309,16 @@
           return;
         }
 
-        // Issue #709: Preload type-specific schema form for viewed node if available
+        // Preload type-specific schema form for viewed node if available
         // This triggers lazy loading of TaskSchemaForm, DateSchemaForm, etc.
         if (node.nodeType) {
-          // Issue #965: Reset generic schema when navigating to a different node
+          // Reset generic schema when navigating to a different node
           schemaFormLoader.resetGenericSchema();
           schemaFormLoader.loadForm(node.nodeType);
         }
 
         // Tab title is derived directly from node data by tab-system.svelte's
-        // computeTabTitle — no push needed here (see issue #1564).
+        // computeTabTitle — no push needed here.
       } catch (error) {
         loadFailed = true;
         log.error('Failed to load children:', error);
@@ -329,7 +329,7 @@
     loadAndSettle();
 
     // If the initial load failed (e.g. daemon still starting up), retry once
-    // the daemon reconnects instead of leaving this viewer permanently empty (#1470).
+    // the daemon reconnects instead of leaving this viewer permanently empty.
     const unsubscribeReconnect = onDaemonReconnect(() => {
       if (isDestroyed || !loadFailed) return;
       loadAndSettle(true);
@@ -359,7 +359,7 @@
    * Handle header content changes (for default editable header).
    * Persists to database; the tab title updates automatically since tab-system.svelte
    * derives it from sharedNodeStore, which nodeManager.updateNodeContent writes to
-   * synchronously (see issue #1564 — titles are computed, never pushed).
+   * synchronously (titles are computed, never pushed).
    */
   function handleHeaderInput(newValue: string) {
     if (nodeId) {
@@ -455,12 +455,12 @@
         // Note: We already checked cache/DB above, so if allNodes is empty, no persisted children exist
 
         // No children at all - placeholder will be created automatically by viewerPlaceholder derived
-        // Issue #653: Removed manual ID creation - getOrCreatePlaceholderId() handles it lazily
+        // Removed manual ID creation - getOrCreatePlaceholderId() handles it lazily
         // Focus is handled by BaseNode's onMount when autoFocus=true
         // DON'T call initializeNodes() - keep placeholder completely viewer-local!
       } else {
         // Real children exist - initialize with ALL nodes
-        // Issue #653: Removed lastSavedContent tracking - no longer needed without content watcher effect
+        // Removed lastSavedContent tracking - no longer needed without content watcher effect
         nodeManager.initializeNodes(allNodes, {
           expanded: true,
           autoFocus: false,
@@ -625,7 +625,7 @@
     }
 
     // Set cursor position using FocusManager (single source of truth)
-    // Issue #664: For inherited type nodes (Enter key on typed node), use focusNodeFromInheritedType
+    // For inherited type nodes (Enter key on typed node), use focusNodeFromInheritedType
     // which sets pattern state to 'inherited' (cannot revert to text).
     // This is different from pattern-detected type conversions which CAN revert.
     if (newNodeCursorPosition !== undefined && !focusOriginalNode) {
@@ -949,7 +949,7 @@
       // Clear placeholder ID synchronously to prevent re-entry
       resetPlaceholderId();
 
-      // CRITICAL FIX (Issue #681): Defer store mutations to next tick
+      // Defer store mutations to next tick
       // sharedNodeStore.setNode() triggers notifySubscribers() which calls wildcard
       // subscription callbacks that mutate $state. If called during template render,
       // Svelte throws "state_unsafe_mutation". tick() ensures we're outside render.
@@ -1022,7 +1022,7 @@
       // Clear placeholder ID synchronously to prevent re-entry
       resetPlaceholderId();
 
-      // CRITICAL FIX (Issue #681): Defer store mutations to next tick to avoid
+      // Defer store mutations to next tick to avoid
       // state_unsafe_mutation during template render (matches contentChanged path).
       const promotionParentId = nodeId;
       tick().then(() => {
@@ -1150,7 +1150,7 @@
       // Clear placeholder ID synchronously to prevent re-entry
       resetPlaceholderId();
 
-      // CRITICAL FIX (Issue #681): Defer store mutations to next tick
+      // Defer store mutations to next tick
       // sharedNodeStore.setNode() triggers notifySubscribers() which calls wildcard
       // subscription callbacks that mutate $state. If called during template render,
       // Svelte throws "state_unsafe_mutation". tick() ensures we're outside render.
@@ -1279,7 +1279,7 @@
     // We must commit globally because visible nodes might be empty if viewer already unmounted
     sharedNodeStore.commitAllBatches();
 
-    // Note: PersistenceCoordinator removed in Issue #558
+    // Note: PersistenceCoordinator removed
     // SimplePersistenceCoordinator handles debouncing inline in shared-node-store
 
     // Set cancellation flag to prevent stale writes
@@ -1319,7 +1319,7 @@
   {/if}
 
   <!-- Schema-Driven Properties Panel - fixed between header and content area -->
-  <!-- Issue #709: Type-specific schema forms use plugin registry for smart dispatch -->
+  <!-- Type-specific schema forms use plugin registry for smart dispatch -->
   <!-- Core types (task, date) use hardcoded forms; user-defined types use generic SchemaPropertyForm -->
   <!-- Only render when a schema form is known to exist: null means "checked, none registered" -->
   {#if currentViewedNode && nodeId && schemaFormLoader.getForm(currentViewedNode.nodeType)}
@@ -1330,7 +1330,7 @@
       <TypedSchemaForm {nodeId} />
     </div>
   {:else if currentViewedNode && nodeId && schemaFormLoader.genericSchema && isCustomSchemaType(currentViewedNode.nodeType)}
-    <!-- Issue #965: Generic schema form for custom schema node types (UUID nodeType) -->
+    <!-- Generic schema form for custom schema node types (UUID nodeType) -->
     <!-- autoOpen is captured once at GenericSchemaForm mount time (not reactively synced).
          Safe only because this branch doesn't render until genericSchema is loaded, so
          hasTitleTemplate is already final by the time autoOpen is read. -->

--- a/packages/desktop-app/src/lib/design/components/base-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node.svelte
@@ -18,7 +18,7 @@
   - Plugin System: Registered viewers extend this base with type-specific logic
 
   Migration Note:
-  - Replaced ContentEditableController with TextareaController (Issue #274)
+  - Replaced ContentEditableController with TextareaController
   - Single source of truth: textarea.value (no dual representation)
   - Simpler state management and cursor positioning
 -->
@@ -505,7 +505,7 @@
       // Don't update nodeType locally - let parent handle it to avoid double re-renders
       // The parent (base-node-viewer) will update nodeType via nodeManager and trigger autoFocus
       //
-      // ARCHITECTURE (Issue #311): Header level changes are handled by HeaderNode component via $effect
+      // ARCHITECTURE: Header level changes are handled by HeaderNode component via $effect
       // TextareaController only detects pattern → header conversion, NOT level changes within headers
       // This separation ensures BaseNode remains node-type agnostic
     }
@@ -543,7 +543,7 @@
 
   // Import structured view mode renderer (avoids {@html} XSS warning)
   import ViewModeRenderer from './view-mode-renderer.svelte';
-  // Pro-only inline badge for sync conflict "losers" (core#1303). Renders nothing
+  // Pro-only inline badge for sync conflict "losers". Renders nothing
   // unless this node has a preserved superseded edit, so it is inert in community.
   import RecoveredItemsBadge from '$lib/components/recovered-items-badge.svelte';
 

--- a/packages/desktop-app/src/lib/design/components/header-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/header-node.svelte
@@ -1,7 +1,7 @@
 <!--
   HeaderNode - Wraps BaseNode with header-specific functionality
 
-  ARCHITECTURE NOTE (Issue #311 Refactor):
+  ARCHITECTURE NOTE:
   - Header level detection moved FROM TextareaController TO HeaderNode $effect
   - CSS styling moved FROM BaseNode TO HeaderNode wrapper classes (.header-h1 through .header-h6)
   - This ensures proper separation of concerns: BaseNode is node-type agnostic
@@ -51,7 +51,7 @@
   const dispatch = createEventDispatcher();
 
   // Header level - derived from markdown syntax (#, ##, ###, etc.)
-  // REFACTOR (Issue #316 Phase 1): Replaced $effect with $derived for pure reactive computation
+  // Replaced $effect with $derived for pure reactive computation
   let headerLevel = $derived(parseHeaderLevel(content));
 
   // Headers use default single-line editing
@@ -90,7 +90,7 @@
 
   /**
    * Handle content changes and sync with parent
-   * REFACTOR (Issue #316 Phase 2): Moved newline stripping from $effect to event handler
+   * Moved newline stripping from $effect to event handler
    * This makes side effects explicit and event-driven instead of reactive
    * REFACTOR: Using $bindable() prop - update content directly via two-way binding
    */

--- a/packages/desktop-app/src/lib/design/components/node-row.svelte
+++ b/packages/desktop-app/src/lib/design/components/node-row.svelte
@@ -291,7 +291,7 @@
     transform: translate(-50%, -50%) rotate(90deg);
   }
 
-  /* Inherit font-size, line-height, and icon positioning from HeaderNode wrapper classes (Issue #311) */
+  /* Inherit font-size, line-height, and icon positioning from HeaderNode wrapper classes */
   .node-content-wrapper:has(:global(.header-h1)) {
     --font-size: 2rem;
     --line-height: 1.2;

--- a/packages/desktop-app/src/lib/design/components/query-node.svelte
+++ b/packages/desktop-app/src/lib/design/components/query-node.svelte
@@ -4,7 +4,7 @@
   Displays query nodes with their description and filter criteria.
   Query nodes are primarily created by AI/MCP, not manually.
 
-  Full query execution and visualization will be implemented in Issue #443.
+  Full query execution and visualization is not yet implemented.
   This component provides the foundation with navigation support via "open" button.
 -->
 

--- a/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
+++ b/packages/desktop-app/src/lib/design/components/textarea-controller.svelte.ts
@@ -5,7 +5,7 @@
  * - TextareaController CLASS: Pure TypeScript, works in tests without Svelte context
  * - createTextareaController FACTORY: Wraps class with reactive effects for components
  *
- * Key Design Decisions (Issue #695):
+ * Key Design Decisions:
  * - Dual usage: Class can be instantiated directly in tests, or via factory in components
  * - Content sync effect: KEPT - necessary for external content changes (SSE, undo/redo)
  * - Config sync effect: ELIMINATED - controller stores getter, reads on-demand
@@ -188,7 +188,7 @@ export class TextareaController {
     private nodeType: string;
     private paneId: string;
     /**
-     * Config getter - reads current config on-demand (Issue #695)
+     * Config getter - reads current config on-demand
      * Eliminates the need for config sync $effect by reading from getter
      * Tests can pass simple functions: () => ({ allowMultiline: true })
      */
@@ -198,7 +198,7 @@ export class TextareaController {
     private isInitialized: boolean = false;
     /**
      * Pattern state machine - manages pattern detection lifecycle
-     * Replaces the old nodeTypeSetViaPattern boolean flag (Issue #664)
+     * Replaces the old nodeTypeSetViaPattern boolean flag
      */
     private patternState: PatternState;
     private lastKnownPixelOffset: number = 0;
@@ -228,13 +228,13 @@ export class TextareaController {
       paneId: string,
       events: TextareaControllerEvents,
       /**
-       * Config getter - reads current config on-demand (Issue #695)
+       * Config getter - reads current config on-demand
        * Pass a function that returns the config object
        * Factory passes reactive getter, tests pass simple functions
        */
       getConfig: () => TextareaControllerConfig = () => ({}),
       /**
-       * Creation source for pattern state (Issue #664)
+       * Creation source for pattern state
        * - 'user': User created node (patterns can be detected)
        * - 'pattern': Node created via pattern detection (can revert to text)
        * - 'inherited': Node inherits type from parent (cannot revert)
@@ -247,10 +247,10 @@ export class TextareaController {
       this.nodeType = nodeType;
       this.paneId = paneId;
       this.events = events;
-      // Store config getter - reads on-demand instead of via $effect (Issue #695)
+      // Store config getter - reads on-demand instead of via $effect
       this.getConfig = getConfig;
 
-      // Initialize pattern state (Issue #664)
+      // Initialize pattern state
       // If creationSource not provided, infer from focusManager for backward compatibility
       const cursorType = focusManager.cursorPosition?.type;
       const isTypeConversion = cursorType === 'node-type-conversion';
@@ -290,7 +290,7 @@ export class TextareaController {
     }
 
     /**
-     * Config getter - reads from getConfig() on-demand (Issue #695)
+     * Config getter - reads from getConfig() on-demand
      * This eliminates the config sync $effect by reading reactively
      */
     private get config(): TextareaControllerConfig {
@@ -320,7 +320,7 @@ export class TextareaController {
       keyboardCommandsRegistered = true;
     }
 
-    // NOTE: updateConfig() REMOVED (Issue #695)
+    // NOTE: updateConfig() REMOVED
     // Config is now read on-demand via the config getter, which calls getConfig()
     // The $effect that previously synced config changes is eliminated
     // Config updates now automatically reflect when getConfig() returns new values
@@ -333,7 +333,7 @@ export class TextareaController {
       this.element.value = content;
 
       // Check if FocusManager has a pending cursor position
-      // Issue #669: ANY cursor position type should skip the default setCursorAtBeginningOfLine
+      // ANY cursor position type should skip the default setCursorAtBeginningOfLine
       // because the positionCursor action handles all cursor positioning cases.
       // Previously only checked for 'node-type-conversion', but 'absolute', 'default', etc.
       // also need to be handled by the action, not overridden here.
@@ -344,7 +344,7 @@ export class TextareaController {
       // The positionCursor action will handle cursor positioning
       // This must happen here (not in the action) to avoid a race condition where
       // RAF runs before initialize() and clears the position before we can check it
-      // Issue #669: Clear for ALL position types, not just node-type-conversion
+      // Clear for ALL position types, not just node-type-conversion
       if (hasPendingCursorPosition) {
         // Use RAF to ensure positionCursor action has a chance to read and process the position
         requestAnimationFrame(() => {
@@ -352,7 +352,7 @@ export class TextareaController {
         });
       }
 
-      // Initialize pattern state for non-text types (Issue #664)
+      // Initialize pattern state for non-text types
       // This enables reversion to text type when the pattern is deleted
       if (this.nodeType !== 'text') {
         // If this component is being created due to a type conversion (via pattern detection),
@@ -361,7 +361,7 @@ export class TextareaController {
           // For non-conversion cases (e.g., page load), check if content matches pattern
           const detection = pluginRegistry.detectPatternInContent(content);
           if (detection && detection.config.targetNodeType === this.nodeType) {
-            // Content matches pattern - enable reversion capability (Issue #667)
+            // Content matches pattern - enable reversion capability
             this.patternState.setPluginPatternExists(detection.plugin);
           }
         }
@@ -373,7 +373,7 @@ export class TextareaController {
           this.justCreated = false;
         }, 50);
 
-        // Issue #669: Skip cursor positioning here if FocusManager has a pending position
+        // Skip cursor positioning here if FocusManager has a pending position
         // The positionCursor action will handle ALL cursor positioning types
         // This prevents the cursor from being positioned at 0 before the action can apply
         // the correct position (e.g., 'absolute' position from Enter key node creation)
@@ -908,7 +908,7 @@ export class TextareaController {
         const { plugin, config, match } = detection;
 
         if (this.nodeType === config.targetNodeType) {
-          // Node type already matches - record pattern for reversion capability (Issue #667)
+          // Node type already matches - record pattern for reversion capability
           this.patternState.setPluginPatternExists(plugin);
           return;
         }
@@ -936,7 +936,7 @@ export class TextareaController {
           });
 
           this.nodeType = config.targetNodeType;
-          // Record pattern match for reversion capability (Issue #667)
+          // Record pattern match for reversion capability
           this.patternState.recordPluginPatternMatch(plugin);
         });
       } else if (this.nodeType !== 'text' && this.patternState.canRevert) {
@@ -1109,7 +1109,7 @@ export function createTextareaController(
   // Events and config
   events: TextareaControllerEvents,
   /**
-   * Pattern state creation source (Issue #664)
+   * Pattern state creation source
    * Controls how pattern detection behaves for this node:
    * - 'user': User-created node, patterns can be detected and can revert
    * - 'pattern': Created via pattern detection, can revert to text
@@ -1131,7 +1131,7 @@ export function createTextareaController(
     untrack(() => {
       if (element && !controller) {
         // Pass getEditableConfig directly - controller stores getter and reads on-demand
-        // This eliminates the need for config sync $effect (Issue #695)
+        // This eliminates the need for config sync $effect
         controller = new TextareaController(
           element,
           nodeId,

--- a/packages/desktop-app/src/lib/plugins/core-plugins.ts
+++ b/packages/desktop-app/src/lib/plugins/core-plugins.ts
@@ -57,7 +57,7 @@ export const headerNodePlugin: PluginDefinition = {
   name: 'Header Node',
   description: 'Create a header with customizable level (1-6)',
   version: '1.0.0',
-  // Plugin-owned pattern behavior (Issue #667)
+  // Plugin-owned pattern behavior
   pattern: {
     detect: /^(#{1,6})\s/,
     canRevert: true,
@@ -134,7 +134,7 @@ export const taskNodePlugin: PluginDefinition = {
     lazyLoad: () => import('../design/components/task-node.svelte'),
     priority: 1
   },
-  // TaskNodeViewer for task-specific UI (Issue #715)
+  // TaskNodeViewer for task-specific UI
   viewer: {
     lazyLoad: () => import('../components/viewers/task-node-viewer.svelte'),
     priority: 1
@@ -143,12 +143,12 @@ export const taskNodePlugin: PluginDefinition = {
     component: BaseNodeReference as NodeReferenceComponent,
     priority: 1
   },
-  // Type-specific metadata extraction (Issue #698, #794, #838)
-  // Issue #838: Backend returns TaskNode with status at TOP LEVEL (flat type-specific fields)
+  // Type-specific metadata extraction
+  // Backend returns TaskNode with status at TOP LEVEL (flat type-specific fields)
   // Also supports generic Node where status is in properties (for SSE events)
   extractMetadata: (node: { nodeType: string; status?: string; priority?: string | number; properties?: Record<string, unknown> }) => {
     const properties = node.properties || {};
-    // Issue #838: Check top-level status first (TaskNode format), fall back to properties.status
+    // Check top-level status first (TaskNode format), fall back to properties.status
     // TaskNode has status at node.status, generic Node has it at node.properties.status
     const status = node.status ?? properties.status;
     const priority = node.priority ?? properties.priority;
@@ -169,7 +169,7 @@ export const taskNodePlugin: PluginDefinition = {
     // This ensures top-level type-specific fields take precedence over properties
     return { ...properties, taskState, status, priority };
   },
-  // Type-specific state mapping (Issue #698)
+  // Type-specific state mapping
   mapStateToSchema: (state: string, _fieldName: string): CoreTaskStatus => {
     switch (state) {
       case 'pending':
@@ -183,7 +183,7 @@ export const taskNodePlugin: PluginDefinition = {
     }
   },
 
-  // Type-specific updater for task node properties (Issue #709)
+  // Type-specific updater for task node properties
   // Routes to updateTaskNode() instead of generic updateNode()
   updater: {
     update: async (id: string, version: number, changes: Record<string, unknown>) => {
@@ -205,7 +205,7 @@ export const taskNodePlugin: PluginDefinition = {
     }
   },
 
-  // Type-specific schema form for task node properties (Issue #709)
+  // Type-specific schema form for task node properties
   schemaForm: {
     lazyLoad: () => import('../components/property-forms/task-schema-form.svelte')
   }
@@ -290,7 +290,7 @@ export const codeBlockNodePlugin: PluginDefinition = {
   name: 'Code Block Node',
   description: 'Code snippet with language selection and syntax',
   version: '1.0.0',
-  // Plugin-owned pattern behavior (Issue #667)
+  // Plugin-owned pattern behavior
   pattern: {
     detect: /^```\n/,  // Matches ``` followed immediately by newline (language set via dropdown only)
     canRevert: true,
@@ -325,7 +325,7 @@ export const codeBlockNodePlugin: PluginDefinition = {
     component: BaseNodeReference as NodeReferenceComponent,
     priority: 1
   },
-  // Structured content - cannot accept arbitrary merges (Issue #698)
+  // Structured content - cannot accept arbitrary merges
   acceptsContentMerge: false
 };
 
@@ -334,7 +334,7 @@ export const quoteBlockNodePlugin: PluginDefinition = {
   name: 'Quote Block Node',
   description: 'Block quote with markdown styling conventions',
   version: '1.0.0',
-  // Plugin-owned pattern behavior (Issue #667)
+  // Plugin-owned pattern behavior
   pattern: {
     detect: /^>\s/,
     canRevert: true,
@@ -368,7 +368,7 @@ export const quoteBlockNodePlugin: PluginDefinition = {
     component: BaseNodeReference as NodeReferenceComponent,
     priority: 1
   },
-  // Structured content - cannot accept arbitrary merges (Issue #698)
+  // Structured content - cannot accept arbitrary merges
   acceptsContentMerge: false
 };
 
@@ -377,7 +377,7 @@ export const orderedListNodePlugin: PluginDefinition = {
   name: 'Ordered List Node',
   description: 'Auto-numbered ordered list items',
   version: '1.0.0',
-  // Plugin-owned pattern behavior (Issue #667)
+  // Plugin-owned pattern behavior
   pattern: {
     detect: /^1\.\s/,
     canRevert: true,
@@ -580,7 +580,7 @@ export const collectionNodePlugin: PluginDefinition = {
     canHaveChildren: true, // Collections can have sub-collections (DAG structure)
     canBeChild: true // Collections can be nested under other nodes
   },
-  // CollectionNodeViewer for collection-specific UI (Issue #757)
+  // CollectionNodeViewer for collection-specific UI
   viewer: {
     lazyLoad: () => import('../components/viewers/collection-node-viewer.svelte'),
     priority: 1
@@ -704,7 +704,7 @@ export function registerCorePlugins(registry: import('./plugin-registry').Plugin
   for (const plugin of corePlugins) {
     registry.register(plugin);
 
-    // Register pattern with PatternRegistry if present (Issue #667)
+    // Register pattern with PatternRegistry if present
     // Convert PluginPattern to PatternTemplate for PatternRegistry compatibility
     if (plugin.pattern) {
       const patternTemplate: PatternTemplate = {

--- a/packages/desktop-app/src/lib/plugins/plugin-registry.ts
+++ b/packages/desktop-app/src/lib/plugins/plugin-registry.ts
@@ -328,7 +328,7 @@ export class PluginRegistry {
    * Get all pattern detection configs from enabled plugins
    * Used by TextareaController to detect node type conversions
    *
-   * Issue #667: Now derives configs from plugin.pattern (new architecture)
+   * Now derives configs from plugin.pattern (new architecture)
    * for backward compatibility with existing code that uses PatternDetectionConfig
    */
   getAllPatternDetectionConfigs(): PatternDetectionConfig[] {
@@ -342,7 +342,7 @@ export class PluginRegistry {
         patterns.push(...plugin.config.patternDetection);
       }
 
-      // New: derive PatternDetectionConfig from plugin.pattern (Issue #667)
+      // New: derive PatternDetectionConfig from plugin.pattern
       if (plugin.pattern) {
         // Get slash command for additional config (desiredCursorPosition)
         const slashCommand = plugin.config.slashCommands.find(
@@ -374,7 +374,7 @@ export class PluginRegistry {
    * Detect node type from content using plugin-owned patterns
    * Returns the plugin and match result if a pattern is detected
    *
-   * Issue #667: Uses plugin.pattern instead of legacy patternDetection arrays
+   * Uses plugin.pattern instead of legacy patternDetection arrays
    *
    * @param content - The content to check for patterns
    * @returns PatternDetectionResult with plugin, pattern config, match result, and metadata, or null if no pattern matches
@@ -438,7 +438,7 @@ export class PluginRegistry {
    * Extract metadata for a node using its plugin's extractMetadata function
    * Falls back to returning properties as-is if plugin doesn't define extractMetadata
    *
-   * Issue #698: Type-agnostic BaseNodeViewer refactoring
+   * Type-agnostic BaseNodeViewer refactoring
    *
    * @param node - Node with properties from database
    * @returns Metadata object compatible with node component expectations
@@ -476,7 +476,7 @@ export class PluginRegistry {
    * Map UI state to schema property value using plugin's mapStateToSchema function
    * Falls back to returning state as-is if plugin doesn't define mapStateToSchema
    *
-   * Issue #698: Type-agnostic BaseNodeViewer refactoring
+   * Type-agnostic BaseNodeViewer refactoring
    *
    * @param nodeType - Node type to get mapping for
    * @param state - UI state value
@@ -500,7 +500,7 @@ export class PluginRegistry {
    * Check if a node type accepts content merges from adjacent nodes
    * Returns true by default if plugin not found or acceptsContentMerge not specified
    *
-   * Issue #698: Type-agnostic BaseNodeViewer refactoring
+   * Type-agnostic BaseNodeViewer refactoring
    *
    * @param nodeType - Node type to check
    * @returns true if node type accepts content merges, false otherwise
@@ -542,7 +542,7 @@ export class PluginRegistry {
   }
 
   // ============================================================================
-  // Type-Safe CRUD Support (Issue #709)
+  // Type-Safe CRUD Support
   // ============================================================================
 
   /**

--- a/packages/desktop-app/src/lib/plugins/types.ts
+++ b/packages/desktop-app/src/lib/plugins/types.ts
@@ -76,7 +76,7 @@ export interface NodeUpdater {
  * making it trivial to add new node types with pattern detection.
  * Each plugin fully owns its pattern detection, reversion, and inheritance behavior.
  *
- * Issue #667: Plugin-Owned Pattern Definitions for Extensibility
+ * Plugin-Owned Pattern Definitions for Extensibility
  */
 export interface PluginPattern {
   /** Regular expression to detect in content */
@@ -204,14 +204,14 @@ export interface PluginDefinition {
   description: string;
   version: string;
   config: NodeTypeConfig;
-  /** Plugin-owned pattern behavior (Issue #667) */
+  /** Plugin-owned pattern behavior */
   pattern?: PluginPattern;
   node?: NodeRegistration; // Individual node component (TaskNode, TextNode, etc.)
   viewer?: ViewerRegistration; // Rich viewer component (TaskNodeViewer, DateNodeViewer, etc.)
   reference?: ReferenceRegistration;
 
   /**
-   * Type-specific schema form for editing type-specific properties (Issue #709)
+   * Type-specific schema form for editing type-specific properties
    *
    * Core node types with type-specific properties (task, date, entity) should provide
    * hardcoded schema forms for full TypeScript type safety.
@@ -226,7 +226,7 @@ export interface PluginDefinition {
   schemaForm?: SchemaFormRegistration;
 
   /**
-   * Type-specific updater for node properties (Issue #709)
+   * Type-specific updater for node properties
    *
    * Provides type-safe update operations that route to the correct
    * backend method (e.g., updateTaskNode instead of generic updateNode).
@@ -245,7 +245,7 @@ export interface PluginDefinition {
    * Extract and transform node properties into component-compatible metadata
    * Used to handle type-specific property transformations without hardcoding in BaseNodeViewer
    *
-   * Issue #838: Backend returns typed nodes (e.g., TaskNode) with type-specific fields at top level.
+   * Backend returns typed nodes (e.g., TaskNode) with type-specific fields at top level.
    * The function receives node with optional top-level type-specific fields AND properties.
    *
    * @param node - Node with optional top-level type-specific fields and properties from database

--- a/packages/desktop-app/src/lib/services/adapter-core.ts
+++ b/packages/desktop-app/src/lib/services/adapter-core.ts
@@ -111,7 +111,7 @@ export interface BackendAdapter {
   // Composite operations
   createContainerNode(input: CreateContainerInput): Promise<string>;
 
-  // Schema operations (read-only - mutation commands removed in Issue #690)
+  // Schema operations (read-only - mutation commands removed)
   // Returns SchemaNode with typed top-level fields (isCore, schemaVersion, description, fields)
   getAllSchemas(): Promise<SchemaNode[]>;
   getSchema(schemaId: string): Promise<SchemaNode>;

--- a/packages/desktop-app/src/lib/services/backend-adapter.ts
+++ b/packages/desktop-app/src/lib/services/backend-adapter.ts
@@ -272,7 +272,7 @@ export class HttpAdapter implements BackendAdapter {
   private getHeaders(): Record<string, string> {
     return {
       'Content-Type': 'application/json'
-      // No X-Client-Id header needed (Issue #715)
+      // No X-Client-Id header needed
       // dev-proxy represents all browser clients as single logical client
     };
   }

--- a/packages/desktop-app/src/lib/services/browser-sync-service.ts
+++ b/packages/desktop-app/src/lib/services/browser-sync-service.ts
@@ -12,7 +12,7 @@
  * which update the SharedNodeStore and ReactiveStructureTree. This allows browser dev mode
  * to have the same real-time sync as the desktop app.
  *
- * Issue #724: Events now send only node_id (not full payload) for efficiency.
+ * Events send only node_id (not full payload) for efficiency.
  * Frontend fetches full node data via getNode() API only when the node is in the active view.
  */
 
@@ -146,7 +146,7 @@ class BrowserSyncService {
 
     this.connectionState = 'connecting';
 
-    // No clientId needed (Issue #715) - dev-proxy handles filtering server-side
+    // No clientId needed - dev-proxy handles filtering server-side
     const sseUrl = this.sseEndpoint;
 
     log.debug('Connecting to SSE endpoint:', sseUrl);
@@ -199,9 +199,9 @@ class BrowserSyncService {
    * Handle parsed SSE event
    *
    * Routes events to appropriate store/tree handlers to update UI.
-   * Filtering handled server-side by dev-proxy (Issue #715).
+   * Filtering handled server-side by dev-proxy.
    *
-   * Issue #724: Events now send only node_id. Frontend fetches full data
+   * Events send only node_id. Frontend fetches full data
    * via getNode() API only when the node is in the active view (SharedNodeStore).
    */
   private handleEvent(event: SseEvent): void {
@@ -213,7 +213,7 @@ class BrowserSyncService {
       case 'nodeCreated': {
         log.debug(`Node created: ${event.nodeId} (type: ${event.nodeType})`);
 
-        // Issue #832: If a collection node is created, refresh collections sidebar
+        // If a collection node is created, refresh collections sidebar
         if (event.nodeType === 'collection') {
           scheduleCollectionRefresh();
         }
@@ -226,7 +226,7 @@ class BrowserSyncService {
           );
         }
 
-        // Issue #724: Fetch full node data only if we need to display it
+        // Fetch full node data only if we need to display it
         // For now, always fetch since the node might be in the current view
         this.fetchAndUpdateNode(event.nodeId, 'nodeCreated');
         break;
@@ -234,7 +234,7 @@ class BrowserSyncService {
 
       case 'nodeUpdated': {
         log.debug('Node updated:', event.nodeId);
-        // Issue #724: Only fetch if node is already in the store (visible to user)
+        // Only fetch if node is already in the store (visible to user)
         // This avoids unnecessary API calls for nodes not in the current view
         if (sharedNodeStore.hasNode(event.nodeId)) {
           this.fetchAndUpdateNode(event.nodeId, 'nodeUpdated');
@@ -247,14 +247,14 @@ class BrowserSyncService {
       case 'nodeDeleted':
         log.debug('Node deleted:', event.nodeId);
         sharedNodeStore.deleteNode(event.nodeId, { type: 'database', reason: 'sse-sync' }, true);
-        // Issue #832: We don't know if deleted node was a collection without fetching,
+        // We don't know if deleted node was a collection without fetching,
         // but if we have it cached in collectionsData, we should refresh
         // For simplicity, we rely on the UI to handle stale data gracefully
         unregisterSchemaPlugin(event.nodeId);
         break;
 
       // ======================================================================
-      // Unified Relationship Events (Issue #811)
+      // Unified Relationship Events
       // All relationship types (has_child, member_of, mentions, custom) use these events.
       // ======================================================================
 
@@ -313,7 +313,7 @@ class BrowserSyncService {
   /**
    * Fetch full node data from API and update SharedNodeStore
    *
-   * Issue #724: Events now send only node_id. This method fetches the full
+   * Events send only node_id. This method fetches the full
    * node data and updates the store.
    */
   private async fetchAndUpdateNode(nodeId: string, eventType: string): Promise<void> {

--- a/packages/desktop-app/src/lib/services/content-processor.ts
+++ b/packages/desktop-app/src/lib/services/content-processor.ts
@@ -2,7 +2,7 @@
  * Enhanced ContentProcessor Service
  *
  * Implements Logseq-inspired dual-representation pattern (Source ↔ AST ↔ Display)
- * as the foundation for Issue #70 (Phase 1.1 of Epic #69: Text Editor Architecture Enhancement).
+ * as the foundation for the Text Editor Architecture Enhancement.
  *
  * Key Features:
  * - Lossless conversions between source markdown, AST, and display HTML

--- a/packages/desktop-app/src/lib/services/focus-manager.svelte.ts
+++ b/packages/desktop-app/src/lib/services/focus-manager.svelte.ts
@@ -1,11 +1,11 @@
 /**
  * FocusManagerService - Single Source of Truth for Editor Focus
  *
- * ARCHITECTURAL IMPROVEMENT (Issue #274):
+ * ARCHITECTURAL IMPROVEMENT:
  * Replaces the three-way conflict between autoFocus, focusedNodeId, and pendingCursorPositions
  * with a single reactive state that works naturally with Svelte 5.
  *
- * ARCHITECTURAL IMPROVEMENT (Issue #281):
+ * ARCHITECTURAL IMPROVEMENT:
  * Consolidates cursor positioning into unified CursorPosition type.
  * Replaces separate state properties with reactive action-based architecture.
  *
@@ -147,7 +147,7 @@ export const focusManager = {
   },
 
   /**
-   * Issue #664: Focus an inherited-type node with cursor preservation.
+   * Focus an inherited-type node with cursor preservation.
    *
    * Called when Enter key creates a new node that inherits its type from the parent.
    * Unlike focusNodeFromTypeConversion, this sets cursor type to 'inherited-type'

--- a/packages/desktop-app/src/lib/services/membership-service.ts
+++ b/packages/desktop-app/src/lib/services/membership-service.ts
@@ -1,6 +1,6 @@
 /**
  * Membership service — thin, typed wrappers over the Pro `pro_*` membership
- * Tauri commands (collection-membership-UI epic #237, slice S1 #238).
+ * Tauri commands.
  *
  * The daemon forwards the signed-in user's JWT to the matching cloud RPC, so the
  * admin / last-admin / open-vs-restricted gates are enforced *server-side*; these
@@ -191,7 +191,7 @@ export class MembershipService {
 		await invoke<void>('pro_approve_request', { requestId, permission });
 	}
 
-	/** List a collection's pending invites (admin only, server-gated). #239. */
+	/** List a collection's pending invites (admin only, server-gated). */
 	async listInvites(collectionId: string): Promise<Invite[]> {
 		log.debug('listInvites', { collectionId });
 		const rows = await invoke<RawInvite[]>('pro_list_invites', { collectionId });
@@ -204,14 +204,14 @@ export class MembershipService {
 		}));
 	}
 
-	/** List a collection's pending join requests (admin only, server-gated). #239. */
+	/** List a collection's pending join requests (admin only, server-gated). */
 	async listRequests(collectionId: string): Promise<JoinRequest[]> {
 		log.debug('listRequests', { collectionId });
 		const rows = await invoke<RawRequest[]>('pro_list_requests', { collectionId });
 		return rows.map((r) => ({ id: r.id, requestedBy: r.requested_by, createdAt: r.created_at }));
 	}
 
-	/** Revoke a pending invite OR join request by id (admin only, server-gated). #239. */
+	/** Revoke a pending invite OR join request by id (admin only, server-gated). */
 	async revokeInvite(inviteId: string): Promise<void> {
 		log.debug('revokeInvite', { inviteId });
 		await invoke<void>('pro_revoke_invite', { inviteId });
@@ -220,7 +220,7 @@ export class MembershipService {
 	/**
 	 * The caller's own identity (bound PersonNode id + email), so the UI can tell
 	 * which roster row is "me" and gate admin controls on the caller's own
-	 * per-collection role. `personId` is `''` on an un-bound device. #239.
+	 * per-collection role. `personId` is `''` on an un-bound device.
 	 */
 	async currentPerson(): Promise<Person> {
 		const p = await invoke<RawPerson>('pro_current_person');

--- a/packages/desktop-app/src/lib/services/navigation-service.ts
+++ b/packages/desktop-app/src/lib/services/navigation-service.ts
@@ -4,7 +4,7 @@
  * CRITICAL: Uses lazy initialization pattern (getter function) to avoid
  * module-level singleton exports that cause app freeze during initialization.
  *
- * Architecture Decision (from PR #306 learnings):
+ * Architecture Decision:
  * - ❌ BAD: export const navigationService = NavigationService.getInstance()
  * - ✅ GOOD: export function getNavigationService(): NavigationService
  *

--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -31,7 +31,7 @@ import { waitForPendingMoveOperations, trackMoveOperation } from './pending-oper
 import { confirmNodeDeletion } from './delete-confirmation.svelte';
 
 const log = createLogger('ReactiveNodeService');
-// Schema defaults extraction removed in Issue #690 simplification
+// Schema defaults extraction removed in a simplification
 // TODO: Re-add schema defaults if needed via backendAdapter.getSchema() + SchemaNodeHelpers
 import { backendAdapter } from './backend-adapter';
 import type { InsertPosition } from '$lib/services/backend-adapter';
@@ -223,7 +223,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     const shouldFocusNewNode = focusNewNode !== undefined ? focusNewNode : !insertAtBeginning;
     const isPlaceholder = initialContent.trim() === '' || /^#{1,6}\s*$/.test(initialContent.trim());
 
-    // Calculate insertPosition for backend ordering (Issue #657, #1216)
+    // Calculate insertPosition for backend ordering
     // - insertAtBeginning: Beginning (insert before all siblings)
     // - afterNodeId defined: After(afterNodeId)
     // - otherwise: End
@@ -371,7 +371,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
               );
             }
           } catch (error) {
-            // ROLLBACK: Revert optimistic UI changes on failure (preserves #656 notification).
+            // ROLLBACK: Revert optimistic UI changes on failure (preserves the move-rejected notification).
             log.error('[createNode] Failed to transfer children to database, rolling back:', error);
             for (const child of children) {
               structureTree.moveInMemoryRelationship(nodeId, afterNodeId, child.id);
@@ -467,7 +467,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     const headerLevel = contentProcessor.parseHeaderLevel(content);
     const isPlaceholder = content.trim() === '';
 
-    // Issue #424 FIX: Always include nodeType to preserve slash command conversions
+    // Always include nodeType to preserve slash command conversions
     // Pattern conversions work correctly because they call updateNodeType() separately
     // BEFORE the content update, so both the pattern-detected type and content persist together
     sharedNodeStore.updateNode(nodeId, { content, nodeType: node.nodeType }, viewerSource);
@@ -810,8 +810,8 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
 
     setExpanded(targetParentId, true);
 
-    // NOTE: Cache management removed (Issue #557) - ReactiveStructureTree handles hierarchy via domain events
-    // Sibling positioning removed (Issue #557) - Backend handles ordering via fractional IDs
+    // NOTE: Cache management removed - ReactiveStructureTree handles hierarchy via domain events
+    // Sibling positioning removed - Backend handles ordering via fractional IDs
 
     // Update ReactiveStructureTree (single source of truth for hierarchy)
     // In Tauri mode, domain events update the tree, but in browser mode we must do it manually
@@ -904,7 +904,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
           // Non-ignorable error: rollback optimistic update
           _uiState[nodeId] = originalUIState;
           _rootNodeIds = originalRootNodeIds;
-          // NOTE: Cache management removed (Issue #557) - ReactiveStructureTree handles rollback via domain events
+          // NOTE: Cache management removed - ReactiveStructureTree handles rollback via domain events
           updateDescendantDepths(nodeId);
           if (currentParentId) {
             structureTree.moveInMemoryRelationship(targetParentId, currentParentId, nodeId);
@@ -947,7 +947,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       ];
     }
 
-    // NOTE: Cache management removed (Issue #557) - ReactiveStructureTree handles hierarchy via domain events
+    // NOTE: Cache management removed - ReactiveStructureTree handles hierarchy via domain events
 
     // Check if node has been persisted to database yet
     const isNodePersisted = sharedNodeStore.isNodePersisted(nodeId);
@@ -1563,7 +1563,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
           expanded: defaults.expanded,
           autoFocus: defaults.autoFocus,
           inheritHeaderLevel: defaults.inheritHeaderLevel,
-          // Issue #479: Mark as placeholder if it's the initial viewer placeholder
+          // Mark as placeholder if it's the initial viewer placeholder
           // This prevents the content watcher from persisting viewer-local placeholders
           isPlaceholder: skipPersistence && isPlaceholder
         });

--- a/packages/desktop-app/src/lib/services/remote-update-policy.ts
+++ b/packages/desktop-app/src/lib/services/remote-update-policy.ts
@@ -2,7 +2,7 @@
  * Remote-update policy for SharedNodeStore.
  *
  * Extracted from the skip-while-editing guard inline in `setNode` /
- * `batchSetNodes` (nodespace-sync#76, #77, #1436, #1437). A daemon-broadcast
+ * `batchSetNodes`. A daemon-broadcast
  * event (`source.type === 'database'`) arriving for a node the user is
  * actively editing — or has unsaved local changes pending — would otherwise
  * overwrite the optimistic store with the *older* server-confirmed state.

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -562,7 +562,7 @@ export class SharedNodeStore {
   // Avoids querying database on every update to check existence
   private persistedNodeIds = new Set<string>();
 
-  // NOTE: childrenCache and parentsCache REMOVED (Issue #557)
+  // NOTE: childrenCache and parentsCache REMOVED
   // Hierarchy is now managed by ReactiveStructureTree (domain events)
   // Use structureTree.getChildren() and structureTree.getParent() instead
 
@@ -592,8 +592,8 @@ export class SharedNodeStore {
   // Non-reactive cache of the latest server-confirmed `node.version` per id.
   // Populated by the skip-while-editing guard in setNode() instead of
   // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
-  // that remount the textarea and reset selectionStart — see
-  // nodespace-sync#76). Consumed by the UpdateNode persistence path so the
+  // that remount the textarea and reset selectionStart). Consumed by the
+  // UpdateNode persistence path so the
   // next OCC carries the freshest version.
   private serverConfirmedVersions = new Map<string, number>();
 
@@ -650,7 +650,7 @@ export class SharedNodeStore {
    * `currentParentId`. If `structureTree` has no opinion (`null`), the
    * hint is preserved and the backend's own retry loop handles it —
    * silently clearing a valid hint here is what produced
-   * nodespace-sync#77's drop-to-the-top behavior.
+   * the drop-to-the-top behavior.
    *
    * If `structureTree.getParent` returns `null` we emit a debug log so
    * the frequency of "tree not yet populated at persistence time" is
@@ -691,7 +691,7 @@ export class SharedNodeStore {
    * Exposed so the skip-while-editing test suite can lock the contract in
    * place — a future refactor that drops the cache read at the
    * persistence call site would fail the corresponding test instead of
-   * silently re-introducing the OCC-defeat bug from nodespace-sync#76.
+   * silently re-introducing the OCC-defeat bug.
    */
   computeOccVersionForUpdate(nodeId: string): number {
     const confirmed = this.serverConfirmedVersions.get(nodeId);
@@ -916,7 +916,7 @@ export class SharedNodeStore {
    * when their first child is saved. A brand-new date node that has never been
    * persisted will return null from the backend. Synthesize a minimal in-memory
    * node so pane-content does not mistake it for a deleted node and close the tab
-   * (mirrors the same logic in doLoadChildrenTree, issue #941).
+   * (mirrors the same logic in doLoadChildrenTree).
    *
    * Called by pane-content before mounting any viewer so every viewer mounts
    * with the guarantee that sharedNodeStore.getNode(nodeId) is defined.
@@ -1080,18 +1080,18 @@ export class SharedNodeStore {
       // This ensures hierarchy operations work while debouncing rapid typing
       const persistBehavior = this.determinePersistenceBehavior(source, options, changes);
       if (persistBehavior.shouldPersist) {
-        // Issue #479: All real nodes (even blank) should be persisted
+        // All real nodes (even blank) should be persisted
         // FOREIGN KEY validation is handled by persistence coordinator dependencies
         // Structural changes (sibling ordering) are now handled via backend moveNode()
 
-        // Issue #709: Smart routing via plugin system supports type-specific properties
+        // Smart routing via plugin system supports type-specific properties
         // Type-specific updaters route to node-specific methods (updateTaskNode, etc.)
         // The persistence whitelist now includes type-specific property changes
         const isStructuralChange = false; // Structural changes now handled via backend moveNode()
         const isContentChange = 'content' in changes;
         const isNodeTypeChange = 'nodeType' in changes;
         const isPropertyChange = 'properties' in changes;
-        // Issue #709: Check for type-specific property changes (status, priority, dueDate, assignee, etc.)
+        // Check for type-specific property changes (status, priority, dueDate, assignee, etc.)
         // These are persisted via type-specific updaters registered in the plugin system
         const currentNode = this.nodes.get(nodeId);
         const hasTypeUpdater = currentNode?.nodeType
@@ -1113,7 +1113,7 @@ export class SharedNodeStore {
           isPropertyChange ||
           isTypeSpecificChange;
 
-        // Issue #479: Do NOT check isPlaceholder here - that's a UI-only concept
+        // Do NOT check isPlaceholder here - that's a UI-only concept
         // Real nodes created by user actions (Enter key) should persist even if blank
         // Only BaseNodeViewer's viewer-local placeholder should be unpersisted
 
@@ -1122,7 +1122,7 @@ export class SharedNodeStore {
         const hasBatchActive = this.activeBatches.has(nodeId);
 
         if (shouldPersist && !hasBatchActive) {
-          // Issue #880: Capture old content for immediate backlinks reactivity
+          // Capture old content for immediate backlinks reactivity
           // This must be captured BEFORE the debounced persistence, from existingNode (line 747)
           const oldContentForMentions = isContentChange ? existingNode.content : undefined;
 
@@ -1157,7 +1157,7 @@ export class SharedNodeStore {
             nodeId,
             async () => {
               try {
-                // Issue #479: All real nodes (even blank) should be persisted
+                // All real nodes (even blank) should be persisted
                 // No placeholder checks here - viewer-local placeholder never enters this code path
 
                 // Check if node has been persisted - use in-memory tracking to avoid database query
@@ -1207,7 +1207,7 @@ export class SharedNodeStore {
                   );
 
                   try {
-                    // Issue #709: Smart routing via plugin system
+                    // Smart routing via plugin system
                     // Type-specific updaters route to node-specific methods (updateTaskNode, etc.)
                     // Generic updater falls back to node properties JSON update
                     //
@@ -1324,7 +1324,7 @@ export class SharedNodeStore {
 
                 }
 
-                // Issue #880: Update mentionedIn on target nodes after successful persistence
+                // Update mentionedIn on target nodes after successful persistence
                 // This enables immediate backlinks reactivity without requiring navigation
                 if (oldContentForMentions !== undefined) {
                   const persistedNode = this.nodes.get(nodeId);
@@ -1475,7 +1475,7 @@ export class SharedNodeStore {
     // intended skip behavior; the only consumers today are
     // `tauri-sync-listener` and `browser-sync-service`.
     //
-    // Fixes nodespace-sync#76 (typing corruption: chars dropped/replaced
+    // Fixes typing corruption (chars dropped/replaced
     // under sustained input as the optimistic store is clobbered by the
     // daemon's own confirmation looped back through the WatchNodes stream).
     //
@@ -1509,7 +1509,7 @@ export class SharedNodeStore {
         this.serverConfirmedVersions.set(node.id, node.version);
       }
       if (decision.notifyConflict) {
-        // #1437: a FOREIGN write to a node the user is actively editing (not
+        // A FOREIGN write to a node the user is actively editing (not
         // our own echo). We skip the clobber to protect the optimistic text,
         // but that must not be silent — raise a version-mismatch
         // notification (deduped per node) so the conflict is visible.
@@ -1566,7 +1566,7 @@ export class SharedNodeStore {
     // For UPDATES from viewer, skip persistence - BaseNodeViewer handles with debouncing
     // This ensures createNode() persistence works while avoiding duplicate writes on updates
     //
-    // Phase 1 of Issue #479: Eliminate ephemeral nodes during editing
+    // Phase 1: Eliminate ephemeral nodes during editing
     // - Only skip persistence when explicitly requested via skipPersistence flag
     // - This flag is ONLY true for initial viewer placeholder (when no children exist)
     // - All other blank nodes (created via Enter key, etc.) persist immediately
@@ -1575,7 +1575,7 @@ export class SharedNodeStore {
       const shouldPersist = source.type !== 'viewer' || isNewNode;
 
       if (shouldPersist) {
-        // Issue #479: No placeholder checks - all real nodes should be persisted
+        // No placeholder checks - all real nodes should be persisted
 
         // Delegate to PersistenceCoordinator
         // CRITICAL FIX: Track InsertPosition.After sibling as dependency to prevent race conditions
@@ -1590,7 +1590,7 @@ export class SharedNodeStore {
           dependencies.push(afterSiblingId);
         }
 
-        // Issue #479: Always persist the full node including content
+        // Always persist the full node including content
         // Real nodes (even with only syntax like "## ") must include content field for backend validation
         // The old code stripped content for "placeholder" header nodes, but now all user-created nodes
         // should persist with their full content, even if it's just syntax
@@ -1813,7 +1813,7 @@ export class SharedNodeStore {
         continue;
       }
 
-      // Same skip-while-editing guard/policy as setNode (nodespace-sync#76): a
+      // Same skip-while-editing guard/policy as setNode: a
       // concurrent tree (re)load with a `database` source must NOT clobber a
       // node the user is actively editing — `doLoadChildrenTree` passes a
       // database source, so a reload for a parent whose child is mid-keystroke
@@ -1965,7 +1965,7 @@ export class SharedNodeStore {
   }
 
   /**
-   * Update a task node with type-safe property updates (Issue #709)
+   * Update a task node with type-safe property updates
    *
    * Routes task-specific field updates (status, priority, dueDate, assignee) through
    * the type-safe update path that directly modifies task node properties in the backend.
@@ -2169,7 +2169,7 @@ export class SharedNodeStore {
   }
 
   // ========================================================================
-  // New Methods for BaseNodeViewer Migration (Issue #237)
+  // New Methods for BaseNodeViewer Migration
   // ========================================================================
 
   /**
@@ -2193,7 +2193,7 @@ export class SharedNodeStore {
 
       // Ensure the parent node itself is in the store before loading children.
       // This prevents BaseNodeViewer from treating a not-yet-loaded parent as a
-      // stale/deleted node and closing the tab prematurely (issue #941).
+      // stale/deleted node and closing the tab prematurely.
       let parentNode: Node | null = null;
       if (!this.nodes.has(parentId)) {
         parentNode = await backendAdapter.getNode(parentId);
@@ -2286,7 +2286,7 @@ export class SharedNodeStore {
         // child is saved. A brand-new date node that has never been persisted will return an
         // empty tree here. Synthesize a minimal in-memory node so BaseNodeViewer's
         // post-load existence check does not mistake it for a deleted/stale node and close
-        // the tab (issue #941).
+        // the tab.
         if (isValidDateId(parentId)) {
           const now = new Date().toISOString();
           const virtualDateNode: Node = {
@@ -2485,7 +2485,7 @@ export class SharedNodeStore {
   /**
    * Handle updates from external sources (MCP server, database sync, etc.)
    *
-   * This method provides the integration point for future MCP server (#112).
+   * This method provides the integration point for a future MCP server.
    * It routes external updates through the same conflict detection and
    * synchronization pipeline as local edits.
    *
@@ -2493,7 +2493,7 @@ export class SharedNodeStore {
    * @param update - The node update to apply
    *
    * @example
-   * // Future: When MCP server from #112 is ready
+   * // Future: When the MCP server is ready
    * mcpServer.on('node:updated', (mcpUpdate) => {
    *   sharedStore.handleExternalUpdate('mcp-server', mcpUpdate);
    * });
@@ -2575,7 +2575,7 @@ export class SharedNodeStore {
    * Idempotent: Safe to call multiple times for the same node.
    * Concurrent calls for the same node will be ignored.
    *
-   * Future enhancement: Implement conflict merge UI (see #720 non-goals)
+   * Future enhancement: Implement conflict merge UI
    */
   async resyncNodeFromServer(nodeId: string): Promise<void> {
     // Idempotency guard: prevent concurrent resync operations on same node
@@ -2752,7 +2752,7 @@ export class SharedNodeStore {
   }
 
   /**
-   * Update mentionedIn on target nodes when content changes (Issue #880)
+   * Update mentionedIn on target nodes when content changes
    *
    * When a mention is created/removed in content, the target node's mentionedIn
    * should update immediately without requiring navigation away and back.
@@ -3120,7 +3120,7 @@ export class SharedNodeStore {
         return;
       }
 
-      // Issue #479: Always persist batched changes - even blank/syntax-only nodes
+      // Always persist batched changes - even blank/syntax-only nodes
       // Real nodes (created by user actions) should always be persisted
       // The viewer-local placeholder never enters batch system
       this.persistBatchedChanges(nodeId, batch.changes, finalNode, batch.originalContent);
@@ -3333,7 +3333,7 @@ export class SharedNodeStore {
             }
           }
 
-          // Issue #880: Update mentionedIn on target nodes after successful batch persistence
+          // Update mentionedIn on target nodes after successful batch persistence
           // This enables immediate backlinks reactivity without requiring navigation
           if (originalContent !== undefined && 'content' in changes) {
             const persistedNode = this.nodes.get(nodeId);

--- a/packages/desktop-app/src/lib/services/tauri-commands.ts
+++ b/packages/desktop-app/src/lib/services/tauri-commands.ts
@@ -1,7 +1,7 @@
 /**
  * Tauri System Commands — non-node Tauri IPC wrappers.
  *
- * Node-CRUD operations were removed in C1a (#1251); use backendAdapter directly.
+ * Node-CRUD operations were removed in C1a; use backendAdapter directly.
  *
  * In browser/proxy mode, model management and agent commands are forwarded to
  * the dev-proxy's /api/agent/* routes, which translate them to gRPC calls on
@@ -143,7 +143,7 @@ export async function ensureModelReady(modelId: string): Promise<boolean> {
 // ACP Commands — temporarily disabled
 // ============================================================================
 //
-// The ACP transport and Tauri command bridge were removed in #1117 ahead of
+// The ACP transport and Tauri command bridge were removed ahead of
 // the PTY-based agent rewrite (ADR-032). The wrappers below stay so callers
 // in the chat store / agent store don't need to be edited mid-transition,
 // but they no longer invoke any Tauri command. The follow-up PTY-UI issue
@@ -170,7 +170,7 @@ export async function acpRefreshAgents(): Promise<AcpAgentInfo[]> {
 }
 
 // ============================================================================
-// PTY Agent Session Commands (Issue #1120)
+// PTY Agent Session Commands
 // ============================================================================
 
 export interface PtyLaunchInput {
@@ -233,7 +233,7 @@ export async function ptyListSessions(): Promise<PtyListSessionsResult> {
 }
 
 // ============================================================================
-// Session Capture Settings Commands (Issue #1125)
+// Session Capture Settings Commands
 // ============================================================================
 
 export type CaptureContentLevel = 'metadata_only' | 'summary' | 'full';
@@ -296,7 +296,7 @@ export async function setOpenAiCompatConfigsOnDaemon(
 }
 
 // ============================================================================
-// PTY Agent Availability Commands (Issue #1124)
+// PTY Agent Availability Commands
 // ============================================================================
 
 export interface AgentAvailabilityInfo {

--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -11,10 +11,10 @@
  *
  * This enables real-time sync when external sources (MCP, other windows) modify data.
  *
- * Issue #724: Events now send only node_id (not full payload) for efficiency.
+ * Events send only node_id (not full payload) for efficiency.
  * Frontend fetches full node data via getNode() API only when the node is in the active view.
  *
- * Issue #811: All relationship types use unified RelationshipCreated/Updated/Deleted events.
+ * All relationship types use unified RelationshipCreated/Updated/Deleted events.
  */
 
 import { listen } from '@tauri-apps/api/event';
@@ -37,10 +37,10 @@ import { isActiveDatabaseEvent } from '$lib/stores/database.svelte';
 const log = createLogger('TauriSync');
 
 // ---------------------------------------------------------------------------
-// Pro-only reconnect-replay render coalescing (#188)
+// Pro-only reconnect-replay render coalescing
 //
 // On reconnect the Pro daemon now flushes a caught-up batch of node events as a
-// single burst (sync PR #194). Applied one-by-one, each `node:created/updated`
+// single burst. Applied one-by-one, each `node:created/updated`
 // triggers its own async fetch + `setNode` → one re-render per node. To render
 // the burst in one pass, when sync is active we collect the node ids over a tiny
 // window, fetch them together, then apply them in a SYNCHRONOUS `setNode` loop —
@@ -60,7 +60,7 @@ let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
 // Ids deleted while a flush is mid-fetch (between the snapshot and the apply
 // loop). The flush skips these so a delete that lands during the fetch wins over
 // the now-stale upsert it raced — without this, the re-fetch could resurrect a
-// just-deleted node (the sync#193 failure class, opened anew by coalescing).
+// just-deleted node (a failure class opened anew by coalescing).
 let flushInProgress = false;
 const tombstonedDuringFlush = new Set<string>();
 
@@ -171,7 +171,7 @@ function stripNodePrefix(id: string): string {
 /**
  * Fetch full node data from API and update SharedNodeStore
  *
- * Issue #724: Events now send only node_id. This function fetches the full
+ * Events send only node_id. This function fetches the full
  * node data and updates the store.
  */
 async function fetchAndUpdateNode(nodeId: string, eventType: string): Promise<void> {
@@ -216,15 +216,15 @@ export async function initializeTauriSyncListeners(): Promise<void> {
 
   try {
     // Listen for node events and update SharedNodeStore
-    // Issue #724: Events now send only node_id, fetch full data if needed
-    // Issue #832: node:created includes nodeType for reactive UI updates
+    // Events send only node_id, fetch full data if needed
+    // node:created includes nodeType for reactive UI updates
     await listen<NodeEventData>('node:created', (event) => {
       // ADR-053: drop events from a database we are no longer viewing (guards
       // the race where a watch stream open across a switch delivers stale events).
       if (!isActiveDatabaseEvent(event.payload.databaseId)) return;
       log.debug(`Node created: ${event.payload.id} (type: ${event.payload.nodeType})`);
 
-      // Issue #832: If a collection node is created, refresh collections sidebar
+      // If a collection node is created, refresh collections sidebar
       if (event.payload.nodeType === 'collection') {
         scheduleCollectionRefresh();
       }
@@ -238,7 +238,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
       }
 
       // Fetch full node data since the node might be in the current view.
-      // Pro: coalesce a reconnect-replay burst into one render (#188); community:
+      // Pro: coalesce a reconnect-replay burst into one render; community:
       // apply immediately (unchanged).
       queueOrFetchNode(event.payload.id, 'node:created');
     });
@@ -258,7 +258,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
       cancelPendingNodeFetch(event.payload.id);
       sharedNodeStore.deleteNode(event.payload.id, { type: 'database', reason: 'domain-event' }, true);
 
-      // Issue #832: We don't know if deleted node was a collection without fetching,
+      // We don't know if deleted node was a collection without fetching,
       // but if we have it cached in collectionsData, we should refresh
       // For simplicity, we rely on the UI to handle stale data gracefully
       // A more robust solution would cache node types or include type in delete events
@@ -266,7 +266,7 @@ export async function initializeTauriSyncListeners(): Promise<void> {
     });
 
     // ========================================================================
-    // Unified Relationship Events (Issue #811)
+    // Unified Relationship Events
     // All relationship types (has_child, member_of, mentions, custom) use these events.
     // ========================================================================
 

--- a/packages/desktop-app/src/lib/state/pattern-state.svelte.ts
+++ b/packages/desktop-app/src/lib/state/pattern-state.svelte.ts
@@ -1,7 +1,7 @@
 /**
  * PatternState - Centralized Pattern Lifecycle Management
  *
- * Issue #664: Replaces the scattered `nodeTypeSetViaPattern` flag with an explicit
+ * Replaces the scattered `nodeTypeSetViaPattern` flag with an explicit
  * state machine that owns all pattern-related lifecycle.
  *
  * The key insight is that pattern detection behavior depends on HOW a node was created:
@@ -9,7 +9,7 @@
  * - 'pattern': Created by pattern detection (# → header) - reversion enabled if plugin allows
  * - 'inherited': Created by inheriting parent's type (Enter on header → header) - reversion controlled by plugin
  *
- * Issue #667: Pattern behavior is now owned by plugins via the `pattern` property.
+ * Pattern behavior is now owned by plugins via the `pattern` property.
  * Each plugin can define:
  * - `detect`: Regex to detect the pattern
  * - `canRevert`: Whether the node can revert to text when pattern is deleted
@@ -68,7 +68,7 @@ export class PatternState {
   private _creationSource = $state<NodeCreationSource>('user');
 
   /**
-   * The plugin that owns this node's pattern behavior (Issue #667)
+   * The plugin that owns this node's pattern behavior
    * Contains detect, canRevert, and revert settings
    */
   private _plugin = $state<PluginDefinition | null>(null);
@@ -115,7 +115,7 @@ export class PatternState {
   /**
    * Whether this node can revert to text type
    *
-   * Issue #667: Uses plugin-owned pattern.canRevert setting.
+   * Uses plugin-owned pattern.canRevert setting.
    *
    * Both 'pattern' and 'inherited' source nodes can revert when their
    * syntax is deleted (e.g., "# Hello" → "#Hello" reverts to text),
@@ -157,7 +157,7 @@ export class PatternState {
   // ============================================================================
 
   /**
-   * Record that a plugin pattern was detected and matched (Issue #667)
+   * Record that a plugin pattern was detected and matched
    *
    * Called when pattern detection finds a match and converts the node type.
    * Changes source to 'pattern' and stores the plugin for reversion.
@@ -173,7 +173,7 @@ export class PatternState {
   /**
    * Attempt to revert node type to text
    *
-   * Issue #667: Uses plugin-owned pattern.revert to check if content should revert.
+   * Uses plugin-owned pattern.revert to check if content should revert.
    *
    * Called when content no longer matches the detected pattern.
    * Only succeeds if the plugin has canRevert: true and the revert pattern matches.
@@ -208,7 +208,7 @@ export class PatternState {
   }
 
   /**
-   * Mark the node type as existing via plugin pattern (Issue #667)
+   * Mark the node type as existing via plugin pattern
    *
    * Called when initializing a controller for a node whose content
    * matches its pattern (e.g., loading a header node with "# " content).

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -1,5 +1,5 @@
 /**
- * Membership store (collection-membership-UI epic #237, slice S1 #238).
+ * Membership store for the collection-membership UI.
  *
  * Holds a per-collection cache of the roster + pending invites/requests and the
  * caller's own identity, so the Collaboration view (S3/S4) and onboarding inbox
@@ -10,8 +10,8 @@
  * {@link MembershipStore.isPro}), so the community build stays behaviorally
  * unchanged — it never touches the membership commands.
  *
- * Caller identity: fetched once via `pro_current_person` (see the S2 design note
- * on #239 — a one-shot query rather than a stream field) and cached; the derived
+ * Caller identity: fetched once via `pro_current_person` (a one-shot query
+ * rather than a stream field) and cached; the derived
  * `currentUserRole(collectionId)` matches the caller's own person id against the
  * roster so admin controls gate correctly. Call {@link MembershipStore.reset} on
  * sign-out to clear it (identity is per-session).

--- a/packages/desktop-app/src/lib/stores/model-store.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/model-store.svelte.ts
@@ -3,8 +3,6 @@
  *
  * Wired to real Tauri invocations for model lifecycle management.
  * Falls back to mock model data and simulated downloads when Tauri is not available.
- *
- * Issue #1008: replaced mock-only implementation with real Tauri integration.
  */
 
 import { createLogger } from '$lib/utils/logger';

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -70,7 +70,7 @@ class ProSyncStore {
   /**
    * Email of the signed-in user, from the daemon's `SyncStatusEvent.user_email`
    * (decoded from the session JWT). Empty when signed out / not yet authenticated.
-   * Drives the "signed in as <email>" affordance (#199 S6) — needed because on the
+   * Drives the "signed in as <email>" affordance — needed because on the
    * silent-resume path the frontend never sees an OAuth response.
    */
   userEmail = $state<string>('');
@@ -272,7 +272,7 @@ class ProSyncStore {
   }
 
   /**
-   * Manual sign-out (#199 S6). Tells the daemon to drop its session and wipe the
+   * Manual sign-out. Tells the daemon to drop its session and wipe the
    * persisted refresh token from the keychain (so a restart won't auto-resume),
    * then optimistically reflects signed-out locally. The daemon's AUTH_REQUIRED
    * transition confirms via `sync:status`. No-op in community mode (the backend

--- a/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
@@ -118,7 +118,7 @@ export class ReactiveStructureTree {
     // arrive in either order — and a move applied on the receiver's daemon emits a
     // RelationshipCreated for the new parent but no delete for the old (the daemon
     // reparents in one step). Rejecting here left the node stranded under its old
-    // parent on every OTHER window (nodespace-sync#162: indent/outdent not
+    // parent on every OTHER window (indent/outdent not
     // reflected across windows / cloud sync). Prune the old parent, then add below.
     const currentParent = this.getParent(childId);
     if (currentParent && currentParent !== parentId) {
@@ -225,8 +225,8 @@ export class ReactiveStructureTree {
    * @param childId - Child node ID
    * @param order - Sort order (use 1.0 for first child, or get max order + 1)
    *
-   * @note This creates a temporary in-memory relationship. Once Issue #603 is complete
-   * (backend returns relationship data from createNode API), this workaround can be
+   * @note This creates a temporary in-memory relationship. Once the backend
+   * returns relationship data from the createNode API, this workaround can be
    * replaced with proper optimistic updates from backend responses.
    */
   addInMemoryRelationship(parentId: string, childId: string, order: number = 1.0) {

--- a/packages/desktop-app/src/lib/stores/recovered-items.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/recovered-items.svelte.ts
@@ -6,7 +6,7 @@ const log = createLogger('RecoveredItems');
 
 /**
  * One superseded local edit, as written by the Pro daemon to the per-user
- * local-only log `~/.nodespace/recovered-items-<user>.jsonl` (core#1303).
+ * local-only log `~/.nodespace/recovered-items-<user>.jsonl`.
  * Field names mirror the on-disk snake_case keys returned by the
  * `pro_list_recovered_items` tauri command.
  */

--- a/packages/desktop-app/src/lib/types/agent-types.ts
+++ b/packages/desktop-app/src/lib/types/agent-types.ts
@@ -5,7 +5,7 @@
  * These interfaces mirror the serde JSON output from the Tauri boundary
  * and are used for type-safe event handling and command return values.
  *
- * Issue #998: prerequisite that unblocks all parallel agent implementation streams.
+ * Prerequisite that unblocks all parallel agent implementation streams.
  */
 
 // ---------------------------------------------------------------------------

--- a/packages/desktop-app/src/lib/types/event-types.ts
+++ b/packages/desktop-app/src/lib/types/event-types.ts
@@ -15,12 +15,12 @@
 // ============================================================================
 
 /**
- * Node event data from domain events (Issue #724)
+ * Node event data from domain events
  *
  * Events now send only node ID for efficiency.
  * Frontend fetches full node data via get_node() API if needed.
  *
- * Issue #832: node:created events include nodeType for reactive UI updates
+ * node:created events include nodeType for reactive UI updates
  * (e.g., collections sidebar needs to know when collection nodes are created)
  */
 export interface NodeEventData {
@@ -53,7 +53,7 @@ export interface HierarchyRelationship {
 }
 
 // ============================================================================
-// Unified Relationship Event (Issue #811)
+// Unified Relationship Event
 // ============================================================================
 
 /**

--- a/packages/desktop-app/src/lib/types/navigation.ts
+++ b/packages/desktop-app/src/lib/types/navigation.ts
@@ -1,6 +1,6 @@
 /**
  * Node Navigation Interface - Entry/Exit Methods
- * Based on GitHub Issue #28: Pluggable Node Navigation System
+ * Pluggable Node Navigation System
  */
 
 export interface NodeNavigationMethods {

--- a/packages/desktop-app/src/lib/types/node-viewers.ts
+++ b/packages/desktop-app/src/lib/types/node-viewers.ts
@@ -13,7 +13,7 @@ import type { Component, Snippet } from 'svelte';
  * onTitleChange/title-push callback: tab titles are always derived from tab content
  * (see computeTabTitle in tab-title.ts), never pushed by a viewer as a side effect of
  * rendering — pushing a computed title during mount/render is what caused a
- * state_unsafe_mutation bug (issue #1564).
+ * state_unsafe_mutation bug.
  */
 export interface NodeViewerProps {
   nodeId: string; // The node to display (date string "2025-10-20", UUID, etc.)

--- a/packages/desktop-app/src/lib/types/node.ts
+++ b/packages/desktop-app/src/lib/types/node.ts
@@ -165,7 +165,7 @@ export interface Node {
   embeddingVector?: number[] | null;
 
   /**
-   * Indexed title for efficient @mention autocomplete search (Issue #821)
+   * Indexed title for efficient @mention autocomplete search
    *
    * Contains markdown-stripped content for clean display and search.
    * Populated only for:

--- a/packages/desktop-app/src/lib/types/query.ts
+++ b/packages/desktop-app/src/lib/types/query.ts
@@ -103,7 +103,7 @@ export interface SortConfig {
  * View configuration (discriminated union)
  *
  * View type and configuration are specified at render time via
- * QueryPreferencesService (#443), enabling different users to view
+ * QueryPreferencesService, enabling different users to view
  * the same query differently.
  */
 export interface BaseViewConfig {

--- a/packages/desktop-app/src/lib/types/sse-events.ts
+++ b/packages/desktop-app/src/lib/types/sse-events.ts
@@ -5,7 +5,7 @@
  * the dev-proxy's `/api/events` endpoint. They mirror the Rust SseEvent
  * enum in dev-proxy.rs.
  *
- * Issue #724: Events send only node_id (not full payload) for efficiency.
+ * Events send only node_id (not full payload) for efficiency.
  * Frontend fetches full node data via get_node() API if needed.
  */
 
@@ -18,7 +18,7 @@ export interface SseEventBase {
 
 /**
  * Event sent when a new node is created (ID only)
- * Issue #832: Includes nodeType for reactive UI updates (e.g., collections sidebar)
+ * Includes nodeType for reactive UI updates (e.g., collections sidebar)
  */
 export interface NodeCreatedEvent extends SseEventBase {
   type: 'nodeCreated';
@@ -47,7 +47,7 @@ export interface NodeDeletedEvent extends SseEventBase {
 }
 
 // ============================================================================
-// Unified Relationship Events (Issue #811)
+// Unified Relationship Events
 // All relationship types (has_child, member_of, mentions, custom) use these events.
 // ============================================================================
 

--- a/packages/desktop-app/src/lib/types/task-node.ts
+++ b/packages/desktop-app/src/lib/types/task-node.ts
@@ -1,7 +1,7 @@
 /**
  * Type-Safe Task Node Interface
  *
- * Flat structure matching Rust backend serialization (Issue #673, #700).
+ * Flat structure matching Rust backend serialization.
  *
  * The Rust backend serializes TaskNode as a flat JSON structure with type-specific fields
  * at the top level, not nested under properties.task. This interface matches that output.
@@ -37,7 +37,7 @@ export type TaskStatus = CoreTaskStatus | string;
 
 /**
  * Core task priority values (user-extensible)
- * Rust backend now uses string enum format (Issue #709)
+ * Rust backend now uses string enum format
  */
 export type CoreTaskPriority = 'low' | 'medium' | 'high';
 

--- a/packages/desktop-app/src/lib/types/update-protocol.ts
+++ b/packages/desktop-app/src/lib/types/update-protocol.ts
@@ -13,7 +13,7 @@ import type { Node } from '$lib/types';
  * IMPORTANT: UpdateSource describes WHERE the update originated from (data provenance),
  * NOT whether the node should be persisted. Use UpdateOptions.persist for persistence control.
  *
- * Type Semantics (Phase 1 Refactor - Issue #393):
+ * Type Semantics (Phase 1 Refactor):
  * - 'viewer': User interaction in the UI (typing, clicking, editing)
  * - 'database': Loaded from backend database (navigation, fetch, initial load)
  * - 'mcp-server': Synchronized from external MCP client (future Phase 3)

--- a/packages/desktop-app/src/lib/utils/collection-refresh.ts
+++ b/packages/desktop-app/src/lib/utils/collection-refresh.ts
@@ -4,7 +4,7 @@
  * Shared debounced collection refresh logic used by both Tauri and browser
  * sync services to update the collections sidebar when member_of relationships change.
  *
- * Issue #832: Extracted from browser-sync-service.ts and tauri-sync-listener.ts
+ * Extracted from browser-sync-service.ts and tauri-sync-listener.ts
  * to follow DRY principle.
  */
 

--- a/packages/desktop-app/src/lib/utils/marked-config.ts
+++ b/packages/desktop-app/src/lib/utils/marked-config.ts
@@ -25,7 +25,7 @@
  *
  * Why GFM is enabled despite NodeSpace's semantic node types:
  * - Provides robust inline formatting parsing (bold, italic, strikethrough, code)
- * - Handles edge cases better than custom regex parsers (see Issue #350)
+ * - Handles edge cases better than custom regex parsers
  * - Table rendering aligns with user expectations from GitHub/Discord
  * - List rendering is overridden (see list() renderer) to fit NodeSpace's architecture
  */

--- a/packages/desktop-app/src/lib/utils/placeholder-detection.ts
+++ b/packages/desktop-app/src/lib/utils/placeholder-detection.ts
@@ -3,11 +3,11 @@
  *
  * Determines if a node is a placeholder (has only type-specific prefix, no actual content).
  *
- * **IMPORTANT - Phase 1 of Issue #479 (Eliminate Ephemeral Nodes):**
+ * **IMPORTANT - Phase 1 (Eliminate Ephemeral Nodes):**
  * This function is now used ONLY for UI styling decisions (gray text, placeholder appearance).
  * It is NO LONGER used for persistence decisions.
  *
- * **Persistence Behavior (as of Issue #479):**
+ * **Persistence Behavior:**
  * - Only ONE ephemeral node exists: initial placeholder when viewer loads with no children
  * - All other nodes (including blank ones) persist immediately with 500ms debounce
  * - Persistence is controlled by explicit `isInitialPlaceholder` flag, not by content detection

--- a/packages/desktop-app/src/lib/utils/tab-title.ts
+++ b/packages/desktop-app/src/lib/utils/tab-title.ts
@@ -1,7 +1,7 @@
 /**
  * Tab title computation — pure derivation from tab content and node data.
  *
- * Tab titles are never pushed/stored as independent state (see issue #1564): a title is
+ * Tab titles are never pushed/stored as independent state: a title is
  * always a pure function of the tab's content and the current node data, computed on
  * read. This avoids a whole class of Svelte state_unsafe_mutation bugs where a viewer
  * component pushes a computed title into the tab store as a side effect of rendering.

--- a/packages/desktop-app/src/routes/+layout.svelte
+++ b/packages/desktop-app/src/routes/+layout.svelte
@@ -60,7 +60,7 @@
   // Initialize Tauri injection, then render AppShell immediately. Daemon
   // readiness is NOT a render-blocking gate — AppShell owns its own
   // connecting/unreachable UI via the daemon-status service, and each
-  // daemon-dependent store retries its load on daemon reconnect. See #1470.
+  // daemon-dependent store retries its load on daemon reconnect.
   onMount(async () => {
     try {
       // Step 1: Initialize Tauri injection (fast, one-time environment check)
@@ -99,7 +99,7 @@
   });
 
   // Retry whichever of the above didn't succeed on the first attempt once
-  // the daemon signals it is reachable (#1470).
+  // the daemon signals it is reachable.
   onMount(() => {
     const unsubscribe = onDaemonReconnect(() => {
       if (!schemaPluginsReady) loadSchemaPlugins();

--- a/packages/desktop-app/src/tests/actions/focus-trap.test.ts
+++ b/packages/desktop-app/src/tests/actions/focus-trap.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the focusTrap Svelte action (#1414).
+ * Tests for the focusTrap Svelte action.
  *
  * Drives REAL keyboard focus (focus an element, dispatch keydown on the focused
  * element) rather than synthetically firing on the overlay — that's the whole

--- a/packages/desktop-app/src/tests/browser/autocomplete-interaction.test.ts
+++ b/packages/desktop-app/src/tests/browser/autocomplete-interaction.test.ts
@@ -14,7 +14,7 @@
  * (NodeServiceContext, FocusManager, etc.) which is beyond the scope of
  * browser mode testing. Business logic is tested in Happy-DOM unit tests.
  *
- * Related: Issue #282 (Vitest Browser Mode)
+ * Related: Vitest Browser Mode
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/packages/desktop-app/src/tests/browser/backspace-focus.test.ts
+++ b/packages/desktop-app/src/tests/browser/backspace-focus.test.ts
@@ -12,7 +12,7 @@
  * Business logic (node deletion, content merging, sibling chains) is tested
  * in Happy-DOM unit tests.
  *
- * Related: Issue #282 (Vitest Browser Mode)
+ * Related: Vitest Browser Mode
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/packages/desktop-app/src/tests/browser/enter-key-focus.test.ts
+++ b/packages/desktop-app/src/tests/browser/enter-key-focus.test.ts
@@ -12,7 +12,7 @@
  * Business logic (node creation, sibling chains, database persistence) is tested
  * in Happy-DOM unit tests.
  *
- * Related: Issue #282 (Vitest Browser Mode)
+ * Related: Vitest Browser Mode
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/packages/desktop-app/src/tests/browser/rapid-keyboard-operations.test.ts
+++ b/packages/desktop-app/src/tests/browser/rapid-keyboard-operations.test.ts
@@ -1,11 +1,11 @@
 /**
- * Browser Tests: Rapid Keyboard Operations (Issue #870 Part 2A)
+ * Browser Tests: Rapid Keyboard Operations
  *
  * These tests run in a real browser (Chromium via Playwright) to test
  * rapid keyboard sequences that could expose race conditions between
  * UI updates and backend persistence.
  *
- * These tests would have caught the PR #861 race conditions where:
+ * These tests would have caught the race conditions where:
  * - Enter→Tab (create node then immediately indent) could use stale parent data
  * - Tab→Shift+Tab (indent then immediate outdent) could corrupt hierarchy
  *
@@ -39,7 +39,7 @@ describe('Rapid Keyboard Operations - Browser Mode (Issue #870)', () => {
         receivedEvents.push(`up:${e.key}`);
       });
 
-      // Simulate rapid Enter→Tab sequence (the PR #861 race condition)
+      // Simulate rapid Enter→Tab sequence (the race condition)
       const events = [
         new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
         new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }),

--- a/packages/desktop-app/src/tests/browser/slash-dropdown-interaction.test.ts
+++ b/packages/desktop-app/src/tests/browser/slash-dropdown-interaction.test.ts
@@ -12,7 +12,7 @@
  * NOTE: These are simplified tests focusing on browser-specific APIs.
  * Business logic (command registry, filtering, execution) is tested in Happy-DOM unit tests.
  *
- * Related: Issue #282 (Vitest Browser Mode), Issue #187 (Slash command callback wiring bug)
+ * Related: Vitest Browser Mode; Slash command callback wiring bug
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/packages/desktop-app/src/tests/commands/keyboard/create-node.command.test.ts
+++ b/packages/desktop-app/src/tests/commands/keyboard/create-node.command.test.ts
@@ -325,7 +325,7 @@ describe('CreateNodeCommand', () => {
     });
   });
 
-  // Regression for #1421: rapid Enter in an empty node piled blank nodes UPWARD.
+  // Regression: rapid Enter in an empty node piled blank nodes UPWARD.
   // An empty node always has cursor position 0, so the "create above" branch
   // (meant for cursor-at-start of a NON-empty node, to push its content down)
   // fired on every Enter — inserting before the node and keeping focus on it

--- a/packages/desktop-app/src/tests/components/ai-chat-model-selector.test.ts
+++ b/packages/desktop-app/src/tests/components/ai-chat-model-selector.test.ts
@@ -1,8 +1,8 @@
 /**
  * AiChatModelSelector Logic Tests
  *
- * Unit tests for the PTY agent selection path (issue #1450, building on the
- * generic PTY entry point added by issue #1489).
+ * Unit tests for the PTY agent selection path, building on the
+ * generic PTY entry point.
  * Follows the project pattern of testing extracted logic functions directly
  * (not rendering Svelte components) using Happy-DOM.
  */

--- a/packages/desktop-app/src/tests/components/chat-link-navigation.test.ts
+++ b/packages/desktop-app/src/tests/components/chat-link-navigation.test.ts
@@ -5,7 +5,7 @@
  * - Click = in-place, Cmd+Click = new tab, Cmd+Shift+Click = other pane
  *
  * (The former chat-tab override was removed alongside the ephemeral ChatPanel /
- *  chatStore in the #1220 follow-up — every conversation is now an ai-chat node,
+ *  chatStore in a later follow-up — every conversation is now an ai-chat node,
  *  so links behave the same in every tab.)
  */
 

--- a/packages/desktop-app/src/tests/components/collaboration-view.test.ts
+++ b/packages/desktop-app/src/tests/components/collaboration-view.test.ts
@@ -1,5 +1,5 @@
 /**
- * CollaborationView component tests (epic #237, slice S3 #240).
+ * CollaborationView component tests.
  * Verifies admin controls gate on the caller's own role and that the community
  * build renders nothing.
  */

--- a/packages/desktop-app/src/tests/components/custom-entity-node.test.ts
+++ b/packages/desktop-app/src/tests/components/custom-entity-node.test.ts
@@ -6,8 +6,6 @@
  * - Schema loading and error handling logic
  * - Visual distinction properties (borders, headers, icons)
  * - State management for loading and errors
- *
- * Issue #449: Generic Custom Entity Rendering - Polish UI for Schema-Driven Types
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';

--- a/packages/desktop-app/src/tests/components/delete-confirmation-modal.test.ts
+++ b/packages/desktop-app/src/tests/components/delete-confirmation-modal.test.ts
@@ -1,5 +1,5 @@
 /**
- * DeleteConfirmationModal tests (#1414 regression).
+ * DeleteConfirmationModal tests (focus-trap regression).
  *
  * focusTrap lands initial focus on Cancel (the first button). The modal must NOT
  * carry a global "Enter → confirm" handler, or Enter-with-Cancel-focused would

--- a/packages/desktop-app/src/tests/components/header-node-pattern-detection.test.ts
+++ b/packages/desktop-app/src/tests/components/header-node-pattern-detection.test.ts
@@ -3,8 +3,6 @@
  *
  * Tests the unified pattern detection system for HeaderNode auto-conversion
  * and bidirectional conversion between TextNode and HeaderNode.
- *
- * Issue #275: Implement HeaderNode component with textarea
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -29,7 +27,7 @@ describe('HeaderNode Pattern Detection', () => {
 
       const headerPlugin = registry.getPlugin('header');
       expect(headerPlugin).toBeDefined();
-      // Issue #667: Pattern now lives on plugin.pattern (new architecture)
+      // Pattern now lives on plugin.pattern (new architecture)
       expect(headerPlugin?.pattern).toBeDefined();
       expect(headerPlugin?.pattern?.detect).toBeDefined();
     });

--- a/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
+++ b/packages/desktop-app/src/tests/components/invitations-inbox.test.ts
@@ -1,5 +1,5 @@
 /**
- * InvitationsInbox component tests (epic #237, slice S5 #242).
+ * InvitationsInbox component tests.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/svelte';

--- a/packages/desktop-app/src/tests/components/node-card-inline.test.ts
+++ b/packages/desktop-app/src/tests/components/node-card-inline.test.ts
@@ -1,5 +1,5 @@
 /**
- * NodeCardInline — on-mount fetch (ADR-049 / #1566).
+ * NodeCardInline — on-mount fetch (ADR-049).
  *
  * The card previously fetched a missing node from inside a $effect that watched the
  * derived `node` value. After the ADR-049 conversion it fetches once on mount (the card

--- a/packages/desktop-app/src/tests/components/onboarding-wizard.test.ts
+++ b/packages/desktop-app/src/tests/components/onboarding-wizard.test.ts
@@ -1,5 +1,5 @@
 /**
- * OnboardingWizard focus-trap tests (#1414)
+ * OnboardingWizard focus-trap tests
  *
  * The first-launch wizard was migrated from a hand-rolled overlay (Escape on the
  * backdrop, no focus management) to the shared `focusTrap` action. Because it is

--- a/packages/desktop-app/src/tests/components/ordered-list-node.test.ts
+++ b/packages/desktop-app/src/tests/components/ordered-list-node.test.ts
@@ -85,7 +85,7 @@ describe('OrderedListNode Plugin', () => {
     it('should preserve content with cleanContent: false (canRevert: true)', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: Pattern now lives on plugin.pattern (new architecture)
+      // Pattern now lives on plugin.pattern (new architecture)
       // canRevert: true means cleanContent: false (content preserved for reversion)
       expect(plugin?.pattern?.canRevert).toBe(true);
     });
@@ -102,7 +102,7 @@ describe('OrderedListNode Plugin', () => {
     });
 
     it('should have correct cursor positioning in pattern detection', () => {
-      // Issue #667: Cursor positioning comes from slash command config
+      // Cursor positioning comes from slash command config
       const patterns = pluginRegistry.getAllPatternDetectionConfigs();
       const pattern = patterns.find((p) => p.targetNodeType === 'ordered-list');
 
@@ -111,7 +111,7 @@ describe('OrderedListNode Plugin', () => {
     });
 
     it('should have correct pattern priority', () => {
-      // Issue #667: Priority is derived from plugin.pattern
+      // Priority is derived from plugin.pattern
       const patterns = pluginRegistry.getAllPatternDetectionConfigs();
       const pattern = patterns.find((p) => p.targetNodeType === 'ordered-list');
 
@@ -124,7 +124,7 @@ describe('OrderedListNode Plugin', () => {
       const commands = pluginRegistry.getAllSlashCommands();
       const slashCommand = commands.find((c) => c.id === 'ordered-list');
 
-      // Issue #667: Pattern config derived from plugin.pattern via getAllPatternDetectionConfigs
+      // Pattern config derived from plugin.pattern via getAllPatternDetectionConfigs
       const patterns = pluginRegistry.getAllPatternDetectionConfigs();
       const patternDetection = patterns.find((p) => p.targetNodeType === 'ordered-list');
 
@@ -140,7 +140,7 @@ describe('OrderedListNode Plugin', () => {
     it('should have pattern detection extract metadata', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: extractMetadata now lives on plugin.pattern
+      // extractMetadata now lives on plugin.pattern
       expect(plugin?.pattern?.extractMetadata).toBeDefined();
 
       // For ordered lists, metadata should be empty (no complex parsing needed)
@@ -184,7 +184,7 @@ describe('OrderedListNode Plugin', () => {
     it('should have correct pattern regex', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: Pattern regex now lives on plugin.pattern.detect
+      // Pattern regex now lives on plugin.pattern.detect
       const regex = plugin?.pattern?.detect;
       expect(regex).toEqual(/^1\.\s/);
 

--- a/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
+++ b/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for the pane-content.svelte hydration behaviour (issue #1564, #1566).
+ * Regression tests for the pane-content.svelte hydration behaviour.
  *
  * Full-component-mount tests for BaseNodeViewer-adjacent components require complex setup
  * (NodeServiceContext, plugin registry, database mocking - see merge-prevention.test.ts).
@@ -93,7 +93,7 @@ describe('pane-content hydration (event-driven, #1564/#1566)', () => {
     const firstCall = harness.hydrateNode('2026-07-08', 'tab-1');
     const secondCall = harness.hydrateNode('2026-07-07', 'tab-1');
 
-    // Resolve newer first, then the stale one — out-of-order, the #1564 repro.
+    // Resolve newer first, then the stale one — out-of-order, the stale-hydration repro.
     resolvers.get('2026-07-07')?.({ id: '2026-07-07' });
     await secondCall;
     resolvers.get('2026-07-08')?.({ id: '2026-07-08' });

--- a/packages/desktop-app/src/tests/components/pro-relogin-modal.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-relogin-modal.test.ts
@@ -1,5 +1,5 @@
 /**
- * ProReloginModal Component Tests (T18, #1304)
+ * ProReloginModal Component Tests
  *
  * The modal the app shell surfaces when the Pro daemon reports AUTH_REQUIRED
  * (refresh token couldn't be renewed). Presentational only — the shell owns

--- a/packages/desktop-app/src/tests/components/property-forms/task-schema-form.test.ts
+++ b/packages/desktop-app/src/tests/components/property-forms/task-schema-form.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for TaskSchemaForm Component Logic (Issue #709)
+ * Tests for TaskSchemaForm Component Logic
  *
  * Tests the utility functions, data transformations, and business logic
  * used by TaskSchemaForm. UI rendering tests would require browser context.

--- a/packages/desktop-app/src/tests/components/quote-block-node.test.ts
+++ b/packages/desktop-app/src/tests/components/quote-block-node.test.ts
@@ -6,8 +6,6 @@
  * - Display content stripping ("> " removed in blur mode)
  * - Content normalization
  *
- * Issue #277: Implement QuoteBlockNode component
- *
  * Note: These test the pure functions that would be used in QuoteBlockNode,
  * not the component itself (component rendering tested manually).
  */

--- a/packages/desktop-app/src/tests/components/textarea-bidirectional-conversion.test.ts
+++ b/packages/desktop-app/src/tests/components/textarea-bidirectional-conversion.test.ts
@@ -5,7 +5,7 @@
  * - Forward: text → header when typing "## "
  * - Reverse: header → text when removing space "##"
  *
- * Critical for issue #275: Ensures controller's internal nodeType stays in sync
+ * Critical: ensures controller's internal nodeType stays in sync
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/packages/desktop-app/src/tests/components/textarea-controller.test.ts
+++ b/packages/desktop-app/src/tests/components/textarea-controller.test.ts
@@ -525,7 +525,7 @@ describe('TextareaController', () => {
       // Replace the navigateArrow handler with our spy
       mockEvents.navigateArrow = navigateArrowSpy;
 
-      // Create controller with multiline enabled (config as getter - Issue #695)
+      // Create controller with multiline enabled (config as getter)
       controller = new TextareaController(
         element,
         'test-node',
@@ -602,7 +602,7 @@ describe('TextareaController', () => {
         controller.destroy();
       }
 
-      // Create controller with multiline enabled (config as getter - Issue #695)
+      // Create controller with multiline enabled (config as getter)
       controller = new TextareaController(
         element,
         'test-node',
@@ -642,7 +642,7 @@ describe('TextareaController', () => {
         controller.destroy();
       }
 
-      // Create controller with multiline disabled (config as getter - Issue #695)
+      // Create controller with multiline disabled (config as getter)
       controller = new TextareaController(
         element,
         'task-node',

--- a/packages/desktop-app/src/tests/e2e/daemon-readiness.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-readiness.e2e.ts
@@ -1,5 +1,5 @@
 /**
- * E2E: daemon readiness — not-ready → degraded → recovered (#1525)
+ * E2E: daemon readiness — not-ready → degraded → recovered
  *
  * ADR-044 decision 3 promises daemon-dependent stores "re-run their load
  * automatically when the daemon transitions from unreachable to healthy."
@@ -28,7 +28,7 @@
  *     reload triggered right then failed silently). Waiting on the real
  *     round-trip the test is about to exercise is the only signal that
  *     means what "ready" needs to mean here — the same "reachable at one
- *     layer is not usable end-to-end" gap #1525 exists to close, this time
+ *     layer is not usable end-to-end" gap this suite exists to close, this time
  *     surfacing in the test's own harness rather than the app. (Checked
  *     separately: production's tonic lazy channel does NOT have this gap —
  *     a call issued right after the daemon binds succeeds immediately, no

--- a/packages/desktop-app/src/tests/e2e/schema-seeding.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/schema-seeding.e2e.ts
@@ -2,7 +2,7 @@
  * E2E: Schema seeding verification
  *
  * Verifies that core schemas are populated after daemon startup, covering
- * the startup timing requirement from issue #1308.
+ * the startup timing requirement.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/desktop-app/src/tests/free-user-guardrail.test.ts
+++ b/packages/desktop-app/src/tests/free-user-guardrail.test.ts
@@ -90,7 +90,7 @@ describe('Free-user guardrail: Pro features stay inert in the community build', 
   });
 
   // -------------------------------------------------------------------------
-  // Recovered Items (core#1303) — the conflict-loser viewer/restore UI.
+  // Recovered Items — the conflict-loser viewer/restore UI.
   // The daemon writes its local-only log only in Pro; the frontend store must
   // never even ask for it in community, so no badge/snackbar can ever appear.
   // -------------------------------------------------------------------------
@@ -118,7 +118,7 @@ describe('Free-user guardrail: Pro features stay inert in the community build', 
   });
 
   // -------------------------------------------------------------------------
-  // #188 reconnect-replay render coalescing — Pro-only. In community, incoming
+  // Reconnect-replay render coalescing — Pro-only. In community, incoming
   // node events must still apply through the unchanged per-event path; the
   // coalescing window must NOT engage. The guarantee for free users is simply:
   // live node updates still land in the store.

--- a/packages/desktop-app/src/tests/global-setup.ts
+++ b/packages/desktop-app/src/tests/global-setup.ts
@@ -100,7 +100,7 @@ export default async function setup() {
   //
   // Solution: Register plugins in setup.ts which runs in the same context as components
 
-  // Note: PersistenceCoordinator removed in Issue #558
+  // Note: PersistenceCoordinator removed
   // Persistence is now handled by SimplePersistenceCoordinator inline in shared-node-store.ts
 
   console.log('✅ Global test setup complete: Plugin registry initialized');

--- a/packages/desktop-app/src/tests/integration/atomic-move-operations.test.ts
+++ b/packages/desktop-app/src/tests/integration/atomic-move-operations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit Tests: Atomic Move Node Operations (Issue #552)
+ * Unit Tests: Atomic Move Node Operations
  *
  * Tests the fractional ordering algorithm used by move_node() to atomically move
  * nodes in the hierarchy with support for insert_after_sibling positioning.

--- a/packages/desktop-app/src/tests/integration/multi-tab-reactivity.test.ts
+++ b/packages/desktop-app/src/tests/integration/multi-tab-reactivity.test.ts
@@ -8,7 +8,7 @@
  * 2. ReactiveStructureTree - Svelte 5 state for parent→child hierarchy
  * 3. ReactiveNodeService - Per-viewer instances that subscribe to SharedNodeStore
  *
- * Test scenarios from issue #641:
+ * Test scenarios:
  * 1. Content Update Propagation - Edit in viewer 1, verify viewer 2 updates
  * 2. Structural Change Propagation - Indent in viewer 1, verify hierarchy in viewer 2
  * 3. Cross-Pane Split View - Split panes with independent scroll positions

--- a/packages/desktop-app/src/tests/integration/ordered-list-workflow.test.ts
+++ b/packages/desktop-app/src/tests/integration/ordered-list-workflow.test.ts
@@ -27,7 +27,7 @@ describe('OrderedListNode Workflow', () => {
     it('should preserve "1. " prefix during conversion (cleanContent: false)', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: canRevert: true means cleanContent: false (content preserved)
+      // canRevert: true means cleanContent: false (content preserved)
       expect(plugin?.pattern?.canRevert).toBe(true);
 
       // With canRevert: true, the pattern is NOT removed from content
@@ -35,7 +35,7 @@ describe('OrderedListNode Workflow', () => {
     });
 
     it('should position cursor after "1. " prefix (position 3)', () => {
-      // Issue #667: Cursor positioning comes from slash command config
+      // Cursor positioning comes from slash command config
       const patterns = pluginRegistry.getAllPatternDetectionConfigs();
       const pattern = patterns.find((p) => p.targetNodeType === 'ordered-list');
 
@@ -50,7 +50,7 @@ describe('OrderedListNode Workflow', () => {
     it('should NOT replace content with template in pattern detection', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: canRevert: true means content is preserved (no template replacement)
+      // canRevert: true means content is preserved (no template replacement)
       expect(plugin?.pattern?.canRevert).toBe(true);
       // contentTemplate is only used by slash commands for initial content
     });
@@ -112,7 +112,7 @@ describe('OrderedListNode Workflow', () => {
     it('should convert to text node if content no longer starts with "1."', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: Pattern regex now lives on plugin.pattern.detect
+      // Pattern regex now lives on plugin.pattern.detect
       // If user deletes the "1. " prefix, the node should convert to text
       // This logic is in OrderedListNode component's handleCreateNewNode
       // Here we verify the pattern is defined for the conversion
@@ -234,7 +234,7 @@ describe('OrderedListNode Workflow', () => {
     it('should preserve "1. " prefix in database storage', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: canRevert: true means cleanContent: false (content preserved)
+      // canRevert: true means cleanContent: false (content preserved)
       // Round-trip consistency: Save "1. Item" → Load → Show as "1. Item" in edit
       expect(plugin?.pattern?.canRevert).toBe(true);
     });
@@ -271,7 +271,7 @@ describe('OrderedListNode Workflow', () => {
     it('should convert to text by removing "1. " prefix on backspace', () => {
       const plugin = pluginRegistry.getPlugin('ordered-list');
 
-      // Issue #667: Pattern regex now lives on plugin.pattern.detect
+      // Pattern regex now lives on plugin.pattern.detect
       // If pattern no longer matches (no "1. " at start), should convert to text
       // Component strips the prefix when converting
       expect(plugin?.pattern?.detect).toEqual(/^1\.\s/);

--- a/packages/desktop-app/src/tests/integration/rapid-hierarchy-operations.test.ts
+++ b/packages/desktop-app/src/tests/integration/rapid-hierarchy-operations.test.ts
@@ -1,9 +1,9 @@
 /**
- * Stress Tests: Rapid Hierarchy Operations (Issue #870 Part 2B)
+ * Stress Tests: Rapid Hierarchy Operations
  *
  * These tests validate the robustness of indent/outdent operations under
  * rapid sequential execution. They would have caught the race conditions
- * discovered in PR #861 (Optimistic operations vs database writes).
+ * discovered when optimistic operations raced database writes.
  *
  * Key scenarios tested:
  * - Rapid Enter→Tab sequences (create node then indent)
@@ -131,7 +131,7 @@ describe('Rapid Hierarchy Operations - Stress Tests (Issue #870)', () => {
   describe('Rapid Sequential Operations', () => {
     it('should handle alternating indent/outdent pattern', () => {
       // Simulate rapid Tab, Shift+Tab, Tab, Shift+Tab pattern
-      // This is the exact pattern that exposed race conditions in PR #861
+      // This is the exact pattern that exposed race conditions
 
       // Track operation order to verify consistency
       const operationSequence: string[] = [];

--- a/packages/desktop-app/src/tests/patterns/performance.test.ts
+++ b/packages/desktop-app/src/tests/patterns/performance.test.ts
@@ -4,7 +4,7 @@
  * Validates that the unified pattern system maintains performance
  * within acceptable thresholds compared to legacy implementation.
  *
- * Acceptance Criteria from #317:
+ * Acceptance Criteria:
  * - Pattern detection performance within 5% of legacy implementation
  * - Splitting performance within 5% of legacy implementation
  */

--- a/packages/desktop-app/src/tests/plugins/core-plugins.test.ts
+++ b/packages/desktop-app/src/tests/plugins/core-plugins.test.ts
@@ -69,7 +69,7 @@ describe('Core Plugins Integration', () => {
       expect(taskNodePlugin.id).toBe('task');
       expect(taskNodePlugin.name).toBe('Task Node');
       expect(taskNodePlugin.config.slashCommands).toHaveLength(1);
-      // Task nodes have TaskNodeViewer for task-specific UI (Issue #715)
+      // Task nodes have TaskNodeViewer for task-specific UI
       expect(taskNodePlugin.viewer).toBeDefined();
       expect(taskNodePlugin.node).toBeDefined(); // Has node component instead
       expect(taskNodePlugin.reference).toBeDefined();
@@ -200,7 +200,7 @@ describe('Core Plugins Integration', () => {
     });
 
     it('should resolve viewer components for plugins with viewers', async () => {
-      // date and task have custom viewers (TaskNodeViewer added in Issue #715)
+      // date and task have custom viewers (TaskNodeViewer)
       const viewerPlugins = ['date', 'task'];
 
       for (const pluginId of viewerPlugins) {
@@ -532,7 +532,7 @@ describe('Core Plugins Integration', () => {
       registerCorePlugins(registry);
 
       // Architecture changed: text, task now use BaseNodeViewer (default)
-      // date and task have custom viewers (TaskNodeViewer added in Issue #715)
+      // date and task have custom viewers (TaskNodeViewer)
       const customViewerTypes = ['date', 'task'];
 
       for (const viewerType of customViewerTypes) {

--- a/packages/desktop-app/src/tests/services/browser-sync-service.test.ts
+++ b/packages/desktop-app/src/tests/services/browser-sync-service.test.ts
@@ -50,7 +50,7 @@ const testableService = browserSyncService as unknown as TestableBrowserSyncServ
  *
  * ## Testing Strategy
  *
- * Issue #724: Events now send only nodeId (not full payload).
+ * Events now send only nodeId (not full payload).
  * Tests mock backendAdapter.getNode to return test data.
  */
 
@@ -131,7 +131,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       registerMockNode(nodeData);
 
       // But events arrive in reverse order (relationship first, then node)
-      // First, the relationship event arrives (unified format - Issue #811)
+      // First, the relationship event arrives (unified format)
       const relationshipEvent: SseEvent = {
         type: 'relationshipCreated',
         id: 'relationship:parent1:node1',
@@ -141,7 +141,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
         properties: { order: 1 }
       };
 
-      // Then, the node event arrives (Issue #724: ID-only)
+      // Then, the node event arrives (ID-only)
       const nodeEvent: SseEvent = {
         type: 'nodeCreated',
         nodeType: 'text',
@@ -196,7 +196,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       // Node doesn't exist in store yet
       expect(sharedNodeStore.getNode('child1')).toBeUndefined();
 
-      // Now create the node event (Issue #724: ID-only)
+      // Now create the node event (ID-only)
       const nodeEvent: SseEvent = {
         type: 'nodeCreated',
         nodeType: 'text',
@@ -218,7 +218,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       // Scenario: Two has_child edges naming DIFFERENT parents for the same child
       // arrive before node:created. ReactiveStructureTree enforces a single-parent
       // tree, so the second edge is treated as a MOVE: the child is pruned from the
-      // first parent and re-attached under the second (nodespace-sync#162). A move
+      // first parent and re-attached under the second. A move
       // applied on another window/cloud delivers the new-parent edge with no old-parent
       // delete, so reparenting (not rejecting) is what keeps windows consistent.
 
@@ -253,7 +253,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       expect(structureTree.getChildren('parent1')).not.toContain('child');
       expect(structureTree.getChildren('parent2')).toContain('child');
 
-      // Now create the node (Issue #724: ID-only)
+      // Now create the node (ID-only)
       testableService.handleEvent({
         type: 'nodeCreated',
         nodeType: 'text',
@@ -363,7 +363,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       registerMockNode(createTestNode('N2', 'Node 2'));
       registerMockNode(createTestNode('N3', 'Node 3'));
 
-      // Relationships arrive first (unified format - Issue #811)
+      // Relationships arrive first (unified format)
       const relationships: SseEvent[] = [
         { type: 'relationshipCreated', id: 'rel:P:N1', fromId: 'P', toId: 'N1', relationshipType: 'has_child', properties: { order: 1 } },
         { type: 'relationshipCreated', id: 'rel:P:N2', fromId: 'P', toId: 'N2', relationshipType: 'has_child', properties: { order: 2 } },
@@ -378,7 +378,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       expect(structureTree.getChildren('P').sort()).toEqual(['N1', 'N2']);
       expect(structureTree.getChildren('N2')).toEqual(['N3']);
 
-      // Now nodes arrive in random order (Issue #724: ID-only)
+      // Now nodes arrive in random order (ID-only)
       const nodes: SseEvent[] = [
         { type: 'nodeCreated', nodeType: 'text', nodeId: 'N2' },
         { type: 'nodeCreated', nodeType: 'text', nodeId: 'N1' },
@@ -409,7 +409,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       // Set up node
       sharedNodeStore.setNode(nodeData, { type: 'database', reason: 'sse-sync' });
 
-      // Create relationship first time (unified format - Issue #811)
+      // Create relationship first time (unified format)
       const relationshipEvent: SseEvent = {
         type: 'relationshipCreated',
         id: 'relationship:parent1:child1',
@@ -448,7 +448,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       };
       registerMockNode(updatedNode);
 
-      // Update event arrives (Issue #724: ID-only)
+      // Update event arrives (ID-only)
       testableService.handleEvent({
         type: 'nodeUpdated',
         nodeId: 'node1'
@@ -477,7 +477,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       registerMockNode(createTestNode('N1', 'Node 1'));
       registerMockNode(createTestNode('N3', 'Node 3'));
 
-      // Interleaved events (Issue #724: ID-only for node events, Issue #811: unified relationships)
+      // Interleaved events (ID-only for node events, unified relationships)
       const events: SseEvent[] = [
         // Tree 1 setup
         { type: 'nodeCreated', nodeType: 'text', nodeId: 'P1' },
@@ -544,7 +544,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       const nodeData = createTestNode('other-client-node', 'Created by another client');
       registerMockNode(nodeData);
 
-      // Issue #724: ID-only event
+      // ID-only event
       const event: SseEvent = {
         type: 'nodeCreated',
         nodeType: 'text',
@@ -572,7 +572,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
       const nodeData = createTestNode('legacy-node', 'Legacy event without clientId');
       registerMockNode(nodeData);
 
-      // Issue #724: ID-only event, no clientId
+      // ID-only event, no clientId
       const event: SseEvent = {
         type: 'nodeCreated',
         nodeType: 'text',
@@ -673,7 +673,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
     });
 
     it('should skip fetch for nodeUpdated when node is not in store', async () => {
-      // Issue #724 optimization: Don't fetch nodes that aren't visible
+      // Optimization: Don't fetch nodes that aren't visible
       const nodeData = createTestNode('invisible-node', 'Not in view');
       registerMockNode(nodeData);
 
@@ -737,7 +737,7 @@ describe('BrowserSyncService - SSE Event Ordering', () => {
 
   describe('Task Node Normalization', () => {
     it('should normalize task nodes from SSE events', async () => {
-      // Issue #724: Task nodes need to be normalized from properties to flat format
+      // Task nodes need to be normalized from properties to flat format
       const taskNodeData: Node = {
         id: 'task1',
         nodeType: 'task',

--- a/packages/desktop-app/src/tests/services/capture-settings.test.ts
+++ b/packages/desktop-app/src/tests/services/capture-settings.test.ts
@@ -1,5 +1,5 @@
 /**
- * Session Capture Settings Tests (Issue #1125)
+ * Session Capture Settings Tests
  *
  * Tests the getCaptureSettings and updateCaptureSettings tauri-commands API surface.
  * In non-Tauri environment these return mock defaults.

--- a/packages/desktop-app/src/tests/services/daemon-status.test.ts
+++ b/packages/desktop-app/src/tests/services/daemon-status.test.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon status service (#1470) — shared daemon-status listener that drives
+ * Daemon status service — shared daemon-status listener that drives
  * AppShell's connecting/unreachable banner and fans out a reconnect signal
  * to daemon-dependent stores (schemas, collections, children-tree) so they
  * retry a failed load once the daemon becomes healthy, instead of staying

--- a/packages/desktop-app/src/tests/services/focus-manager-cursor-positioning.test.ts
+++ b/packages/desktop-app/src/tests/services/focus-manager-cursor-positioning.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for FocusManager cursor positioning refactor (Issue #281)
+ * Tests for FocusManager cursor positioning refactor
  *
  * Verifies unified cursor position state and API methods
  */

--- a/packages/desktop-app/src/tests/services/mcp-integration.test.ts
+++ b/packages/desktop-app/src/tests/services/mcp-integration.test.ts
@@ -2,7 +2,7 @@
  * MCP Integration Tests (Phase 3)
  *
  * These tests simulate MCP server behavior to validate the architecture
- * is ready for MCP integration (Issue #112). Tests use SharedNodeStore
+ * is ready for MCP integration. Tests use SharedNodeStore
  * directly with domain events architecture for real-time sync.
  */
 

--- a/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for issue #1307: node content not persisting to database.
+ * Regression tests: node content not persisting to database.
  *
  * Covers the write → flush → read-back cycle so that edits made in the Tauri
  * desktop app reliably reach the backend.

--- a/packages/desktop-app/src/tests/services/node-type-conflict-detection.test.ts
+++ b/packages/desktop-app/src/tests/services/node-type-conflict-detection.test.ts
@@ -5,8 +5,6 @@
  * - NodeType conversions bypass conflict detection
  * - Regular concurrent edits still trigger conflict detection
  * - Edge cases around rapid updates
- *
- * Part of issue #275: HeaderNode implementation
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/persistence-serial-writer-regression.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for issue #1492: edit persistence amplifies writes and
+ * Regression tests: edit persistence amplifies writes and
  * self-conflicts during fast typing.
  *
  * Covers the SimplePersistenceCoordinator's per-node serial writer: a

--- a/packages/desktop-app/src/tests/services/reactive-node-service.test.ts
+++ b/packages/desktop-app/src/tests/services/reactive-node-service.test.ts
@@ -1768,7 +1768,7 @@ describe('ReactiveNodeService - CreateNode Edge Cases', () => {
       expect(moveChildrenMock.mock.calls.length).toBe(callsBefore + 1);
     }, { timeout: 3000 });
 
-    // After moveChildrenToParent rejects, the catch block should emit the #656 notification
+    // After moveChildrenToParent rejects, the catch block should emit the rollback notification
     await vi.waitFor(() => {
       expect(conflictNotifications.notifications.length).toBeGreaterThan(0);
     }, { timeout: 1000 });

--- a/packages/desktop-app/src/tests/services/shared-node-store-extended.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-extended.test.ts
@@ -690,7 +690,7 @@ describe('SharedNodeStore - Extended Coverage', () => {
   });
 
   // ========================================================================
-  // Issue #880: Immediate Backlinks Reactivity
+  // Immediate Backlinks Reactivity
   // ========================================================================
 
   describe('Immediate Backlinks Reactivity (Issue #880)', () => {

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for the skip-while-editing guard in SharedNodeStore.setNode().
  *
- * Repro context: nodespace-sync#76 (typing corruption) and #77 (Enter
- * relocates text). Root cause: daemon broadcasts of just-confirmed writes
+ * Repro context: typing corruption and Enter relocating text. Root cause:
+ * daemon broadcasts of just-confirmed writes
  * arrive via the WatchNodes gRPC stream while the user is still typing.
  * The unguarded `setNode()` clobbers the optimistic store with the older
  * server-confirmed state.
@@ -71,7 +71,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // Local content stays at the user's optimistic state. Crucially the
     // local node's `.version` is also unchanged — mutating it inside the
     // reactive Map would cause Svelte to re-render and remount the focused
-    // textarea (resetting selectionStart → triggers sync#77).
+    // textarea (resetting selectionStart → triggers the text-relocation bug).
     const after = store.getNode('n1');
     expect(after?.content).toBe('hello world');
     expect(after?.version).toBe(1);
@@ -223,7 +223,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     // which routes through the same `serverConfirmedVersions` cache the
     // skip-while-editing guard populates. Without this test, a future
     // refactor that drops that read would silently reintroduce the
-    // OCC-defeat from nodespace-sync#76 — the unit tests above only
+    // OCC-defeat from the typing-corruption bug — the unit tests above only
     // assert cache *population*, not *consumption*.
     store.setNode(makeNode('persist', 'abc', 1), databaseSource);
     // Simulate that the local client just persisted 'abc' (own echo
@@ -297,7 +297,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     expect(after?.version).toBe(15);
   });
 
-  // #1436: batchSetNodes (used by doLoadChildrenTree with a database source)
+  // batchSetNodes (used by doLoadChildrenTree with a database source)
   // must apply the SAME skip-while-editing guard as setNode — a concurrent tree
   // reload would otherwise overwrite a child being edited mid-keystroke.
   describe('batchSetNodes guard (#1436)', () => {
@@ -353,7 +353,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     });
   });
 
-  // #1437: a foreign write to an actively-edited node is skipped to protect the
+  // A foreign write to an actively-edited node is skipped to protect the
   // optimistic text — but it must NOT be silent. Surface a version-mismatch
   // conflict notification so the user knows another writer changed the node.
   describe('foreign-write conflict signal (#1437)', () => {

--- a/packages/desktop-app/src/tests/services/shared-node-store.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store.test.ts
@@ -414,7 +414,7 @@ describe('SharedNodeStore', () => {
   });
 
   // ========================================================================
-  // New Methods for BaseNodeViewer Migration (Issue #237)
+  // New Methods for BaseNodeViewer Migration
   // ========================================================================
 
   describe('BaseNodeViewer Migration Methods', () => {
@@ -514,12 +514,12 @@ describe('SharedNodeStore', () => {
         expect(store.getNode(mockNode.id)?.content).toBe('Updated content');
       });
 
-      // Note: Tests for PersistenceCoordinator integration removed (service deleted in #558)
+      // Note: Tests for PersistenceCoordinator integration removed (service deleted)
     });
 
-    // Note: hasPendingSave tests removed (PersistenceCoordinator deleted in #558)
+    // Note: hasPendingSave tests removed (PersistenceCoordinator deleted)
 
-    // Note: waitForNodeSaves tests removed (PersistenceCoordinator deleted in #558)
+    // Note: waitForNodeSaves tests removed (PersistenceCoordinator deleted)
 
   });
 
@@ -923,7 +923,7 @@ describe('SharedNodeStore', () => {
     });
   });
 
-  // Note: Explicit Persistence API tests removed (PersistenceCoordinator deleted in #558)
+  // Note: Explicit Persistence API tests removed (PersistenceCoordinator deleted)
 
   // ========================================================================
   // loadChildrenTree() - NodeWithChildren handling
@@ -1031,7 +1031,7 @@ describe('SharedNodeStore', () => {
     it('should synthesize virtual date node when backend returns null for a valid date id', async () => {
       // A brand-new date with no children yet returns null from the backend.
       // The store must synthesise a minimal in-memory node so the viewer does not
-      // mistake the missing node for a deleted/stale one and close the tab (#941).
+      // mistake the missing node for a deleted/stale one and close the tab.
       const dateId = '2026-03-14';
 
       const getChildrenTreeSpy = vi
@@ -1516,7 +1516,7 @@ describe('SharedNodeStore', () => {
   });
 
   // ========================================================================
-  // OCC Error Recovery Tests (Issue #720)
+  // OCC Error Recovery Tests
   // ========================================================================
 
   describe('OCC Error Recovery', () => {

--- a/packages/desktop-app/src/tests/services/tauri-commands.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-commands.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tauri System Commands Service Tests
  *
- * Tests the non-node commands that remain in tauri-commands after C1a (#1251).
+ * Tests the non-node commands that remain in tauri-commands after C1a.
  * Node-CRUD functions were removed; use backend-adapter directly.
  */
 

--- a/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
@@ -18,7 +18,7 @@ import { proSync } from '$lib/stores/pro-sync.svelte';
  * 2. Tauri event system forwards events to frontend
  * 3. TauriSyncListener handles events and updates stores
  *
- * ## Issue #724: ID-Only Events
+ * ## ID-Only Events
  *
  * Events now send only node_id (not full payload). Tests mock backendAdapter.getNode
  * to return test data when frontend fetches node details.
@@ -170,7 +170,7 @@ describe('TauriSyncListener', () => {
 			expect(mockEventListeners.has('node:created')).toBe(true);
 			expect(mockEventListeners.has('node:updated')).toBe(true);
 			expect(mockEventListeners.has('node:deleted')).toBe(true);
-			// Issue #811: Unified relationship events replace old edge:* events
+			// Unified relationship events replace old edge:* events
 			expect(mockEventListeners.has('relationship:created')).toBe(true);
 			expect(mockEventListeners.has('relationship:updated')).toBe(true);
 			expect(mockEventListeners.has('relationship:deleted')).toBe(true);
@@ -261,7 +261,7 @@ describe('TauriSyncListener', () => {
 		});
 	});
 
-	// #188: when sync is active, a reconnect-replay burst of node events is
+	// When sync is active, a reconnect-replay burst of node events is
 	// coalesced — collected over a short window, then applied in one synchronous
 	// pass so the caught-up set renders once instead of once per node.
 	describe('Pro reconnect-replay render coalescing (#188)', () => {
@@ -473,8 +473,8 @@ describe('TauriSyncListener', () => {
 
 	describe('Relationship Events — node: prefix normalization (Issue #1209)', () => {
 		// Backend's `RelationshipEvent` serialization contract emits
-		// `from_id` / `to_id` already prefixed with `node:` (see
-		// nodespace-core#1206 + #1208). The listener's `stripNodePrefix`
+		// `from_id` / `to_id` already prefixed with `node:`. The
+		// listener's `stripNodePrefix`
 		// helper normalizes at the boundary so the structureTree's
 		// bare-id keyspace stays consistent with the local-action path.
 		// Without these tests, deleting `stripNodePrefix` from any of

--- a/packages/desktop-app/src/tests/setup.ts
+++ b/packages/desktop-app/src/tests/setup.ts
@@ -6,7 +6,7 @@ import { vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom';
 import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
 
-// Note: PersistenceCoordinator removed in Issue #558
+// Note: PersistenceCoordinator removed
 // SimplePersistenceCoordinator is now inline in shared-node-store.ts
 
 // Ensure global object is available for legacy test compatibility
@@ -323,7 +323,7 @@ if (typeof window !== 'undefined') {
 }
 
 // SharedNodeStore cleanup for each test
-// NOTE: PersistenceCoordinator removed in Issue #558
+// NOTE: PersistenceCoordinator removed
 beforeEach(() => {
   // Reset SharedNodeStore to clear all nodes between tests
   sharedNodeStore.__resetForTesting();

--- a/packages/desktop-app/src/tests/state/pattern-state.test.ts
+++ b/packages/desktop-app/src/tests/state/pattern-state.test.ts
@@ -2,8 +2,8 @@
  * PatternState Unit Tests
  *
  * Tests for the PatternState class that manages pattern detection lifecycle.
- * Issue #664: Replace scattered nodeTypeSetViaPattern flag with explicit state machine.
- * Issue #667: Plugin-owned pattern behavior (canRevert, revert regex).
+ * Replace scattered nodeTypeSetViaPattern flag with explicit state machine.
+ * Plugin-owned pattern behavior (canRevert, revert regex).
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/desktop-app/src/tests/stores/daemon-reconnect-retry.test.ts
+++ b/packages/desktop-app/src/tests/stores/daemon-reconnect-retry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon-reconnect retry wiring (#1470) — schemasData and collectionsData
+ * Daemon-reconnect retry wiring — schemasData and collectionsData
  * both register with the shared daemon-status reconnect hook at module load
  * so a load that failed while the daemon was still starting up retries
  * automatically once the daemon becomes healthy, instead of staying failed

--- a/packages/desktop-app/src/tests/stores/model-store.test.ts
+++ b/packages/desktop-app/src/tests/stores/model-store.test.ts
@@ -223,7 +223,7 @@ describe('ModelStore', () => {
 
       const modelId = modelStore.models[0].id;
 
-      // Simulate the daemon hanging (issue #1471): chatModelDownload's
+      // Simulate the daemon hanging: chatModelDownload's
       // returned promise never resolves because a stale progress-callback
       // sender keeps the gRPC stream open. The regression fix is that the
       // ready event alone -- independent of that promise -- must flip the

--- a/packages/desktop-app/src/tests/stores/pro-sync.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync.test.ts
@@ -1,5 +1,5 @@
 /**
- * ProSync store — signed-in identity + manual sign-out (#199 S6).
+ * ProSync store — signed-in identity + manual sign-out.
  *
  * Asserts the store surfaces `SyncStatusEvent.user_email` (the "signed in as
  * <email>" affordance) from the `sync:status` stream and clears it on sign-out,

--- a/packages/desktop-app/src/tests/types/mermaid-split-panel.test.ts
+++ b/packages/desktop-app/src/tests/types/mermaid-split-panel.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Mermaid split-panel edit mode logic (issue #925)
+ * Tests for Mermaid split-panel edit mode logic
  *
  * Tests the debounce behavior and language-gating that controls the
  * live preview in code-block-node.svelte. The component logic is tested

--- a/packages/desktop-app/src/tests/types/task-node.test.ts
+++ b/packages/desktop-app/src/tests/types/task-node.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for TaskNode Type-Safe Wrapper
  *
- * TaskNode uses flat structure matching Rust backend serialization (Issue #673, #700).
+ * TaskNode uses flat structure matching Rust backend serialization.
  * Spoke fields (status, priority, dueDate, assignee) are at the top level, not nested.
  */
 

--- a/packages/desktop-app/src/tests/unit/backlinks-panel.test.ts
+++ b/packages/desktop-app/src/tests/unit/backlinks-panel.test.ts
@@ -1,11 +1,11 @@
 /**
- * BacklinksPanel Component Tests (Issue #882, #1384)
+ * BacklinksPanel Component Tests
  *
  * Tests the BacklinksPanel component's business logic and utility functions.
  * Since the component uses bits-ui which has module resolution issues in tests,
  * we test the underlying logic patterns directly.
  *
- * After Issue #1384 refactor: BacklinksPanel is now props-driven — it accepts
+ * After the props-driven refactor: BacklinksPanel now accepts
  * `backlinks: NodeReference[]` as a prop instead of reading from sharedNodeStore.
  *
  * Test Coverage:

--- a/packages/desktop-app/src/tests/unit/indent-outdent-race-condition.test.ts
+++ b/packages/desktop-app/src/tests/unit/indent-outdent-race-condition.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for indent/outdent race condition prevention (Issue #662)
+ * Tests for indent/outdent race condition prevention
  *
  * Verifies that rapid indent/outdent operations are serialized properly
  * through the pending move operation tracking mechanism.

--- a/packages/desktop-app/src/tests/unit/outdent-ordering.test.ts
+++ b/packages/desktop-app/src/tests/unit/outdent-ordering.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for C3a: Frontend outdent ordering math removal (Issue #1259)
+ * Tests for C3a: Frontend outdent ordering math removal
  *
  * Verifies that:
  * 1. No frontend code computes fractional order values for optimistic placement.

--- a/packages/desktop-app/src/tests/unit/props-driven-components.test.ts
+++ b/packages/desktop-app/src/tests/unit/props-driven-components.test.ts
@@ -1,5 +1,5 @@
 /**
- * Props-Driven Component Tests (Issue #1384)
+ * Props-Driven Component Tests
  *
  * Verifies that refactored UI components are props-driven and Tauri-independent:
  * - BacklinksPanel: accepts backlinks as a prop (no sharedNodeStore import)

--- a/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
+++ b/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
@@ -507,7 +507,7 @@ describe('ReactiveStructureTree', () => {
       // The one-parent invariant is preserved by MOVING, not by rejecting: a
       // has_child edge under a new parent (an indent synced from another window)
       // means the node moved. Rejecting it left the node stranded under its old
-      // parent across windows (nodespace-sync#162).
+      // parent across windows.
       structureTree.children.clear();
 
       structureTree.__testOnly_addChild({ parentId: 'parent1', childId: 'child1', order: 1.0 });
@@ -831,7 +831,7 @@ describe('ReactiveStructureTree', () => {
       // window): the daemon reparents in one step, so only a relationship:created
       // for the new parent is delivered — possibly before any old-edge delete.
       // It must MOVE the node, not be rejected as an "invariant violation"
-      // (nodespace-sync#162: indent not reflected across windows).
+      // (indent not reflected across windows).
       structureTree.addChild({ parentId: 'p1', childId: 'n', order: 1 });
 
       expect(structureTree.getChildren('p1')).toEqual(['n']);

--- a/packages/desktop-app/src/tests/utils/tab-title.test.ts
+++ b/packages/desktop-app/src/tests/utils/tab-title.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for computeTabTitle (issue #1564).
+ * Unit tests for computeTabTitle.
  *
  * Type-specific title logic is covered separately in plugin-registry.test.ts
  * (getNodeTitle/getTitle hook) — these tests isolate computeTabTitle's own branching:

--- a/packages/desktop-app/src/tests/utils/test-database.ts
+++ b/packages/desktop-app/src/tests/utils/test-database.ts
@@ -1,7 +1,7 @@
 /**
  * Test Database Utilities - DEPRECATED
  *
- * NOTE: Issue #558 deleted the backend-adapter service that this module depended on.
+ * NOTE: The backend-adapter service that this module depended on was deleted.
  * HTTP dev server testing is no longer supported. Tests should use in-memory mode
  * or be rewritten to use Tauri commands directly (when running in Tauri context).
  *
@@ -45,7 +45,7 @@ export async function cleanupTestDatabase(dbPath: string): Promise<void> {
 
 /**
  * Initialize a test database - NO LONGER FUNCTIONAL
- * @deprecated HTTP dev server and backend-adapter were deleted in Issue #558
+ * @deprecated HTTP dev server and backend-adapter were deleted
  * @throws Error indicating the function is deprecated
  */
 export async function initializeTestDatabase(
@@ -71,7 +71,7 @@ export interface CleanDatabaseResult {
 
 /**
  * Clean database - NO LONGER FUNCTIONAL
- * @deprecated HTTP dev server and backend-adapter were deleted in Issue #558
+ * @deprecated HTTP dev server and backend-adapter were deleted
  */
 export async function cleanDatabase(_backend: unknown): Promise<CleanDatabaseResult> {
   console.warn('[DEPRECATED] cleanDatabase is no longer functional.');

--- a/packages/desktop-app/src/tests/utils/test-node-helpers.ts
+++ b/packages/desktop-app/src/tests/utils/test-node-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Test Node Helper Utilities - DEPRECATED
  *
- * NOTE: Issue #558 deleted the backend-adapter service that this module depended on.
+ * NOTE: The backend-adapter service that this module depended on was deleted.
  * HTTP dev server testing is no longer supported. Tests should use in-memory mode
  * or be rewritten to use Tauri commands directly (when running in Tauri context).
  */
@@ -50,7 +50,7 @@ export async function retryOperation<T>(
 
 /**
  * Creates a node via HttpAdapter and fetches it back - NO LONGER FUNCTIONAL
- * @deprecated HTTP dev server and backend-adapter were deleted in Issue #558
+ * @deprecated HTTP dev server and backend-adapter were deleted
  */
 export async function createAndFetchNode(
   _adapter: HttpAdapter,
@@ -70,7 +70,7 @@ export async function createAndFetchNode(
 
 /**
  * Checks if the HTTP dev server is running - NO LONGER FUNCTIONAL
- * @deprecated HTTP dev server testing was removed in Issue #558
+ * @deprecated HTTP dev server testing was removed
  */
 export async function checkServerHealth(_adapter: HttpAdapter): Promise<void> {
   if (shouldUseDatabase()) {

--- a/packages/desktop-app/vitest.config.ts
+++ b/packages/desktop-app/vitest.config.ts
@@ -185,7 +185,7 @@ export default defineConfig({
       }
     },
 
-    // Coverage configuration - targeting 90% for testable business logic (Issue #735)
+    // Coverage configuration - targeting 90% for testable business logic
     // We focus on logic that is practically testable without complex mocking
     coverage: {
       provider: 'v8', // Use V8 coverage provider (fast and accurate)
@@ -201,7 +201,7 @@ export default defineConfig({
         '.svelte-kit/**', // SvelteKit generated files
         'scripts/**', // Build/dev scripts
         'eslint-rules/**', // Custom eslint rules
-        // Excluded from coverage targets (Issue #735)
+        // Excluded from coverage targets
         'src/lib/components/ui/**', // Third-party shadcn-svelte wrappers
         'src/lib/design/**', // Svelte components - tested via browser-mode tests
         'src/lib/components/**', // Svelte UI components - require browser testing
@@ -239,7 +239,7 @@ export default defineConfig({
     testTimeout: 5000,
     hookTimeout: 5000,
 
-    // CRITICAL: Run tests sequentially to prevent SharedNodeStore interference (Issue #228, #255)
+    // CRITICAL: Run tests sequentially to prevent SharedNodeStore interference
     // SharedNodeStore is a singleton, so parallel tests within a file share state.
     // Even though singleFork: true runs test FILES sequentially, individual tests
     // within a file can run concurrently, causing state corruption.
@@ -248,7 +248,7 @@ export default defineConfig({
       shuffle: false // Don't randomize test order
     },
 
-    // Run integration tests sequentially to prevent database race conditions (Issue #255)
+    // Run integration tests sequentially to prevent database race conditions
     // Each test swaps the dev-server's database path, so parallel execution causes
     // "no such table" errors when operations read the wrong database
     pool: 'forks',

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -1544,7 +1544,7 @@ mod tests {
     #[test]
     fn oai_value_tool_result_includes_name_for_ministral() {
         // Ministral's Jinja template requires "name" on tool-result messages.
-        // Missing "name" → Jinja exception → ffi error -3 (issue #1373).
+        // Missing "name" → Jinja exception → ffi error -3.
         let m = ChatMessage::tool_result("[]", "tc_1", "search_nodes");
         let v = chat_message_to_oai_value(&m);
         assert_eq!(
@@ -1581,7 +1581,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Regression fixture — Gemma 4 12B tool-call delta (issue #1355)
+    // Regression fixture — Gemma 4 12B tool-call delta
     //
     // With the old vendored engine (pre-b8660) chat_format=0 caused tool calls
     // to be emitted as plain content, never reaching emit_oai_delta as
@@ -1627,7 +1627,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // augment_gemma4_stops — Gemma 4 runaway fix (issue #1365)
+    // augment_gemma4_stops — Gemma 4 runaway fix
     //
     // The ggml-org GGUF does not mark <turn|> as EOG, so llama.cpp's template
     // engine may omit it from additional_stops. augment_gemma4_stops injects

--- a/packages/nlp-engine/src/chat/parser.rs
+++ b/packages/nlp-engine/src/chat/parser.rs
@@ -1182,7 +1182,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Regression fixtures — historical engine failures (issue #1355)
+    // Regression fixtures — historical engine failures
     //
     // These tests pin the two tool-call failures that were misattributed to
     // model capability but were caused by the old vendored llama.cpp engine

--- a/packages/nlp-engine/src/embedding.rs
+++ b/packages/nlp-engine/src/embedding.rs
@@ -4,7 +4,7 @@
 /// - Text: Uses asymmetric prefixes (search_document/search_query) for optimal retrieval
 /// - Images: Foundation for future multimodal embedding support
 ///
-/// ## Performance Optimization (Issue #776)
+/// ## Performance Optimization
 ///
 /// The service reuses LlamaContext across embedding calls to avoid the overhead
 /// of Metal kernel compilation on each call. The context is created once during
@@ -195,7 +195,7 @@ pub fn release_llama_backend() {
 
 /// Wrapper to hold model and context together with proper lifetimes.
 ///
-/// ## Safety (Issue #776)
+/// ## Safety
 /// This struct uses `unsafe` to store a `LlamaContext` with an extended lifetime.
 /// This is safe because:
 /// 1. The context is only used while model is alive (owned by this struct)
@@ -340,7 +340,7 @@ impl EmbeddingService {
     /// If the model file is not found, the service will operate in stub mode
     /// returning zero vectors. This allows tests to run without the model.
     ///
-    /// ## Performance (Issue #776)
+    /// ## Performance
     /// Creates a persistent LlamaContext that is reused across all embedding calls.
     /// This avoids the overhead of Metal kernel compilation on each embedding request.
     pub fn initialize(&mut self) -> Result<()> {
@@ -516,7 +516,7 @@ impl EmbeddingService {
         }
     }
 
-    /// Generate embedding using llama.cpp with persistent context (Issue #776)
+    /// Generate embedding using llama.cpp with persistent context
     ///
     /// ## Performance Optimization
     /// This method reuses a persistent `LlamaContext` across calls, avoiding the

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -283,7 +283,7 @@ mod wire_contract {
 /// If someone adds a field to the stored shape but forgets to model it on the
 /// wire struct (`TaskNode` / `AiChatNode`), the promoted field vanishes from the
 /// output and the corresponding proptest fails — turning a silent data-drop into
-/// a test failure, which is the whole point of issue #1502.
+/// a test failure, which is the whole point of this guard.
 #[cfg(test)]
 mod promotion_proptests {
     use super::*;

--- a/packages/nodespace-types/src/node.rs
+++ b/packages/nodespace-types/src/node.rs
@@ -120,7 +120,7 @@ pub struct NodeQuery {
     pub id: Option<String>,
     /// Restrict the result to this explicit set of ids (e.g. a collection's
     /// members). Translated to an `id IN (…)` clause, chunked under SQLite's
-    /// bound-parameter ceiling (#1430). `None` = no id restriction.
+    /// bound-parameter ceiling. `None` = no id restriction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

One-time cleanup ahead of moving the docs/decision record into NodeSpace itself: sweep the Rust/TS/Svelte sources and reword provenance comments that hard-referenced GitHub issue numbers (`#1234`, `Issue #665`, `nodespace-sync#125`, `epic #237`) to describe the behavior/constraint directly. Where a decision is captured by an ADR, the ADR reference is kept and only the ticket number dropped.

## Scope

**212 files, ~810 references reworded**, across every workspace package that carried them:

| Package | Files | ~Refs |
|---|---|---|
| core | 47 | ~400 |
| desktop-app (.ts/.svelte/src-tauri) | ~140 | ~360 |
| agent + nlp-engine | 18 | ~40 |
| daemon + nodespace-types | 7 | ~16 |

## Comment content only — verified

The code portion of every touched line is **byte-identical**; only comment text changed. Verified mechanically: of the changed lines, 1744 are pure-comment lines and the remaining ~26 are block-comment continuation lines (`<!-- -->` / `/** */` doc blocks) or inline `code; //` comments whose code prefix is unchanged.

Deliberately **left intact** (not comments): issue numbers inside string literals, assertion/log messages, test titles, fixtures (`'Invoice #001'`), CSS/Svelte hex colors (`#333`), and `#[...]` attributes. Third-party references were reduced to prose (e.g. an upstream `tauri-apps/tray-icon` bug), not linked by number.

## Testing

Full pre-push gate green: `bun run test:all` + `cargo build --bin nodespaced` + `bun run test:e2e` + `cargo test -p nodespace-app`. Because the change is comment-only, it cannot affect compilation or behavior.

**Note on `quality:fix`:** `bun run quality:fix` currently fails on a **pre-existing** clippy warning in `packages/daemon/src/services/import_service.rs:645` (`if !(exists && !replace)` can be simplified) that is present on clean `main` and unrelated to this sweep. Its `cargo fmt` step also wants to reformat pre-existing formatting drift in files this sweep does not touch. Both are left out of scope here to keep this PR strictly comment-only; they are pre-existing tech debt for a separate cleanup.

## Acceptance criteria

- [x] No GitHub issue-number references remain in code comments (excluding process mechanics)
- [x] Provenance comments reworded to describe behavior, not tickets
- [x] Tests pass (`bun run test:all` + full gate green)
- [ ] `bun run quality:fix` — blocked by a pre-existing, unrelated clippy warning (see note); the sweep itself is lint/format-neutral

Closes #1494 (child of the cross-repo epic #1493)