### PR TITLE
Poll daemon-status steady-state so a mid-session restart re-fires onDaemonReconnect (#1678)

### DIFF
--- a/packages/desktop-app/src/lib/services/daemon-status.ts
+++ b/packages/desktop-app/src/lib/services/daemon-status.ts
@@ -35,6 +35,19 @@ const log = createLogger('DaemonStatus');
 /** How long to show a "connecting" banner before any status is known. */
 const CONNECTING_GRACE_PERIOD_MS = 1500;
 
+/**
+ * How often to re-probe daemon health once the listener is running.
+ *
+ * The backend pushes `daemon-status` only from its one-shot startup task, so a
+ * daemon that dies and is relaunched mid-session emits nothing — every
+ * reconnect consumer would stay wedged until an app restart. A low-frequency
+ * pull observes the `healthy → not_running → healthy` cycle so `applyStatus`
+ * re-fires `onDaemonReconnect`. Kept slow because the only work on a steady
+ * healthy poll is a cheap socket probe; the reconnect callbacks fire only on
+ * the not-healthy → healthy edge, never on repeated healthy polls.
+ */
+const STEADY_STATE_POLL_MS = 15000;
+
 export interface DaemonStatusState {
   /** True until the first status is known or the grace period elapses. */
   connecting: boolean;
@@ -63,6 +76,9 @@ const reconnectListeners = new Set<() => void>();
 let started = false;
 let lastHealthy = false;
 let activeSource: DaemonStatusSource | null = null;
+let steadyStatePoll: ReturnType<typeof setInterval> | null = null;
+/** Guards against overlapping polls if a `getCurrent` probe runs long. */
+let pollInFlight = false;
 
 /**
  * Register a callback to run whenever the daemon transitions to healthy
@@ -156,6 +172,42 @@ export function startDaemonStatusListener(source?: DaemonStatusSource): void {
     .catch((err) => {
       log.warn('Failed to pull initial daemon status', err);
     });
+
+  // Steady-state poll: keep re-probing at a low frequency so a mid-session
+  // daemon restart (healthy → not_running → healthy) is observed here. The
+  // backend emits `daemon-status` only from its one-shot startup task, so a
+  // relaunched daemon pushes nothing; without this poll every reconnect
+  // consumer (schemas, collections, children-tree, pane hydration) stays
+  // wedged until an app restart.
+  steadyStatePoll = setInterval(() => {
+    if (pollInFlight || !activeSource) return;
+    pollInFlight = true;
+    activeSource
+      .getCurrent()
+      .then(applyStatus)
+      .catch((err) => log.warn('Steady-state daemon status poll failed', err))
+      .finally(() => {
+        pollInFlight = false;
+      });
+  }, STEADY_STATE_POLL_MS);
+  // Never let the poll on its own keep a runtime (or a test worker) alive.
+  (steadyStatePoll as unknown as { unref?: () => void })?.unref?.();
+}
+
+/**
+ * Stop the steady-state poll and reset the listener so it can be started
+ * again. Production never calls this (the service lives for the whole session);
+ * it exists so tests can tear the singleton down between cases.
+ */
+export function stopDaemonStatusListener(): void {
+  if (steadyStatePoll) {
+    clearInterval(steadyStatePoll);
+    steadyStatePoll = null;
+  }
+  pollInFlight = false;
+  started = false;
+  lastHealthy = false;
+  activeSource = null;
 }
 
 /**

--- a/packages/desktop-app/src/tests/services/daemon-status.test.ts
+++ b/packages/desktop-app/src/tests/services/daemon-status.test.ts
@@ -6,7 +6,7 @@
  * failed until a manual app restart.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 
 vi.mock('$lib/utils/logger', () => ({
@@ -47,6 +47,14 @@ describe('daemon-status service (#1470)', () => {
     mockIsTauri.mockReturnValue(true);
     mockInvoke.mockReturnValue(new Promise<string>(() => {}));
     daemonStatusHandler = null;
+  });
+
+  afterEach(async () => {
+    // Tear down the singleton's steady-state poll so its interval doesn't leak
+    // into the next case (the module instance imported here is the same one the
+    // test used — beforeEach's resetModules only fires before the next case).
+    const { stopDaemonStatusListener } = await import('$lib/services/daemon-status');
+    stopDaemonStatusListener();
   });
 
   it('clears connecting via the grace-period timer if no daemon-status event ever arrives', async () => {
@@ -262,5 +270,56 @@ describe('daemon-status service (#1470)', () => {
     const { refreshDaemonStatus } = await import('$lib/services/daemon-status');
     await expect(refreshDaemonStatus()).resolves.toBeUndefined();
     expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('re-probes daemon health on a steady-state interval after start', async () => {
+    vi.useFakeTimers();
+    try {
+      mockInvoke.mockResolvedValue('healthy');
+      const { startDaemonStatusListener } = await import('$lib/services/daemon-status');
+      startDaemonStatusListener();
+      // Let the async listen() registration + the initial pull settle.
+      await vi.advanceTimersByTimeAsync(0);
+      const callsAfterStart = mockInvoke.mock.calls.length;
+      expect(callsAfterStart).toBeGreaterThanOrEqual(1); // initial pull happened
+
+      // One poll interval later, the steady-state poll fires another probe —
+      // this is the signal source a mid-session restart needs, since the
+      // backend never pushes daemon-status again after its startup task.
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(mockInvoke.mock.calls.length).toBeGreaterThan(callsAfterStart);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-fires onDaemonReconnect when a steady-state poll observes a healthy → not_running → healthy restart', async () => {
+    vi.useFakeTimers();
+    try {
+      mockInvoke.mockResolvedValue('healthy');
+      const { startDaemonStatusListener, onDaemonReconnect } = await import(
+        '$lib/services/daemon-status'
+      );
+      const callback = vi.fn();
+      onDaemonReconnect(callback);
+
+      startDaemonStatusListener();
+      // Initial pull observes healthy → first reconnect fires.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // Daemon dies. Nothing is pushed mid-session; only the poll observes it.
+      mockInvoke.mockResolvedValue('not_running');
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // Daemon is relaunched. The poll observes healthy again and re-fires the
+      // reconnect signal — the wedged-until-restart gap this fix closes.
+      mockInvoke.mockResolvedValue('healthy');
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(callback).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
Fixes #1678. The shared daemon-status service fans a reconnect signal to every daemon-dependent store (schemas, collections, children-tree, pane hydration) via `onDaemonReconnect`, fired on a not-healthy → healthy transition. That signal was reliable for the **initial** boot, but a **mid-session daemon restart** emitted nothing: all `daemon-status` emit sites live in the backend's one-shot startup task (`src-tauri/src/lib.rs`), so a daemon that dies and is relaunched while the app is running pushes no `healthy` event and no consumer retries — a wedged pane/store stays wedged until an app restart.

## Fix
Add a low-frequency steady-state poll of `check_daemon_status` (which probes the socket live each call) in `daemon-status.ts`, started after the listener wires up. A `healthy → not_running → healthy` cycle is now observed and `applyStatus` re-fires `onDaemonReconnect`. Reconnect callbacks fire only on the not-healthy → healthy edge, so steady healthy polls are no-ops. Also adds `stopDaemonStatusListener` (test teardown; production never calls it) and `.unref()`s the interval so it can't keep a process alive on its own.

## Why it matters for #1672
This closes one of the two plausible root causes of the journal "Loading…" hang: the case where the daemon's `healthy` transition is never *observed* by the frontend (the push fires before the webview registers its listener, and the single pull-on-subscribe caught `starting`), so the pane's `onDaemonReconnect` retry never runs. With the steady-state poll the daemon is re-observed and the pane self-heals.

## Tests
- `re-probes daemon health on a steady-state interval after start`
- `re-fires onDaemonReconnect when a steady-state poll observes a healthy → not_running → healthy restart` (the #1678 scenario, driven purely by the poll — no push)
- Full daemon-status suite 16/16; pre-push gate green (test:all + cargo build + e2e).

Relates: #1672, #1644, #1677.
