### PR TITLE
Coalesce relationship sync events + O(1) parent index to unblock the UI during a large pull (#1673)

### DIFF
--- a/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
+++ b/packages/desktop-app/src/lib/services/tauri-sync-listener.ts
@@ -55,6 +55,11 @@ const log = createLogger('TauriSync');
  *  collect a daemon-flushed batch without adding perceptible latency. */
 const REPLAY_COALESCE_WINDOW_MS = 16;
 
+/** Max node fetches dispatched and applied per chunk of a coalesced flush.
+ *  Chunks are separated by a macrotask yield so an initial-pull burst of tens
+ *  of thousands of nodes cannot monopolize the webview main thread. */
+const NODE_FETCH_CHUNK_SIZE = 200;
+
 const pendingNodeIds = new Set<string>();
 let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
 // Ids deleted while a flush is mid-fetch (between the snapshot and the apply
@@ -90,11 +95,20 @@ function enqueueNodeFetch(nodeId: string): void {
   coalesceTimer = setTimeout(flushPendingNodeFetches, REPLAY_COALESCE_WINDOW_MS);
 }
 
-/** Fetch all queued nodes, then apply them in one synchronous pass so the burst
- *  renders once. A failed fetch for a single node is skipped, never fatal; a node
- *  tombstoned (deleted) during the fetch is skipped so the delete wins. */
+/** Fetch all queued nodes in chunks, applying each chunk in one synchronous
+ *  pass so it renders once, with a macrotask yield between chunks so a huge
+ *  burst never monopolizes the main thread. A failed fetch for a single node
+ *  is skipped, never fatal; a node tombstoned (deleted) during the flush is
+ *  skipped so the delete wins. */
 async function flushPendingNodeFetches(): Promise<void> {
   coalesceTimer = null;
+  // A previous flush is still working through its chunks — re-arm the window
+  // so this batch flushes after it completes. Two interleaved flushes would
+  // share (and prematurely clear) the tombstone/in-progress state.
+  if (flushInProgress) {
+    coalesceTimer = setTimeout(flushPendingNodeFetches, REPLAY_COALESCE_WINDOW_MS);
+    return;
+  }
   const ids = [...pendingNodeIds];
   pendingNodeIds.clear();
   if (ids.length === 0) return;
@@ -103,39 +117,52 @@ async function flushPendingNodeFetches(): Promise<void> {
   tombstonedDuringFlush.clear();
   try {
     // ADR-053: capture the database generation before the reads so a switch
-    // mid-flush drops the whole burst rather than writing the previous
+    // mid-flush drops the rest of the burst rather than writing the previous
     // database's rows into the now-active store. isActiveDatabaseEvent gates on
     // event arrival, before these async fetches dispatch, so it cannot close
     // this in-flight window on its own.
     const epoch = sharedNodeStore.currentEpoch();
-    const fetched = await Promise.all(
-      ids.map((id) =>
-        backendAdapter.getNode(id).catch((error) => {
-          log.error('replay-coalesce: failed to fetch node', { nodeId: id, error });
-          return null;
-        })
-      )
-    );
-
-    // The active database switched while these reads were in flight — the rows
-    // belong to the previous database, so apply none of them.
-    if (sharedNodeStore.currentEpoch() !== epoch) return;
-
-    // Synchronous apply loop — no `await` between setNode calls, so Svelte
-    // coalesces the resulting reactive updates into a single render. A node
-    // deleted while we were fetching is skipped so the delete is not clobbered.
     let applied = 0;
-    for (let i = 0; i < fetched.length; i++) {
-      const node = fetched[i];
-      if (!node || tombstonedDuringFlush.has(ids[i])) continue;
-      sharedNodeStore.setNode(
-        normalizeNodeData(node),
-        { type: 'database', reason: 'domain-event' },
-        true
+    for (let start = 0; start < ids.length; start += NODE_FETCH_CHUNK_SIZE) {
+      if (start > 0) {
+        // Yield a macrotask between chunks so rendering and input handling
+        // stay responsive while a large burst is applied.
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      // Re-check the generation guard per chunk: a database switch during an
+      // earlier chunk or the yield must drop the remainder of the burst, not
+      // just the chunk whose fetch it happened to race.
+      if (sharedNodeStore.currentEpoch() !== epoch) return;
+
+      const chunk = ids.slice(start, start + NODE_FETCH_CHUNK_SIZE);
+      const fetched = await Promise.all(
+        chunk.map((id) =>
+          backendAdapter.getNode(id).catch((error) => {
+            log.error('replay-coalesce: failed to fetch node', { nodeId: id, error });
+            return null;
+          })
+        )
       );
-      applied++;
+
+      // The active database switched while these reads were in flight — the
+      // rows belong to the previous database, so apply none of them.
+      if (sharedNodeStore.currentEpoch() !== epoch) return;
+
+      // Synchronous apply loop — no `await` between setNode calls, so Svelte
+      // coalesces the chunk's reactive updates into a single render. A node
+      // deleted while we were fetching is skipped so the delete is not clobbered.
+      for (let i = 0; i < fetched.length; i++) {
+        const node = fetched[i];
+        if (!node || tombstonedDuringFlush.has(chunk[i])) continue;
+        sharedNodeStore.setNode(
+          normalizeNodeData(node),
+          { type: 'database', reason: 'domain-event' },
+          true
+        );
+        applied++;
+      }
     }
-    log.info('replay-coalesce: applied node burst in one pass', {
+    log.info('replay-coalesce: applied node burst', {
       requested: ids.length,
       applied
     });
@@ -152,6 +179,122 @@ function queueOrFetchNode(nodeId: string, eventType: string): void {
     enqueueNodeFetch(nodeId);
   } else {
     fetchAndUpdateNode(nodeId, eventType);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pro-only has_child relationship-event coalescing
+//
+// The initial cloud-sync pull of a populated tenant floods the event stream
+// with tens of thousands of relationship events. Applied one-by-one, each
+// `relationship:*` synchronously mutates the structure tree and triggers a
+// full reactive invalidation on the webview main thread, freezing the UI
+// (and backing up the daemon's WatchNodes stream until it drops events).
+//
+// When sync is active we instead buffer has_child ops over the same small
+// window the node coalescer uses, then apply the whole burst inside a single
+// structureTree.runBatch — one reactive notification per burst. Ops are
+// applied strictly in arrival order through the same per-event appliers, so
+// a create followed by a delete of one edge (or the reverse) resolves exactly
+// as it would un-coalesced — the delete-wins/tombstone semantics fall out of
+// order preservation rather than a separate reconciliation pass.
+//
+// Gated on `proSync.isPro` like the node coalescer: the community build never
+// enters this path and its per-event behavior is unchanged.
+// ---------------------------------------------------------------------------
+
+interface HasChildOp {
+  kind: 'created' | 'updated' | 'deleted';
+  parentId: string;
+  childId: string;
+  order: unknown;
+  /** Database generation at arrival — ops from before a switch are dropped. */
+  epoch: number;
+}
+
+let pendingHasChildOps: HasChildOp[] = [];
+let relationshipCoalesceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Reset all relationship-coalescer state. Called on (re)init so a stale
+ *  in-flight timer from a prior listener registration can't fire into fresh
+ *  state. */
+function resetRelationshipCoalescer(): void {
+  if (relationshipCoalesceTimer !== null) {
+    clearTimeout(relationshipCoalesceTimer);
+    relationshipCoalesceTimer = null;
+  }
+  pendingHasChildOps = [];
+}
+
+/** Queue a has_child op for the next coalesced flush (Pro path). Arrival
+ *  order is preserved so interleaved creates/deletes of the same edge resolve
+ *  the same way they would applied one-by-one. */
+function enqueueHasChildOp(op: Omit<HasChildOp, 'epoch'>): void {
+  pendingHasChildOps.push({ ...op, epoch: sharedNodeStore.currentEpoch() });
+  if (relationshipCoalesceTimer !== null) return;
+  relationshipCoalesceTimer = setTimeout(flushPendingHasChildOps, REPLAY_COALESCE_WINDOW_MS);
+}
+
+/** Apply all queued has_child ops in arrival order inside one structureTree
+ *  batch, so the burst costs a single reactive invalidation. Ops that arrived
+ *  before a database switch are dropped (the tree was rebuilt for the new
+ *  database; those edges belong to the old one). */
+function flushPendingHasChildOps(): void {
+  relationshipCoalesceTimer = null;
+  const ops = pendingHasChildOps;
+  pendingHasChildOps = [];
+  if (ops.length === 0) return;
+
+  const epoch = sharedNodeStore.currentEpoch();
+  let applied = 0;
+  structureTree.runBatch(() => {
+    for (const op of ops) {
+      if (op.epoch !== epoch) continue;
+      if (op.kind === 'created') {
+        applyHasChildCreated(structureTree, {
+          parentId: op.parentId,
+          childId: op.childId,
+          order: op.order
+        });
+      } else if (op.kind === 'updated') {
+        applyHasChildUpdated(structureTree, {
+          parentId: op.parentId,
+          childId: op.childId,
+          order: op.order
+        });
+      } else {
+        applyHasChildDeleted(structureTree, { parentId: op.parentId, childId: op.childId });
+      }
+      applied++;
+    }
+  });
+  log.info('relationship-coalesce: applied has_child burst in one batch', {
+    queued: ops.length,
+    applied
+  });
+}
+
+/** Route a has_child op through the Pro coalescer, or apply immediately in
+ *  the community build (unchanged behavior). */
+function queueOrApplyHasChildOp(op: Omit<HasChildOp, 'epoch'>): void {
+  if (proSync.isPro) {
+    enqueueHasChildOp(op);
+    return;
+  }
+  if (op.kind === 'created') {
+    applyHasChildCreated(structureTree, {
+      parentId: op.parentId,
+      childId: op.childId,
+      order: op.order
+    });
+  } else if (op.kind === 'updated') {
+    applyHasChildUpdated(structureTree, {
+      parentId: op.parentId,
+      childId: op.childId,
+      order: op.order
+    });
+  } else {
+    applyHasChildDeleted(structureTree, { parentId: op.parentId, childId: op.childId });
   }
 }
 
@@ -211,8 +354,9 @@ export async function initializeTauriSyncListeners(): Promise<void> {
 
   log.info('Initializing Tauri real-time sync listeners');
 
-  // Clear any coalescer state (and a stale in-flight timer) from a prior init.
+  // Clear any coalescer state (and stale in-flight timers) from a prior init.
   resetNodeFetchCoalescer();
+  resetRelationshipCoalescer();
 
   try {
     // Listen for node events and update SharedNodeStore
@@ -256,7 +400,11 @@ export async function initializeTauriSyncListeners(): Promise<void> {
       // Evict any coalesced re-fetch first so a delete racing an upsert in the
       // same window can't be clobbered by the queued fetch re-adding the node.
       cancelPendingNodeFetch(event.payload.id);
-      sharedNodeStore.deleteNode(event.payload.id, { type: 'database', reason: 'domain-event' }, true);
+      sharedNodeStore.deleteNode(
+        event.payload.id,
+        { type: 'database', reason: 'domain-event' },
+        true
+      );
 
       // We don't know if deleted node was a collection without fetching,
       // but if we have it cached in collectionsData, we should refresh
@@ -277,11 +425,12 @@ export async function initializeTauriSyncListeners(): Promise<void> {
 
       // Handle different relationship types
       if (rel.relationshipType === 'has_child') {
-        const parentBare = stripNodePrefix(rel.fromId);
-        const childBare = stripNodePrefix(rel.toId);
-        applyHasChildCreated(structureTree, {
-          parentId: parentBare,
-          childId: childBare,
+        // Pro: coalesce a sync burst into one tree batch; community: apply
+        // immediately (unchanged).
+        queueOrApplyHasChildOp({
+          kind: 'created',
+          parentId: stripNodePrefix(rel.fromId),
+          childId: stripNodePrefix(rel.toId),
           order: (rel.properties as { order?: unknown } | undefined)?.order
         });
       } else if (rel.relationshipType === 'member_of') {
@@ -317,10 +466,11 @@ export async function initializeTauriSyncListeners(): Promise<void> {
       const rel = event.payload;
       log.debug(`Relationship updated: ${rel.relationshipType} (${rel.fromId} -> ${rel.toId})`);
       if (rel.relationshipType === 'has_child') {
-        applyHasChildUpdated(structureTree, {
+        queueOrApplyHasChildOp({
+          kind: 'updated',
           parentId: stripNodePrefix(rel.fromId),
           childId: stripNodePrefix(rel.toId),
-          order: (rel.properties?.order as unknown)
+          order: rel.properties?.order
         });
       }
     });
@@ -331,9 +481,11 @@ export async function initializeTauriSyncListeners(): Promise<void> {
       log.debug(`Relationship deleted: ${relationshipType} (${id}) from ${fromId} to ${toId}`);
 
       if (relationshipType === 'has_child') {
-        applyHasChildDeleted(structureTree, {
+        queueOrApplyHasChildOp({
+          kind: 'deleted',
           parentId: stripNodePrefix(fromId),
-          childId: stripNodePrefix(toId)
+          childId: stripNodePrefix(toId),
+          order: undefined
         });
       } else if (relationshipType === 'member_of') {
         // Collection membership removed - refresh collections sidebar.
@@ -379,7 +531,6 @@ export async function initializeTauriSyncListeners(): Promise<void> {
  */
 function isRunningInTauri(): boolean {
   return (
-    typeof window !== 'undefined' &&
-    ('__TAURI__' in window || '__TAURI_INTERNALS__' in window)
+    typeof window !== 'undefined' && ('__TAURI__' in window || '__TAURI_INTERNALS__' in window)
   );
 }

--- a/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/reactive-structure-tree.svelte.ts
@@ -8,6 +8,8 @@
  * Features:
  * - Svelte 5 $state for automatic UI reactivity
  * - Binary search insertion to maintain sorted children
+ * - Reverse child→parent index for O(1) getParent
+ * - runBatch() to apply a burst of mutations with one reactive notification
  * - Snapshot/restore for optimistic rollback
  */
 
@@ -25,11 +27,63 @@ export class ReactiveStructureTree {
   children = $state.raw(new Map<string, ChildInfo[]>());
 
   /**
+   * Reverse child→parent index so getParent is O(1) instead of a scan over
+   * every edge in the tree. Non-reactive bookkeeping: every mutator
+   * (addChildInternal, removeChild, clear, restore) keeps it consistent, and
+   * getParent verifies each hit against `children` (self-healing on a stale
+   * entry), so an inconsistent entry can never leak out of the API.
+   */
+  private parentIndex = new Map<string, string>();
+
+  /** Depth of nested runBatch() calls; while >0, notifyChange() is deferred. */
+  private batchDepth = 0;
+  /** Whether any mutation was notified inside the current batch. */
+  private batchDirty = false;
+
+  /**
    * Reassign the children map to trigger Svelte reactivity.
    * $state.raw() only tracks reassignment, not in-place Map mutations.
+   * Inside runBatch() the reassignment is deferred to the end of the
+   * outermost batch so a burst of mutations invalidates consumers once.
    */
   private notifyChange() {
+    if (this.batchDepth > 0) {
+      this.batchDirty = true;
+      return;
+    }
     this.children = new Map(this.children);
+  }
+
+  /**
+   * Run a sequence of tree mutations as one batch: mutations apply in call
+   * order, but the reactive notification (the map reassignment every
+   * getChildren consumer depends on) fires at most once, when the outermost
+   * batch completes.
+   *
+   * Used by the sync-event coalescer to apply a burst of relationship events
+   * without paying one full-tree invalidation per event.
+   */
+  runBatch(mutate: () => void): void {
+    this.batchDepth++;
+    try {
+      mutate();
+    } finally {
+      this.batchDepth--;
+      if (this.batchDepth === 0 && this.batchDirty) {
+        this.batchDirty = false;
+        this.children = new Map(this.children);
+      }
+    }
+  }
+
+  /** Rebuild the reverse child→parent index from the current children map. */
+  private rebuildParentIndex(): void {
+    this.parentIndex.clear();
+    for (const [parentId, childrenList] of this.children) {
+      for (const child of childrenList) {
+        this.parentIndex.set(child.nodeId, parentId);
+      }
+    }
   }
 
   /**
@@ -58,15 +112,25 @@ export class ReactiveStructureTree {
   }
 
   /**
-   * Get parent of a node by searching all edges
-   * Note: This is O(n) - consider adding reverse map if performance issue
+   * Get parent of a node (reactive).
+   *
+   * O(1) via the reverse child→parent index — a full-edge scan here made a
+   * cloud-sync relationship burst O(N²) on the main thread. Each hit is
+   * verified against the children map (and a stale entry dropped) so the
+   * index can never disagree with the tree an observer sees.
    */
   getParent(nodeId: string): string | null {
-    for (const [parentId, childrenList] of this.children) {
-      if (childrenList.some((c) => c.nodeId === nodeId)) {
-        return parentId;
-      }
+    // Read the reactive map first so consumers re-run on any tree change,
+    // including when the lookup below misses ($state.raw tracks reassignment).
+    const children = this.children;
+    const parentId = this.parentIndex.get(nodeId);
+    if (parentId === undefined) return null;
+    const siblings = children.get(parentId);
+    if (siblings && siblings.some((c) => c.nodeId === nodeId)) {
+      return parentId;
     }
+    // Stale entry (e.g. the map was replaced externally) — self-heal.
+    this.parentIndex.delete(nodeId);
     return null;
   }
 
@@ -101,7 +165,8 @@ export class ReactiveStructureTree {
     if (existingIndex >= 0) {
       // Duplicate detected - this is expected when relationships are loaded from multiple sources
       // (e.g., bulk edge load + children-tree endpoint). Silently handle it.
-      // Update order if different
+      // Refresh the reverse index (self-healing, cheap) and update order if different.
+      this.parentIndex.set(childId, parentId);
       if (children[existingIndex].order !== order) {
         children[existingIndex].order = order;
         // Re-sort array
@@ -144,6 +209,7 @@ export class ReactiveStructureTree {
 
     children.splice(insertIndex, 0, newChild);
     this.children.set(parentId, children);
+    this.parentIndex.set(childId, parentId);
   }
 
   /**
@@ -158,6 +224,13 @@ export class ReactiveStructureTree {
 
     const children = this.children.get(parentId) || [];
     const filtered = children.filter((c) => c.nodeId !== childId);
+
+    // Drop the reverse-index entry only when this edge actually existed AND
+    // the index still points at this parent — a stale delete for an edge the
+    // child was already reparented away from must not clobber the live entry.
+    if (filtered.length !== children.length && this.parentIndex.get(childId) === parentId) {
+      this.parentIndex.delete(childId);
+    }
 
     if (filtered.length === 0) {
       this.children.delete(parentId);
@@ -206,6 +279,7 @@ export class ReactiveStructureTree {
    */
   restore(snapshot: Map<string, ChildInfo[]>) {
     this.children = snapshot;
+    this.rebuildParentIndex();
   }
 
   /**
@@ -213,6 +287,7 @@ export class ReactiveStructureTree {
    */
   clear() {
     this.children = new Map();
+    this.parentIndex.clear();
   }
 
   /**
@@ -240,7 +315,9 @@ export class ReactiveStructureTree {
   /**
    * Batch add multiple relationships with a single reactivity notification.
    */
-  batchAddRelationships(relationships: Array<{parentId: string, childId: string, order: number}>) {
+  batchAddRelationships(
+    relationships: Array<{ parentId: string; childId: string; order: number }>
+  ) {
     for (const rel of relationships) {
       this.addChildInternal(rel);
     }
@@ -328,11 +405,15 @@ export class ReactiveStructureTree {
         }
         const existingParent = seen.get(nodeId);
         if (existingParent && existingParent !== parentId) {
-          violations.push(`I2: dual-parent "${nodeId}" under "${existingParent}" and "${parentId}"`);
+          violations.push(
+            `I2: dual-parent "${nodeId}" under "${existingParent}" and "${parentId}"`
+          );
         }
         seen.set(nodeId, parentId);
         if (order < prevOrder) {
-          violations.push(`I3: unsorted order for "${nodeId}" under "${parentId}" (${order} < ${prevOrder})`);
+          violations.push(
+            `I3: unsorted order for "${nodeId}" under "${parentId}" (${order} < ${prevOrder})`
+          );
         }
         prevOrder = order;
       }

--- a/packages/desktop-app/src/tests/services/hierarchy-sync.test.ts
+++ b/packages/desktop-app/src/tests/services/hierarchy-sync.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { applyHasChildCreated, applyHasChildUpdated, applyHasChildDeleted } from '$lib/services/hierarchy-sync';
+import {
+  applyHasChildCreated,
+  applyHasChildUpdated,
+  applyHasChildDeleted
+} from '$lib/services/hierarchy-sync';
 import { structureTree } from '$lib/stores/reactive-structure-tree.svelte';
 
 describe('hierarchy-sync', () => {
   beforeEach(() => {
-    structureTree.children.clear();
+    structureTree.clear();
   });
 
   describe('applyHasChildCreated', () => {
@@ -43,7 +47,7 @@ describe('hierarchy-sync', () => {
       applyHasChildCreated(structureTree, { parentId: 'p', childId: 'c2', order: undefined });
       const order1 = structureTree.getChildrenWithOrder('p').find((c) => c.nodeId === 'c2')!.order;
 
-      structureTree.children.clear();
+      structureTree.clear();
       applyHasChildCreated(structureTree, { parentId: 'p', childId: 'c1', order: 5 });
       applyHasChildCreated(structureTree, { parentId: 'p', childId: 'c2', order: undefined });
       const order2 = structureTree.getChildrenWithOrder('p').find((c) => c.nodeId === 'c2')!.order;
@@ -58,7 +62,7 @@ describe('hierarchy-sync', () => {
       applyHasChildCreated(tree1, { parentId: 'parent', childId: 'child', order: 2.5 });
       const tauri = structureTree.getChildrenWithOrder('parent');
 
-      structureTree.children.clear();
+      structureTree.clear();
       applyHasChildCreated(structureTree, { parentId: 'parent', childId: 'child', order: 2.5 });
       const browser = structureTree.getChildrenWithOrder('parent');
 

--- a/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
+++ b/packages/desktop-app/src/tests/services/tauri-sync-listener.test.ts
@@ -36,16 +36,16 @@ import { proSync } from '$lib/stores/pro-sync.svelte';
  * Helper to create test nodes with proper schema
  */
 function createTestNode(id: string, content = 'Test node'): Node {
-	return {
-		id,
-		nodeType: 'text',
-		content,
-		properties: {},
-		mentions: [],
-		createdAt: new Date().toISOString(),
-		modifiedAt: new Date().toISOString(),
-		version: 1
-	};
+  return {
+    id,
+    nodeType: 'text',
+    content,
+    properties: {},
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
 }
 
 /**
@@ -57,7 +57,7 @@ const mockNodes = new Map<string, Node>();
  * Mock Tauri event type
  */
 interface MockTauriEvent<T = unknown> {
-	payload: T;
+  payload: T;
 }
 
 /**
@@ -70,704 +70,903 @@ const mockEventListeners = new Map<string, (event: MockTauriEvent) => void>();
  * Setup mock for backendAdapter.getNode
  */
 function setupMockGetNode() {
-	vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockImplementation(
-		async (id: string) => {
-			return mockNodes.get(id) || null;
-		}
-	);
+  vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockImplementation(
+    async (id: string) => {
+      return mockNodes.get(id) || null;
+    }
+  );
 }
 
 /**
  * Register a node to be returned by mocked getNode
  */
 function registerMockNode(node: Node) {
-	mockNodes.set(node.id, node);
+  mockNodes.set(node.id, node);
 }
 
 /**
  * Mock Tauri's listen function to capture event listeners
  */
 function setupMockTauriListen() {
-	// Mock @tauri-apps/api/event module
-	vi.mock('@tauri-apps/api/event', () => ({
-		listen: vi.fn(async (eventName: string, handler: (event: MockTauriEvent) => void) => {
-			mockEventListeners.set(eventName, handler);
-			// Return unsubscribe function (not used in tests)
-			return () => {
-				mockEventListeners.delete(eventName);
-			};
-		})
-	}));
+  // Mock @tauri-apps/api/event module
+  vi.mock('@tauri-apps/api/event', () => ({
+    listen: vi.fn(async (eventName: string, handler: (event: MockTauriEvent) => void) => {
+      mockEventListeners.set(eventName, handler);
+      // Return unsubscribe function (not used in tests)
+      return () => {
+        mockEventListeners.delete(eventName);
+      };
+    })
+  }));
 }
 
 /**
  * Simulate emitting a Tauri event
  */
 function emitTauriEvent(eventName: string, payload: unknown) {
-	const handler = mockEventListeners.get(eventName);
-	if (handler) {
-		handler({ payload });
-	} else {
-		throw new Error(`No listener registered for event: ${eventName}`);
-	}
+  const handler = mockEventListeners.get(eventName);
+  if (handler) {
+    handler({ payload });
+  } else {
+    throw new Error(`No listener registered for event: ${eventName}`);
+  }
 }
 
 /**
  * Mock Tauri environment detection
  */
 function mockTauriEnvironment(isTauri: boolean) {
-	interface WindowWithTauri extends Window {
-		__TAURI__?: Record<string, unknown>;
-	}
+  interface WindowWithTauri extends Window {
+    __TAURI__?: Record<string, unknown>;
+  }
 
-	if (isTauri) {
-		(global.window as WindowWithTauri).__TAURI__ = {};
-	} else {
-		delete (global.window as WindowWithTauri).__TAURI__;
-	}
+  if (isTauri) {
+    (global.window as WindowWithTauri).__TAURI__ = {};
+  } else {
+    delete (global.window as WindowWithTauri).__TAURI__;
+  }
 }
 
 describe('TauriSyncListener', () => {
-	beforeEach(() => {
-		// Reset stores
-		SharedNodeStore.resetInstance();
-		structureTree.children.clear();
-		mockNodes.clear();
-		mockEventListeners.clear();
-
-		// Setup mocks
-		setupMockGetNode();
-		setupMockTauriListen();
-		mockTauriEnvironment(true);
-	});
-
-	afterEach(() => {
-		// Cleanup
-		sharedNodeStore.clearAll();
-		structureTree.children.clear();
-		SharedNodeStore.resetInstance();
-		mockNodes.clear();
-		mockEventListeners.clear();
-		vi.restoreAllMocks();
-	});
-
-	describe('Environment Detection', () => {
-		it('should skip initialization when not in Tauri environment', async () => {
-			mockTauriEnvironment(false);
-
-			await initializeTauriSyncListeners();
-
-			// No listeners should be registered
-			expect(mockEventListeners.size).toBe(0);
-		});
-
-		it('should initialize listeners in Tauri environment', async () => {
-			mockTauriEnvironment(true);
-
-			await initializeTauriSyncListeners();
-
-			// Verify all expected listeners are registered
-			expect(mockEventListeners.has('node:created')).toBe(true);
-			expect(mockEventListeners.has('node:updated')).toBe(true);
-			expect(mockEventListeners.has('node:deleted')).toBe(true);
-			// Unified relationship events replace old edge:* events
-			expect(mockEventListeners.has('relationship:created')).toBe(true);
-			expect(mockEventListeners.has('relationship:updated')).toBe(true);
-			expect(mockEventListeners.has('relationship:deleted')).toBe(true);
-			expect(mockEventListeners.has('sync:error')).toBe(true);
-			expect(mockEventListeners.has('sync:status')).toBe(true);
-		});
-	});
-
-	describe('Node Events - Issue #724 ID-Only Optimization', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should fetch and store node on node:created event', async () => {
-			const testNode = createTestNode('node1', 'New node');
-			registerMockNode(testNode);
-
-			emitTauriEvent('node:created', { id: 'node1' });
-
-			// Wait for async fetch to complete
-			await vi.waitFor(() => {
-				expect(sharedNodeStore.hasNode('node1')).toBe(true);
-			});
-
-			const storedNode = sharedNodeStore.getNode('node1');
-			expect(storedNode).toBeDefined();
-			expect(storedNode?.content).toBe('New node');
-		});
-
-		it('should always fetch node data on node:created (unconditional)', async () => {
-			const testNode = createTestNode('node1');
-			registerMockNode(testNode);
-
-			// Node is NOT in store yet
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-
-			emitTauriEvent('node:created', { id: 'node1' });
-
-			// Should fetch even though node is not in store
-			await vi.waitFor(() => {
-				expect(backendAdapterModule.backendAdapter.getNode).toHaveBeenCalledWith('node1');
-			});
-		});
-
-		it('should only fetch node:updated if node already in store', async () => {
-			const testNode = createTestNode('node1', 'Original content');
-			registerMockNode(testNode);
-
-			// Pre-populate store with node
-			sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
-
-			// Update node in mock backend
-			const updatedNode = { ...testNode, content: 'Updated content' };
-			registerMockNode(updatedNode);
-
-			emitTauriEvent('node:updated', { id: 'node1' });
-
-			// Should fetch since node is in store
-			await vi.waitFor(() => {
-				const storedNode = sharedNodeStore.getNode('node1');
-				expect(storedNode?.content).toBe('Updated content');
-			});
-		});
-
-		it('should fetch node:updated even if node not yet in store', async () => {
-			const testNode = createTestNode('node1');
-			registerMockNode(testNode);
-
-			// Node is NOT in store
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-
-			emitTauriEvent('node:updated', { id: 'node1' });
-
-			// Should fetch and add to store (daemon may update ai-chat nodes not yet loaded)
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			expect(sharedNodeStore.hasNode('node1')).toBe(true);
-		});
-
-		it('should delete node on node:deleted event', async () => {
-			const testNode = createTestNode('node1');
-			sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
-
-			expect(sharedNodeStore.hasNode('node1')).toBe(true);
-
-			emitTauriEvent('node:deleted', { id: 'node1' });
-
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-		});
-	});
-
-	// When sync is active, a reconnect-replay burst of node events is
-	// coalesced — collected over a short window, then applied in one synchronous
-	// pass so the caught-up set renders once instead of once per node.
-	describe('Pro reconnect-replay render coalescing (#188)', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-			proSync.tier = 'pro'; // activate the Pro coalescing path
-		});
-
-		afterEach(() => {
-			proSync.tier = 'unknown'; // singleton — restore so other tests see community
-		});
-
-		it('defers a burst then applies every node in one pass', async () => {
-			for (const id of ['n1', 'n2', 'n3']) {
-				registerMockNode(createTestNode(id, `content ${id}`));
-				emitTauriEvent('node:created', { id });
-			}
-
-			// Synchronously after the burst the applies are still deferred (the
-			// coalescing window hasn't fired) — proves we don't render per node.
-			expect(sharedNodeStore.hasNode('n1')).toBe(false);
-			expect(sharedNodeStore.hasNode('n2')).toBe(false);
-			expect(sharedNodeStore.hasNode('n3')).toBe(false);
-
-			// After the window flushes, the whole burst has landed.
-			await vi.waitFor(() => {
-				expect(sharedNodeStore.hasNode('n1')).toBe(true);
-				expect(sharedNodeStore.hasNode('n2')).toBe(true);
-				expect(sharedNodeStore.hasNode('n3')).toBe(true);
-			});
-			expect(sharedNodeStore.getNode('n2')?.content).toBe('content n2');
-		});
-
-		it('community build (not Pro) still applies each event immediately', async () => {
-			proSync.tier = 'community';
-			registerMockNode(createTestNode('c1', 'community node'));
-
-			emitTauriEvent('node:updated', { id: 'c1' });
-
-			// No coalescing window — the existing per-event path applies right away.
-			await vi.waitFor(() => {
-				expect(sharedNodeStore.hasNode('c1')).toBe(true);
-			});
-		});
-
-		it('a delete during the window wins — the queued upsert does not resurrect the node', async () => {
-			// Node is updated (queued for coalesced re-fetch) then deleted before the
-			// window flushes. Even though getNode would still return it, the delete
-			// must win — the coalescer evicts the pending re-fetch.
-			registerMockNode(createTestNode('zombie', 'should not come back'));
-
-			emitTauriEvent('node:updated', { id: 'zombie' }); // queued
-			emitTauriEvent('node:deleted', { id: 'zombie' }); // evicts the queued re-fetch
-
-			// Give the coalescing window time to fire.
-			await new Promise((resolve) => setTimeout(resolve, 40));
-
-			expect(sharedNodeStore.hasNode('zombie')).toBe(false);
-		});
-	});
-
-	// ADR-053: switching the active database bumps the store's database epoch.
-	// A domain-event hydration whose read was already in flight across that
-	// switch resolves with the previous database's row — it must be dropped, not
-	// written into the now-active store, or the switch leaks orphan nodes.
-	describe('ADR-053 in-flight read drop across a database switch', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		afterEach(() => {
-			proSync.tier = 'unknown'; // singleton — restore for later tests
-		});
-
-		it('community path drops a node:created fetch that resolves after a switch', async () => {
-			proSync.tier = 'community'; // direct fetchAndUpdateNode path
-
-			// getNode hangs so the database can switch while the read is in flight.
-			let resolveGet!: (node: Node | null) => void;
-			const pending = new Promise<Node | null>((resolve) => {
-				resolveGet = resolve;
-			});
-			vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
-
-			// The event dispatches the fetch (now pending on the previous database).
-			emitTauriEvent('node:created', { id: 'node1' });
-
-			// The active database switches while the read is outstanding.
-			sharedNodeStore.clearAll();
-
-			// The read finally resolves with the previous database's row.
-			resolveGet(createTestNode('node1'));
-			await new Promise((resolve) => setTimeout(resolve, 0));
-
-			// Dropped — not written into the now-active store.
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-		});
-
-		it('Pro coalescer drops a queued burst that resolves after a switch', async () => {
-			proSync.tier = 'pro'; // flushPendingNodeFetches path
-
-			let resolveGet!: (node: Node | null) => void;
-			const pending = new Promise<Node | null>((resolve) => {
-				resolveGet = resolve;
-			});
-			vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
-
-			// Queue the event; let the coalescing window fire so the flush reaches
-			// its (now-pending) read.
-			emitTauriEvent('node:created', { id: 'node1' });
-			await new Promise((resolve) => setTimeout(resolve, 40));
-
-			// Switch databases while the coalesced read is outstanding.
-			sharedNodeStore.clearAll();
-
-			resolveGet(createTestNode('node1'));
-			await new Promise((resolve) => setTimeout(resolve, 0));
-
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-		});
-	});
-
-	describe('Unified Relationship Events - has_child (Issue #811)', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should add hierarchy edge on relationship:created with has_child type', async () => {
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child',
-				properties: { order: 100 }
-			});
-
-			const children = structureTree.getChildrenWithOrder('parent1');
-			expect(children).toHaveLength(1);
-			expect(children[0].nodeId).toBe('child1');
-			expect(children[0].order).toBe(100);
-		});
-
-		it('should not add duplicate edges (idempotent)', async () => {
-			// Add edge first time
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child',
-				properties: { order: 100 }
-			});
-
-			// Try to add same edge again
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child',
-				properties: { order: 100 }
-			});
-
-			// Should still only have one child
-			const children = structureTree.getChildrenWithOrder('parent1');
-			expect(children).toHaveLength(1);
-		});
-
-		it('should remove hierarchy edge on relationship:deleted with has_child type', async () => {
-			// Add edge first
-			structureTree.addChild({
-				parentId: 'parent1',
-				childId: 'child1',
-				order: 100
-			});
-
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
-
-			// Delete edge
-			emitTauriEvent('relationship:deleted', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child'
-			});
-
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
-		});
-
-		it('should update child order on relationship:updated for has_child', async () => {
-			// Add edge first at order 100
-			structureTree.addChild({
-				parentId: 'parent1',
-				childId: 'child1',
-				order: 100
-			});
-
-			// Emit relationship:updated with new order
-			emitTauriEvent('relationship:updated', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child',
-				properties: { order: 200 }
-			});
-
-			const children = structureTree.getChildrenWithOrder('parent1');
-			expect(children[0].order).toBe(200);
-		});
-	});
-
-	describe('Relationship Events — node: prefix normalization (Issue #1209)', () => {
-		// Backend's `RelationshipEvent` serialization contract emits
-		// `from_id` / `to_id` already prefixed with `node:`. The
-		// listener's `stripNodePrefix`
-		// helper normalizes at the boundary so the structureTree's
-		// bare-id keyspace stays consistent with the local-action path.
-		// Without these tests, deleting `stripNodePrefix` from any of
-		// the call sites would silently regress (existing tests pass
-		// bare ids only).
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('strips node: prefix on relationship:created → addChild', async () => {
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent1:child1',
-				fromId: 'node:parent1',
-				toId: 'node:child1',
-				relationshipType: 'has_child',
-				properties: { order: 150 }
-			});
-
-			// structureTree must see bare ids. If stripNodePrefix were
-			// removed, the key would be "node:parent1" and this lookup
-			// against the bare-id key "parent1" would return empty.
-			const children = structureTree.getChildrenWithOrder('parent1');
-			expect(children).toHaveLength(1);
-			expect(children[0].nodeId).toBe('child1');
-			expect(children[0].order).toBe(150);
-
-			// And the prefixed key must NOT have been used.
-			expect(structureTree.getChildrenWithOrder('node:parent1')).toHaveLength(0);
-		});
-
-		it('strips node: prefix on relationship:updated → updateChildOrder', async () => {
-			// Seed with bare ids (matches what the local-action path does).
-			structureTree.addChild({
-				parentId: 'parent1',
-				childId: 'child1',
-				order: 100
-			});
-
-			emitTauriEvent('relationship:updated', {
-				id: 'relationship:parent1:child1',
-				fromId: 'node:parent1',
-				toId: 'node:child1',
-				relationshipType: 'has_child',
-				properties: { order: 250 }
-			});
-
-			const children = structureTree.getChildrenWithOrder('parent1');
-			expect(children).toHaveLength(1);
-			expect(children[0].order).toBe(250);
-		});
-
-		it('strips node: prefix on relationship:deleted → removeChild', async () => {
-			structureTree.addChild({
-				parentId: 'parent1',
-				childId: 'child1',
-				order: 100
-			});
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
-
-			emitTauriEvent('relationship:deleted', {
-				id: 'relationship:parent1:child1',
-				fromId: 'node:parent1',
-				toId: 'node:child1',
-				relationshipType: 'has_child'
-			});
-
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
-		});
-
-		it('handles a mix of prefixed-and-bare ids identically (defensive)', async () => {
-			// In practice the contract is "always prefixed" — but the
-			// helper is a pass-through for already-bare ids, and the
-			// listener shouldn't behave differently if a future
-			// backend (or replay tool) emits the bare form.
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent2:child2',
-				fromId: 'parent2', // bare
-				toId: 'node:child2', // prefixed
-				relationshipType: 'has_child',
-				properties: { order: 100 }
-			});
-
-			const children = structureTree.getChildrenWithOrder('parent2');
-			expect(children).toHaveLength(1);
-			expect(children[0].nodeId).toBe('child2');
-		});
-	});
-
-	describe('Unified Relationship Events - Mentions (Issue #811)', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should handle relationship:created with mentions type (logs only)', async () => {
-			expect(() => {
-				emitTauriEvent('relationship:created', {
-					id: 'relationship:mention:node1:node2',
-					fromId: 'node1',
-					toId: 'node2',
-					relationshipType: 'mentions',
-					properties: {}
-				});
-			}).not.toThrow();
-		});
-
-		it('should handle relationship:updated with mentions type (logs only)', async () => {
-			expect(() => {
-				emitTauriEvent('relationship:updated', {
-					id: 'relationship:mention:node1:node2',
-					fromId: 'node1',
-					toId: 'node2',
-					relationshipType: 'mentions',
-					properties: {}
-				});
-			}).not.toThrow();
-		});
-
-		it('should handle relationship:deleted with mentions type (logs only)', async () => {
-			expect(() => {
-				emitTauriEvent('relationship:deleted', {
-					id: 'relationship:mention:node1:node2',
-					fromId: 'node1',
-					toId: 'node2',
-					relationshipType: 'mentions'
-				});
-			}).not.toThrow();
-		});
-	});
-
-	describe('Error Handling', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should handle failed node fetch gracefully', async () => {
-			// Mock getNode to throw error
-			vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockRejectedValue(
-				new Error('Network error')
-			);
-
-			// Should not throw
-			expect(() => {
-				emitTauriEvent('node:created', { id: 'node1' });
-			}).not.toThrow();
-
-			// Node should not be in store
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			expect(sharedNodeStore.hasNode('node1')).toBe(false);
-		});
-
-		it('should handle node not found (returns null)', async () => {
-			// Mock getNode to return null
-			vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockResolvedValue(null);
-
-			emitTauriEvent('node:created', { id: 'nonexistent' });
-
-			// Should not crash, node should not be in store
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			expect(sharedNodeStore.hasNode('nonexistent')).toBe(false);
-		});
-
-		it('should handle sync:error events', async () => {
-			// Should not crash
-			expect(() => {
-				emitTauriEvent('sync:error', {
-					message: 'Database connection lost',
-					errorType: 'connection'
-				});
-			}).not.toThrow();
-		});
-
-		it('should handle sync:status events', async () => {
-			// Should not crash
-			expect(() => {
-				emitTauriEvent('sync:status', {
-					status: 'connected',
-					reason: 'Initial connection'
-				});
-			}).not.toThrow();
-		});
-	});
-
-	describe('Event Ordering Scenarios', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should handle relationship created before node exists', async () => {
-			// Relationship event arrives first
-			emitTauriEvent('relationship:created', {
-				id: 'relationship:parent1:child1',
-				fromId: 'parent1',
-				toId: 'child1',
-				relationshipType: 'has_child',
-				properties: { order: 100 }
-			});
-
-			// Edge should be in structure tree
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
-
-			// Node event arrives later
-			const testNode = createTestNode('child1');
-			registerMockNode(testNode);
-			emitTauriEvent('node:created', { id: 'child1' });
-
-			// Node should be in store
-			await vi.waitFor(() => {
-				expect(sharedNodeStore.hasNode('child1')).toBe(true);
-			});
-		});
-
-		it('should handle node deleted before relationship deleted', async () => {
-			// Setup: node and edge exist
-			const testNode = createTestNode('child1');
-			sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
-			structureTree.addChild({
-				parentId: 'parent1',
-				childId: 'child1',
-				order: 100
-			});
-
-			// Node deleted first
-			emitTauriEvent('node:deleted', { id: 'child1' });
-			expect(sharedNodeStore.hasNode('child1')).toBe(false);
-
-			// Relationship deleted second (should not crash)
-			expect(() => {
-				emitTauriEvent('relationship:deleted', {
-					id: 'relationship:parent1:child1',
-					fromId: 'parent1',
-					toId: 'child1',
-					relationshipType: 'has_child'
-				});
-			}).not.toThrow();
-
-			expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
-		});
-
-		it('should handle multiple concurrent node creations', async () => {
-			const node1 = createTestNode('node1');
-			const node2 = createTestNode('node2');
-			const node3 = createTestNode('node3');
-
-			registerMockNode(node1);
-			registerMockNode(node2);
-			registerMockNode(node3);
-
-			// Emit events rapidly
-			emitTauriEvent('node:created', { id: 'node1' });
-			emitTauriEvent('node:created', { id: 'node2' });
-			emitTauriEvent('node:created', { id: 'node3' });
-
-			// All nodes should be fetched and stored
-			await vi.waitFor(() => {
-				expect(sharedNodeStore.hasNode('node1')).toBe(true);
-				expect(sharedNodeStore.hasNode('node2')).toBe(true);
-				expect(sharedNodeStore.hasNode('node3')).toBe(true);
-			});
-		});
-	});
-
-	describe('Task Node Normalization', () => {
-		beforeEach(async () => {
-			await initializeTauriSyncListeners();
-		});
-
-		it('should normalize task nodes with flat status field', async () => {
-			const taskNode: Node = {
-				id: 'task1',
-				nodeType: 'task',
-				content: 'Test task',
-				properties: {
-					status: 'open',
-					priority: 'high'
-				},
-				mentions: [],
-				createdAt: new Date().toISOString(),
-				modifiedAt: new Date().toISOString(),
-				version: 1
-			};
-
-			registerMockNode(taskNode);
-			emitTauriEvent('node:created', { id: 'task1' });
-
-			await vi.waitFor(() => {
-				const storedNode = sharedNodeStore.getNode('task1');
-				expect(storedNode).toBeDefined();
-				// After normalization, task nodes have flat status field
-				interface TaskNode extends Node {
-					status?: string;
-				}
-				expect((storedNode as TaskNode).status).toBeDefined();
-			});
-		});
-	});
+  beforeEach(() => {
+    // Reset stores
+    SharedNodeStore.resetInstance();
+    structureTree.clear();
+    mockNodes.clear();
+    mockEventListeners.clear();
+
+    // Setup mocks
+    setupMockGetNode();
+    setupMockTauriListen();
+    mockTauriEnvironment(true);
+  });
+
+  afterEach(() => {
+    // Cleanup
+    sharedNodeStore.clearAll();
+    structureTree.clear();
+    SharedNodeStore.resetInstance();
+    mockNodes.clear();
+    mockEventListeners.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('Environment Detection', () => {
+    it('should skip initialization when not in Tauri environment', async () => {
+      mockTauriEnvironment(false);
+
+      await initializeTauriSyncListeners();
+
+      // No listeners should be registered
+      expect(mockEventListeners.size).toBe(0);
+    });
+
+    it('should initialize listeners in Tauri environment', async () => {
+      mockTauriEnvironment(true);
+
+      await initializeTauriSyncListeners();
+
+      // Verify all expected listeners are registered
+      expect(mockEventListeners.has('node:created')).toBe(true);
+      expect(mockEventListeners.has('node:updated')).toBe(true);
+      expect(mockEventListeners.has('node:deleted')).toBe(true);
+      // Unified relationship events replace old edge:* events
+      expect(mockEventListeners.has('relationship:created')).toBe(true);
+      expect(mockEventListeners.has('relationship:updated')).toBe(true);
+      expect(mockEventListeners.has('relationship:deleted')).toBe(true);
+      expect(mockEventListeners.has('sync:error')).toBe(true);
+      expect(mockEventListeners.has('sync:status')).toBe(true);
+    });
+  });
+
+  describe('Node Events - Issue #724 ID-Only Optimization', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should fetch and store node on node:created event', async () => {
+      const testNode = createTestNode('node1', 'New node');
+      registerMockNode(testNode);
+
+      emitTauriEvent('node:created', { id: 'node1' });
+
+      // Wait for async fetch to complete
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('node1')).toBe(true);
+      });
+
+      const storedNode = sharedNodeStore.getNode('node1');
+      expect(storedNode).toBeDefined();
+      expect(storedNode?.content).toBe('New node');
+    });
+
+    it('should always fetch node data on node:created (unconditional)', async () => {
+      const testNode = createTestNode('node1');
+      registerMockNode(testNode);
+
+      // Node is NOT in store yet
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+
+      emitTauriEvent('node:created', { id: 'node1' });
+
+      // Should fetch even though node is not in store
+      await vi.waitFor(() => {
+        expect(backendAdapterModule.backendAdapter.getNode).toHaveBeenCalledWith('node1');
+      });
+    });
+
+    it('should only fetch node:updated if node already in store', async () => {
+      const testNode = createTestNode('node1', 'Original content');
+      registerMockNode(testNode);
+
+      // Pre-populate store with node
+      sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
+
+      // Update node in mock backend
+      const updatedNode = { ...testNode, content: 'Updated content' };
+      registerMockNode(updatedNode);
+
+      emitTauriEvent('node:updated', { id: 'node1' });
+
+      // Should fetch since node is in store
+      await vi.waitFor(() => {
+        const storedNode = sharedNodeStore.getNode('node1');
+        expect(storedNode?.content).toBe('Updated content');
+      });
+    });
+
+    it('should fetch node:updated even if node not yet in store', async () => {
+      const testNode = createTestNode('node1');
+      registerMockNode(testNode);
+
+      // Node is NOT in store
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+
+      emitTauriEvent('node:updated', { id: 'node1' });
+
+      // Should fetch and add to store (daemon may update ai-chat nodes not yet loaded)
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(sharedNodeStore.hasNode('node1')).toBe(true);
+    });
+
+    it('should delete node on node:deleted event', async () => {
+      const testNode = createTestNode('node1');
+      sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
+
+      expect(sharedNodeStore.hasNode('node1')).toBe(true);
+
+      emitTauriEvent('node:deleted', { id: 'node1' });
+
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+    });
+  });
+
+  // When sync is active, a reconnect-replay burst of node events is
+  // coalesced — collected over a short window, then applied in one synchronous
+  // pass so the caught-up set renders once instead of once per node.
+  describe('Pro reconnect-replay render coalescing (#188)', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+      proSync.tier = 'pro'; // activate the Pro coalescing path
+    });
+
+    afterEach(() => {
+      proSync.tier = 'unknown'; // singleton — restore so other tests see community
+    });
+
+    it('defers a burst then applies every node in one pass', async () => {
+      for (const id of ['n1', 'n2', 'n3']) {
+        registerMockNode(createTestNode(id, `content ${id}`));
+        emitTauriEvent('node:created', { id });
+      }
+
+      // Synchronously after the burst the applies are still deferred (the
+      // coalescing window hasn't fired) — proves we don't render per node.
+      expect(sharedNodeStore.hasNode('n1')).toBe(false);
+      expect(sharedNodeStore.hasNode('n2')).toBe(false);
+      expect(sharedNodeStore.hasNode('n3')).toBe(false);
+
+      // After the window flushes, the whole burst has landed.
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('n1')).toBe(true);
+        expect(sharedNodeStore.hasNode('n2')).toBe(true);
+        expect(sharedNodeStore.hasNode('n3')).toBe(true);
+      });
+      expect(sharedNodeStore.getNode('n2')?.content).toBe('content n2');
+    });
+
+    it('community build (not Pro) still applies each event immediately', async () => {
+      proSync.tier = 'community';
+      registerMockNode(createTestNode('c1', 'community node'));
+
+      emitTauriEvent('node:updated', { id: 'c1' });
+
+      // No coalescing window — the existing per-event path applies right away.
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('c1')).toBe(true);
+      });
+    });
+
+    it('a delete during the window wins — the queued upsert does not resurrect the node', async () => {
+      // Node is updated (queued for coalesced re-fetch) then deleted before the
+      // window flushes. Even though getNode would still return it, the delete
+      // must win — the coalescer evicts the pending re-fetch.
+      registerMockNode(createTestNode('zombie', 'should not come back'));
+
+      emitTauriEvent('node:updated', { id: 'zombie' }); // queued
+      emitTauriEvent('node:deleted', { id: 'zombie' }); // evicts the queued re-fetch
+
+      // Give the coalescing window time to fire.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(sharedNodeStore.hasNode('zombie')).toBe(false);
+    });
+  });
+
+  // A cloud-sync pull floods relationship events (tens of thousands for a
+  // populated tenant). Applied one-by-one each event costs a full reactive
+  // invalidation of the structure tree on the main thread. When sync is
+  // active the has_child ops are buffered over the coalescing window and the
+  // whole burst is applied inside one structureTree batch.
+  describe('Pro relationship-event coalescing', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+      proSync.tier = 'pro'; // activate the Pro coalescing path
+    });
+
+    afterEach(() => {
+      proSync.tier = 'unknown'; // singleton — restore so other tests see community
+    });
+
+    function emitHasChildCreated(parentId: string, childId: string, order: number): void {
+      emitTauriEvent('relationship:created', {
+        id: `relationship:${parentId}:${childId}`,
+        fromId: `node:${parentId}`,
+        toId: `node:${childId}`,
+        relationshipType: 'has_child',
+        properties: { order }
+      });
+    }
+
+    function emitHasChildDeleted(parentId: string, childId: string): void {
+      emitTauriEvent('relationship:deleted', {
+        id: `relationship:${parentId}:${childId}`,
+        fromId: `node:${parentId}`,
+        toId: `node:${childId}`,
+        relationshipType: 'has_child'
+      });
+    }
+
+    it('applies a burst of relationship:created events in a single batch', async () => {
+      const runBatchSpy = vi.spyOn(structureTree, 'runBatch');
+
+      const burst = 25;
+      for (let i = 0; i < burst; i++) {
+        emitHasChildCreated('parent1', `child${i}`, i + 1);
+      }
+
+      // Synchronously after the burst nothing has been applied — the ops are
+      // buffered, not applied per event.
+      expect(structureTree.getChildren('parent1')).toHaveLength(0);
+      expect(runBatchSpy).not.toHaveBeenCalled();
+
+      // After the window flushes, the whole burst has landed ...
+      await vi.waitFor(() => {
+        expect(structureTree.getChildren('parent1')).toHaveLength(burst);
+      });
+      // ... through exactly one batch (one reactive notification), not N.
+      expect(runBatchSpy).toHaveBeenCalledTimes(1);
+      // Per-event order values were honored (children sorted by order).
+      expect(structureTree.getChildren('parent1')[0]).toBe('child0');
+      expect(structureTree.getChildren('parent1')[burst - 1]).toBe(`child${burst - 1}`);
+    });
+
+    it('create followed by delete of the same edge in one window resolves to absent', async () => {
+      emitHasChildCreated('parent1', 'child1', 1);
+      emitHasChildDeleted('parent1', 'child1');
+
+      // Let the coalescing window flush.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(structureTree.getChildren('parent1')).toHaveLength(0);
+      expect(structureTree.getParent('child1')).toBeNull();
+    });
+
+    it('delete followed by re-create of the same edge in one window resolves to present', async () => {
+      // Edge exists before the window opens.
+      structureTree.addChild({ parentId: 'parent1', childId: 'child1', order: 1 });
+
+      emitHasChildDeleted('parent1', 'child1');
+      emitHasChildCreated('parent1', 'child1', 2);
+
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(structureTree.getChildren('parent1')).toEqual(['child1']);
+      expect(structureTree.getChildrenWithOrder('parent1')[0].order).toBe(2);
+    });
+
+    it('community build (not Pro) still applies relationship events immediately', () => {
+      proSync.tier = 'community';
+
+      emitHasChildCreated('parent1', 'child1', 1);
+
+      // No coalescing window — the per-event path applied synchronously.
+      expect(structureTree.getChildren('parent1')).toEqual(['child1']);
+    });
+
+    it('drops relationship ops buffered before a database switch', async () => {
+      emitHasChildCreated('parent1', 'child1', 1); // buffered
+
+      // The active database switches (epoch bump) before the window flushes.
+      sharedNodeStore.clearAll();
+
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      // The buffered edge belonged to the previous database — dropped.
+      expect(structureTree.getChildren('parent1')).toHaveLength(0);
+    });
+  });
+
+  // A coalesced node flush processes ids in chunks with a macrotask yield
+  // between them, so a huge burst (initial pull) cannot monopolize the main
+  // thread — and the database-switch guard is re-checked per chunk.
+  describe('Pro node-fetch flush chunking', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+      proSync.tier = 'pro';
+    });
+
+    afterEach(() => {
+      proSync.tier = 'unknown';
+    });
+
+    /** Mock getNode with per-id deferred promises so chunk boundaries are
+     *  observable and controllable. */
+    function setupDeferredGetNode(): Map<string, (node: Node | null) => void> {
+      const resolvers = new Map<string, (node: Node | null) => void>();
+      vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(
+        (id: string) =>
+          new Promise<Node | null>((resolve) => {
+            resolvers.set(id, resolve);
+          })
+      );
+      return resolvers;
+    }
+
+    function getNodeCalls(): string[] {
+      return vi
+        .mocked(backendAdapterModule.backendAdapter.getNode)
+        .mock.calls.map((call) => call[0]);
+    }
+
+    it('fetches a large burst in chunks of 200, yielding between chunks', async () => {
+      const resolvers = setupDeferredGetNode();
+
+      const total = 250; // chunk size is 200 → two chunks
+      for (let i = 0; i < total; i++) {
+        emitTauriEvent('node:created', { id: `bulk${i}` });
+      }
+
+      // Only the first chunk's fetches are dispatched — the flush does not
+      // fan out all 250 at once.
+      await vi.waitFor(() => {
+        expect(getNodeCalls()).toHaveLength(200);
+      });
+      expect(getNodeCalls()).not.toContain('bulk200');
+
+      // Completing chunk 1 lets the flush apply it, yield, then dispatch
+      // chunk 2.
+      for (let i = 0; i < 200; i++) {
+        resolvers.get(`bulk${i}`)!(createTestNode(`bulk${i}`));
+      }
+      await vi.waitFor(() => {
+        expect(getNodeCalls()).toHaveLength(250);
+      });
+      for (let i = 200; i < total; i++) {
+        resolvers.get(`bulk${i}`)!(createTestNode(`bulk${i}`));
+      }
+
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('bulk0')).toBe(true);
+        expect(sharedNodeStore.hasNode('bulk199')).toBe(true);
+        expect(sharedNodeStore.hasNode('bulk249')).toBe(true);
+      });
+    });
+
+    it('re-checks the database-switch guard per chunk — a switch between chunks drops the remainder', async () => {
+      const resolvers = setupDeferredGetNode();
+
+      for (let i = 0; i < 250; i++) {
+        emitTauriEvent('node:created', { id: `bulk${i}` });
+      }
+      await vi.waitFor(() => {
+        expect(getNodeCalls()).toHaveLength(200);
+      });
+
+      // Resolve chunk 1, and queue the database switch as a macrotask: it
+      // runs after chunk 1 is applied (a microtask) but before the flush's
+      // between-chunk yield timer, which is scheduled later than this one.
+      for (let i = 0; i < 200; i++) {
+        resolvers.get(`bulk${i}`)!(createTestNode(`bulk${i}`));
+      }
+      setTimeout(() => sharedNodeStore.clearAll(), 0);
+
+      // Give the flush ample time to (incorrectly) dispatch chunk 2.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      // The per-chunk guard saw the epoch change at the chunk boundary and
+      // dropped the remainder — chunk 2 was never even fetched.
+      expect(getNodeCalls()).toHaveLength(200);
+      expect(getNodeCalls()).not.toContain('bulk200');
+      expect(sharedNodeStore.hasNode('bulk200')).toBe(false);
+    });
+  });
+
+  // ADR-053: switching the active database bumps the store's database epoch.
+  // A domain-event hydration whose read was already in flight across that
+  // switch resolves with the previous database's row — it must be dropped, not
+  // written into the now-active store, or the switch leaks orphan nodes.
+  describe('ADR-053 in-flight read drop across a database switch', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    afterEach(() => {
+      proSync.tier = 'unknown'; // singleton — restore for later tests
+    });
+
+    it('community path drops a node:created fetch that resolves after a switch', async () => {
+      proSync.tier = 'community'; // direct fetchAndUpdateNode path
+
+      // getNode hangs so the database can switch while the read is in flight.
+      let resolveGet!: (node: Node | null) => void;
+      const pending = new Promise<Node | null>((resolve) => {
+        resolveGet = resolve;
+      });
+      vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
+
+      // The event dispatches the fetch (now pending on the previous database).
+      emitTauriEvent('node:created', { id: 'node1' });
+
+      // The active database switches while the read is outstanding.
+      sharedNodeStore.clearAll();
+
+      // The read finally resolves with the previous database's row.
+      resolveGet(createTestNode('node1'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Dropped — not written into the now-active store.
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+    });
+
+    it('Pro coalescer drops a queued burst that resolves after a switch', async () => {
+      proSync.tier = 'pro'; // flushPendingNodeFetches path
+
+      let resolveGet!: (node: Node | null) => void;
+      const pending = new Promise<Node | null>((resolve) => {
+        resolveGet = resolve;
+      });
+      vi.mocked(backendAdapterModule.backendAdapter.getNode).mockImplementation(() => pending);
+
+      // Queue the event; let the coalescing window fire so the flush reaches
+      // its (now-pending) read.
+      emitTauriEvent('node:created', { id: 'node1' });
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      // Switch databases while the coalesced read is outstanding.
+      sharedNodeStore.clearAll();
+
+      resolveGet(createTestNode('node1'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+    });
+  });
+
+  describe('Unified Relationship Events - has_child (Issue #811)', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should add hierarchy edge on relationship:created with has_child type', async () => {
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child',
+        properties: { order: 100 }
+      });
+
+      const children = structureTree.getChildrenWithOrder('parent1');
+      expect(children).toHaveLength(1);
+      expect(children[0].nodeId).toBe('child1');
+      expect(children[0].order).toBe(100);
+    });
+
+    it('should not add duplicate edges (idempotent)', async () => {
+      // Add edge first time
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child',
+        properties: { order: 100 }
+      });
+
+      // Try to add same edge again
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child',
+        properties: { order: 100 }
+      });
+
+      // Should still only have one child
+      const children = structureTree.getChildrenWithOrder('parent1');
+      expect(children).toHaveLength(1);
+    });
+
+    it('should remove hierarchy edge on relationship:deleted with has_child type', async () => {
+      // Add edge first
+      structureTree.addChild({
+        parentId: 'parent1',
+        childId: 'child1',
+        order: 100
+      });
+
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
+
+      // Delete edge
+      emitTauriEvent('relationship:deleted', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child'
+      });
+
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
+    });
+
+    it('should update child order on relationship:updated for has_child', async () => {
+      // Add edge first at order 100
+      structureTree.addChild({
+        parentId: 'parent1',
+        childId: 'child1',
+        order: 100
+      });
+
+      // Emit relationship:updated with new order
+      emitTauriEvent('relationship:updated', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child',
+        properties: { order: 200 }
+      });
+
+      const children = structureTree.getChildrenWithOrder('parent1');
+      expect(children[0].order).toBe(200);
+    });
+  });
+
+  describe('Relationship Events — node: prefix normalization (Issue #1209)', () => {
+    // Backend's `RelationshipEvent` serialization contract emits
+    // `from_id` / `to_id` already prefixed with `node:`. The
+    // listener's `stripNodePrefix`
+    // helper normalizes at the boundary so the structureTree's
+    // bare-id keyspace stays consistent with the local-action path.
+    // Without these tests, deleting `stripNodePrefix` from any of
+    // the call sites would silently regress (existing tests pass
+    // bare ids only).
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('strips node: prefix on relationship:created → addChild', async () => {
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent1:child1',
+        fromId: 'node:parent1',
+        toId: 'node:child1',
+        relationshipType: 'has_child',
+        properties: { order: 150 }
+      });
+
+      // structureTree must see bare ids. If stripNodePrefix were
+      // removed, the key would be "node:parent1" and this lookup
+      // against the bare-id key "parent1" would return empty.
+      const children = structureTree.getChildrenWithOrder('parent1');
+      expect(children).toHaveLength(1);
+      expect(children[0].nodeId).toBe('child1');
+      expect(children[0].order).toBe(150);
+
+      // And the prefixed key must NOT have been used.
+      expect(structureTree.getChildrenWithOrder('node:parent1')).toHaveLength(0);
+    });
+
+    it('strips node: prefix on relationship:updated → updateChildOrder', async () => {
+      // Seed with bare ids (matches what the local-action path does).
+      structureTree.addChild({
+        parentId: 'parent1',
+        childId: 'child1',
+        order: 100
+      });
+
+      emitTauriEvent('relationship:updated', {
+        id: 'relationship:parent1:child1',
+        fromId: 'node:parent1',
+        toId: 'node:child1',
+        relationshipType: 'has_child',
+        properties: { order: 250 }
+      });
+
+      const children = structureTree.getChildrenWithOrder('parent1');
+      expect(children).toHaveLength(1);
+      expect(children[0].order).toBe(250);
+    });
+
+    it('strips node: prefix on relationship:deleted → removeChild', async () => {
+      structureTree.addChild({
+        parentId: 'parent1',
+        childId: 'child1',
+        order: 100
+      });
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
+
+      emitTauriEvent('relationship:deleted', {
+        id: 'relationship:parent1:child1',
+        fromId: 'node:parent1',
+        toId: 'node:child1',
+        relationshipType: 'has_child'
+      });
+
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
+    });
+
+    it('handles a mix of prefixed-and-bare ids identically (defensive)', async () => {
+      // In practice the contract is "always prefixed" — but the
+      // helper is a pass-through for already-bare ids, and the
+      // listener shouldn't behave differently if a future
+      // backend (or replay tool) emits the bare form.
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent2:child2',
+        fromId: 'parent2', // bare
+        toId: 'node:child2', // prefixed
+        relationshipType: 'has_child',
+        properties: { order: 100 }
+      });
+
+      const children = structureTree.getChildrenWithOrder('parent2');
+      expect(children).toHaveLength(1);
+      expect(children[0].nodeId).toBe('child2');
+    });
+  });
+
+  describe('Unified Relationship Events - Mentions (Issue #811)', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should handle relationship:created with mentions type (logs only)', async () => {
+      expect(() => {
+        emitTauriEvent('relationship:created', {
+          id: 'relationship:mention:node1:node2',
+          fromId: 'node1',
+          toId: 'node2',
+          relationshipType: 'mentions',
+          properties: {}
+        });
+      }).not.toThrow();
+    });
+
+    it('should handle relationship:updated with mentions type (logs only)', async () => {
+      expect(() => {
+        emitTauriEvent('relationship:updated', {
+          id: 'relationship:mention:node1:node2',
+          fromId: 'node1',
+          toId: 'node2',
+          relationshipType: 'mentions',
+          properties: {}
+        });
+      }).not.toThrow();
+    });
+
+    it('should handle relationship:deleted with mentions type (logs only)', async () => {
+      expect(() => {
+        emitTauriEvent('relationship:deleted', {
+          id: 'relationship:mention:node1:node2',
+          fromId: 'node1',
+          toId: 'node2',
+          relationshipType: 'mentions'
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should handle failed node fetch gracefully', async () => {
+      // Mock getNode to throw error
+      vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockRejectedValue(
+        new Error('Network error')
+      );
+
+      // Should not throw
+      expect(() => {
+        emitTauriEvent('node:created', { id: 'node1' });
+      }).not.toThrow();
+
+      // Node should not be in store
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(sharedNodeStore.hasNode('node1')).toBe(false);
+    });
+
+    it('should handle node not found (returns null)', async () => {
+      // Mock getNode to return null
+      vi.spyOn(backendAdapterModule.backendAdapter, 'getNode').mockResolvedValue(null);
+
+      emitTauriEvent('node:created', { id: 'nonexistent' });
+
+      // Should not crash, node should not be in store
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(sharedNodeStore.hasNode('nonexistent')).toBe(false);
+    });
+
+    it('should handle sync:error events', async () => {
+      // Should not crash
+      expect(() => {
+        emitTauriEvent('sync:error', {
+          message: 'Database connection lost',
+          errorType: 'connection'
+        });
+      }).not.toThrow();
+    });
+
+    it('should handle sync:status events', async () => {
+      // Should not crash
+      expect(() => {
+        emitTauriEvent('sync:status', {
+          status: 'connected',
+          reason: 'Initial connection'
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('Event Ordering Scenarios', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should handle relationship created before node exists', async () => {
+      // Relationship event arrives first
+      emitTauriEvent('relationship:created', {
+        id: 'relationship:parent1:child1',
+        fromId: 'parent1',
+        toId: 'child1',
+        relationshipType: 'has_child',
+        properties: { order: 100 }
+      });
+
+      // Edge should be in structure tree
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(1);
+
+      // Node event arrives later
+      const testNode = createTestNode('child1');
+      registerMockNode(testNode);
+      emitTauriEvent('node:created', { id: 'child1' });
+
+      // Node should be in store
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('child1')).toBe(true);
+      });
+    });
+
+    it('should handle node deleted before relationship deleted', async () => {
+      // Setup: node and edge exist
+      const testNode = createTestNode('child1');
+      sharedNodeStore.setNode(testNode, { type: 'database', reason: 'test' }, false);
+      structureTree.addChild({
+        parentId: 'parent1',
+        childId: 'child1',
+        order: 100
+      });
+
+      // Node deleted first
+      emitTauriEvent('node:deleted', { id: 'child1' });
+      expect(sharedNodeStore.hasNode('child1')).toBe(false);
+
+      // Relationship deleted second (should not crash)
+      expect(() => {
+        emitTauriEvent('relationship:deleted', {
+          id: 'relationship:parent1:child1',
+          fromId: 'parent1',
+          toId: 'child1',
+          relationshipType: 'has_child'
+        });
+      }).not.toThrow();
+
+      expect(structureTree.getChildrenWithOrder('parent1')).toHaveLength(0);
+    });
+
+    it('should handle multiple concurrent node creations', async () => {
+      const node1 = createTestNode('node1');
+      const node2 = createTestNode('node2');
+      const node3 = createTestNode('node3');
+
+      registerMockNode(node1);
+      registerMockNode(node2);
+      registerMockNode(node3);
+
+      // Emit events rapidly
+      emitTauriEvent('node:created', { id: 'node1' });
+      emitTauriEvent('node:created', { id: 'node2' });
+      emitTauriEvent('node:created', { id: 'node3' });
+
+      // All nodes should be fetched and stored
+      await vi.waitFor(() => {
+        expect(sharedNodeStore.hasNode('node1')).toBe(true);
+        expect(sharedNodeStore.hasNode('node2')).toBe(true);
+        expect(sharedNodeStore.hasNode('node3')).toBe(true);
+      });
+    });
+  });
+
+  describe('Task Node Normalization', () => {
+    beforeEach(async () => {
+      await initializeTauriSyncListeners();
+    });
+
+    it('should normalize task nodes with flat status field', async () => {
+      const taskNode: Node = {
+        id: 'task1',
+        nodeType: 'task',
+        content: 'Test task',
+        properties: {
+          status: 'open',
+          priority: 'high'
+        },
+        mentions: [],
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        version: 1
+      };
+
+      registerMockNode(taskNode);
+      emitTauriEvent('node:created', { id: 'task1' });
+
+      await vi.waitFor(() => {
+        const storedNode = sharedNodeStore.getNode('task1');
+        expect(storedNode).toBeDefined();
+        // After normalization, task nodes have flat status field
+        interface TaskNode extends Node {
+          status?: string;
+        }
+        expect((storedNode as TaskNode).status).toBeDefined();
+      });
+    });
+  });
 });

--- a/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
+++ b/packages/desktop-app/src/tests/unit/reactive-structure-tree.test.ts
@@ -17,13 +17,13 @@ describe('ReactiveStructureTree', () => {
     // Initialize with event listeners disabled in test environment
     // (Tauri events won't work in test runner)
     vi.clearAllMocks();
-    // Clear any previous state
-    structureTree.children.clear();
+    // Clear any previous state (clear() also resets the reverse parent index)
+    structureTree.clear();
   });
 
   afterEach(async () => {
     // Cleanup
-    structureTree.children.clear();
+    structureTree.clear();
   });
 
   describe('getChildren', () => {
@@ -95,14 +95,16 @@ describe('ReactiveStructureTree', () => {
     });
 
     it('should return parent ID for existing child', () => {
-      structureTree.children.set('parent1', [{ nodeId: 'child1', order: 1.0 }]);
+      // Mutate through the public API — getParent is answered by the reverse
+      // child→parent index, which the mutators maintain.
+      structureTree.addChild({ parentId: 'parent1', childId: 'child1', order: 1.0 });
       const parent = structureTree.getParent('child1');
       expect(parent).toBe('parent1');
     });
 
     it('should find correct parent among multiple parents', () => {
-      structureTree.children.set('parent1', [{ nodeId: 'child1', order: 1.0 }]);
-      structureTree.children.set('parent2', [{ nodeId: 'child2', order: 1.0 }]);
+      structureTree.addChild({ parentId: 'parent1', childId: 'child1', order: 1.0 });
+      structureTree.addChild({ parentId: 'parent2', childId: 'child2', order: 1.0 });
 
       expect(structureTree.getParent('child1')).toBe('parent1');
       expect(structureTree.getParent('child2')).toBe('parent2');
@@ -411,9 +413,7 @@ describe('ReactiveStructureTree', () => {
 
       // Verify parent2 has its child
       const parent2Children = structureTree.getChildrenWithOrder('parent2');
-      expect(parent2Children).toEqual([
-        { nodeId: 'child3', order: 1.0 }
-      ]);
+      expect(parent2Children).toEqual([{ nodeId: 'child3', order: 1.0 }]);
     });
 
     it('should handle bulk load with many relationships and maintain sort order', () => {
@@ -433,7 +433,7 @@ describe('ReactiveStructureTree', () => {
 
       // Verify relationships are sorted correctly
       const children = structureTree.getChildrenWithOrder('root');
-      expect(children.map(c => c.nodeId)).toEqual(['b', 'c', 'a', 'd']);
+      expect(children.map((c) => c.nodeId)).toEqual(['b', 'c', 'a', 'd']);
     });
 
     it('should handle empty bulk load', () => {
@@ -500,7 +500,7 @@ describe('ReactiveStructureTree', () => {
 
       // Verify order was updated
       const childInfo = structureTree.getChildrenWithOrder('parent1');
-      expect(childInfo.find(c => c.nodeId === 'child1')?.order).toBe(5.0);
+      expect(childInfo.find((c) => c.nodeId === 'child1')?.order).toBe(5.0);
     });
 
     it('reparents (moves) a child when added under a different parent', () => {
@@ -712,7 +712,10 @@ describe('ReactiveStructureTree', () => {
 
     it('I3: throws in dev for unsorted order', () => {
       // Directly set unsorted state bypassing addChild
-      structureTree.children.set('p', [{ nodeId: 'c1', order: 5 }, { nodeId: 'c2', order: 2 }]);
+      structureTree.children.set('p', [
+        { nodeId: 'c1', order: 5 },
+        { nodeId: 'c2', order: 2 }
+      ]);
       const nodeIds = new Set(['c1', 'c2', 'p']);
       expect(() => structureTree.assertInvariants(nodeIds)).toThrow(/I3/);
     });
@@ -786,7 +789,7 @@ describe('ReactiveStructureTree', () => {
 
       // Verify order was auto-calculated (should be 3.0 = existing length + 1)
       const childInfo = structureTree.getChildrenWithOrder('parent2');
-      expect(childInfo.find(c => c.nodeId === 'child1')?.order).toBe(3.0);
+      expect(childInfo.find((c) => c.nodeId === 'child1')?.order).toBe(3.0);
     });
 
     it('should calculate order 1.0 when moving to empty parent', () => {
@@ -846,6 +849,158 @@ describe('ReactiveStructureTree', () => {
       structureTree.removeChild({ parentId: 'old', childId: 'n', order: 0 });
       expect(structureTree.getChildren('p1')).toEqual(['n']);
       expect(structureTree.getParent('n')).toBe('p1');
+    });
+  });
+
+  describe('reverse parent index', () => {
+    it('getParent reflects each step of an add → move → remove lifecycle', () => {
+      structureTree.addChild({ parentId: 'p1', childId: 'c', order: 1 });
+      expect(structureTree.getParent('c')).toBe('p1');
+
+      structureTree.moveInMemoryRelationship('p1', 'p2', 'c', 1);
+      expect(structureTree.getParent('c')).toBe('p2');
+      expect(structureTree.getChildren('p1')).toEqual([]);
+
+      structureTree.removeChild({ parentId: 'p2', childId: 'c', order: 0 });
+      expect(structureTree.getParent('c')).toBeNull();
+    });
+
+    it('getParent is correct for every edge after a large batchAddRelationships', () => {
+      const relationships: Array<{ parentId: string; childId: string; order: number }> = [];
+      for (let i = 0; i < 1000; i++) {
+        relationships.push({ parentId: `p${i % 50}`, childId: `c${i}`, order: i });
+      }
+      structureTree.batchAddRelationships(relationships);
+
+      for (let i = 0; i < 1000; i++) {
+        expect(structureTree.getParent(`c${i}`)).toBe(`p${i % 50}`);
+      }
+    });
+
+    it('reparenting inside a batch keeps the index on the latest parent', () => {
+      structureTree.batchAddRelationships([
+        { parentId: 'p1', childId: 'c', order: 1 },
+        { parentId: 'p2', childId: 'c', order: 1 } // reparent within the same batch
+      ]);
+      expect(structureTree.getParent('c')).toBe('p2');
+      expect(structureTree.getChildren('p1')).toEqual([]);
+    });
+
+    it('restore() rebuilds the index from the snapshot', () => {
+      structureTree.addChild({ parentId: 'p1', childId: 'c1', order: 1 });
+      const snapshot = structureTree.snapshot();
+
+      structureTree.clear();
+      expect(structureTree.getParent('c1')).toBeNull();
+
+      structureTree.restore(snapshot);
+      expect(structureTree.getParent('c1')).toBe('p1');
+    });
+
+    it('clear() empties the index', () => {
+      structureTree.addChild({ parentId: 'p1', childId: 'c1', order: 1 });
+      structureTree.clear();
+      expect(structureTree.getParent('c1')).toBeNull();
+    });
+
+    it('getParent never iterates the whole tree (O(1) per lookup)', () => {
+      // Build a wide tree through the public API.
+      for (let i = 0; i < 500; i++) {
+        structureTree.addChild({ parentId: `p${i}`, childId: `c${i}`, order: 1 });
+      }
+
+      // Swap in an iteration-counting map via restore() (which rebuilds the
+      // index). The removed O(N) implementation walked the map with for..of
+      // (Symbol.iterator) on every call; the index-backed one must not.
+      class CountingMap extends Map<string, Array<{ nodeId: string; order: number }>> {
+        scans = 0;
+        [Symbol.iterator]() {
+          this.scans++;
+          return super[Symbol.iterator]();
+        }
+      }
+      const counting = new CountingMap(structureTree.snapshot());
+      structureTree.restore(counting);
+      counting.scans = 0; // restore's own index rebuild iterates once — reset
+
+      for (let i = 0; i < 500; i++) {
+        expect(structureTree.getParent(`c${i}`)).toBe(`p${i}`);
+      }
+      expect(structureTree.getParent('not-in-tree')).toBeNull();
+      expect(counting.scans).toBe(0);
+    });
+  });
+
+  describe('runBatch', () => {
+    it('applies all mutations with exactly one reactive notification', () => {
+      const before = structureTree.children;
+      let during: unknown = null;
+
+      structureTree.runBatch(() => {
+        structureTree.addChild({ parentId: 'p', childId: 'a', order: 1 });
+        structureTree.addChild({ parentId: 'p', childId: 'b', order: 2 });
+        structureTree.removeChild({ parentId: 'p', childId: 'a', order: 0 });
+        during = structureTree.children;
+      });
+
+      // No reassignment while the batch is open ($state.raw consumers are not
+      // invalidated per-op) ...
+      expect(during).toBe(before);
+      // ... exactly one reassignment when the batch closes.
+      expect(structureTree.children).not.toBe(before);
+      expect(structureTree.getChildren('p')).toEqual(['b']);
+    });
+
+    it('preserves op order — create then delete of the same edge ends absent', () => {
+      structureTree.runBatch(() => {
+        structureTree.addChild({ parentId: 'p', childId: 'c', order: 1 });
+        structureTree.removeChild({ parentId: 'p', childId: 'c', order: 0 });
+      });
+      expect(structureTree.getChildren('p')).toEqual([]);
+      expect(structureTree.getParent('c')).toBeNull();
+    });
+
+    it('preserves op order — delete then re-create of the same edge ends present', () => {
+      structureTree.addChild({ parentId: 'p', childId: 'c', order: 1 });
+      structureTree.runBatch(() => {
+        structureTree.removeChild({ parentId: 'p', childId: 'c', order: 0 });
+        structureTree.addChild({ parentId: 'p', childId: 'c', order: 2 });
+      });
+      expect(structureTree.getChildren('p')).toEqual(['c']);
+      expect(structureTree.getParent('c')).toBe('p');
+    });
+
+    it('a batch with no mutations does not notify', () => {
+      const before = structureTree.children;
+      structureTree.runBatch(() => {});
+      expect(structureTree.children).toBe(before);
+    });
+
+    it('nested batches notify once, at the end of the outermost batch', () => {
+      const before = structureTree.children;
+      structureTree.runBatch(() => {
+        structureTree.addChild({ parentId: 'p', childId: 'a', order: 1 });
+        structureTree.runBatch(() => {
+          structureTree.addChild({ parentId: 'p', childId: 'b', order: 2 });
+        });
+        // Inner batch closed, but the outer one is still open — no notify yet.
+        expect(structureTree.children).toBe(before);
+      });
+      expect(structureTree.children).not.toBe(before);
+      expect(structureTree.getChildren('p')).toEqual(['a', 'b']);
+    });
+
+    it('notifies even when the batch callback throws after mutating', () => {
+      const before = structureTree.children;
+      expect(() =>
+        structureTree.runBatch(() => {
+          structureTree.addChild({ parentId: 'p', childId: 'a', order: 1 });
+          throw new Error('boom');
+        })
+      ).toThrow('boom');
+      // The mutation landed, so consumers must still be invalidated.
+      expect(structureTree.children).not.toBe(before);
+      expect(structureTree.getChildren('p')).toEqual(['a']);
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #1673 — the round-1 P0 where the app is unusable during the initial cloud-sync pull of a populated tenant (24,197 nodes / 39,183 relationships): the daemon floods the WatchNodes stream (69× "subscriber lagged; events dropped") and the webview applied each event synchronously. Every `has_child` relationship event ran an **O(N) parent scan** and copied the entire children map (a global reactive invalidation), so a 39k-edge burst was **O(N²)** on the main thread — the app sat on "Loading…".

## Changes
- **`reactive-structure-tree.svelte.ts`** — a reverse child→parent index makes `getParent` **O(1)** (verified against the children map, self-healing on a miss so a stale entry can't return a wrong parent). New `runBatch()` applies a burst of ops under a **single** `notifyChange` instead of one per op.
- **`tauri-sync-listener.ts`** (Pro path) — buffer `has_child` relationship events over the existing 16 ms coalescing window and flush them through one `runBatch` in **arrival order** (so create/delete of the same edge in a window resolves exactly as un-coalesced). Chunk the node-fetch flush (200/chunk) with a main-thread yield and a **per-chunk** epoch re-check, plus a reentrancy guard so overlapping flushes can't share tombstone state.

## Community build unchanged
Non-Pro relationship events still apply synchronously per event (a dedicated guardrail test asserts this); `free-user-guardrail.test.ts` 11/11.

## Tests
+19: single `notifyChange` per burst; O(1) `getParent` asserted via a counting map (zero full-map iterations over 500 calls); create→delete and delete→create ordering both ways; per-chunk epoch drop on a mid-flush database switch; reverse-index consistency across add/remove/reparent/clear/restore. Full frontend suite **4079** green; svelte-check 0 errors; eslint/prettier clean.

Companion: the daemon-side double-spawn + startup-progress work is nodespace-sync#324 (progress `detail` renders here). Round-1 evidence: `validation-round1/reports/val-P0-ui-blocked-during-sync.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
