### PR TITLE
Create the DB file on `database create`; error on wrong-database reads instead of serving the active DB

### DIFF
--- a/packages/cli/tests/cli_integration.rs
+++ b/packages/cli/tests/cli_integration.rs
@@ -1291,11 +1291,15 @@ async fn database_registry_round_trip() {
         .expect("second registered")
         .id
         .clone();
+    // Create makes the database file before registering it — it exists on disk
+    // as soon as the command returns, without any request having routed to it.
+    assert!(
+        tempdir.path().join("second.db").exists(),
+        "create must create the database file"
+    );
 
-    // Open the second database by routing a write to it, so its file exists on
-    // disk — this lets the remove assertion below prove the file is preserved
-    // rather than merely never created (a freshly created DB is "missing" until
-    // first opened).
+    // Route a write to the second database, proving the freshly created
+    // database serves requests immediately.
     let mut node_second = node_client_for(&sock, &second_id).await;
     node_second
         .create_node(CreateNodeRequest {

--- a/packages/daemon/src/db_routing.rs
+++ b/packages/daemon/src/db_routing.rs
@@ -17,15 +17,62 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use tonic::codegen::http;
+use tonic::Status;
 use tower::{Layer, Service};
 
 use crate::services::database_manager::DatabaseManager;
+use crate::services::DatabaseServices;
 
 /// The metadata/header key a client sets to target a specific registered
 /// database. Re-exported from the wire-contract crate so the daemon and every
 /// client share one canonical key; see [`nodespace_proto::DATABASE_ID_HEADER`]
 /// for the full semantics.
 pub use nodespace_proto::DATABASE_ID_HEADER;
+
+/// Resolve the database a routed request targets (ADR-053). This is the single
+/// routing contract shared by every per-database service's `route` adapter
+/// (node, embeddings, import, agent-session).
+///
+/// When the routing middleware ([`DbManagerLayer`]) injected a
+/// [`DatabaseManager`], the `x-ns-database-id` header selects a registered
+/// database (an unregistered id → `NOT_FOUND`) and an absent header selects the
+/// default; the target's service set is opened (lazily) and returned.
+///
+/// Returns `Ok(None)` when no manager was injected AND no routing header is
+/// present — the caller then serves its own single-database service set, which
+/// is how the Pro daemon and directly-constructed test impls behave. A request
+/// that names a database on a daemon without routing installed is rejected
+/// (`UNIMPLEMENTED`) rather than silently served from the active database:
+/// answering with another database's data is a wrong-database read the caller
+/// cannot detect.
+pub(crate) async fn routed_database_services<T>(
+    request: &tonic::Request<T>,
+) -> Result<Option<Arc<DatabaseServices>>, Status> {
+    let header = request
+        .metadata()
+        .get(DATABASE_ID_HEADER)
+        .map(|v| v.to_str())
+        .transpose()
+        .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
+    let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
+        return match header {
+            Some(id) => Err(Status::unimplemented(format!(
+                "this daemon does not route requests to a specific database; \
+                 cannot serve the request targeting database id {id}"
+            ))),
+            None => Ok(None),
+        };
+    };
+    let id = manager
+        .resolve_database_id(header)
+        .await
+        .map_err(|e| Status::not_found(e.to_string()))?;
+    let services = manager
+        .get_or_open(&id)
+        .await
+        .map_err(|e| Status::internal(e.to_string()))?;
+    Ok(Some(services))
+}
 
 /// `tower::Layer` that inserts the shared [`Arc<DatabaseManager>`] into each
 /// request's extensions. See the module docs for why this is core-only and

--- a/packages/daemon/src/services/agent_session_service.rs
+++ b/packages/daemon/src/services/agent_session_service.rs
@@ -24,7 +24,6 @@ use tokio::sync::broadcast::error::RecvError;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
-use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     agent_session_service_server::AgentSessionService, AgentAvailability, CheckAvailabilityRequest,
     CheckAvailabilityResponse, LaunchSessionRequest, LaunchSessionResponse, ListSessionsRequest,
@@ -33,7 +32,6 @@ use crate::nodespace::{
     WriteInputResponse,
 };
 use crate::services::capture_service::{finalize_capture, CompletedSession};
-use crate::services::database_manager::DatabaseManager;
 use crate::services::settings_service::{read_capture_settings, CaptureConfig};
 
 /// gRPC adapter that owns shared handles to the PTY engine.
@@ -61,10 +59,11 @@ impl AgentSessionHandler {
     }
 
     /// Resolve which database this request targets (ADR-053) and return that
-    /// database's handler. See [`crate::services::NodeServiceImpl::route`] for
-    /// the shared contract: no manager injected (Pro daemon, unit tests) →
-    /// `self`; an `x-ns-database-id` header selects a registered database
-    /// (unregistered → rejected).
+    /// database's handler. The routing contract lives in
+    /// [`crate::db_routing::routed_database_services`]: a header selects a
+    /// registered database, header-less requests hit the default, and with no
+    /// routing middleware installed a header-less request falls back to `self`
+    /// while a header-carrying one is rejected.
     ///
     /// Only [`launch_session`](Self::launch_session) routes: the `PtySessionManager`
     /// is process-global (the same `Arc` backs every database), so PTY
@@ -73,24 +72,10 @@ impl AgentSessionHandler {
     /// per-database context assembler and node service (for context + capture),
     /// so it follows the targeted database.
     async fn route<T>(&self, request: &Request<T>) -> Result<AgentSessionHandler, Status> {
-        let Some(db_manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
-            return Ok(self.clone());
-        };
-        let header = request
-            .metadata()
-            .get(DATABASE_ID_HEADER)
-            .map(|v| v.to_str())
-            .transpose()
-            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
-        let id = db_manager
-            .resolve_database_id(header)
-            .await
-            .map_err(|e| Status::not_found(e.to_string()))?;
-        let services = db_manager
-            .get_or_open(&id)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        Ok(services.agent_session.clone())
+        match crate::db_routing::routed_database_services(request).await? {
+            Some(services) => Ok(services.agent_session.clone()),
+            None => Ok(self.clone()),
+        }
     }
 }
 

--- a/packages/daemon/src/services/database_manager.rs
+++ b/packages/daemon/src/services/database_manager.rs
@@ -283,11 +283,16 @@ impl DatabaseManager {
         }
     }
 
-    /// Register a brand-new database under `name`. When `path` is `None` the
-    /// daemon derives a path under its managed database directory. The registry
-    /// entry is created and persisted; the database file itself is created
-    /// lazily on first open (a follow-on stage), so a freshly created entry
-    /// reports [`DatabaseStatus::Missing`] until then.
+    /// Create a brand-new database under `name`. When `path` is `None` the
+    /// daemon derives a path under its managed database directory.
+    ///
+    /// The database file is created and opened BEFORE the registry entry is
+    /// persisted, so the registry never advertises a database whose file does
+    /// not exist. The open handle is cached, so a freshly created database
+    /// reports [`DatabaseStatus::Open`] and serves routed requests immediately.
+    /// If registration fails after the file was created, the creation is rolled
+    /// back — the handle is closed and the just-created file removed — leaving
+    /// the daemon exactly as it was before the call.
     pub async fn create(&self, name: String, path: Option<PathBuf>) -> Result<DatabaseEntry> {
         let id = DatabaseId::generate();
         let path = match path {
@@ -296,12 +301,56 @@ impl DatabaseManager {
                 .join("database")
                 .join(format!("{id}.db")),
         };
-        self.insert_entry(id, name, path).await
+        // Creating on top of an existing file would silently adopt (and share)
+        // foreign data; `register` is the path for existing database files.
+        // This check is also what makes the rollback below safe: any file at
+        // `path` afterwards is one this call created.
+        if path.exists() {
+            return Err(anyhow!(
+                "a file already exists at {}; use register to add an existing database",
+                path.display()
+            ));
+        }
+
+        // Create and open the database (file, schema, service set) first.
+        let (services, _embed_task) = build_database_services(&path, &self.context, id.as_str())
+            .await
+            .with_context(|| format!("creating database file {}", path.display()))?;
+
+        // Cache the open handle before the entry becomes resolvable: no request
+        // can route to the id until `insert_entry` persists it, so the first
+        // routed request reuses this handle instead of racing a second open.
+        self.open
+            .write()
+            .await
+            .insert(id.clone(), Arc::new(services));
+        self.touch(&id).await;
+
+        match self.insert_entry(id.clone(), name, path.clone()).await {
+            Ok(entry) => Ok(entry),
+            Err(e) => {
+                // Registration failed → roll back the creation: drop the open
+                // handle and remove the file this call just created, so a
+                // failed create leaves no half-registered state behind.
+                self.close(&id).await;
+                remove_database_files(&path).await;
+                Err(e)
+            }
+        }
     }
 
     /// Register an existing database file already present on disk. The name is
-    /// derived from the file stem. Registering never creates or moves files.
+    /// derived from the file stem. Registering never creates or moves files, so
+    /// the file must already exist — a registry entry pointing at nothing would
+    /// report [`DatabaseStatus::Missing`] forever. Use
+    /// [`DatabaseManager::create`] for a new database.
     pub async fn register(&self, path: PathBuf) -> Result<DatabaseEntry> {
+        if !path.exists() {
+            return Err(anyhow!(
+                "no database file exists at {}; use create to make a new database",
+                path.display()
+            ));
+        }
         let name = path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -683,7 +732,9 @@ impl DatabaseManager {
     }
 
     /// Push a new entry into the registry and persist it. The first registered
-    /// database becomes the default.
+    /// database becomes the default. If persisting fails, the in-memory
+    /// mutation is rolled back so the registry map never drifts from the file
+    /// on disk.
     async fn insert_entry(
         &self,
         id: DatabaseId,
@@ -701,11 +752,43 @@ impl DatabaseManager {
         };
         let mut registry = self.registry.write().await;
         registry.databases.push(entry.clone());
-        if registry.default_database.is_none() {
+        let adopted_default = registry.default_database.is_none();
+        if adopted_default {
             registry.default_database = Some(id);
         }
-        registry.save(&self.registry_path).await?;
+        if let Err(e) = registry.save(&self.registry_path).await {
+            // The write lock is held throughout, so the pushed entry is still
+            // last — pop restores exactly the pre-call state.
+            registry.databases.pop();
+            if adopted_default {
+                registry.default_database = None;
+            }
+            return Err(e);
+        }
         Ok(entry)
+    }
+}
+
+/// Best-effort removal of a database file and its SQLite sidecars (`-wal`,
+/// `-shm`) while rolling back a failed create. Failures are logged rather than
+/// returned — the caller is already unwinding a more meaningful error.
+async fn remove_database_files(path: &Path) {
+    let mut candidates = vec![path.to_path_buf()];
+    for suffix in ["-wal", "-shm"] {
+        let mut file = path.as_os_str().to_owned();
+        file.push(suffix);
+        candidates.push(PathBuf::from(file));
+    }
+    for candidate in candidates {
+        match tokio::fs::remove_file(&candidate).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(
+                path = %candidate.display(),
+                error = %e,
+                "failed to remove database file while rolling back a failed create"
+            ),
+        }
     }
 }
 
@@ -912,7 +995,9 @@ mod tests {
 
         // Registering a second database does not change routing of header-less
         // requests, and the second id routes explicitly.
-        let second = mgr.register(PathBuf::from("/tmp/second.db")).await.unwrap();
+        let second_path = _dir.path().join("second.db");
+        std::fs::write(&second_path, b"").unwrap();
+        let second = mgr.register(second_path).await.unwrap();
         assert_eq!(
             mgr.resolve_database_id(Some(second.id.as_str()))
                 .await
@@ -932,6 +1017,140 @@ mod tests {
     async fn resolve_without_default_errors() {
         let (mgr, _dir) = temp_manager().await;
         assert!(mgr.resolve_database_id(None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_creates_and_opens_the_database_file_before_registering() {
+        let (mgr, dir) = temp_manager().await;
+        let path = dir.path().join("fresh.db");
+
+        let entry = mgr
+            .create("Fresh".into(), Some(path.clone()))
+            .await
+            .unwrap();
+
+        // The database file exists on disk the moment create returns — the
+        // registry never advertises a database with no file behind it.
+        assert!(path.exists(), "create must create the database file");
+
+        // The fresh database is open and, as the first registration, default.
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases.len(), 1);
+        assert_eq!(snap.databases[0].status, DatabaseStatus::Open);
+        assert!(snap.databases[0].is_default);
+        assert_eq!(snap.default_database.as_ref(), Some(&entry.id));
+
+        // The handle cached by create is the one routing reuses — no second open.
+        let first = mgr.get_or_open(&entry.id).await.unwrap();
+        let second = mgr.get_or_open(&entry.id).await.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_an_existing_file() {
+        let (mgr, dir) = temp_manager().await;
+        let path = dir.path().join("existing.db");
+        std::fs::write(&path, b"data").unwrap();
+
+        let err = mgr
+            .create("Clobber".into(), Some(path.clone()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "unexpected error: {err}"
+        );
+
+        // Nothing was registered and the existing file is untouched.
+        assert!(mgr.list().await.databases.is_empty());
+        assert_eq!(std::fs::read(&path).unwrap(), b"data");
+    }
+
+    #[tokio::test]
+    async fn failed_create_rolls_back_and_leaves_the_daemon_serviceable() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("databases.toml");
+        let mgr = DatabaseManager::load(registry_path.clone(), test_context())
+            .await
+            .unwrap();
+
+        // Register + open a healthy default first, as the daemon boot path does.
+        let default_path = dir.path().join("default.db");
+        let default_id = mgr
+            .ensure_default_registered("Default".into(), default_path)
+            .await
+            .unwrap();
+        mgr.get_or_open(&default_id).await.unwrap();
+
+        // Break registry persistence by replacing the registry file with a
+        // directory, so create fails at the registration step — after the
+        // database file has already been created.
+        tokio::fs::remove_file(&registry_path).await.unwrap();
+        tokio::fs::create_dir(&registry_path).await.unwrap();
+
+        let fresh_path = dir.path().join("fresh.db");
+        mgr.create("Fresh".into(), Some(fresh_path.clone()))
+            .await
+            .unwrap_err();
+
+        // Rolled back: no registry entry, no leftover file, and the default
+        // still resolves and serves — a failed create must not wedge routing.
+        let snap = mgr.list().await;
+        assert_eq!(
+            snap.databases.len(),
+            1,
+            "a failed create must not leave a registry entry"
+        );
+        assert!(
+            !fresh_path.exists(),
+            "a failed create must remove the file it created"
+        );
+        assert_eq!(mgr.resolve_database_id(None).await.unwrap(), default_id);
+        assert!(mgr.get_or_open(&default_id).await.is_ok());
+
+        // With persistence restored, the same create succeeds cleanly.
+        tokio::fs::remove_dir(&registry_path).await.unwrap();
+        let entry = mgr
+            .create("Fresh".into(), Some(fresh_path.clone()))
+            .await
+            .unwrap();
+        assert!(fresh_path.exists());
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases.len(), 2);
+        assert_eq!(
+            snap.databases
+                .iter()
+                .find(|d| d.entry.id == entry.id)
+                .unwrap()
+                .status,
+            DatabaseStatus::Open
+        );
+    }
+
+    #[tokio::test]
+    async fn register_requires_an_existing_file() {
+        let (mgr, dir) = temp_manager().await;
+
+        // An absent path is rejected — a registration pointing at nothing would
+        // report Missing forever.
+        let absent = dir.path().join("not-here.db");
+        let err = mgr.register(absent).await.unwrap_err();
+        assert!(
+            err.to_string().contains("no database file exists"),
+            "unexpected error: {err}"
+        );
+        assert!(mgr.list().await.databases.is_empty());
+
+        // An existing file registers (name from the file stem) and reports
+        // Closed until first opened.
+        let present = dir.path().join("present.db");
+        std::fs::write(&present, b"").unwrap();
+        mgr.register(present).await.unwrap();
+        let snap = mgr.list().await;
+        assert_eq!(snap.databases.len(), 1);
+        assert_eq!(snap.databases[0].status, DatabaseStatus::Closed);
+        assert_eq!(snap.databases[0].entry.name, "present");
+        assert!(snap.databases[0].is_default);
     }
 
     #[tokio::test]

--- a/packages/daemon/src/services/database_service.rs
+++ b/packages/daemon/src/services/database_service.rs
@@ -205,8 +205,10 @@ mod tests {
             .into_inner();
         assert_eq!(first.name, "First");
         assert!(first.is_default);
-        // File not created until first open, so a freshly created entry is Missing.
-        assert_eq!(first.status, ProtoDatabaseStatus::Missing as i32);
+        // Create makes the file and opens it before registering, so a freshly
+        // created entry reports Open — never Missing.
+        assert_eq!(first.status, ProtoDatabaseStatus::Open as i32);
+        assert!(dir.path().join("first.db").exists());
 
         let second = svc
             .create(Request::new(CreateDatabaseRequest {
@@ -274,17 +276,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_reports_missing_for_absent_file() {
+    async fn register_rejects_an_absent_file_and_accepts_an_existing_one() {
         let (svc, dir) = service().await;
-        let info = svc
+
+        // Registering never creates files, so an absent target is rejected
+        // rather than registered as permanently Missing.
+        let err = svc
             .register(Request::new(RegisterDatabaseRequest {
                 path: dir.path().join("not-here.db").display().to_string(),
             }))
             .await
+            .unwrap_err();
+        assert!(
+            err.message().contains("no database file exists"),
+            "unexpected error: {}",
+            err.message()
+        );
+
+        // An existing file registers and reports Closed until first opened.
+        let present = dir.path().join("present.db");
+        std::fs::write(&present, b"").unwrap();
+        let info = svc
+            .register(Request::new(RegisterDatabaseRequest {
+                path: present.display().to_string(),
+            }))
+            .await
             .unwrap()
             .into_inner();
-        // Registering never creates the file, so an absent target reports Missing.
-        assert_eq!(info.status, ProtoDatabaseStatus::Missing as i32);
+        assert_eq!(info.status, ProtoDatabaseStatus::Closed as i32);
         assert!(info.is_default); // first registered → default
     }
 

--- a/packages/daemon/src/services/embeddings_service.rs
+++ b/packages/daemon/src/services/embeddings_service.rs
@@ -15,7 +15,6 @@ use nodespace_core::services::{EmbeddingProcessor, NodeEmbeddingService, NodeSer
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
-use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     embeddings_service_server::EmbeddingsService as GrpcEmbeddingsService, BatchEmbeddingFailure,
     BatchQueueEmbeddingsRequest, BatchQueueEmbeddingsResponse, EmbeddingStatusResponse,
@@ -24,7 +23,6 @@ use crate::nodespace::{
     SearchSemanticRequest, SearchSemanticResponse, TriggerBatchEmbedRequest,
     TriggerBatchEmbedResponse,
 };
-use crate::services::database_manager::DatabaseManager;
 use crate::services::node_service::node_to_proto;
 
 /// Live embedding state once the model has finished loading.
@@ -53,35 +51,24 @@ impl EmbeddingsServiceImpl {
     }
 
     /// Resolve which database this request targets (ADR-053) and return that
-    /// database's embeddings service. See
-    /// [`crate::services::NodeServiceImpl::route`] for the shared contract: no
-    /// manager injected (Pro daemon, unit tests) → `self`; an `x-ns-database-id`
-    /// header selects a registered database (unregistered → rejected). If the
-    /// target database has no embeddings service (no model — which, since the
-    /// model is process-global, cannot happen while this service is registered)
-    /// fall back to `self`.
+    /// database's embeddings service. The routing contract lives in
+    /// [`crate::db_routing::routed_database_services`]: a header selects a
+    /// registered database, header-less requests hit the default, and with no
+    /// routing middleware installed a header-less request falls back to `self`
+    /// while a header-carrying one is rejected rather than silently served from
+    /// the active database.
     async fn route<T>(&self, request: &Request<T>) -> Result<EmbeddingsServiceImpl, Status> {
-        let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
-            return Ok(self.clone());
-        };
-        let header = request
-            .metadata()
-            .get(DATABASE_ID_HEADER)
-            .map(|v| v.to_str())
-            .transpose()
-            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
-        let id = manager
-            .resolve_database_id(header)
-            .await
-            .map_err(|e| Status::not_found(e.to_string()))?;
-        let services = manager
-            .get_or_open(&id)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        Ok(services
-            .embeddings_service_grpc
-            .clone()
-            .unwrap_or_else(|| self.clone()))
+        match crate::db_routing::routed_database_services(request).await? {
+            // The embedding model is process-global, so a registered
+            // EmbeddingsService implies every open database has one; if the
+            // target somehow has none, answering from `self` would silently
+            // serve another database, so fail instead.
+            Some(services) => services
+                .embeddings_service_grpc
+                .clone()
+                .ok_or_else(|| Status::internal("the target database has no embeddings service")),
+            None => Ok(self.clone()),
+        }
     }
 
     /// Shared implementation for stale-count queries used by both

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -19,12 +19,10 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
-use crate::db_routing::DATABASE_ID_HEADER;
 use crate::nodespace::{
     import_service_server::ImportService as GrpcImportService, FileImportResult,
     ImportMarkdownFilesRequest, ImportMarkdownRequest, ImportOptions, ImportProgressEvent,
 };
-use crate::services::database_manager::DatabaseManager;
 
 const CHANNEL_BUFFER: usize = 64;
 
@@ -55,30 +53,16 @@ impl ImportServiceImpl {
     }
 
     /// Resolve which database this request targets (ADR-053) and return that
-    /// database's import service. See [`crate::services::NodeServiceImpl::route`]
-    /// for the shared routing contract: with no manager injected (Pro daemon,
-    /// unit tests) this returns `self`, so behavior is unchanged; an
-    /// `x-ns-database-id` header selects a registered database (unregistered →
-    /// rejected).
+    /// database's import service. The routing contract lives in
+    /// [`crate::db_routing::routed_database_services`]: a header selects a
+    /// registered database, header-less requests hit the default, and with no
+    /// routing middleware installed a header-less request falls back to `self`
+    /// while a header-carrying one is rejected.
     async fn route<T>(&self, request: &Request<T>) -> Result<ImportServiceImpl, Status> {
-        let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
-            return Ok(self.clone());
-        };
-        let header = request
-            .metadata()
-            .get(DATABASE_ID_HEADER)
-            .map(|v| v.to_str())
-            .transpose()
-            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
-        let id = manager
-            .resolve_database_id(header)
-            .await
-            .map_err(|e| Status::not_found(e.to_string()))?;
-        let services = manager
-            .get_or_open(&id)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        Ok(services.import.clone())
+        match crate::db_routing::routed_database_services(request).await? {
+            Some(services) => Ok(services.import.clone()),
+            None => Ok(self.clone()),
+        }
     }
 }
 
@@ -1288,6 +1272,8 @@ async fn import_markdown_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db_routing::DATABASE_ID_HEADER;
+    use crate::services::database_manager::DatabaseManager;
     use crate::services::SharedContext;
     use nodespace_agent::pty::PtySessionManager;
     use nodespace_core::services::EmbeddingScheduler;

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -35,8 +35,6 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::db_routing::DATABASE_ID_HEADER;
-use crate::services::database_manager::DatabaseManager;
 use crate::services::embeddings_service::EmbeddingReady;
 use tonic::{Request, Response, Status};
 
@@ -104,35 +102,17 @@ impl NodeServiceImpl {
     }
 
     /// Resolve which database a request targets (ADR-053) and return that
-    /// database's node service.
-    ///
-    /// When the routing middleware ([`crate::db_routing::DbManagerLayer`])
-    /// injected a [`DatabaseManager`], resolve the `x-ns-database-id` header
-    /// (absent → the default database) and hand back that database's cached
-    /// [`NodeServiceImpl`]; a header naming an unregistered database is
-    /// rejected rather than silently served from the default. When no manager
-    /// is present — the Pro daemon does not install the layer, and unit tests
-    /// construct the impl directly — fall back to `self` so behavior is
-    /// unchanged.
+    /// database's node service. The routing contract lives in
+    /// [`crate::db_routing::routed_database_services`]: a header selects a
+    /// registered database, header-less requests hit the default, and with no
+    /// routing middleware installed a header-less request falls back to `self`
+    /// while a header-carrying one is rejected rather than silently served from
+    /// the active database.
     async fn route<T>(&self, request: &Request<T>) -> Result<NodeServiceImpl, Status> {
-        let Some(manager) = request.extensions().get::<Arc<DatabaseManager>>() else {
-            return Ok(self.clone());
-        };
-        let header = request
-            .metadata()
-            .get(DATABASE_ID_HEADER)
-            .map(|v| v.to_str())
-            .transpose()
-            .map_err(|_| Status::invalid_argument("x-ns-database-id must be valid ASCII"))?;
-        let id = manager
-            .resolve_database_id(header)
-            .await
-            .map_err(|e| Status::not_found(e.to_string()))?;
-        let services = manager
-            .get_or_open(&id)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        Ok(services.node_service_grpc.clone())
+        match crate::db_routing::routed_database_services(request).await? {
+            Some(services) => Ok(services.node_service_grpc.clone()),
+            None => Ok(self.clone()),
+        }
     }
 }
 
@@ -1740,6 +1720,8 @@ fn normalize_date_for_storage(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db_routing::DATABASE_ID_HEADER;
+    use crate::services::database_manager::DatabaseManager;
     use crate::services::SharedContext;
     use nodespace_agent::pty::PtySessionManager;
     use nodespace_core::db::SqliteStore;
@@ -1853,6 +1835,39 @@ mod tests {
         assert_eq!(
             svc.get_node(get_bad).await.unwrap_err().code(),
             tonic::Code::NotFound
+        );
+    }
+
+    /// A request that names a database on a daemon without the routing
+    /// middleware installed is rejected rather than silently served from the
+    /// active database — silently answering would be a wrong-database read the
+    /// client cannot detect.
+    #[tokio::test]
+    async fn database_header_without_routing_middleware_is_rejected() {
+        let (svc, _tmp) = make_service().await;
+
+        // Header-less requests keep working against the impl's own database.
+        let plain = Request::new(crate::nodespace::GetNodeRequest {
+            node_id: "no-such-node".into(),
+        });
+        assert_eq!(
+            svc.get_node(plain).await.unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+
+        // A routing header with no manager injected must be rejected.
+        let mut routed = Request::new(crate::nodespace::GetNodeRequest {
+            node_id: "no-such-node".into(),
+        });
+        routed
+            .metadata_mut()
+            .insert(DATABASE_ID_HEADER, "SOME-DB-ID".parse().unwrap());
+        let err = svc.get_node(routed).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert!(
+            err.message().contains("SOME-DB-ID"),
+            "rejection must name the database the request targeted: {}",
+            err.message()
         );
     }
 

--- a/packages/daemon/tests/database_service_e2e.rs
+++ b/packages/daemon/tests/database_service_e2e.rs
@@ -149,6 +149,10 @@ async fn create_second_database_then_route_a_write_to_it() {
         .unwrap()
         .into_inner();
     assert!(!second.is_default);
+    // Create makes the file and opens the database before registering it, so
+    // the response already reports Open and the file exists on disk.
+    assert_eq!(second.status, ProtoDatabaseStatus::Open as i32);
+    assert!(tempdir.path().join("second.db").exists());
     let second_id = second.id.clone();
 
     // Write a node addressed to the second database via the routing header.
@@ -198,8 +202,7 @@ async fn create_second_database_then_route_a_write_to_it() {
         .unwrap_err();
     assert_eq!(miss.code(), Code::NotFound);
 
-    // The routed write opened the second database: it now reports Open where it
-    // was Missing before, proving the write hit db2 and not the default.
+    // The second database is still listed Open after serving the routed write.
     let listed = db.list(ListDatabasesRequest {}).await.unwrap().into_inner();
     assert_eq!(listed.databases.len(), 2);
     let second_listed = listed.databases.iter().find(|d| d.id == second_id).unwrap();


### PR DESCRIPTION
## Summary

Two round-1 daemon findings on the multi-database (ADR-053) path:

1. **`database create` never created the DB file.** `DatabaseManager::create()` registered the database in the registry but never created/opened the SQLite file, so a freshly-"created" database 500'd on first use. `create()` now creates and opens the file *before* registering, and rolls the registry entry back if the open fails. `register()` now errors when the target file is absent instead of silently registering a phantom.

2. **A wrong-`--database` read silently served the active DB.** When a request carried an `x-ns-database-id` header naming a database the daemon has no `DatabaseManager` for, routing fell through to the default services and returned the *active* database's data — a silent wrong-answer. `routed_database_services()` now returns `UNIMPLEMENTED` for a named-DB request when no `DatabaseManager` is present, while a header-less request keeps the default-fallback behavior. Verified safe for normal flows: the CLI and desktop app only stamp the header on an explicit database-switcher selection, never on the default single-DB path.

## Testing
- `bun run test:all` + `cargo build --bin nodespaced` + `test:e2e` (full pre-push gate) green.
- Unit coverage: create-then-open rollback, register-absent-file error, routed-services header cases.

Closes #1675
Closes #1676