### PR TITLE
Pin the pane's daemon-reconnect rehydration by mounting the real component

### DIFF
--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -587,8 +587,8 @@ async fn run_batch_import(
                 // Refresh in place. Update the root now (non-destructive) so its
                 // id and inbound links/mentions survive, and capture its current
                 // children to prune only after the fresh subtree is inserted.
-                let update = nodespace_core::NodeUpdate::new()
-                    .with_content(prepared.root_content.clone());
+                let update =
+                    nodespace_core::NodeUpdate::new().with_content(prepared.root_content.clone());
                 if let Err(e) = store
                     .update_node(&prepared.root_id, update, Some("import".to_string()))
                     .await
@@ -603,8 +603,7 @@ async fn run_batch_import(
                             prepared.root_id,
                             e
                         );
-                        phase2_error
-                            .get_or_insert_with(|| format!("Subtree replace failed: {e}"));
+                        phase2_error.get_or_insert_with(|| format!("Subtree replace failed: {e}"));
                     }
                 }
                 replaced_roots.push(prepared.root_id.clone());
@@ -627,7 +626,7 @@ async fn run_batch_import(
 
             // Children are (re)created for new and replaced roots. Skipped roots
             // keep their existing subtree, so contribute no children here.
-            if !(exists && !replace) {
+            if !exists || replace {
                 for child in &prepared.children {
                     let parent = child
                         .parent_id
@@ -748,7 +747,10 @@ async fn run_batch_import(
         // insert) means a failed bulk insert leaves the previous content intact
         // instead of truncating it — re-import is never destructive on error.
         if !bulk_insert_failed && !prune_after_insert.is_empty() {
-            if let Err(e) = store.delete_nodes_by_ids_unchecked(&prune_after_insert).await {
+            if let Err(e) = store
+                .delete_nodes_by_ids_unchecked(&prune_after_insert)
+                .await
+            {
                 tracing::error!(
                     "Failed to prune {} stale node(s) after replace: {}",
                     prune_after_insert.len(),
@@ -762,7 +764,10 @@ async fn run_batch_import(
         // content effectively changed — re-mark it stale so it re-embeds. New
         // roots already get their markers inside bulk_create_hierarchy_trusted.
         if !bulk_insert_failed && !replaced_roots.is_empty() {
-            if let Err(e) = store.create_stale_embedding_markers_bulk(&replaced_roots).await {
+            if let Err(e) = store
+                .create_stale_embedding_markers_bulk(&replaced_roots)
+                .await
+            {
                 tracing::warn!(
                     "Failed to re-mark {} replaced root(s) stale: {}",
                     replaced_roots.len(),
@@ -1496,7 +1501,11 @@ mod tests {
         assert!(ns.get_node(&id_b).await.unwrap().is_some(), "Doc B created");
         let headers_after_first = ns.store().count_nodes_by_type("header").await.unwrap();
         assert!(
-            !ns.store().get_node_memberships(&id_a).await.unwrap().is_empty(),
+            !ns.store()
+                .get_node_memberships(&id_a)
+                .await
+                .unwrap()
+                .is_empty(),
             "Doc A is assigned to a collection",
         );
 
@@ -1531,7 +1540,11 @@ mod tests {
             "Doc B root kept across replace",
         );
         assert!(
-            !ns.store().get_node_memberships(&id_a).await.unwrap().is_empty(),
+            !ns.store()
+                .get_node_memberships(&id_a)
+                .await
+                .unwrap()
+                .is_empty(),
             "collection membership survives replace",
         );
     }

--- a/packages/desktop-app/src/tests/components/pane-content-reconnect-hydration.test.ts
+++ b/packages/desktop-app/src/tests/components/pane-content-reconnect-hydration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Mounts the real pane-content.svelte and drives the daemon-reconnect path.
+ *
+ * The sibling `pane-content-hydration` suite exercises a local copy of
+ * hydrateNode()'s logic, so it cannot catch the wiring regressing — if the
+ * component stopped subscribing to `onDaemonReconnect`, or subscribed with a
+ * callback that no longer re-hydrates, every one of those tests would still
+ * pass. These tests mount the component itself and assert the observable
+ * contract instead: a hydration fetch that fails inside the daemon's boot
+ * window (fresh install — the webview renders while the sidecar is still
+ * seeding its DB and binding the socket) is retried when the daemon reports
+ * healthy, and the pane leaves its "Loading..." state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+// Ids and the shared handles the mocks write into all live in `vi.hoisted`:
+// vi.mock factories are hoisted above normal module-scope initialization, so
+// anything they close over must be hoisted too.
+const { PANE_ID, TAB_ID, NODE_ID, h } = vi.hoisted(() => ({
+  PANE_ID: 'pane-1',
+  TAB_ID: 'tab-1',
+  NODE_ID: 'node-journal-1',
+  h: {
+    reconnectCallbacks: [] as Array<() => void>,
+    nodes: new Map<string, { id: string }>(),
+    ensureCalls: [] as string[],
+    /** Queue of outcomes for successive ensureNode() calls. */
+    ensureOutcomes: [] as Array<'boot-window-failure' | 'success'>,
+    closedTabs: [] as string[]
+  }
+}));
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/services/daemon-status', () => ({
+  onDaemonReconnect: (cb: () => void) => {
+    h.reconnectCallbacks.push(cb);
+    return () => {
+      h.reconnectCallbacks = h.reconnectCallbacks.filter((c) => c !== cb);
+    };
+  }
+}));
+
+vi.mock('$lib/services/shared-node-store.svelte', () => ({
+  sharedNodeStore: {
+    getNode: (id: string) => h.nodes.get(id),
+    ensureNode: async (id: string) => {
+      h.ensureCalls.push(id);
+      const outcome = h.ensureOutcomes.shift() ?? 'success';
+      if (outcome === 'boot-window-failure') {
+        // What the daemon boot window actually looks like to the webview: the
+        // fetch rejects (socket not yet bound) rather than resolving "absent".
+        throw new Error('daemon socket not ready');
+      }
+      const node = { id };
+      h.nodes.set(id, node);
+      return node;
+    }
+  }
+}));
+
+vi.mock('$lib/stores/navigation.svelte', () => ({
+  navigationStore: {
+    state: {
+      tabs: [
+        {
+          id: TAB_ID,
+          type: 'content',
+          title: 'Journal',
+          content: { nodeId: NODE_ID, nodeType: 'date' }
+        }
+      ],
+      activeTabIds: { [PANE_ID]: TAB_ID },
+      panes: [{ id: PANE_ID }]
+    }
+  },
+  updateTabContent: vi.fn(),
+  closeTab: (tabId: string) => h.closedTabs.push(tabId)
+}));
+
+vi.mock('$lib/plugins/plugin-registry', () => ({
+  pluginRegistry: {
+    hasViewer: () => false,
+    getViewer: async () => null
+  }
+}));
+
+// Stub the panes pane-content can route to. They are not under test here, and
+// importing them for real drags in the whole viewer tree (bits-ui et al), which
+// is what pushed the sibling suite into mirroring the logic instead of mounting
+// the component. A Svelte 5 component is just a function, so a no-op renders
+// nothing and keeps the import graph shallow.
+vi.mock('$lib/design/components/base-node-viewer.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/settings/settings-pane.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/search/search-pane.svelte', () => ({ default: () => {} }));
+
+import PaneContent from '$lib/components/layout/pane-content.svelte';
+import type { Pane } from '$lib/stores/navigation.svelte';
+
+const pane: Pane = { id: PANE_ID, width: 100, tabIds: [TAB_ID] };
+
+/** Let the mount $effect and its awaited hydration settle. */
+async function settle() {
+  for (let i = 0; i < 5; i++) {
+    await tick();
+    await Promise.resolve();
+  }
+}
+
+function fireDaemonHealthy() {
+  for (const cb of [...h.reconnectCallbacks]) cb();
+}
+
+describe('pane-content daemon-reconnect hydration', () => {
+  beforeEach(() => {
+    h.reconnectCallbacks = [];
+    h.nodes.clear();
+    h.ensureCalls.length = 0;
+    h.ensureOutcomes.length = 0;
+    h.closedTabs.length = 0;
+  });
+
+  afterEach(() => cleanup());
+
+  it('subscribes to daemon reconnect while mounted', () => {
+    h.ensureOutcomes.push('success');
+    render(PaneContent, { props: { pane } });
+
+    expect(h.reconnectCallbacks.length).toBe(1);
+  });
+
+  it('retries a boot-window hydration failure when the daemon reports healthy', async () => {
+    h.ensureOutcomes.push('boot-window-failure', 'success');
+
+    const { getByText } = render(PaneContent, { props: { pane } });
+    await settle();
+
+    // The first fetch raced the boot window and failed: the node never landed
+    // in the store, so the pane is stuck on its loading state — this is exactly
+    // the state that used to be permanent.
+    expect(h.ensureCalls).toEqual([NODE_ID]);
+    expect(h.nodes.has(NODE_ID)).toBe(false);
+    expect(getByText('Loading...')).toBeTruthy();
+    // A failed fetch is not a missing node — the tab must survive to be retried.
+    expect(h.closedTabs).toEqual([]);
+
+    fireDaemonHealthy();
+    await settle();
+
+    // The retry is the whole point: the pane refetched and the node landed.
+    // Asserting the "Loading..." text then disappears would only be testing the
+    // real store's reactivity (isNodeHydrated is $derived off the store cell) —
+    // this mock store is a plain Map, and the suite stubs runes non-reactively.
+    // The store's own suite covers that; here the contract is the refetch.
+    expect(h.ensureCalls).toEqual([NODE_ID, NODE_ID]);
+    expect(h.nodes.has(NODE_ID)).toBe(true);
+  });
+
+  it('does not re-fetch on reconnect once the node is already hydrated', async () => {
+    h.ensureOutcomes.push('success');
+
+    render(PaneContent, { props: { pane } });
+    await settle();
+
+    expect(h.ensureCalls).toEqual([NODE_ID]);
+    expect(h.nodes.has(NODE_ID)).toBe(true);
+
+    // A later reconnect (daemon restart mid-session) must be a no-op for a pane
+    // whose node is present, not a redundant refetch of the whole graph.
+    fireDaemonHealthy();
+    await settle();
+
+    expect(h.ensureCalls).toEqual([NODE_ID]);
+  });
+
+  it('stops retrying after the pane unmounts', async () => {
+    h.ensureOutcomes.push('boot-window-failure');
+
+    const { unmount } = render(PaneContent, { props: { pane } });
+    await settle();
+    expect(h.ensureCalls).toEqual([NODE_ID]);
+
+    unmount();
+    fireDaemonHealthy();
+    await settle();
+
+    // The unmounted pane must not fetch: its subscription is released on destroy.
+    expect(h.ensureCalls).toEqual([NODE_ID]);
+  });
+});


### PR DESCRIPTION
## Summary

Round-1 fix validation turned up a real coverage gap on the journal-hydration fix.

The existing `pane-content-hydration` suite drives a **local copy** of `hydrateNode()`'s logic rather than the component, and says so in its own header. That means it cannot catch the wiring regressing: if the pane stopped subscribing to `onDaemonReconnect`, or subscribed with a callback that no longer re-hydrates, every one of those tests would still pass. This is the gap the #1677 adversarial review flagged ("the new test pins nothing — it doesn't import the component/daemon-status"). It matters because that subscription is the only thing that rescues a first hydration fetch which raced the daemon's boot window — without it the pane sits on "Loading..." forever.

`pane-content-reconnect-hydration.test.ts` mounts the real component and asserts the observable contract:
- it subscribes to daemon reconnect while mounted;
- a boot-window fetch failure is **retried** when the daemon reports healthy, and the tab survives (a failed fetch is not a missing node, so it must not be closed);
- reconnect is a **no-op** once the node is already present (no redundant refetch on a mid-session daemon restart);
- an unmounted pane stops retrying (subscription released on destroy).

**Mutation-tested:** with the `onDaemonReconnect` subscription removed from the component, the first two tests fail (`expected +0 to be 1`, `[1 call] != [2 calls]`) — so those genuinely pin the fix. To be precise about what each test buys: the last two (no-op-when-hydrated, stop-after-unmount) still *pass* under that mutation, since they only assert `ensureCalls` did not grow, which is trivially true when nothing is subscribed. They are kept as guards against an over-eager refetch, not as anti-regression cover for this fix.

The panes pane-content routes to are stubbed to keep the import graph shallow; pulling the real viewer tree in (`bits-ui` et al) is exactly what pushed the sibling suite into mirroring the logic.

One assertion is deliberately omitted and commented: that "Loading..." disappears after the retry. That would only be testing the real store's reactivity (`isNodeHydrated` is `$derived` off the store cell) — the mock store is a plain Map and this suite stubs runes non-reactively. The store's own suite covers that. Residual gap worth naming: nothing here proves the reconnect clears the UI end-to-end; that stays live-validation territory.

### Drive-by: unblock `quality:fix`

`import_service.rs` had a double-negative (`!(exists && !replace)`) that clippy rejects under `-D warnings`, which was failing `bun run quality:fix` for the whole repo (pre-existing, from `3489a323d` — not from this branch). Simplified to `!exists || replace`: identical by De Morgan, and it is the exact negation of the `if exists && !replace { skipped_roots… }` branch above it, so children are contributed for precisely the new + replaced roots — matching the comment. No semantic change to `--replace`.

Note the Rust diff is **not** a one-liner: running `quality:fix` also applied `cargo fmt`, which reflowed ~6 unrelated pre-existing lines in the same file (pure line-wrapping, no semantic change).

## Testing
- Full FE suite: **4102 passed / 4102** (166 files).
- `quality:fix`: 1767 files, **0 errors, 0 warnings** (was failing before this).
- `cargo test -p nodespace-daemon import`: green.
- Pre-push gate (test:all + `cargo build --bin nodespaced` + e2e): green.

Relates to #1672 — which stays **open**: this pins the hardening, but the root cause is still unconfirmed and needs a live fresh-install repro in the real Tauri app (browser mode can't exercise it — `daemon-status` is Tauri-only).