### PR TITLE
Daemon does not suppress same-origin WatchNodes echo — frontend guesses via content-comparison heuristic instead of authoritative client identity

### DIFF
--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -26,6 +26,17 @@ use tonic::transport::Channel;
 /// nothing, letting the daemon fall back to its default database; that variant
 /// is applied uniformly so a client's type is the same whether or not a
 /// database was selected.
+///
+/// Deliberately does NOT stamp `x-ns-client-id` (ADR-026 C5 extension,
+/// implemented in the desktop app's own `DatabaseIdInterceptor` at
+/// `packages/desktop-app/src-tauri/src/services/grpc_client.rs`) — a separate,
+/// same-named struct in a different crate. The CLI is a one-shot process per
+/// invocation that never opens `WatchNodes`, so it has no same-origin echo to
+/// suppress; leaving its writes untagged means they carry no
+/// `source_client_id` and are therefore always visible as foreign writes to
+/// any other subscriber (e.g. a desktop window), which is the correct
+/// behavior. If the CLI ever needs its own stable client id, add it here to
+/// this struct — the desktop-app copy is independent and not shared.
 #[derive(Clone)]
 pub struct DatabaseIdInterceptor {
     // Some(id) → stamp header on every request; None → stamp nothing (daemon

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -65,6 +65,17 @@ use crate::nodespace::{
 ///
 /// `embedding_state` is `None` while the model is loading or when the NLP
 /// engine is absent. Semantic search returns `UNAVAILABLE` in both cases.
+///
+/// **Adding a new unary RPC handler**: call `self.route(&request).await?`
+/// first, exactly like every existing handler — this both resolves ADR-053
+/// database routing and scopes the returned `node_service` for same-origin
+/// write tagging (ADR-026 C5 extension) via the `x-ns-client-id` header.
+/// **Adding a new streaming (subscribe-style) handler**: if it should also
+/// suppress the subscriber's own writes, read `x-ns-client-id` via the
+/// standalone `client_id_header()` helper *before* calling `route()` — see
+/// `watch_nodes` for the reference implementation. Do not rely on `route()`
+/// alone for a subscribing handler: `route()`'s use of the header scopes
+/// *writes*, which a read-only streaming handler never performs.
 #[derive(Clone)]
 pub struct NodeServiceImpl {
     node_service: Arc<CoreNodeService>,

--- a/packages/daemon/src/services/node_service.rs
+++ b/packages/daemon/src/services/node_service.rs
@@ -108,12 +108,44 @@ impl NodeServiceImpl {
     /// routing middleware installed a header-less request falls back to `self`
     /// while a header-carrying one is rejected rather than silently served from
     /// the active database.
+    ///
+    /// Also applies same-origin write tagging (ADR-026 C5 extension): a
+    /// request carrying `x-ns-client-id` gets its `node_service` scoped via
+    /// `with_client(id)`, so any event this request's write emits is stamped
+    /// with that id as `source_client_id` — the signal `watch_nodes` uses to
+    /// drop the writer's own echo. Applied here, once, so every RPC handler
+    /// (which all start with `let this = self.route(&request).await?`) picks
+    /// it up without individually touching the client-id header.
     async fn route<T>(&self, request: &Request<T>) -> Result<NodeServiceImpl, Status> {
-        match crate::db_routing::routed_database_services(request).await? {
-            Some(services) => Ok(services.node_service_grpc.clone()),
-            None => Ok(self.clone()),
+        let mut this = match crate::db_routing::routed_database_services(request).await? {
+            Some(services) => services.node_service_grpc.clone(),
+            None => self.clone(),
+        };
+        if let Some(client_id) = client_id_header(request).map_err(|e| *e)? {
+            this.node_service = Arc::new(this.node_service.with_client(client_id));
         }
+        Ok(this)
     }
+}
+
+/// Read the `x-ns-client-id` header off a request, if present. Absent →
+/// `Ok(None)`, meaning the caller's writes emit no `source_client_id` and are
+/// never suppressed on any `WatchNodes` stream — behavior identical to before
+/// this header existed. `Status` is boxed on the error path so this small
+/// `Option<String>` success type doesn't blow up `Result`'s stack size next
+/// to it (`clippy::result_large_err`).
+fn client_id_header<T>(request: &Request<T>) -> Result<Option<String>, Box<Status>> {
+    request
+        .metadata()
+        .get(nodespace_proto::CLIENT_ID_HEADER)
+        .map(|v| {
+            v.to_str().map(str::to_owned).map_err(|_| {
+                Box::new(Status::invalid_argument(
+                    "x-ns-client-id must be valid ASCII",
+                ))
+            })
+        })
+        .transpose()
 }
 
 #[tonic::async_trait]
@@ -1393,6 +1425,12 @@ impl GrpcNodeService for NodeServiceImpl {
         &self,
         request: Request<WatchRequest>,
     ) -> Result<Response<Self::WatchNodesStream>, Status> {
+        // Read the subscriber's own client id BEFORE `route()`: `route()` also
+        // reads `x-ns-client-id`, but to scope *writes* made through the
+        // returned `node_service` — irrelevant here, since this handler never
+        // writes. The subscriber's id is instead used below to filter its own
+        // echoes out of the stream it is opening.
+        let subscriber_client_id = client_id_header(&request).map_err(|e| *e)?;
         let this = self.route(&request).await?;
 
         // A live edit stream marks this database active (ADR-053: per-database
@@ -1426,6 +1464,23 @@ impl GrpcNodeService for NodeServiceImpl {
             loop {
                 match rx.recv().await {
                     Ok(envelope) => {
+                        // Same-origin echo suppression (ADR-026 C5 extension):
+                        // the daemon is the sole authority on "is this my own
+                        // write echoed back" — a subscriber with a client id
+                        // never sees an event whose write was made through a
+                        // `node_service` scoped with that same id. A
+                        // subscriber with no client id (legacy/anonymous
+                        // caller) suppresses nothing, matching pre-existing
+                        // behavior; an event with no `source_client_id`
+                        // (write made through an unscoped `node_service`) is
+                        // never suppressed either.
+                        let is_own_echo = matches!(
+                            (&subscriber_client_id, &envelope.metadata.source_client_id),
+                            (Some(sub), Some(src)) if sub == src
+                        );
+                        if is_own_echo {
+                            continue;
+                        }
                         // Translation is serial: a slow `get_node` lookup will
                         // delay the next `rx.recv()` and increase the risk of
                         // `Lagged`. Acceptable because lookups are SQLite
@@ -1733,6 +1788,7 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::sync::watch;
+    use tokio_stream::StreamExt;
 
     async fn make_service() -> (Arc<NodeServiceImpl>, TempDir) {
         let tmp = TempDir::new().unwrap();
@@ -2319,5 +2375,142 @@ mod tests {
     fn error_mapping_not_a_container_returns_invalid_argument() {
         let s = to_status(NodeServiceError::not_a_container("parent-id", "query"));
         assert_eq!(s.code(), tonic::Code::InvalidArgument);
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-origin echo suppression (ADR-026 C5 extension)
+    //
+    // A gRPC connection tags its writes with `x-ns-client-id` (scoped through
+    // `NodeService::with_client()` in `route()`) and tags its `WatchNodes`
+    // subscription with the same header. The daemon — not the frontend's old
+    // content-comparison heuristic — is the sole authority on "is this my own
+    // write echoed back": `watch_nodes` drops any envelope whose
+    // `source_client_id` matches the subscriber's own id.
+    // -----------------------------------------------------------------------
+
+    /// Open a `WatchNodes` stream tagged with `subscriber_client_id` (or
+    /// untagged if `None`), and return it pinned so the caller can pull the
+    /// next few events with a timeout.
+    async fn watch_as(
+        svc: &Arc<NodeServiceImpl>,
+        subscriber_client_id: Option<&str>,
+    ) -> std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<NodeEvent, Status>> + Send>> {
+        let mut req = Request::new(WatchRequest::default());
+        if let Some(id) = subscriber_client_id {
+            req.metadata_mut()
+                .insert(nodespace_proto::CLIENT_ID_HEADER, id.parse().unwrap());
+        }
+        svc.watch_nodes(req).await.unwrap().into_inner()
+    }
+
+    /// Pull the next event off a `WatchNodes` stream, or `None` if none
+    /// arrives within the timeout — used to assert an echo was suppressed
+    /// (absence, not just "some other event came first").
+    async fn next_event(
+        stream: &mut (impl tokio_stream::Stream<Item = Result<NodeEvent, Status>> + Unpin),
+    ) -> Option<NodeEvent> {
+        tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .ok()
+            .flatten()
+            .map(|r| r.unwrap())
+    }
+
+    /// A write made through a connection tagged `x-ns-client-id: alice` is not
+    /// delivered back to alice's own `WatchNodes` subscription (same id on
+    /// both), but IS delivered to a subscription tagged with a different id
+    /// (bob) — genuine foreign-write delivery is unaffected.
+    #[tokio::test]
+    async fn watch_nodes_suppresses_own_echo_but_delivers_to_other_clients() {
+        let (svc, _tmp) = make_service().await;
+
+        let mut alice_stream = watch_as(&svc, Some("alice")).await;
+        let mut bob_stream = watch_as(&svc, Some("bob")).await;
+
+        let mut create = Request::new(crate::nodespace::CreateNodeRequest {
+            id: None,
+            node_type: "text".into(),
+            content: "alice's node".into(),
+            parent_id: None,
+            collection: None,
+            lifecycle_status: None,
+            properties: "{}".into(),
+            position: None,
+        });
+        create
+            .metadata_mut()
+            .insert(nodespace_proto::CLIENT_ID_HEADER, "alice".parse().unwrap());
+        svc.create_node(create).await.unwrap();
+
+        // Bob (a different client) sees the create.
+        let bob_event = next_event(&mut bob_stream)
+            .await
+            .expect("a different client must see a foreign write");
+        assert!(matches!(bob_event.event, Some(NodeEventKind::Created(_))));
+
+        // Alice does not see her own write echoed back.
+        assert!(
+            next_event(&mut alice_stream).await.is_none(),
+            "the writer's own WatchNodes subscription must not see its own echo"
+        );
+    }
+
+    /// A subscriber with no `x-ns-client-id` header suppresses nothing —
+    /// matches pre-existing behavior for callers that never adopt the header.
+    #[tokio::test]
+    async fn watch_nodes_without_client_id_header_suppresses_nothing() {
+        let (svc, _tmp) = make_service().await;
+
+        let mut anon_stream = watch_as(&svc, None).await;
+
+        let mut create = Request::new(crate::nodespace::CreateNodeRequest {
+            id: None,
+            node_type: "text".into(),
+            content: "untagged write".into(),
+            parent_id: None,
+            collection: None,
+            lifecycle_status: None,
+            properties: "{}".into(),
+            position: None,
+        });
+        // Written through a client-id-tagged connection, but the anonymous
+        // subscriber has no id of its own to match against.
+        create
+            .metadata_mut()
+            .insert(nodespace_proto::CLIENT_ID_HEADER, "alice".parse().unwrap());
+        svc.create_node(create).await.unwrap();
+
+        assert!(
+            next_event(&mut anon_stream).await.is_some(),
+            "a subscriber with no client id must still see every write"
+        );
+    }
+
+    /// A write made through a connection with no `x-ns-client-id` header is
+    /// never suppressed on any subscription, including one tagged with an id —
+    /// only an exact id-to-id match suppresses.
+    #[tokio::test]
+    async fn watch_nodes_untagged_write_is_delivered_to_tagged_subscriber() {
+        let (svc, _tmp) = make_service().await;
+
+        let mut alice_stream = watch_as(&svc, Some("alice")).await;
+
+        // No x-ns-client-id header on this write.
+        let create = Request::new(crate::nodespace::CreateNodeRequest {
+            id: None,
+            node_type: "text".into(),
+            content: "anonymous write".into(),
+            parent_id: None,
+            collection: None,
+            lifecycle_status: None,
+            properties: "{}".into(),
+            position: None,
+        });
+        svc.create_node(create).await.unwrap();
+
+        assert!(
+            next_event(&mut alice_stream).await.is_some(),
+            "an untagged write must still reach a client-id-tagged subscriber"
+        );
     }
 }

--- a/packages/daemon/tests/grpc_round_trip.rs
+++ b/packages/daemon/tests/grpc_round_trip.rs
@@ -465,6 +465,91 @@ async fn watch_nodes_supports_multiple_concurrent_watchers() {
     let _ = shutdown.send(());
 }
 
+/// End-to-end regression for ADR-026's C5 extension (daemon-side same-origin
+/// echo suppression): a desktop window's own write must never echo back on
+/// its own `WatchNodes` stream, over the real tonic wire format — not just
+/// the in-process `Request::new()` construction covered by the daemon's unit
+/// tests. Same-origin classification was previously a client-side
+/// content-comparison guess that repeatedly produced false-positive/false-
+/// negative conflict toasts; the daemon is now the sole authority, keyed on a
+/// real `x-ns-client-id` metadata header round-tripped over the wire exactly
+/// as `packages/desktop-app/src-tauri/src/services/grpc_client.rs`'s
+/// `DatabaseIdInterceptor` stamps it on every request.
+#[tokio::test]
+async fn watch_nodes_over_real_transport_suppresses_own_echo_and_delivers_foreign_writes() {
+    let (client, shutdown, _tempdir) = spawn_test_daemon().await;
+
+    // "window-a" and "window-b" simulate two independent GrpcClient instances
+    // (two desktop windows / a desktop window + a future second client),
+    // each with its own stable x-ns-client-id, exactly as production code
+    // stamps it via the interceptor.
+    let mut window_a = client.clone();
+    let mut window_b = client.clone();
+
+    let mut watch_a = tonic::Request::new(WatchRequest::default());
+    watch_a
+        .metadata_mut()
+        .insert("x-ns-client-id", "window-a".parse().unwrap());
+    let mut stream_a = window_a
+        .watch_nodes(watch_a)
+        .await
+        .expect("watch_a failed")
+        .into_inner();
+
+    let mut watch_b = tonic::Request::new(WatchRequest::default());
+    watch_b
+        .metadata_mut()
+        .insert("x-ns-client-id", "window-b".parse().unwrap());
+    let mut stream_b = window_b
+        .watch_nodes(watch_b)
+        .await
+        .expect("watch_b failed")
+        .into_inner();
+
+    // window-a creates a node, tagging the write with its own client id —
+    // exactly as every routed write RPC does in production.
+    let mut create = tonic::Request::new(CreateNodeRequest {
+        node_type: "text".into(),
+        content: "window-a's own write".into(),
+        parent_id: None,
+        properties: String::new(),
+        collection: None,
+        lifecycle_status: None,
+        id: None,
+        position: None,
+    });
+    create
+        .metadata_mut()
+        .insert("x-ns-client-id", "window-a".parse().unwrap());
+    let created = window_a
+        .create_node(create)
+        .await
+        .expect("create_node failed")
+        .into_inner();
+
+    // window-b (a different client) sees the write.
+    let event_b = next_event_with_timeout(&mut stream_b).await;
+    match event_b.event {
+        Some(NodeEventKind::Created(data)) => assert_eq!(data.id, created.node_id),
+        other => panic!(
+            "expected window-b to see the foreign write, got {:?}",
+            other
+        ),
+    }
+
+    // window-a's own WatchNodes stream must NOT receive its own write back.
+    // Race the real event (if the bug were reintroduced) against a timeout —
+    // this must resolve via timeout, not via receiving the echo.
+    let no_echo = tokio::time::timeout(Duration::from_millis(500), stream_a.next()).await;
+    assert!(
+        no_echo.is_err(),
+        "window-a's own WatchNodes stream must not see its own write echoed back, got: {:?}",
+        no_echo
+    );
+
+    let _ = shutdown.send(());
+}
+
 /// Verifies the server-side stream closes cleanly when the client drops its
 /// receiver, rather than holding the broadcast subscription forever. Matches
 /// the AC "Stream closes gracefully when the client disconnects".

--- a/packages/daemon/tests/grpc_round_trip.rs
+++ b/packages/daemon/tests/grpc_round_trip.rs
@@ -480,9 +480,13 @@ async fn watch_nodes_over_real_transport_suppresses_own_echo_and_delivers_foreig
     let (client, shutdown, _tempdir) = spawn_test_daemon().await;
 
     // "window-a" and "window-b" simulate two independent GrpcClient instances
-    // (two desktop windows / a desktop window + a future second client),
-    // each with its own stable x-ns-client-id, exactly as production code
-    // stamps it via the interceptor.
+    // (two desktop windows / a desktop window + a future second client), each
+    // with its own stable x-ns-client-id, exactly as production code stamps
+    // it via the interceptor. Both handles below are clones of the SAME tonic
+    // client/channel — the daemon distinguishes them purely by the
+    // x-ns-client-id metadata header on each request, not by transport
+    // connection, so reusing one client with per-request headers is a
+    // faithful simulation of two separate GrpcClient processes.
     let mut window_a = client.clone();
     let mut window_b = client.clone();
 

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 
 use nodespace_proto::{
     AgentSessionServiceClient, DatabaseServiceClient, EmbeddingsServiceClient, ImportServiceClient,
-    LocalAgentServiceClient, NodeServiceClient, SettingsServiceClient, DATABASE_ID_HEADER,
+    LocalAgentServiceClient, NodeServiceClient, SettingsServiceClient, CLIENT_ID_HEADER,
+    DATABASE_ID_HEADER,
 };
 use tokio::sync::{watch, RwLock};
 use tonic::metadata::{Ascii, MetadataValue};
@@ -20,8 +21,8 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::service::Interceptor;
 use tonic::transport::Channel;
 
-/// Stamps the ADR-053 `x-ns-database-id` routing header on every outgoing
-/// request so the daemon routes it to a specific local database.
+/// Stamps the ADR-053 `x-ns-database-id` routing header and the ADR-026's C5-extension
+/// `x-ns-client-id` identity header on every outgoing request.
 ///
 /// Concrete (not a closure) so the intercepted client types stay nameable and
 /// aliasable — see [`NodeClient`] and friends. `database_id: None` stamps
@@ -29,25 +30,41 @@ use tonic::transport::Channel;
 /// is applied uniformly so a routed client's type is the same whether or not a
 /// database is currently selected. Mirrors the CLI's interceptor of the same
 /// name.
+///
+/// `client_id` is always `Some` in production — generated once per
+/// `GrpcClient` (i.e. once per app process/window) in [`GrpcClient::from_channel`]
+/// and carried through every interceptor rebuild (database switches rebuild
+/// the routed clients but must keep the SAME client id, or the daemon would
+/// stop recognizing this window's own writes on echo suppression after every
+/// switch). Stamping it lets the daemon scope this connection's writes via
+/// `NodeService::with_client()` and drop their echo on this connection's own
+/// `WatchNodes` stream (see `watcher.rs`) — see ADR-026 C5.
 #[derive(Clone)]
 pub struct DatabaseIdInterceptor {
     // Some(id) → stamp header on every request; None → stamp nothing (daemon
     // uses its default database).
     database_id: Option<MetadataValue<Ascii>>,
+    client_id: MetadataValue<Ascii>,
 }
 
 impl DatabaseIdInterceptor {
-    /// No routing header — the daemon serves its default database.
-    pub fn none() -> Self {
-        Self { database_id: None }
+    /// No routing header — the daemon serves its default database. Still
+    /// stamps `client_id` so writes made before any database is selected are
+    /// still attributable.
+    pub fn none(client_id: MetadataValue<Ascii>) -> Self {
+        Self {
+            database_id: None,
+            client_id,
+        }
     }
 
-    /// Stamp `x-ns-database-id: <id>` on every request when `id` is `Some`.
+    /// Stamp `x-ns-database-id: <id>` on every request when `id` is `Some`,
+    /// and `x-ns-client-id: <client_id>` unconditionally.
     /// `id` must be an already resolved registry identifier (ULID); the daemon
     /// resolves the header as an id only, never a name. An id that is not a
     /// valid gRPC header value falls back to no routing (default database)
     /// rather than poisoning every subsequent request.
-    pub fn for_id(id: Option<&str>) -> Self {
+    pub fn for_id(id: Option<&str>, client_id: MetadataValue<Ascii>) -> Self {
         let database_id = id.and_then(|id| match MetadataValue::try_from(id) {
             Ok(value) => Some(value),
             Err(_) => {
@@ -62,7 +79,10 @@ impl DatabaseIdInterceptor {
                 None
             }
         });
-        Self { database_id }
+        Self {
+            database_id,
+            client_id,
+        }
     }
 }
 
@@ -71,8 +91,18 @@ impl Interceptor for DatabaseIdInterceptor {
         if let Some(id) = &self.database_id {
             req.metadata_mut().insert(DATABASE_ID_HEADER, id.clone());
         }
+        req.metadata_mut()
+            .insert(CLIENT_ID_HEADER, self.client_id.clone());
         Ok(req)
     }
+}
+
+/// Generate a fresh client id for this `GrpcClient` (one per app
+/// process/window, per ADR-026's C5 extension). A UUID is always valid ASCII, so this
+/// cannot fail in practice.
+fn generate_client_id() -> MetadataValue<Ascii> {
+    MetadataValue::try_from(uuid::Uuid::new_v4().to_string())
+        .expect("uuid v4 string is always a valid ascii metadata value")
 }
 
 /// A channel wrapped so every request carries the database routing header.
@@ -103,6 +133,13 @@ struct GrpcClientInner {
     /// daemon's default database. Distinct from the daemon-wide default set via
     /// `DatabaseService::SetDefault`.
     active_database_id: Option<String>,
+    /// This process/window's stable identity (ADR-026's C5 extension), generated once in
+    /// [`GrpcClient::from_channel`] and re-stamped by every interceptor rebuild
+    /// in [`GrpcClient::set_active_database`] — it must never change for the
+    /// lifetime of this `GrpcClient`, or the daemon would stop recognizing this
+    /// window's own writes on its `WatchNodes` echo-suppression check after a
+    /// database switch.
+    client_id: MetadataValue<Ascii>,
     /// Underlying transport channel — held so Pro-tier services can
     /// ride the same h2 connection via `GrpcClient::channel()`. One
     /// channel, multiple service surfaces. Opening a parallel channel
@@ -160,10 +197,14 @@ impl GrpcClient {
     /// Shared by [`connect`] and [`connect_lazy`] so the set of service clients
     /// stays in sync as new services are added. `Channel` is platform-agnostic.
     fn from_channel(channel: Channel) -> Self {
+        // One stable id for this GrpcClient's whole lifetime (ADR-026's C5 extension) —
+        // generated once here, never regenerated on a database switch.
+        let client_id = generate_client_id();
         // No database selected initially → the routed clients carry an empty
         // interceptor and requests fall back to the daemon's default database,
-        // exactly as before ADR-053 client routing existed.
-        let interceptor = DatabaseIdInterceptor::none();
+        // exactly as before ADR-053 client routing existed. The client-id
+        // header is still stamped.
+        let interceptor = DatabaseIdInterceptor::none(client_id.clone());
         let inner = GrpcClientInner {
             node: NodeServiceClient::with_interceptor(channel.clone(), interceptor.clone()),
             import: ImportServiceClient::with_interceptor(channel.clone(), interceptor.clone()),
@@ -179,6 +220,7 @@ impl GrpcClient {
             local_agent: LocalAgentServiceClient::new(channel.clone()),
             database_service: DatabaseServiceClient::new(channel.clone()),
             active_database_id: None,
+            client_id,
             channel,
         };
         let (db_generation, _) = watch::channel(0u64);
@@ -269,7 +311,7 @@ impl GrpcClient {
             if inner.active_database_id == id {
                 return;
             }
-            let interceptor = DatabaseIdInterceptor::for_id(id.as_deref());
+            let interceptor = DatabaseIdInterceptor::for_id(id.as_deref(), inner.client_id.clone());
             let channel = inner.channel.clone();
             inner.node = NodeServiceClient::with_interceptor(channel.clone(), interceptor.clone());
             inner.import =

--- a/packages/desktop-app/src-tauri/src/services/grpc_client.rs
+++ b/packages/desktop-app/src-tauri/src/services/grpc_client.rs
@@ -21,15 +21,17 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::service::Interceptor;
 use tonic::transport::Channel;
 
-/// Stamps the ADR-053 `x-ns-database-id` routing header and the ADR-026's C5-extension
-/// `x-ns-client-id` identity header on every outgoing request.
+/// Stamps the ADR-053 `x-ns-database-id` routing header and the ADR-026 C5
+/// extension's `x-ns-client-id` identity header on every outgoing request.
 ///
 /// Concrete (not a closure) so the intercepted client types stay nameable and
 /// aliasable — see [`NodeClient`] and friends. `database_id: None` stamps
 /// nothing, letting the daemon fall back to its default database; the variant
 /// is applied uniformly so a routed client's type is the same whether or not a
-/// database is currently selected. Mirrors the CLI's interceptor of the same
-/// name.
+/// database is currently selected. Same-named struct as the CLI's interceptor
+/// (`packages/cli/src/lib.rs`) but an independent implementation in a
+/// different crate — the CLI's copy deliberately does not stamp
+/// `x-ns-client-id`; see its doc comment for why.
 ///
 /// `client_id` is always `Some` in production — generated once per
 /// `GrpcClient` (i.e. once per app process/window) in [`GrpcClient::from_channel`]
@@ -38,7 +40,7 @@ use tonic::transport::Channel;
 /// stop recognizing this window's own writes on echo suppression after every
 /// switch). Stamping it lets the daemon scope this connection's writes via
 /// `NodeService::with_client()` and drop their echo on this connection's own
-/// `WatchNodes` stream (see `watcher.rs`) — see ADR-026 C5.
+/// `WatchNodes` stream (see `watcher.rs`).
 #[derive(Clone)]
 pub struct DatabaseIdInterceptor {
     // Some(id) → stamp header on every request; None → stamp nothing (daemon

--- a/packages/desktop-app/src-tauri/src/watcher.rs
+++ b/packages/desktop-app/src-tauri/src/watcher.rs
@@ -14,7 +14,10 @@
 //!
 //! - Opens a `WatchNodes` stream over the shared [`GrpcClient`], so the stream
 //!   carries the active database's `x-ns-database-id` routing header (ADR-053)
-//!   and rides the same h2 connection as every other data-plane request.
+//!   and rides the same h2 connection as every other data-plane request. The
+//!   same client also stamps `x-ns-client-id` (ADR-026's C5 extension) on every request
+//!   including this one, so the daemon recognizes and drops this window's own
+//!   write echoes before they ever reach this stream — see ADR-026 C5.
 //! - Translates each proto `NodeEvent` to a Tauri event (id + optional
 //!   node_type + originating `database_id`).
 //! - On stream error or disconnection, reconnects with exponential backoff

--- a/packages/desktop-app/src-tauri/test-support/src/lib.rs
+++ b/packages/desktop-app/src-tauri/test-support/src/lib.rs
@@ -176,7 +176,11 @@ pub static CONNECT_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new
 
 /// Wait until the daemon's socket is reachable, then connect a real
 /// `GrpcClient` to it — the same client type `#[tauri::command]` handlers
-/// take as `State<'_, GrpcClient>`.
+/// take as `State<'_, GrpcClient>`. Each call builds an independent
+/// `GrpcClient` with its own stable `x-ns-client-id` (ADR-026 C5 extension) —
+/// calling `TauriTestApp::connect` twice against the same daemon therefore
+/// produces two clients the daemon treats as genuinely different writers, the
+/// same as two real desktop windows. See `optimistic_echo_race_test.rs`.
 async fn connected_client(daemon: &SpawnedDaemon, timeout: Duration) -> GrpcClient {
     use nodespace_app_lib::daemon_setup::{wait_for_daemon, DaemonStatus};
 

--- a/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
+++ b/packages/desktop-app/src-tauri/tests/optimistic_echo_race_test.rs
@@ -5,16 +5,27 @@
 //! unconditionally spawned).
 //!
 //! This is the regression class ADR-048 exists to catch: the frontend
-//! applies an edit optimistically to local state, the daemon later echoes
-//! the authoritative version back over the watch stream, and if that echo
-//! arrives out of order — or carries a value the user has already typed
-//! past — it must not overwrite newer local state. A synchronous mock
-//! cannot reproduce this: the race is between two independent clocks (the
-//! local optimistic write and the daemon's asynchronous echo), and a mock
-//! collapses them onto one tick. Here, `watcher::run` is driven for real
-//! against a real daemon, emitting real `node:updated` events on a real
-//! Tauri event bus (`tauri::test`'s `MockRuntime` — no webview, but a real
-//! `Emitter`/`Listener` implementation, not a stand-in).
+//! applies an edit optimistically to local state, and a broadcast for the
+//! SAME node arrives over the watch stream out of order — or carrying a
+//! value the user has already typed past — and it must not overwrite newer
+//! local state. Before the ADR-026 C5 extension (daemon-side same-origin
+//! echo suppression), a single window's own write always echoed back to
+//! itself, so this scenario was reachable purely from one client's own
+//! traffic. Under the C5 extension the daemon never echoes a connection's
+//! own writes back to it at all, so the only way this race remains reachable
+//! is a genuinely foreign write — a SECOND window/client editing the same
+//! node — landing on the first window's `WatchNodes` stream while its own
+//! newer write is in flight. This file drives exactly that: two independent
+//! `GrpcClient`s (via two `TauriTestApp::connect` calls against the same
+//! daemon, each generating its own stable `x-ns-client-id`), so window A's
+//! watcher observes window B's write as the late/out-of-order echo. A
+//! synchronous mock cannot reproduce this: the race is between two
+//! independent clocks (window A's local optimistic write and window B's
+//! asynchronous broadcast), and a mock collapses them onto one tick. Here,
+//! `watcher::run` is driven for real against a real daemon, emitting real
+//! `node:updated` events on a real Tauri event bus (`tauri::test`'s
+//! `MockRuntime` — no webview, but a real `Emitter`/`Listener`
+//! implementation, not a stand-in).
 //!
 //! `watcher::run` was made generic over `tauri::Runtime` (previously
 //! hardcoded to the real `Wry` runtime, like the rest of the module) SOLELY
@@ -75,47 +86,60 @@ async fn wait_for_updates(
     }
 }
 
-/// The core regression: apply a real update through the command layer, let
-/// the REAL watcher (real gRPC WatchNodes stream, real Tauri event bus)
-/// echo it back, then apply a NEWER update. A late-arriving stale echo for
-/// the first write must not be interpreted by a listener as more current
-/// than the second, already-applied write's own echo — asserted here by
-/// checking that get_node (the authoritative source) reflects the LATEST
-/// content after both echoes have had time to arrive, regardless of
-/// arrival order.
+/// The core regression: window A watches a node while window B (a genuinely
+/// different `GrpcClient`/`x-ns-client-id`, simulating a second desktop
+/// window) makes two real updates through the command layer. Window A's REAL
+/// watcher (real gRPC WatchNodes stream, real Tauri event bus) must observe
+/// both of window B's writes — and by the time both broadcasts have arrived,
+/// the authoritative source (`get_node`) must reflect window B's LATEST
+/// write, regardless of any transient reordering. Before the ADR-026 C5
+/// extension this scenario was reachable with a single client (its own write
+/// echoed back to itself); the daemon now suppresses a connection's own
+/// echoes, so a second, independently-connected client is required to
+/// reproduce it — see this file's module doc for the full rationale.
 #[tokio::test]
 async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
     let daemon = SpawnedDaemon::spawn();
     // TauriTestApp::connect briefly acquires and releases CONNECT_MUTEX
-    // internally (it's safe on its own: the GrpcClient's channel is fixed to
+    // internally (it's safe on its own: each GrpcClient's channel is fixed to
     // whatever socket NODESPACED_SOCKET resolved to at connect() time and is
     // immune to later env changes). The guard acquired below is a SEPARATE,
-    // later, longer-held acquisition — for watcher::run, not for this
+    // later, longer-held acquisition — for watcher::run, not for either
     // connect() call.
-    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
-    let state = harness.client_state();
-    let handle = harness.handle();
+    //
+    // Two independent harnesses simulate two desktop windows: each
+    // TauriTestApp::connect call produces its own GrpcClient with its own
+    // stable x-ns-client-id, so the daemon treats window_b's writes as
+    // foreign to window_a's WatchNodes subscription — exactly the same
+    // identity split two real windows would have.
+    let window_a = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
+    let window_b = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
+    let state_a = window_a.client_state();
+    let state_b = window_b.client_state();
+    let handle_a = window_a.handle();
 
-    // The watcher rides the shared GrpcClient's channel (fixed to whatever
-    // socket NODESPACED_SOCKET resolved to at connect() time). Hold this guard
-    // for the watcher's lifetime anyway to serialize this test against every
-    // other test in the binary that touches the process-global NODESPACED_SOCKET
-    // env var while this test's daemon is the intended target.
+    // The watcher rides window A's shared GrpcClient channel (fixed to
+    // whatever socket NODESPACED_SOCKET resolved to at connect() time). Hold
+    // this guard for the watcher's lifetime anyway to serialize this test
+    // against every other test in the binary that touches the process-global
+    // NODESPACED_SOCKET env var while this test's daemon is the intended
+    // target.
     let _socket_guard = hold_connect_mutex_and_socket_env(&daemon).await;
 
     let cancel_token = CancellationToken::new();
     let watcher_handle = tokio::spawn(watcher::run(
-        handle.clone(),
-        (*state).clone(),
+        handle_a.clone(),
+        (*state_a).clone(),
         cancel_token.child_token(),
     ));
-    // Give the watcher a moment to open its WatchNodes stream before the
-    // first write, so its echo isn't lost to a stream that hasn't opened yet.
+    // Give window A's watcher a moment to open its WatchNodes stream before
+    // window B's first write, so the broadcast isn't lost to a stream that
+    // hasn't opened yet.
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let received_clone = received.clone();
-    handle.listen("node:updated", move |event| {
+    handle_a.listen("node:updated", move |event| {
         // Payload is `{ "id": "...", "nodeType": ... }` (nodeType omitted for
         // updates) — extract just the id for this test's purposes.
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(event.payload()) {
@@ -125,15 +149,17 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
         }
     });
 
+    // Window B creates and edits the node — window A never writes to it, only
+    // watches.
     let id = uuid::Uuid::new_v4().to_string();
-    create_node(state.clone(), text_input(&id, "v0"))
+    create_node(state_b.clone(), text_input(&id, "v0"))
         .await
         .expect("create_node failed");
 
-    // First write: "optimistic" content the user has already typed past by
-    // the time its echo arrives.
+    // First write: content window A's watcher should see as an earlier
+    // broadcast for this node.
     update_node(
-        state.clone(),
+        state_b.clone(),
         id.clone(),
         1,
         NodeUpdate {
@@ -144,11 +170,10 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
     .await
     .expect("first update_node failed");
 
-    // Second, newer write — sequenced correctly (using the confirmed
-    // version from the first commit), simulating the user continuing to
-    // type before the first echo has necessarily arrived.
+    // Second, newer write from window B — sequenced correctly (using the
+    // confirmed version from the first commit).
     update_node(
-        state.clone(),
+        state_b.clone(),
         id.clone(),
         2,
         NodeUpdate {
@@ -159,19 +184,20 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
     .await
     .expect("second update_node failed");
 
-    // Wait for both echoes to arrive over the real watch stream.
+    // Wait for both of window B's writes to arrive on window A's real watch
+    // stream.
     wait_for_updates(&received, &id, 2, Duration::from_secs(10)).await;
 
-    // The authoritative source must reflect the LATEST write — a real
-    // out-of-order or late echo of "stale content" must never win over it.
-    let node = nodespace_app_lib::commands::nodes::get_node(state.clone(), id.clone())
+    // The authoritative source must reflect window B's LATEST write — a real
+    // out-of-order or late broadcast of "stale content" must never win over it.
+    let node = nodespace_app_lib::commands::nodes::get_node(state_a.clone(), id.clone())
         .await
         .expect("get_node failed")
         .expect("node must exist");
     assert_eq!(
         node["content"],
         json!("newest content"),
-        "the newer write must not be clobbered by a late echo of the older write"
+        "the newer write must not be clobbered by a late broadcast of the older write"
     );
     assert_eq!(node["version"], json!(3));
 
@@ -181,26 +207,31 @@ async fn newer_local_write_is_not_clobbered_by_a_late_echo_of_an_older_write() {
 
 /// Confirms the watcher actually delivers `node:created` for a real create,
 /// over the real event bus — the minimal proof that this test file is
-/// exercising the live path (`watcher::run`), not a dead one.
+/// exercising the live path (`watcher::run`), not a dead one. Uses a second,
+/// independent `GrpcClient` (window B) to create the node — since the
+/// ADR-026 C5 extension, a window's own writes are suppressed on its own
+/// `WatchNodes` stream, so watching window A must observe a genuinely
+/// foreign creation for this to prove the live path is wired up.
 #[tokio::test]
 async fn watcher_delivers_a_real_node_created_event() {
     let daemon = SpawnedDaemon::spawn();
-    let harness = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
-    let state = harness.client_state();
-    let handle = harness.handle();
+    let window_a = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
+    let window_b = TauriTestApp::connect(&daemon, DAEMON_CONNECT_TIMEOUT).await;
+    let state_b = window_b.client_state();
+    let handle_a = window_a.handle();
     let _socket_guard = hold_connect_mutex_and_socket_env(&daemon).await;
 
     let cancel_token = CancellationToken::new();
     let watcher_handle = tokio::spawn(watcher::run(
-        handle.clone(),
-        (*state).clone(),
+        handle_a.clone(),
+        (*window_a.client_state()).clone(),
         cancel_token.child_token(),
     ));
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let created: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let created_clone = created.clone();
-    handle.listen("node:created", move |event| {
+    handle_a.listen("node:created", move |event| {
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(event.payload()) {
             if let Some(id) = v["id"].as_str() {
                 created_clone.lock().unwrap().push(id.to_string());
@@ -209,7 +240,7 @@ async fn watcher_delivers_a_real_node_created_event() {
     });
 
     let id = uuid::Uuid::new_v4().to_string();
-    create_node(state.clone(), text_input(&id, "hello"))
+    create_node(state_b.clone(), text_input(&id, "hello"))
         .await
         .expect("create_node failed");
 

--- a/packages/desktop-app/src/lib/services/remote-update-policy.ts
+++ b/packages/desktop-app/src/lib/services/remote-update-policy.ts
@@ -2,11 +2,11 @@
  * Remote-update policy for SharedNodeStore.
  *
  * Extracted from the skip-while-editing guard inline in `setNode` /
- * `batchSetNodes`. A daemon-broadcast
- * event (`source.type === 'database'`) arriving for a node the user is
- * actively editing — or has unsaved local changes pending — would otherwise
- * overwrite the optimistic store with the *older* server-confirmed state.
- * The optimistic state is authoritative until persistence settles.
+ * `batchSetNodes`. A daemon-broadcast event (`source.type === 'database'`)
+ * arriving for a node the user is actively editing — or has unsaved local
+ * changes pending — would otherwise overwrite the optimistic store with the
+ * *older* server-confirmed state. The optimistic state is authoritative
+ * until persistence settles.
  *
  * `decideRemoteUpdate` is a pure function: it takes the incoming node, the
  * existing local node (if any), the update source, and the caller's
@@ -15,6 +15,19 @@
  * caller computes `isFocused`/`hasPending` once (each is a live read that
  * can disagree between two reads within the same guard) and passes them in,
  * so this module stays reactivity-free and independently testable.
+ *
+ * Own-write echo classification (ADR-026's C5 extension): earlier versions of
+ * this module guessed whether an incoming broadcast was this client's own
+ * write looping back, by comparing its content against the last content this
+ * client sent (`isPlausibleOwnEcho`). That guess was inherently racy across an
+ * async network round-trip and repeatedly produced false-positive/false-
+ * negative conflict toasts — the exact failure mode ADR-026's C5 amendment
+ * already rejected for a prior client-side heuristic. The daemon now
+ * suppresses a connection's own write echoes before they ever reach
+ * `WatchNodes` (`packages/daemon/src/services/node_service.rs`,
+ * `x-ns-client-id`-scoped `NodeService::with_client()`), so a `database`-
+ * sourced event reaching this module is now guaranteed to be a genuine
+ * foreign write. No content comparison is needed or performed here anymore.
  */
 
 import type { Node } from '$lib/types';
@@ -29,43 +42,20 @@ export type RemoteUpdateDecision =
   | { apply: true }
   | {
       apply: false;
-      /** Stash `incoming.version` as the server-confirmed version for the next OCC write. */
-      stashVersion: boolean;
       /** Raise a version-mismatch conflict notification (foreign write to an actively-edited node). */
       notifyConflict: boolean;
     };
 
 /**
- * Decide whether an incoming database broadcast is plausibly an echo of
- * *this client's own* most-recent write. Used to decide whether to stash
- * the broadcast's `node.version` for the next OCC write.
- *
- * Returns `true` only when `incoming.content` matches the content this
- * client last sent to the backend for this node. That covers the canonical
- * case the guard exists for: our own write looping back through the daemon
- * broadcast.
- *
- * Returns `false` for everything else, including any incoming content we
- * have no last-sent record for. This is deliberately conservative — false
- * negatives just defer to OCC (the next UpdateNode RPC carries the local
- * `node.version` and the backend's OCC surfaces any conflict), while false
- * positives would silently overwrite a foreign writer's change. An earlier
- * `local.startsWith(incoming)` heuristic had exactly that false-positive
- * shape: alice with optimistic `"hello world"` + bob writes `"hello"` →
- * bob's broadcast falsely classified as own-echo → bob's version stashed →
- * alice's next RPC overwrites bob.
- */
-export function isPlausibleOwnEcho(incoming: Node, lastSentContent: string | undefined): boolean {
-  if (lastSentContent === undefined) return false;
-  return lastSentContent === (incoming.content ?? '');
-}
-
-/**
  * Core remote-update policy. Given the incoming node, the existing local
  * node (undefined if this id has never been seen locally), the update
- * source, the caller's editing state, and the content this client last
- * persisted for the node (for the own-echo check), decide whether the
- * caller should apply the incoming node to the store.
+ * source, and the caller's editing state, decide whether the caller should
+ * apply the incoming node to the store.
+ *
+ * A `database`-sourced update to a node the user is actively editing is
+ * never applied — the daemon's echo suppression (ADR-026's C5 extension) guarantees
+ * any such event is a genuine foreign write, so the optimistic local content
+ * is protected and a conflict notification is always raised.
  *
  * ai-chat nodes are exempt from the skip — see `shouldSkipStaleAiChatUpdate`
  * for that separate guard (message-count heuristic, not editing state).
@@ -74,8 +64,7 @@ export function decideRemoteUpdate(
   incoming: Node,
   existingNode: Node | undefined,
   source: UpdateSource,
-  editingState: EditingState,
-  lastSentContent: string | undefined
+  editingState: EditingState
 ): RemoteUpdateDecision {
   const isDatabaseSource = source.type === 'database';
   const isActivelyEdited = editingState.isFocused || editingState.hasPending;
@@ -84,16 +73,7 @@ export function decideRemoteUpdate(
     return { apply: true };
   }
 
-  const stashVersion =
-    typeof incoming.version === 'number' && isPlausibleOwnEcho(incoming, lastSentContent);
-
-  return {
-    apply: false,
-    stashVersion,
-    // A foreign write (not our own echo) to an actively-edited node is
-    // skipped to protect the optimistic text, but must not be silent.
-    notifyConflict: !stashVersion
-  };
+  return { apply: false, notifyConflict: true };
 }
 
 /**

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -589,55 +589,6 @@ export class SharedNodeStore {
   // Version tracking for optimistic concurrency
   private versions = new Map<string, number>();
 
-  // Non-reactive cache of the latest server-confirmed `node.version` per id.
-  // Populated by the skip-while-editing guard in setNode() instead of
-  // mutating the reactive `nodes` Map (which would trigger Svelte re-renders
-  // that remount the textarea and reset selectionStart). Consumed by the
-  // UpdateNode persistence path so the
-  // next OCC carries the freshest version.
-  private serverConfirmedVersions = new Map<string, number>();
-
-  // The content this client most-recently sent to the backend per node.
-  // Set by the UpdateNode/CreateNode persistence paths right before the RPC
-  // fires. Used by `isPlausibleOwnEcho` to recognise true own-write echoes
-  // (broadcast.content matches what WE just sent) rather than guessing
-  // from prefix relationships — the previous `local.startsWith(incoming)`
-  // heuristic mis-classified bob's `"hello"` write as alice's echo when
-  // alice's optimistic state was `"hello world"`.
-  private lastPersistedContent = new Map<string, string>();
-
-  /**
-   * Test-only helper to seed the "content this client last sent" cache
-   * without running the persistence path. Production code populates this
-   * cache from the UpdateNode/CreateNode RPC sites; tests don't have a
-   * backendAdapter mock running and need a way to assert the
-   * `isPlausibleOwnEcho` heuristic's gate on real own-write history.
-   * Marked `__test_` to keep it out of the production call surface.
-   */
-  __test_setLastPersistedContent(nodeId: string, content: string): void {
-    this.lastPersistedContent.set(nodeId, content);
-  }
-
-  /**
-   * Record a node's server-confirmed content as the own-echo baseline that
-   * `isPlausibleOwnEcho` compares against. Called whenever a node is accepted
-   * from the daemon broadcast or hydrated from the backend — i.e. whenever its
-   * content is known to equal the server state.
-   *
-   * Without this baseline, the FIRST broadcast for a node the user then starts
-   * editing has no `lastPersistedContent` entry, so `isPlausibleOwnEcho`
-   * false-classifies that echo (the daemon streaming a node's current state
-   * after the subscription opens) as a foreign write. The skip-while-editing
-   * guard then fires a spurious "Your edit conflicted with a remote change"
-   * notification even though nothing else touched the node. Priming here — not
-   * only after the first local edit — gives that echo a baseline to match. A
-   * genuinely different foreign write still fails the equality check and
-   * correctly surfaces the conflict.
-   */
-  private primeOwnEchoBaseline(node: Node): void {
-    this.lastPersistedContent.set(node.id, node.content ?? '');
-  }
-
   /**
    * Decide whether the persistence path should clear a CREATE's
    * `InsertPosition.After` hint as "stale" before talking to the backend.
@@ -672,32 +623,18 @@ export class SharedNodeStore {
   }
 
   /**
-   * Test-only accessor for the non-reactive server-confirmed-version cache.
-   * Production code consumes this cache via the persistence path
-   * (UpdateNode OCC version selection). Tests use this to assert the cache
-   * was populated/cleared as expected — see
-   * `shared-node-store-skip-while-editing.test.ts`.
-   */
-  peekServerConfirmedVersion(nodeId: string): number | undefined {
-    return this.serverConfirmedVersions.get(nodeId);
-  }
-
-  /**
-   * Returns the version the next UpdateNode RPC would send for this node,
-   * applying the same lookup the persistence closure uses:
+   * Returns the version the next UpdateNode RPC would send for this node.
    *
-   *   serverConfirmedVersions[nodeId] ?? localNode.version ?? 1
-   *
-   * Exposed so the skip-while-editing test suite can lock the contract in
-   * place — a future refactor that drops the cache read at the
-   * persistence call site would fail the corresponding test instead of
-   * silently re-introducing the OCC-defeat bug.
+   * Before ADR-026's C5 extension, this also consulted a server-confirmed-version cache
+   * the skip-while-editing guard populated for a broadcast plausibly
+   * classified as this client's own echo. That classification no longer
+   * exists (the daemon suppresses echoes before they reach the frontend at
+   * all — see `remote-update-policy.ts`), so every database-sourced
+   * broadcast to an actively-edited node is now always treated as foreign:
+   * this simply reads the local node's own version.
    */
   computeOccVersionForUpdate(nodeId: string): number {
-    const confirmed = this.serverConfirmedVersions.get(nodeId);
-    if (typeof confirmed === 'number') return confirmed;
-    const local = this.nodes.get(nodeId);
-    return local?.version ?? 1;
+    return this.nodes.get(nodeId)?.version ?? 1;
   }
 
   // Test error tracking (populated only in NODE_ENV='test', cleared between tests)
@@ -1460,8 +1397,10 @@ export class SharedNodeStore {
     // 'database') arriving for a node the user is actively editing — or has
     // unsaved local changes for — would otherwise overwrite the optimistic
     // store with the *older* server-confirmed state. The optimistic state is
-    // authoritative until persistence settles, so we keep the local content
-    // and stash the server-confirmed version in a non-reactive cache.
+    // authoritative until persistence settles, so we keep the local content.
+    // Every such event is a genuine foreign write: the daemon suppresses this
+    // client's own write echoes before they ever reach here (ADR-026's C5 extension),
+    // so there is nothing left to classify.
     //
     // CRITICAL: do NOT call `this.nodes.set()` or mutate any property of a
     // node inside the reactive Map. Either triggers Svelte re-renders that
@@ -1492,27 +1431,18 @@ export class SharedNodeStore {
       return;
     }
 
-    const decision = decideRemoteUpdate(
-      node,
-      existingNode,
-      source,
-      { isFocused, hasPending },
-      this.lastPersistedContent.get(node.id)
-    );
+    const decision = decideRemoteUpdate(node, existingNode, source, { isFocused, hasPending });
 
     if (!decision.apply) {
       log.debug(
         `setNode: skipping clobber of actively-edited node ${node.id} ` +
           `(focused=${isFocused}, pending=${hasPending})`
       );
-      if (decision.stashVersion && typeof node.version === 'number') {
-        this.serverConfirmedVersions.set(node.id, node.version);
-      }
       if (decision.notifyConflict) {
-        // A FOREIGN write to a node the user is actively editing (not
-        // our own echo). We skip the clobber to protect the optimistic text,
-        // but that must not be silent — raise a version-mismatch
-        // notification (deduped per node) so the conflict is visible.
+        // A foreign write to a node the user is actively editing. We skip
+        // the clobber to protect the optimistic text, but that must not be
+        // silent — raise a version-mismatch notification (deduped per node)
+        // so the conflict is visible.
         const alreadyFlagged = conflictNotifications.notifications.some(
           (n) => n.nodeId === node.id && n.conflictType === 'version-mismatch'
         );
@@ -1538,11 +1468,6 @@ export class SharedNodeStore {
 
     this.nodesSet(node.id, node);
     this.versions.set(node.id, this.getNextVersion(node.id));
-    // A non-guarded setNode means the local store has caught up with the
-    // server (either the user blurred, persistence settled, or the node is
-    // arriving fresh). Drop any stale entry from the skip-while-editing
-    // cache so it doesn't shadow a now-current node.version.
-    this.serverConfirmedVersions.delete(node.id);
     this.notifySubscribers(node.id, node, source);
 
     if (isHierarchyChange) {
@@ -1556,9 +1481,6 @@ export class SharedNodeStore {
     // Mark as persisted if explicitly requested or loaded from backend
     if (shouldMarkAsPersisted) {
       this.persistedNodeIds.add(node.id);
-      // This content came from the server (daemon broadcast / backend hydration),
-      // so record it as the own-echo baseline for the skip-while-editing guard.
-      this.primeOwnEchoBaseline(node);
     }
 
     // Phase 2.4: Persist to database
@@ -1632,16 +1554,7 @@ export class SharedNodeStore {
 
                 try {
                   // Get current version for optimistic concurrency control.
-                  // Routes through `computeOccVersionForUpdate` so the
-                  // skip-while-editing guard (see `setNode`) can stash a
-                  // server-confirmed version without mutating reactive
-                  // state. Test coverage:
-                  // `shared-node-store-skip-while-editing.test.ts`.
                   const currentVersion = this.computeOccVersionForUpdate(nodeId);
-                  // Record the content we are about to send so the next
-                  // database broadcast for this node can be classified as
-                  // an own-echo (see `isPlausibleOwnEcho`).
-                  this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                   const updatedFromBackend = await backendAdapter.updateNode(nodeId, currentVersion, currentNode);
                   // Sync the backend-assigned version into the local node so the next
                   // OCC uses a fresh version rather than the now-stale pre-update value.
@@ -1674,7 +1587,6 @@ export class SharedNodeStore {
                       parentId: this.getParentId(nodeId),
                       insertPosition: null
                     };
-                    this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                     await backendAdapter.createNode(fallbackCreateInput);
                     this.persistedNodeIds.add(nodeId);
                   } else {
@@ -1706,7 +1618,6 @@ export class SharedNodeStore {
                   parentId: this.getParentId(nodeId),
                   insertPosition: nodeWithInsertPos.insertPosition ?? null
                 };
-                this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                 await backendAdapter.createNode(createInput);
                 this.persistedNodeIds.add(nodeId); // Track as persisted
 
@@ -1820,26 +1731,18 @@ export class SharedNodeStore {
       // would overwrite the child's optimistic content.
       const isFocused = focusManager.editingNodeId === node.id;
       const hasPending = PersistenceCoordinator.getInstance().hasPending(node.id);
-      const decision = decideRemoteUpdate(
-        node,
-        existingNode,
-        source,
-        { isFocused, hasPending },
-        this.lastPersistedContent.get(node.id)
-      );
+      const decision = decideRemoteUpdate(node, existingNode, source, { isFocused, hasPending });
       if (!decision.apply) {
         log.debug(
           `batchSetNodes: skipping clobber of actively-edited node ${node.id} ` +
             `(focused=${isFocused}, pending=${hasPending})`
         );
-        // Stash the server-confirmed version only when the broadcast is plausibly
-        // an echo of THIS client's own write; otherwise leave it empty so the next
-        // RPC uses our local version, conflicts, and surfaces the foreign change
-        // (preserves OCC). Mirrors setNode's decision, but batchSetNodes does not
-        // raise conflict notifications (pre-existing behavior, unchanged here).
-        if (decision.stashVersion && typeof node.version === 'number') {
-          this.serverConfirmedVersions.set(node.id, node.version);
-        }
+        // Every database-sourced event reaching here is a genuine foreign
+        // write (the daemon suppresses this client's own echoes before they
+        // arrive — ADR-026's C5 extension): leave the node's version alone so the next
+        // RPC uses our local version, conflicts, and surfaces the foreign
+        // change (preserves OCC). batchSetNodes does not raise conflict
+        // notifications (pre-existing behavior, unchanged here).
         this.persistedNodeIds.add(node.id);
         continue;
       }
@@ -1862,10 +1765,6 @@ export class SharedNodeStore {
 
       if (shouldMarkAsPersisted) {
         this.persistedNodeIds.add(node.id);
-        // Bulk hydration (initial tree load) flows through here — prime the
-        // own-echo baseline so a subsequently-focused node's first daemon echo
-        // isn't misread as a foreign write (mirrors setNode).
-        this.primeOwnEchoBaseline(node);
       }
     }
 
@@ -2159,8 +2058,6 @@ export class SharedNodeStore {
     this.versions.clear();
     this.pendingUpdates.clear();
     this.persistedNodeIds.clear();
-    this.serverConfirmedVersions.clear();
-    this.lastPersistedContent.clear();
     this.batchedNotifications.clear();
     this.activeBatches.clear();
     this.pendingTreeLoads.clear();

--- a/packages/desktop-app/src/tests/services/remote-update-policy.test.ts
+++ b/packages/desktop-app/src/tests/services/remote-update-policy.test.ts
@@ -9,11 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  decideRemoteUpdate,
-  isPlausibleOwnEcho,
-  shouldSkipStaleAiChatUpdate
-} from '$lib/services/remote-update-policy';
+import { decideRemoteUpdate, shouldSkipStaleAiChatUpdate } from '$lib/services/remote-update-policy';
 import type { Node } from '$lib/types';
 import type { UpdateSource } from '$lib/types/update-protocol';
 
@@ -35,57 +31,25 @@ const viewerSource: UpdateSource = { type: 'viewer', viewerId: 'v1' };
 const databaseSource: UpdateSource = { type: 'database', reason: 'domain-event' };
 const notEditing = { isFocused: false, hasPending: false };
 
-describe('isPlausibleOwnEcho', () => {
-  it('returns false when there is no last-sent record', () => {
-    expect(isPlausibleOwnEcho(makeNode({ content: 'x' }), undefined)).toBe(false);
-  });
-
-  it('returns true when incoming content matches the last-sent content exactly', () => {
-    expect(isPlausibleOwnEcho(makeNode({ content: 'hello world' }), 'hello world')).toBe(true);
-  });
-
-  it('returns false for a prefix-compatible but different foreign write (not a startsWith heuristic)', () => {
-    // Regression: an older `local.startsWith(incoming)` heuristic mis-classified
-    // this as an echo. The content-equality contract must not do that.
-    expect(isPlausibleOwnEcho(makeNode({ content: 'hello' }), 'hello world')).toBe(false);
-  });
-
-  it('treats missing content as empty string', () => {
-    expect(isPlausibleOwnEcho(makeNode({ content: undefined }), '')).toBe(true);
-  });
-});
-
 describe('decideRemoteUpdate', () => {
   it('applies when source is not database', () => {
-    const decision = decideRemoteUpdate(
-      makeNode(),
-      makeNode(),
-      viewerSource,
-      { isFocused: true, hasPending: false },
-      undefined
-    );
+    const decision = decideRemoteUpdate(makeNode(), makeNode(), viewerSource, {
+      isFocused: true,
+      hasPending: false
+    });
     expect(decision.apply).toBe(true);
   });
 
   it('applies when there is no existing node (first sighting)', () => {
-    const decision = decideRemoteUpdate(
-      makeNode(),
-      undefined,
-      databaseSource,
-      { isFocused: true, hasPending: false },
-      undefined
-    );
+    const decision = decideRemoteUpdate(makeNode(), undefined, databaseSource, {
+      isFocused: true,
+      hasPending: false
+    });
     expect(decision.apply).toBe(true);
   });
 
   it('applies when the node is not actively edited (not focused, no pending write)', () => {
-    const decision = decideRemoteUpdate(
-      makeNode(),
-      makeNode(),
-      databaseSource,
-      notEditing,
-      undefined
-    );
+    const decision = decideRemoteUpdate(makeNode(), makeNode(), databaseSource, notEditing);
     expect(decision.apply).toBe(true);
   });
 
@@ -94,8 +58,7 @@ describe('decideRemoteUpdate', () => {
       makeNode({ content: 'incoming' }),
       makeNode({ content: 'local' }),
       databaseSource,
-      { isFocused: true, hasPending: false },
-      undefined
+      { isFocused: true, hasPending: false }
     );
     expect(decision.apply).toBe(false);
   });
@@ -105,51 +68,24 @@ describe('decideRemoteUpdate', () => {
       makeNode({ content: 'incoming' }),
       makeNode({ content: 'local' }),
       databaseSource,
-      { isFocused: false, hasPending: true },
-      undefined
+      { isFocused: false, hasPending: true }
     );
     expect(decision.apply).toBe(false);
   });
 
-  it('stashes the version and does not notify when the broadcast is a plausible own-echo', () => {
-    const decision = decideRemoteUpdate(
-      makeNode({ content: 'hello world', version: 6 }),
-      makeNode({ content: 'hello world', version: 3 }),
-      databaseSource,
-      { isFocused: true, hasPending: false },
-      'hello world'
-    );
-    expect(decision.apply).toBe(false);
-    if (decision.apply) throw new Error('unreachable');
-    expect(decision.stashVersion).toBe(true);
-    expect(decision.notifyConflict).toBe(false);
-  });
-
-  it('does not stash the version and notifies when the broadcast looks like a foreign write', () => {
+  // ADR-026's C5 extension: the daemon suppresses a connection's own write echoes before
+  // they ever reach WatchNodes, so every database-sourced event reaching this
+  // policy is guaranteed to be a genuine foreign write — always skip with a
+  // conflict notification, never attempt to classify it as an own-echo.
+  it('always notifies a foreign write to an actively-edited node (no own-echo classification)', () => {
     const decision = decideRemoteUpdate(
       makeNode({ content: 'bob wrote this', version: 9 }),
       makeNode({ content: 'alice typed this', version: 3 }),
       databaseSource,
-      { isFocused: true, hasPending: false },
-      'alice typed this'
+      { isFocused: true, hasPending: false }
     );
     expect(decision.apply).toBe(false);
     if (decision.apply) throw new Error('unreachable');
-    expect(decision.stashVersion).toBe(false);
-    expect(decision.notifyConflict).toBe(true);
-  });
-
-  it('treats an incoming node with no numeric version as never stash-eligible', () => {
-    const decision = decideRemoteUpdate(
-      makeNode({ content: 'hello world', version: undefined as unknown as number }),
-      makeNode({ content: 'hello world', version: 3 }),
-      databaseSource,
-      { isFocused: true, hasPending: false },
-      'hello world'
-    );
-    expect(decision.apply).toBe(false);
-    if (decision.apply) throw new Error('unreachable');
-    expect(decision.stashVersion).toBe(false);
     expect(decision.notifyConflict).toBe(true);
   });
 });

--- a/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store-skip-while-editing.test.ts
@@ -145,102 +145,33 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     const after = store.getNode('n6');
     expect(after?.content).toBe('local-newer'); // content preserved
     expect(after?.version).toBe(3); // local version NOT touched
-    // The server-confirmed version (7) is stashed in a non-reactive cache
-    // and consumed by the persistence path; not observable via getNode.
   });
 
-  it('does NOT stash the server-confirmed version when the broadcast looks like a foreign write (preserves OCC)', () => {
-    // The guard's whole point is to avoid clobbering local optimistic
-    // content with the server-confirmed snapshot. But the broadcast
-    // mechanism doesn't distinguish "my-own-write echoing back" from
-    // "another client's write to the same node arriving via cloud
-    // round-trip". For the latter case, blindly stashing the foreign
-    // writer's version would defeat OCC: alice's next UpdateNode would
-    // carry bob's version against alice's content and the backend would
-    // silently overwrite bob's change.
-    //
-    // The "is plausibly an own echo" heuristic resolves this: stash only
-    // when `incoming.content` matches this client's recorded last-sent
-    // content for the node. For any other broadcast (including the
-    // alice="hello world" + bob="hello" prefix-compatible race the
-    // earlier startsWith heuristic mis-classified), treat as foreign.
+  it('never stashes a broadcast version, preserving OCC for every database-sourced event (ADR-026 C5 extension)', () => {
+    // Before the ADR-026 C5 extension, the guard tried to distinguish "my own write
+    // echoing back" from "a different client's write" by comparing the
+    // broadcast's content against what this client last sent, and stashed
+    // the broadcast version only for a plausible own-echo. The daemon now
+    // suppresses a connection's own write echoes before they ever reach
+    // WatchNodes (`packages/daemon/src/services/node_service.rs`), so every
+    // database-sourced broadcast the frontend receives is guaranteed
+    // foreign — there is no case left where stashing a broadcast version is
+    // safe, and the guard never does so. The next UpdateNode always carries
+    // this client's own local version, so a real conflict surfaces via OCC
+    // instead of silently overwriting the foreign write.
     const optimistic = makeNode('foreign', 'alice typed this', 3);
     store.setNode(optimistic, viewerSource);
     focusManager.focusNode('foreign', 'default');
-    // Alice last persisted "alice typed this" to backend.
-    store.__test_setLastPersistedContent('foreign', 'alice typed this');
 
-    // Foreign-looking broadcast (different writer altered the node).
     const foreignBroadcast = makeNode('foreign', 'bob wrote something else', 9);
     store.setNode(foreignBroadcast, databaseSource);
 
     // Local content is preserved (guard still fired — we keep optimistic).
     expect(store.getNode('foreign')?.content).toBe('alice typed this');
     expect(store.getNode('foreign')?.version).toBe(3);
-    // Foreign version was NOT stashed: next UpdateNode uses local v3,
-    // backend has v9, OCC conflict surfaces.
-    expect(store.peekServerConfirmedVersion('foreign')).toBeUndefined();
-  });
-
-  it('does NOT mis-classify a prefix-compatible foreign write as an own-echo (regression for the startsWith hole)', () => {
-    // Previously the heuristic was `localContent.startsWith(incomingContent)`.
-    // That would mis-classify the following case as own-echo and stash
-    // bob's version, defeating OCC for bob's change:
-    //
-    //   alice's optimistic state: "hello world"
-    //   bob writes (in a parallel window): "hello"
-    //   bob's broadcast hits alice with content="hello", version=v_bob
-    //
-    // `"hello world".startsWith("hello")` is true, so the old code
-    // stashed v_bob. Next UpdateNode from alice would have carried
-    // v_bob against "hello world" and silently overwritten bob.
-    //
-    // The current heuristic compares against this client's recorded
-    // last-sent content. Alice never sent "hello" — her last persisted
-    // value (if any) is whatever she actually persisted. So bob's
-    // broadcast is correctly classified as foreign.
-    const aliceOptimistic = makeNode('shared', 'hello world', 5);
-    store.setNode(aliceOptimistic, viewerSource);
-    focusManager.focusNode('shared', 'default');
-    // Alice has never persisted "hello" — only "hello world" via her
-    // own typing. (For the regression check the exact prior value
-    // doesn't matter — what matters is that it ISN'T "hello".)
-    store.__test_setLastPersistedContent('shared', 'hello world');
-
-    const bobsBroadcast = makeNode('shared', 'hello', 7);
-    store.setNode(bobsBroadcast, databaseSource);
-
-    // Bob's version must NOT be stashed.
-    expect(store.peekServerConfirmedVersion('shared')).toBeUndefined();
-    // Alice's content and version are preserved (no clobber).
-    expect(store.getNode('shared')?.content).toBe('hello world');
-    expect(store.getNode('shared')?.version).toBe(5);
-  });
-
-  it('persistence path uses the stashed server-confirmed version for OCC (not the stale local node.version)', () => {
-    // Contract test for the cache's read site. The actual persistence
-    // closure inside SharedNodeStore calls `computeOccVersionForUpdate`,
-    // which routes through the same `serverConfirmedVersions` cache the
-    // skip-while-editing guard populates. Without this test, a future
-    // refactor that drops that read would silently reintroduce the
-    // OCC-defeat from the typing-corruption bug — the unit tests above only
-    // assert cache *population*, not *consumption*.
-    store.setNode(makeNode('persist', 'abc', 1), databaseSource);
-    // Simulate that the local client just persisted 'abc' (own echo
-    // gate). Without this, the guard correctly treats the next
-    // broadcast as foreign and does NOT stash the version.
-    store.__test_setLastPersistedContent('persist', 'abc');
-
-    // Before the guard fires, the OCC version is the local one.
-    expect(store.computeOccVersionForUpdate('persist')).toBe(1);
-
-    // Guard fires for an own-echo broadcast (content matches what we sent).
-    focusManager.focusNode('persist', 'default');
-    store.setNode(makeNode('persist', 'abc', 5), databaseSource);
-
-    // Local .version unchanged, but the persistence path now picks 5.
-    expect(store.getNode('persist')?.version).toBe(1);
-    expect(store.computeOccVersionForUpdate('persist')).toBe(5);
+    // The next UpdateNode still uses the local version — an OCC conflict
+    // against the backend's v9 will surface it rather than silently losing it.
+    expect(store.computeOccVersionForUpdate('foreign')).toBe(3);
   });
 
   it('preserves insertAfterNodeId when structureTree agrees on parent (sync#77)', () => {
@@ -271,14 +202,10 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     structureTree.clear();
   });
 
-  it('clears the server-confirmed-version cache when a non-guarded setNode applies (no shadowing)', () => {
-    // Seed via the database path so no persistence is scheduled — we want
-    // to exercise just the focus/clear-cache flow without a pending op
-    // tripping the guard.
+  it('applies the next database event normally once the user blurs (guard only fires while actively editing)', () => {
     store.setNode(makeNode('n7', 'seed', 3), databaseSource);
 
-    // Focus the node so the next database event hits the guard and stashes
-    // its version in the non-reactive cache.
+    // Focus the node so the next database event hits the guard.
     focusManager.focusNode('n7', 'default');
     store.setNode(makeNode('n7', 'older', 9), databaseSource);
     // Verify the local view didn't change (guard fired).
@@ -286,9 +213,7 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     expect(store.getNode('n7')?.version).toBe(3);
 
     // User blurs. Subsequent database event no longer matches the guard;
-    // the normal setNode path runs, writes the new state, and MUST clear
-    // the cache so a stale stashed version can't shadow it on the next
-    // persistence.
+    // the normal setNode path runs and writes the new state.
     focusManager.clearEditing();
     store.setNode(makeNode('n7', 'cloud-current', 15), databaseSource);
 
@@ -365,9 +290,8 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
     it('raises a version-mismatch notification when a foreign broadcast hits a focused node', () => {
       store.setNode(makeNode('shared', 'hello world', 5), viewerSource);
       focusManager.focusNode('shared', 'default');
-      store.__test_setLastPersistedContent('shared', 'hello world');
 
-      // Bob's foreign write (not a prefix/echo of alice's optimistic content).
+      // Bob's foreign write.
       store.setNode(makeNode('shared', 'totally different text', 7), databaseSource);
 
       expect(versionMismatchFor('shared')).toHaveLength(1);
@@ -375,22 +299,9 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
       expect(store.getNode('shared')?.content).toBe('hello world');
     });
 
-    it('does NOT notify for an own-echo broadcast', () => {
-      store.setNode(makeNode('echo', 'hello world', 5), viewerSource);
-      focusManager.focusNode('echo', 'default');
-      // isPlausibleOwnEcho is true iff the incoming content equals our last-sent
-      // content — the daemon echoing back exactly what we persisted.
-      store.__test_setLastPersistedContent('echo', 'hello world');
-
-      store.setNode(makeNode('echo', 'hello world', 6), databaseSource);
-
-      expect(versionMismatchFor('echo')).toHaveLength(0);
-    });
-
     it('dedupes repeated foreign broadcasts for the same node', () => {
       store.setNode(makeNode('dup', 'hello world', 5), viewerSource);
       focusManager.focusNode('dup', 'default');
-      store.__test_setLastPersistedContent('dup', 'hello world');
 
       store.setNode(makeNode('dup', 'foreign one', 7), databaseSource);
       store.setNode(makeNode('dup', 'foreign two', 8), databaseSource);
@@ -398,32 +309,28 @@ describe('SharedNodeStore — skip-while-editing guard', () => {
       expect(versionMismatchFor('dup')).toHaveLength(1);
     });
 
-    // Regression for the "conflict toast on effectively every edit" bug: the
-    // own-echo test above pre-seeds lastPersistedContent through the __test_
-    // backdoor, so it never exercised the real cold path. Here a node is
-    // hydrated from the backend (database source) with NO backdoor — the accept
-    // path must prime the own-echo baseline itself, so the daemon's first echo
-    // after the subscription opens is not misread as a foreign write.
-    it('does NOT notify on a load-echo of a backend-hydrated node (real path, no backdoor)', () => {
-      // Node arrives from the backend/daemon; this alone must prime the baseline.
+    // ADR-026's C5 extension: the daemon suppresses a connection's own write echoes
+    // before they ever reach WatchNodes, so the frontend never receives a
+    // database-sourced broadcast that is its own echo — there is no "own
+    // echo, don't notify" case left to test here. Every database-sourced
+    // broadcast reaching an actively-edited node is a genuine foreign write
+    // and always raises the conflict notification, including one whose
+    // content happens to be identical to what the client last saw (the old
+    // content-comparison heuristic would have misclassified this as an echo
+    // — the daemon's authoritative signal does not need content at all).
+    it('still notifies even when the broadcast content is identical to what was last seen (no content-based echo guessing)', () => {
       store.setNode(makeNode('hydrated', 'hello world', 5), databaseSource);
       focusManager.focusNode('hydrated', 'default');
 
-      // The daemon streams the node's current state back after WatchNodes opens.
-      // Before this fix, that echo (no lastPersistedContent entry) fired a
-      // spurious version-mismatch toast even though nothing else changed.
       store.setNode(makeNode('hydrated', 'hello world', 6), databaseSource);
 
-      expect(versionMismatchFor('hydrated')).toHaveLength(0);
+      expect(versionMismatchFor('hydrated')).toHaveLength(1);
     });
 
-    it('still notifies on a genuine foreign write after real-path priming (no backdoor)', () => {
-      // Same real hydration priming as above — no __test_ backdoor.
+    it('notifies on a genuine foreign write to a focused node', () => {
       store.setNode(makeNode('hydrated2', 'hello world', 5), databaseSource);
       focusManager.focusNode('hydrated2', 'default');
 
-      // A DIFFERENT writer changes the node. The primed baseline ('hello world')
-      // does not match the incoming content, so the conflict is still surfaced.
       store.setNode(makeNode('hydrated2', 'a foreign edit', 7), databaseSource);
 
       expect(versionMismatchFor('hydrated2')).toHaveLength(1);

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -17,6 +17,23 @@ pub mod nodespace {
 /// daemon reference one canonical key.
 pub const DATABASE_ID_HEADER: &str = "x-ns-database-id";
 
+/// The gRPC metadata/header key a client sets to identify itself for
+/// same-origin write-echo suppression on the `WatchNodes` stream.
+///
+/// Every write RPC that carries this header is scoped through
+/// `NodeService::with_client(id)`, so its emitted events are stamped with
+/// `source_client_id = id`. `WatchNodes` reads the same header off the
+/// subscribing request and drops any event whose `source_client_id` matches —
+/// the daemon, not the frontend, is the authority on "is this my own echo".
+///
+/// Absent → writes emit no `source_client_id` and are never suppressed on any
+/// stream (unchanged pre-issue-1689 behavior). Each process that opens its own
+/// long-lived connection to the daemon (one desktop-app window, one CLI
+/// invocation, one local-agent session) should generate its own stable id for
+/// the lifetime of that connection — never share one across processes, or a
+/// genuinely foreign writer's events would be suppressed too.
+pub const CLIENT_ID_HEADER: &str = "x-ns-client-id";
+
 pub use nodespace::agent_session_service_client::AgentSessionServiceClient;
 pub use nodespace::agent_session_service_server::AgentSessionServiceServer;
 pub use nodespace::database_service_client::DatabaseServiceClient;


### PR DESCRIPTION
Closes #1689