### PR TITLE
Harden pane hydration + poll daemon readiness until healthy (relates #1672)

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/pane-content.svelte
+++ b/packages/desktop-app/src/lib/components/layout/pane-content.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { setContext, untrack } from 'svelte';
+  import { onMount, setContext, untrack } from 'svelte';
   import BaseNodeViewer from '$lib/design/components/base-node-viewer.svelte';
   import { navigationStore, updateTabContent, closeTab } from '$lib/stores/navigation.svelte';
   import { pluginRegistry } from '$lib/plugins/plugin-registry';
   import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
+  import { onDaemonReconnect } from '$lib/services/daemon-status';
   import type { Pane } from '$lib/stores/navigation.svelte';
   import { createLogger } from '$lib/utils/logger';
   import SettingsPane from '$lib/components/settings/settings-pane.svelte';
@@ -34,7 +35,11 @@
 
   // Load viewer when needed - moved to function called from onMount to avoid derived context issues
   async function loadViewerForNodeType(nodeType: string) {
-    if (viewerComponents.has(nodeType) || viewerLoadErrors.has(nodeType) || viewerLoading.has(nodeType)) {
+    if (
+      viewerComponents.has(nodeType) ||
+      viewerLoadErrors.has(nodeType) ||
+      viewerLoading.has(nodeType)
+    ) {
       return;
     }
 
@@ -136,6 +141,22 @@
     }
   });
 
+  // A hydration fetch that fails is otherwise permanent: the $effect above only
+  // re-runs on tab changes, so a pane whose first fetch raced the daemon's boot
+  // window (fresh install: the webview renders while the sidecar is still
+  // seeding its DB and binding the socket) sits on "Loading..." forever. Retry
+  // the active tab's hydration whenever the daemon transitions back to healthy.
+  // hydrateNode's store-presence guard makes this a no-op once hydration has
+  // succeeded; same idiom as the sidebar stores and base-node-viewer.
+  onMount(() =>
+    onDaemonReconnect(() => {
+      const nodeId = activeTab?.content?.nodeId;
+      const tabId = activeTabId;
+      if (nodeId && tabId && !sharedNodeStore.getNode(nodeId)) {
+        hydrateNode(nodeId, tabId);
+      }
+    })
+  );
 </script>
 
 {#if activeTab?.type === 'settings'}

--- a/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
+++ b/packages/desktop-app/src/tests/components/pane-content-hydration.test.ts
@@ -106,7 +106,7 @@ describe('pane-content hydration (event-driven, #1564/#1566)', () => {
     expect(harness.isHydrated('2026-07-08')).toBe(true);
   });
 
-  it('closes the tab only if the not-found response is still the tab\'s current nodeId', async () => {
+  it("closes the tab only if the not-found response is still the tab's current nodeId", async () => {
     const resolvers = new Map<string, (node: Node | undefined) => void>();
     const ensureNode = vi.fn(
       (nodeId: string) =>
@@ -172,5 +172,39 @@ describe('pane-content hydration (event-driven, #1564/#1566)', () => {
     await harness.hydrateNode('2026-07-07', 'tab-1'); // second call is a no-op
 
     expect(ensureNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('a hydration that failed during the daemon boot window succeeds on the reconnect retry', async () => {
+    // First fetch races the daemon's startup (fresh install: the webview renders
+    // while the sidecar is still seeding its DB and binding the socket) → the
+    // invoke rejects with a transport error, not a clean not-found. Without a
+    // retry the pane sits on "Loading..." forever — the round-1 fresh-install
+    // hang. pane-content now re-runs hydrateNode via onDaemonReconnect; this
+    // mirrors that wiring: retry only when the node is still absent.
+    const ensureNode = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transport error: connection refused'))
+      .mockResolvedValue({ id: '2026-07-16' });
+    const harness = createHydrationHarness(ensureNode, () => '2026-07-16');
+
+    await harness.hydrateNode('2026-07-16', 'tab-1');
+    expect(harness.isHydrated('2026-07-16')).toBe(false);
+    expect(harness.errors).toHaveLength(1);
+
+    // Daemon flips not-healthy → healthy; the reconnect listener retries the
+    // active tab's hydration iff its node is still missing from the store.
+    const onReconnect = async () => {
+      if (!harness.isHydrated('2026-07-16')) {
+        await harness.hydrateNode('2026-07-16', 'tab-1');
+      }
+    };
+    await onReconnect();
+
+    expect(harness.isHydrated('2026-07-16')).toBe(true);
+    expect(ensureNode).toHaveBeenCalledTimes(2);
+
+    // A second healthy transition is a no-op — the store-presence guard holds.
+    await onReconnect();
+    expect(ensureNode).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## What this is
Hardening of the pane-hydration path plus a persistent daemon-readiness poll. It **relates to #1672** (the fresh-install "Daily Journal Loading… forever" P0) and is the most likely fix, but the root cause is not yet confirmed on a live device, so **#1672 stays open** until the fresh-install validation leg runs (round-2, on the validation Mac). Do not auto-close #1672 on this merge.

## Why it's framed as hardening, not a confirmed fix
The round-1 report notes "reload does not fix it" and "no WatchNodes activity" across the hung session — both consistent with a failure at or below the app→daemon transport (e.g. a wedged lazy gRPC channel) rather than a swallowed one-shot fetch alone. A frontend re-invoke can only heal the latter. This PR fixes a real terminal-failure path (a hydration fetch that fails during the daemon boot window is never retried) and closes the signal hole that would defeat that retry — but confirming it resolves the user-visible hang needs a live fresh-install run, which can't be done headlessly.

## Changes
- `pane-content.svelte`: retry the active tab's hydration when the daemon becomes healthy (guarded by store-presence; not-found→close-tab semantics unchanged).
- `daemon-status.ts`: **poll `check_daemon_status` until the daemon is first observed healthy, then stop** and let the push channel carry later transitions. Previously the "healthy" signal came only from the backend's one-shot readiness emit (bounded by a fixed timeout) — a slower fresh-install boot would emit a single non-healthy status and never emit healthy, so `onDaemonReconnect` (this retry, and the sidebar stores) would wait forever. This makes the signal reliable for **every** consumer.

## Tests
- `daemon-status.test.ts` (+2): a boot where the push never carries healthy but a later poll observes it still fires `onDaemonReconnect`; the poll stops once healthy (no further pulls).
- `pane-content-hydration.test.ts` (+1): a hydration that fails then succeeds on the reconnect retry.
- Full frontend suite green (4063).

## Addresses the review
- **F1** — reframed to hardening; #1672 kept open for live validation (this comment + title).
- **F2** — the persistent readiness poll removes the one-shot-emit dependency. (The mid-session-daemon-restart-emits-nothing case is a broader daemon-status gap filed separately — see the follow-up issue.)
- **F3** — added tests that pin the actual daemon-status poll wiring (the load-bearing new behavior), not just the hydrate mirror.
- **F4** — the readiness poll logs each retry distinctly; the hydrate retry rides the existing error log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
