### PR TITLE
Render the consent variant reliably; stop the pill claiming "Synced" while sync is off (#1674)

### DIFF
--- a/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
+++ b/packages/desktop-app/src/lib/components/first-pro-consent-slot.svelte
@@ -85,7 +85,10 @@
     } finally {
       pending = false;
       proSync.consentPromptOpen = false;
-      // Enabling flips the variant to `connected`, unmounting this slot.
+      // Enabling flips the variant to `connected`, unmounting this slot. Re-pull
+      // the settings node directly so that flip doesn't depend on the
+      // `node:updated` watch event, which can be lost for good (#1674).
+      databaseStore.refreshDatabaseSettings();
     }
   }
 

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -11,6 +11,11 @@
     green      — CONNECTED
     red        — ERROR
 
+  Exception (#1674): CONNECTED/SYNCING only prove the daemon's realtime session
+  is live — i.e. signed in. When the active database has not opted into sync
+  (`sync_enabled: false` on its DatabaseSettingsNode, via isProSyncActive), the
+  pill shows a neutral "Signed in — sync off" instead, never "Synced".
+
   Click: when the daemon is signed out (DISCONNECTED, AUTH_REQUIRED,
   UNSPECIFIED, ERROR), clicking triggers the PKCE flow via
   `pro_initiate_oauth`. The daemon opens the browser; this UI just
@@ -21,40 +26,36 @@
   import { invoke } from '@tauri-apps/api/core';
   import { proSync, type SyncState } from '$lib/stores/pro-sync.svelte';
   import { membership } from '$lib/stores/membership.svelte';
+  import { isProSyncActive } from '$lib/plugins/ui-extensions.svelte';
   import InvitationsInbox from '$lib/components/collaboration/invitations-inbox.svelte';
   import { createLogger } from '$lib/utils/logger';
 
   const log = createLogger('ProSyncPill');
 
   const labels: Record<SyncState, string> = {
-    'unspecified': 'Sign in',
-    'disconnected': 'Sign in',
-    'connecting': 'Connecting…',
-    'authenticating': 'Signing in…',
+    unspecified: 'Sign in',
+    disconnected: 'Sign in',
+    connecting: 'Connecting…',
+    authenticating: 'Signing in…',
     'auth-required': 'Sign in required',
-    'syncing': 'Syncing…',
-    'connected': 'Synced',
-    'error': 'Retry sign-in',
+    syncing: 'Syncing…',
+    connected: 'Synced',
+    error: 'Retry sign-in'
   };
 
   const tones: Record<SyncState, string> = {
-    'unspecified': 'grey',
-    'disconnected': 'grey',
-    'connecting': 'amber',
-    'authenticating': 'amber',
+    unspecified: 'grey',
+    disconnected: 'grey',
+    connecting: 'amber',
+    authenticating: 'amber',
     'auth-required': 'blue',
-    'syncing': 'amber',
-    'connected': 'green',
-    'error': 'red',
+    syncing: 'amber',
+    connected: 'green',
+    error: 'red'
   };
 
   // States where clicking should kick off a fresh sign-in attempt.
-  const SIGN_IN_STATES: SyncState[] = [
-    'unspecified',
-    'disconnected',
-    'auth-required',
-    'error',
-  ];
+  const SIGN_IN_STATES: SyncState[] = ['unspecified', 'disconnected', 'auth-required', 'error'];
 
   // While an InitiateOAuth call is in flight, disable the pill so a
   // double-click doesn't spawn two browser windows.
@@ -94,16 +95,31 @@
   // starting a new sign-in.
   let signedIn = $derived(proSync.userEmail !== '');
   let clickable = $derived(SIGN_IN_STATES.includes(proSync.state) || signedIn);
+
+  // Axis-2 cross-check (#1674): the realtime state reads 'connected' whenever
+  // the daemon's session is live — that only proves sign-in, not sync. Whether
+  // data actually leaves the device is the settings node's `sync_enabled`
+  // (surfaced via isProSyncActive, which fails safe to false while the node is
+  // unhydrated). Without this, the sign-in variant's pill claimed "Synced"
+  // while sync was off. Never claim synced/syncing unless the settings node
+  // confirms it.
+  const syncEnabled = $derived(isProSyncActive());
+  const syncOffOverride = $derived(
+    !syncEnabled && (proSync.state === 'connected' || proSync.state === 'syncing')
+  );
+  const label = $derived(syncOffOverride ? 'Signed in — sync off' : labels[proSync.state]);
+  const tone = $derived(syncOffOverride ? 'grey' : tones[proSync.state]);
+
   // While the daemon catches up in the background (state 'syncing'), the app is
   // fully usable on the local cache — so the tooltip surfaces that progress even
   // when signed in, rather than only "Signed in as <email>". Never a blocking gate;
   // the pill is purely a status indicator.
   let pillTitle = $derived(
     signedIn
-      ? proSync.state === 'syncing'
+      ? proSync.state === 'syncing' && syncEnabled
         ? `${labels.syncing} — signed in as ${proSync.userEmail}`
         : `Signed in as ${proSync.userEmail}`
-      : proSync.detail || labels[proSync.state]
+      : proSync.detail || label
   );
 
   // The inbox is open when explicitly opened, or auto-opened for a fresh, undismissed
@@ -146,10 +162,7 @@
     menuOpen = false;
     pending = true;
     try {
-      const attemptId = await invoke<string>(
-        'pro_initiate_oauth',
-        provider ? { provider } : {}
-      );
+      const attemptId = await invoke<string>('pro_initiate_oauth', provider ? { provider } : {});
       log.info('PKCE attempt started', { attemptId, provider: provider || 'email' });
     } catch (e) {
       log.warn('pro_initiate_oauth failed', { error: e, provider });
@@ -189,17 +202,17 @@
     <button
       class="pro-sync-pill"
       class:clickable
-      data-tone={tones[proSync.state]}
+      data-tone={tone}
       title={pillTitle}
       type="button"
-      aria-label="NodeSpace Pro sync status: {labels[proSync.state]}"
+      aria-label="NodeSpace Pro sync status: {label}"
       aria-haspopup={clickable ? 'menu' : undefined}
       aria-expanded={clickable ? menuOpen : undefined}
       disabled={pending || !clickable}
       onclick={onClick}
     >
       <span class="dot" aria-hidden="true"></span>
-      <span class="label">{labels[proSync.state]}</span>
+      <span class="label">{label}</span>
     </button>
 
     {#if menuOpen && clickable}
@@ -241,12 +254,7 @@
           >
             Continue with Google
           </button>
-          <button
-            class="menu-item"
-            type="button"
-            role="menuitem"
-            onclick={() => startSignIn('')}
-          >
+          <button class="menu-item" type="button" role="menuitem" onclick={() => startSignIn('')}>
             Sign in with email
           </button>
         {/if}

--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '$lib/utils/logger';
+import { backendAdapter } from '$lib/services/backend-adapter';
+import { onDaemonReconnect } from '$lib/services/daemon-status';
 import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
 import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 import { collectionsData } from '$lib/stores/collections.svelte';
@@ -115,7 +117,7 @@ class DatabaseStore {
       this.defaultDatabaseId = IMPLICIT_BROWSER_DATABASE.id;
       if (this.activeDatabaseId === null) {
         this.activeDatabaseId = IMPLICIT_BROWSER_DATABASE.id;
-        this.hydrateDatabaseSettings();
+        this.refreshDatabaseSettings();
       }
       this.loading = false;
       return;
@@ -132,7 +134,7 @@ class DatabaseStore {
         this.activeDatabaseId = this.defaultDatabaseId ?? this.databases[0]?.id ?? null;
         // Hydrate the active database's DatabaseSettingsNode so the Pro-sync
         // variant machine can read sync_enabled/auth_status.
-        this.hydrateDatabaseSettings();
+        this.refreshDatabaseSettings();
       }
     } catch (err) {
       this.error = String(err);
@@ -195,7 +197,7 @@ class DatabaseStore {
       schemasData.loadSchemas();
       // Re-hydrate the new database's DatabaseSettingsNode (the previous one was
       // evicted by clearAll) so the Pro-sync variant re-resolves for it.
-      this.hydrateDatabaseSettings();
+      this.refreshDatabaseSettings();
     } catch (err) {
       this.error = String(err);
       log.error('Failed to switch database', { id, error: err });
@@ -203,15 +205,38 @@ class DatabaseStore {
   }
 
   /**
-   * Load the active database's `DatabaseSettingsNode` into the shared store so the
-   * Pro-sync variant machine resolves from its `sync_enabled`/`auth_status`.
-   * Fire-and-forget: the switch/load must not block on it, and a missing node
-   * (older database not yet backfilled) simply leaves the variant at its default.
+   * Force-refetch the active database's `DatabaseSettingsNode` into the shared
+   * store (bypassing the cache-first `ensureNode` path) so the Pro-sync variant
+   * machine re-resolves from fresh `sync_enabled`/`auth_status` values.
+   *
+   * The node is otherwise read once per app life and then kept fresh only by
+   * `node:updated` watch events, which have unrecoverable loss modes (watcher
+   * reconnect backoff, broadcast lag drops, failed coalescer refetch) — miss one
+   * and the variant is stuck stale, e.g. at `sign-in` after the daemon already
+   * flipped `auth_status` to connected (#1674). Callers re-pull on the
+   * transitions that matter: sync-status edges, the consent decision, database
+   * switch, and initial load.
+   *
+   * Fire-and-forget: callers must not block on it, and a missing node (older
+   * database not yet backfilled) simply leaves the variant at its default.
    */
-  private hydrateDatabaseSettings(): void {
-    sharedNodeStore.ensureNode(DATABASE_SETTINGS_NODE_ID).catch((err) => {
-      log.debug('Could not hydrate DatabaseSettingsNode', { error: err });
-    });
+  refreshDatabaseSettings(): void {
+    const epoch = sharedNodeStore.currentEpoch();
+    backendAdapter
+      .getNode(DATABASE_SETTINGS_NODE_ID)
+      .then((node) => {
+        // The active database switched while the read was in flight — the row
+        // belongs to the previous database, so drop it (see `currentEpoch()`).
+        if (!node || sharedNodeStore.currentEpoch() !== epoch) return;
+        sharedNodeStore.setNode(
+          node,
+          { type: 'database', reason: 'refresh-database-settings' },
+          true
+        );
+      })
+      .catch((err: unknown) => {
+        log.debug('Could not refresh DatabaseSettingsNode', { error: err });
+      });
   }
 
   /**
@@ -277,6 +302,17 @@ class DatabaseStore {
 }
 
 export const databaseStore = new DatabaseStore();
+
+// Retry the initial registry load once the daemon becomes reachable, mirroring
+// the collections/schemas stores: a `load()` that ran while the daemon was
+// still starting fails and leaves `activeDatabaseId` null (and the settings
+// node unhydrated) until a manual reload. Guarded on the not-yet-loaded state
+// so a background reconnect never re-runs against an established selection.
+onDaemonReconnect(() => {
+  if (databaseStore.activeDatabaseId === null) {
+    void databaseStore.load();
+  }
+});
 
 /**
  * True when a `database_id` event envelope belongs to the active database.

--- a/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/pro-sync.svelte.ts
@@ -15,6 +15,7 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '$lib/utils/logger';
+import { databaseStore } from '$lib/stores/database.svelte';
 
 const log = createLogger('ProSync');
 
@@ -159,6 +160,16 @@ class ProSyncStore {
   private setState(next: SyncState) {
     if (next === 'auth-required' && this.state !== 'auth-required') {
       this.authRequiredEpisode++;
+    }
+    if (next !== this.state) {
+      // Axis 2 (the settings node's auth_status/sync_enabled) generally changes
+      // when axis 1 (this realtime state) transitions — e.g. a sign-in flips
+      // auth_status to 'connected'. Re-pull the settings node on every edge
+      // rather than relying solely on the `node:updated` watch event, which can
+      // be lost for good (watcher reconnect backoff, broadcast lag drops, failed
+      // coalescer refetch) and would leave the Pro-sync variant permanently
+      // stuck — e.g. at `sign-in` with the consent modal never appearing (#1674).
+      databaseStore.refreshDatabaseSettings();
     }
     this.state = next;
   }

--- a/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
+++ b/packages/desktop-app/src/tests/components/first-pro-consent-slot.test.ts
@@ -69,6 +69,19 @@ describe('FirstProConsentSlot', () => {
     await waitFor(() => expect(proSync.consentPromptOpen).toBe(false));
   });
 
+  it('merge re-pulls the settings node so the consent → connected flip does not depend on a watch event (#1674)', async () => {
+    const refreshSpy = vi
+      .spyOn(databaseStore, 'refreshDatabaseSettings')
+      .mockImplementation(() => {});
+    const { getByRole, findByRole } = render(FirstProConsentSlot);
+    await findByRole('dialog');
+
+    await fireEvent.click(getByRole('checkbox'));
+    await fireEvent.click(getByRole('button', { name: /merge into public workspace/i }));
+
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+  });
+
   it('keep-local closes with no daemon call, records the decline, and confirms', async () => {
     const { getByRole, findByRole, findByText } = render(FirstProConsentSlot);
     await findByRole('dialog');

--- a/packages/desktop-app/src/tests/components/pro-sync-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-sync-pill.test.ts
@@ -1,0 +1,123 @@
+/**
+ * pro-sync-pill component — fail-safe label mapping (#1674).
+ *
+ * The realtime axis reads 'connected' whenever the daemon's session is live,
+ * which only proves sign-in — not that data syncs. The pill must never claim
+ * "Synced"/"Syncing…" unless the active database's DatabaseSettingsNode
+ * confirms `sync_enabled: true` (via isProSyncActive, which fails safe to
+ * false while the node is unhydrated). Otherwise it shows a neutral
+ * "Signed in — sync off".
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import type { Node } from '$lib/types';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => mockInvoke(...args) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+import ProSyncPill from '$lib/components/pro-sync-pill.svelte';
+import { proSync, type SyncState } from '$lib/stores/pro-sync.svelte';
+import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
+
+/** Seed the active database's settings singleton with the given namespaced props. */
+function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
+  const node: Node = {
+    id: DATABASE_SETTINGS_NODE_ID,
+    nodeType: 'database-settings',
+    content: '',
+    properties: { 'database-settings': props },
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
+  SharedNodeStore.getInstance().setNode(node, { type: 'database', reason: 'seed' }, true);
+}
+
+function pillButton(container: HTMLElement): Element {
+  const button = container.querySelector('.pro-sync-pill');
+  expect(button).not.toBeNull();
+  return button!;
+}
+
+function renderPill(state: SyncState) {
+  proSync.state = state;
+  return render(ProSyncPill);
+}
+
+describe('ProSyncPill — fail-safe sync_enabled cross-check (#1674)', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    SharedNodeStore.resetInstance();
+    proSync.tier = 'pro';
+    proSync.userEmail = 'mayank@nodespace.dev';
+  });
+
+  afterEach(() => {
+    cleanup();
+    proSync.tier = 'unknown';
+    proSync.state = 'unspecified';
+    proSync.userEmail = '';
+    SharedNodeStore.resetInstance();
+    vi.restoreAllMocks();
+  });
+
+  it("state 'connected' + sync_enabled false → 'Signed in — sync off', never 'Synced'", () => {
+    seedSettings({ sync_enabled: false, auth_status: 'connected' });
+    const { container, queryByText, getByText } = renderPill('connected');
+
+    expect(getByText('Signed in — sync off')).toBeTruthy();
+    expect(queryByText('Synced')).toBeNull();
+    // Neutral tone, not the green "all synced" dot.
+    expect(pillButton(container).getAttribute('data-tone')).toBe('grey');
+  });
+
+  it("state 'connected' + sync_enabled true → 'Synced'", () => {
+    seedSettings({ sync_enabled: true, auth_status: 'connected' });
+    const { container, getByText, queryByText } = renderPill('connected');
+
+    expect(getByText('Synced')).toBeTruthy();
+    expect(queryByText('Signed in — sync off')).toBeNull();
+    expect(pillButton(container).getAttribute('data-tone')).toBe('green');
+  });
+
+  it("state 'syncing' + sync_enabled false → 'Signed in — sync off', never 'Syncing…'", () => {
+    seedSettings({ sync_enabled: false, auth_status: 'connected' });
+    const { container, queryByText, getByText } = renderPill('syncing');
+
+    expect(getByText('Signed in — sync off')).toBeTruthy();
+    expect(queryByText('Syncing…')).toBeNull();
+    expect(pillButton(container).getAttribute('data-tone')).toBe('grey');
+    // The tooltip must not claim syncing either.
+    expect(pillButton(container).getAttribute('title')).toBe('Signed in as mayank@nodespace.dev');
+  });
+
+  it("state 'syncing' + sync_enabled true → 'Syncing…'", () => {
+    seedSettings({ sync_enabled: true, auth_status: 'connected' });
+    const { container, getByText } = renderPill('syncing');
+
+    expect(getByText('Syncing…')).toBeTruthy();
+    expect(pillButton(container).getAttribute('data-tone')).toBe('amber');
+  });
+
+  it('fails safe when the settings node is not hydrated: connected reads as sync off', () => {
+    // No seedSettings call — the axis-2 node is absent (e.g. hydration lost).
+    const { queryByText, getByText } = renderPill('connected');
+
+    expect(getByText('Signed in — sync off')).toBeTruthy();
+    expect(queryByText('Synced')).toBeNull();
+  });
+
+  it('signed-out states keep their realtime labels (no override outside connected/syncing)', () => {
+    seedSettings({ sync_enabled: false, auth_status: 'local' });
+    proSync.userEmail = '';
+    const { getByText } = renderPill('auth-required');
+
+    expect(getByText('Sign in required')).toBeTruthy();
+  });
+});

--- a/packages/desktop-app/src/tests/stores/daemon-reconnect-retry.test.ts
+++ b/packages/desktop-app/src/tests/stores/daemon-reconnect-retry.test.ts
@@ -13,9 +13,11 @@ vi.mock('$lib/utils/logger', () => ({
 }));
 
 const mockGetAllSchemas = vi.fn();
+const mockGetNode = vi.fn(async (..._args: unknown[]) => null);
 vi.mock('$lib/services/backend-adapter', () => ({
   backendAdapter: {
-    getAllSchemas: (...args: unknown[]) => mockGetAllSchemas(...args)
+    getAllSchemas: (...args: unknown[]) => mockGetAllSchemas(...args),
+    getNode: (...args: unknown[]) => mockGetNode(...args)
   }
 }));
 
@@ -83,5 +85,38 @@ describe('daemon-reconnect retry wiring (#1470)', () => {
     await goHealthy();
 
     expect(mockGetAllCollections).toHaveBeenCalledTimes(1);
+  });
+
+  it('databaseStore retries load once the daemon reconnects when nothing is loaded yet (#1674)', async () => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    try {
+      await import('$lib/stores/database.svelte');
+      expect(mockInvoke).not.toHaveBeenCalledWith('list_databases');
+
+      await goHealthy();
+
+      // The registry load runs, which also hydrates the DatabaseSettingsNode —
+      // the Pro-sync variant machine's axis-2 feed.
+      expect(mockInvoke).toHaveBeenCalledWith('list_databases');
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    }
+  });
+
+  it('databaseStore does NOT reload on reconnect once a selection is established', async () => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    try {
+      const { databaseStore } = await import('$lib/stores/database.svelte');
+      // An earlier load already established the selection; a background
+      // reconnect must not yank it or refire the registry query.
+      databaseStore.activeDatabaseId = 'db-a';
+
+      await goHealthy();
+
+      expect(mockInvoke).not.toHaveBeenCalledWith('list_databases');
+      expect(databaseStore.activeDatabaseId).toBe('db-a');
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    }
   });
 });

--- a/packages/desktop-app/src/tests/stores/database.test.ts
+++ b/packages/desktop-app/src/tests/stores/database.test.ts
@@ -16,14 +16,27 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 // Collaborators exercised by switchTo — stubbed so we can assert the flush →
 // switch → clear → reset → reload orchestration without their real behavior.
+// `epochValue` backs currentEpoch() so tests can simulate a database switch
+// landing while a settings refetch is in flight.
 const flushAllPendingSaves = vi.fn((..._a: unknown[]) => Promise.resolve(new Set<string>()));
 const clearAll = vi.fn((..._a: unknown[]) => undefined);
-const ensureNode = vi.fn((..._a: unknown[]) => Promise.resolve(undefined));
+const setNode = vi.fn((..._a: unknown[]) => undefined);
+let epochValue = 0;
 vi.mock('$lib/services/shared-node-store.svelte', () => ({
   sharedNodeStore: {
     flushAllPendingSaves: (...a: unknown[]) => flushAllPendingSaves(...a),
     clearAll: (...a: unknown[]) => clearAll(...a),
-    ensureNode: (...a: unknown[]) => ensureNode(...a)
+    setNode: (...a: unknown[]) => setNode(...a),
+    currentEpoch: () => epochValue
+  }
+}));
+
+// The settings-node refetch goes through the backend adapter directly (it must
+// bypass the cache-first ensureNode path).
+const mockGetNode = vi.fn((..._a: unknown[]) => Promise.resolve<unknown>(null));
+vi.mock('$lib/services/backend-adapter', () => ({
+  backendAdapter: {
+    getNode: (...a: unknown[]) => mockGetNode(...a)
   }
 }));
 
@@ -60,6 +73,8 @@ import {
   isActiveDatabaseEvent,
   type DatabaseInfo
 } from '$lib/stores/database.svelte';
+import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
+import type { Node } from '$lib/types';
 
 function db(id: string, overrides: Partial<DatabaseInfo> = {}): DatabaseInfo {
   return {
@@ -74,9 +89,32 @@ function db(id: string, overrides: Partial<DatabaseInfo> = {}): DatabaseInfo {
   };
 }
 
+function settingsNode(): Node {
+  return {
+    id: DATABASE_SETTINGS_NODE_ID,
+    nodeType: 'database-settings',
+    content: '',
+    properties: { 'database-settings': { sync_enabled: false, auth_status: 'connected' } },
+    mentions: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    modifiedAt: '2026-01-01T00:00:00Z',
+    version: 1
+  };
+}
+
+/** Let the fire-and-forget settings refetch (`.then` chain) settle. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('Database Store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetNode.mockReset();
+    mockGetNode.mockResolvedValue(null);
+    epochValue = 0;
     // The store gates `load()` on the Tauri bridge; present it so these tests
     // exercise the invoke path. The browser-mode describe removes it.
     (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
@@ -209,6 +247,83 @@ describe('Database Store', () => {
       // Only the winner cleared caches and reloaded — no stale mid-switch state.
       expect(clearAll).toHaveBeenCalledOnce();
       expect(loadCollections).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('refreshDatabaseSettings (#1674)', () => {
+    it('force-refetches the settings node via the adapter and lands it in the shared store', async () => {
+      const node = settingsNode();
+      mockGetNode.mockResolvedValueOnce(node);
+
+      databaseStore.refreshDatabaseSettings();
+      await flushMicrotasks();
+
+      // Bypasses the cache-first ensureNode path: always a fresh backend read.
+      expect(mockGetNode).toHaveBeenCalledWith(DATABASE_SETTINGS_NODE_ID);
+      expect(setNode).toHaveBeenCalledWith(
+        node,
+        { type: 'database', reason: 'refresh-database-settings' },
+        true
+      );
+    });
+
+    it('load() hydrates the settings node through the same forced refetch', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        databases: [db('a', { isDefault: true })],
+        defaultDatabaseId: 'a'
+      });
+      mockGetNode.mockResolvedValueOnce(settingsNode());
+
+      await databaseStore.load();
+      await flushMicrotasks();
+
+      expect(mockGetNode).toHaveBeenCalledWith(DATABASE_SETTINGS_NODE_ID);
+      expect(setNode).toHaveBeenCalledOnce();
+    });
+
+    it('a missing settings node (older database) leaves the store untouched', async () => {
+      mockGetNode.mockResolvedValueOnce(null);
+
+      databaseStore.refreshDatabaseSettings();
+      await flushMicrotasks();
+
+      expect(setNode).not.toHaveBeenCalled();
+    });
+
+    it('drops the fetched node when the database epoch changed mid-flight', async () => {
+      // The fetch resolves only after a database switch bumped the epoch — the
+      // row belongs to the previous database and must not land.
+      mockGetNode.mockImplementationOnce(async () => {
+        epochValue = 1;
+        return settingsNode();
+      });
+
+      databaseStore.refreshDatabaseSettings();
+      await flushMicrotasks();
+
+      expect(setNode).not.toHaveBeenCalled();
+    });
+
+    it('is fire-and-forget: a failed refetch is swallowed at debug level', async () => {
+      mockGetNode.mockRejectedValueOnce(new Error('daemon unavailable'));
+
+      expect(() => databaseStore.refreshDatabaseSettings()).not.toThrow();
+      await flushMicrotasks();
+
+      expect(setNode).not.toHaveBeenCalled();
+    });
+
+    it('switchTo re-pulls the new database settings after the caches are cleared', async () => {
+      databaseStore.databases = [db('a'), db('b')];
+      databaseStore.activeDatabaseId = 'a';
+      mockInvoke.mockResolvedValueOnce(undefined); // set_active_database
+      mockGetNode.mockResolvedValueOnce(settingsNode());
+
+      await databaseStore.switchTo('b');
+      await flushMicrotasks();
+
+      expect(mockGetNode).toHaveBeenCalledWith(DATABASE_SETTINGS_NODE_ID);
+      expect(setNode).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/desktop-app/src/tests/stores/pro-sync-settings-refresh.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync-settings-refresh.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Sync-status → settings-node re-hydration (#1674).
+ *
+ * The Pro-sync variant machine resolves from the active database's
+ * DatabaseSettingsNode (axis 2), which used to be read once per app life and
+ * then kept fresh only by `node:updated` watch events — with unrecoverable loss
+ * modes (watcher reconnect backoff, broadcast lag drops, failed coalescer
+ * refetch). Miss one and the variant stayed at `sign-in` forever: no consent
+ * modal, wrong pill.
+ *
+ * These tests drive a real `sync:status` transition edge through the proSync
+ * store and assert the settings node is force-refetched (bypassing the
+ * cache-first path) so the variant flips `sign-in → consent` once the fresh
+ * settings land — no watch event involved.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Node } from '$lib/types';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args)
+}));
+
+// Capture the `sync:status` / `pro:tier-detected` handlers so tests can drive them.
+const listeners = new Map<string, (event: { payload: unknown }) => void>();
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (name: string, handler: (event: { payload: unknown }) => void) => {
+    listeners.set(name, handler);
+    return () => listeners.delete(name);
+  })
+}));
+
+// The forced refetch reads through the backend adapter (not invoke, not the
+// cache-first ensureNode path) — intercept it here.
+const mockGetNode = vi.fn((..._a: unknown[]) => Promise.resolve<Node | null>(null));
+vi.mock('$lib/services/backend-adapter', () => ({
+  backendAdapter: {
+    getNode: (...a: unknown[]) => mockGetNode(...a)
+  }
+}));
+
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import { resolveProSyncVariant } from '$lib/plugins/ui-extensions.svelte';
+import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
+
+function emit(name: string, payload: unknown) {
+  listeners.get(name)?.({ payload });
+}
+
+function settingsNode(props: { sync_enabled?: boolean; auth_status?: string }): Node {
+  return {
+    id: DATABASE_SETTINGS_NODE_ID,
+    nodeType: 'database-settings',
+    content: '',
+    properties: { 'database-settings': props },
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
+}
+
+/** Seed the shared store's settings singleton directly (the pre-refresh state). */
+function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
+  SharedNodeStore.getInstance().setNode(
+    settingsNode(props),
+    { type: 'database', reason: 'seed' },
+    true
+  );
+}
+
+describe('sync:status transition → DatabaseSettingsNode re-hydration (#1674)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    listeners.clear();
+    mockGetNode.mockReset();
+    mockGetNode.mockResolvedValue(null);
+    mockInvoke.mockImplementation(async (cmd: string) => (cmd === 'pro_tier' ? 'pro' : null));
+    // proSync is a module singleton: normalize to a known signed-out baseline so
+    // each test exercises a fresh transition edge.
+    proSync.stop();
+    proSync.state = 'unspecified';
+    proSync.userEmail = '';
+    proSync.tier = 'pro';
+    await proSync.start();
+  });
+
+  afterEach(() => {
+    proSync.stop();
+    proSync.tier = 'unknown';
+    proSync.state = 'unspecified';
+    proSync.userEmail = '';
+    SharedNodeStore.getInstance().clearAll();
+    vi.restoreAllMocks();
+  });
+
+  it('a state edge force-refetches the settings node and flips sign-in → consent', async () => {
+    // Stale axis-2 state: signed out, sync off → the sign-in variant.
+    seedSettings({ sync_enabled: false, auth_status: 'local' });
+    expect(resolveProSyncVariant()).toBe('sign-in');
+
+    // The daemon has since flipped auth_status (the watch event for it was
+    // lost); the forced refetch is the only feed left.
+    mockGetNode.mockResolvedValue(settingsNode({ sync_enabled: false, auth_status: 'connected' }));
+
+    // Realtime edge: unspecified → connected (sign-in completed).
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+
+    expect(mockGetNode).toHaveBeenCalledWith(DATABASE_SETTINGS_NODE_ID);
+    // Once the fresh settings land, the consent modal's variant resolves — the
+    // flow un-sticks without any node:updated event.
+    await vi.waitFor(() => expect(resolveProSyncVariant()).toBe('consent'));
+  });
+
+  it('does not refetch on a redundant (non-edge) status event', async () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    expect(proSync.state).toBe('connected');
+    mockGetNode.mockClear();
+
+    // Same state delivered again (duplicate/heartbeat) — no new transition.
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+
+    expect(mockGetNode).not.toHaveBeenCalled();
+  });
+
+  it('refetches on every distinct transition (connected → syncing → connected)', async () => {
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+    mockGetNode.mockClear();
+
+    emit('sync:status', { state: 5, detail: '', user_email: 'mayank@nodespace.dev' });
+    emit('sync:status', { state: 6, detail: '', user_email: 'mayank@nodespace.dev' });
+
+    expect(mockGetNode).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1674 — the first-Pro consent flow (#1665 "Part B") never rendered. On a genuinely fresh DB after sign-in the daemon reported exactly the consent-variant state (`auth_status=connected`, `sync_enabled=false`) but no consent modal appeared and the pill showed "Synced".

## Root cause
The variant machine's second axis — the per-database `database-settings-singleton` node — was read **once** at boot (fire-and-forget) and then relied on a single `node:updated` watch event to learn that sign-in flipped `auth_status`. That event has unrecoverable loss modes (watcher reconnect backoff, broadcast lag drops, a failed coalescer refetch), so the variant stayed stuck at `sign-in` (no modal), while the pill labelled purely off the realtime axis and showed "Synced" — realtime connects on sign-in by design even though push stays gated (#321).

## Changes
- **`database.svelte.ts`** — `refreshDatabaseSettings()` force-refetches the settings node (epoch-guarded against a database switch); a reconnect hook retries `load()` when nothing is loaded yet.
- **`pro-sync.svelte.ts`** — `setState` re-hydrates the settings node on every sync-state **transition edge**, so axis 2 follows axis 1 without depending on the lossy watch event.
- **`first-pro-consent-slot.svelte`** — refresh after EnableSync so consent→connected doesn't depend on the watch event either.
- **`pro-sync-pill.svelte`** — fail-safe mapping: never render "Synced" unless the settings node confirms `sync_enabled`; otherwise "Signed in — sync off" (label, tone, aria-label, tooltip). `isProSyncActive()` fails safe to false when the settings node is unhydrated.

## Tests
+18: a `sync:status` edge refetches the settings node and flips `resolveProSyncVariant()` sign-in→consent (real proSync + real store + real ui-extensions); pill label/tone pairs for connected/syncing × sync_enabled true/false + unhydrated fail-safe; refresh bypasses cache + epoch-drop; reconnect reload; merge triggers refresh. Full suite **4078** green; svelte-check 0/0; eslint/prettier clean; `free-user-guardrail` 11/11.

⚠️ Pairs with the daemon consent-gate (nodespace-sync#321, merged): UI + enforcement together. The "Signed in — sync off" copy is new; live validation on a real Pro sidecar (the #1665 repro) is still worthwhile in round-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
