### PR TITLE
Fix Pro-sync pill resolution, conflict-toast churn, collaboration roster, and add create-collection UI

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
+++ b/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
@@ -6,7 +6,7 @@
 -->
 
 <script lang="ts">
-  import Icon from '$lib/design/icons/icon.svelte';
+  import Icon, { type IconName } from '$lib/design/icons/icon.svelte';
   import type { CollectionMember } from '$lib/stores/collections.svelte';
 
   interface Props {
@@ -21,13 +21,58 @@
 
   let { open, collectionName, members, onClose, onNodeClick, onOpenCollection }: Props = $props();
 
-  function getNodeIcon(nodeType: string): 'calendar' | 'circle' | 'text' {
-    const iconMap: Record<string, 'calendar' | 'circle' | 'text'> = {
+  // Map content node types to the closest available icon (see icon.svelte for
+  // the full IconName set). Anything unmapped falls back to the generic text glyph.
+  function getNodeIcon(nodeType: string): IconName {
+    const iconMap: Record<string, IconName> = {
       date: 'calendar',
-      task: 'circle',
-      text: 'text'
+      task: 'taskIncomplete',
+      checkbox: 'taskIncomplete',
+      'ai-chat': 'aiSquare',
+      prompt: 'aiSquare',
+      skill: 'aiSquare',
+      query: 'aiSquare',
+      text: 'text',
+      header: 'text',
+      'code-block': 'text',
+      'quote-block': 'text',
+      'ordered-list': 'text'
     };
-    return iconMap[nodeType] || 'text';
+    return iconMap[nodeType] ?? 'text';
+  }
+
+  // Nicely-cased display labels for known content types; anything else is
+  // title-cased from its raw id (e.g. 'my-thing' -> 'My Thing').
+  const NODE_TYPE_LABELS: Record<string, string> = {
+    text: 'Text',
+    header: 'Header',
+    task: 'Task',
+    checkbox: 'Checkbox',
+    'code-block': 'Code',
+    'quote-block': 'Quote',
+    'ordered-list': 'List',
+    'ai-chat': 'AI Chat',
+    query: 'Query',
+    prompt: 'Prompt',
+    skill: 'Skill',
+    date: 'Date'
+  };
+
+  function humanizeNodeType(nodeType: string): string {
+    return (
+      NODE_TYPE_LABELS[nodeType] ??
+      nodeType
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    );
+  }
+
+  // A muted placeholder for content with no name, so blank rows read as
+  // "Untitled text" / "Untitled task" instead of appearing empty/unclickable.
+  function fallbackName(nodeType: string): string {
+    return `Untitled ${humanizeNodeType(nodeType).toLowerCase()}`;
   }
 </script>
 
@@ -50,10 +95,14 @@
 
   <ul class="node-list">
     {#each members as member (member.id)}
+      {@const trimmedName = member.name.trim()}
       <li>
         <button class="node-item" onclick={() => onNodeClick(member.id, member.nodeType)}>
           <Icon name={getNodeIcon(member.nodeType)} size={16} />
-          <span class="node-name">{member.name}</span>
+          <span class="node-name" class:node-name--untitled={!trimmedName}>
+            {trimmedName || fallbackName(member.nodeType)}
+          </span>
+          <span class="node-type-tag">{humanizeNodeType(member.nodeType)}</span>
         </button>
       </li>
     {/each}
@@ -184,9 +233,27 @@
   }
 
   .node-name {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* Muted placeholder styling for blank/untitled content. */
+  .node-name--untitled {
+    font-style: italic;
+    opacity: 0.7;
+  }
+
+  /* Small muted type tag so content types are distinguishable at a glance. */
+  .node-type-tag {
+    flex-shrink: 0;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: hsl(var(--muted-foreground));
+    opacity: 0.65;
   }
 
   .empty-state {

--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -35,6 +35,34 @@
   let collectionForPanel = $derived(collectionsState.selectedCollection);
   let collectionMembers = $derived(collectionsState.selectedCollectionMembers);
 
+  // Inline "New collection" form for the Collections section. New collections are
+  // created open (the app has no privacy toggle yet); the daemon makes the caller
+  // an admin member so it appears in this list on the loadCollections refresh.
+  let creatingCollection = $state(false);
+  let newCollectionName = $state('');
+  let createBusy = $state(false);
+
+  function focusOnMount(node: HTMLInputElement) {
+    node.focus();
+  }
+
+  async function submitNewCollection() {
+    const name = newCollectionName.trim();
+    if (!name || createBusy) return;
+    createBusy = true;
+    const id = await collectionsData.createCollection(name);
+    createBusy = false;
+    if (id) {
+      newCollectionName = '';
+      creatingCollection = false;
+    }
+  }
+
+  function cancelNewCollection() {
+    newCollectionName = '';
+    creatingCollection = false;
+  }
+
   // Schema types from global store (reactive — updates when schemas are created/deleted externally)
   let builtInSchemas = $derived(schemasStore.builtInSchemas);
   let customSchemas = $derived(schemasStore.customSchemas);
@@ -425,6 +453,32 @@
                 {/each}
               {/if}
             {/each}
+
+            <!-- Create a new collection -->
+            {#if creatingCollection}
+              <div class="collection-item">
+                <div class="expand-area"></div>
+                <input
+                  class="new-collection-input"
+                  placeholder="Collection name…"
+                  bind:value={newCollectionName}
+                  disabled={createBusy}
+                  use:focusOnMount
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') submitNewCollection();
+                    else if (e.key === 'Escape') cancelNewCollection();
+                  }}
+                />
+              </div>
+            {:else}
+              <button
+                class="new-collection-btn"
+                onclick={() => (creatingCollection = true)}
+                title="Create a new collection"
+              >
+                + New collection
+              </button>
+            {/if}
           </div>
         </Collapsible.Content>
       </Collapsible.Root>
@@ -836,6 +890,33 @@
     padding: 0.4rem 0;
     font-size: inherit;
     white-space: nowrap; /* Keep on single line, scroll horizontally if needed */
+  }
+
+  .new-collection-btn {
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+    text-align: left;
+    padding: 0.4rem 0 0.4rem 1.5rem;
+    font-size: inherit;
+    white-space: nowrap;
+  }
+
+  .new-collection-btn:hover {
+    color: hsl(var(--foreground));
+  }
+
+  .new-collection-input {
+    flex: 1;
+    min-width: 0;
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    color: inherit;
+    padding: 0.25rem 0.4rem;
+    font-size: inherit;
   }
 
   /* Expand chevron inside collection item */

--- a/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
+++ b/packages/desktop-app/src/lib/plugins/ui-extensions.svelte.ts
@@ -30,22 +30,27 @@ import {
   type ProSyncVariant
 } from './ui-extensions';
 
-/** The `database-settings`-namespaced properties held on the settings singleton. */
+/** The FLAT properties the daemon serializes onto the settings singleton. */
 interface DatabaseSettings {
   sync_enabled?: boolean;
   auth_status?: string;
 }
 
 /**
- * Read the active database's `DatabaseSettingsNode` properties (the
- * `database-settings` sub-object), or `undefined` when the node isn't hydrated
- * yet. Reads the reactive `SharedNodeStore` map, so callers in a reactive context
- * re-run when the node lands or changes.
+ * Read the active database's `DatabaseSettingsNode` properties (the FLAT
+ * `sync_enabled`/`auth_status` fields), or `undefined` when the node isn't
+ * hydrated yet. Reads the reactive `SharedNodeStore` map, so callers in a
+ * reactive context re-run when the node lands or changes.
  */
 export function activeDatabaseSettings(): DatabaseSettings | undefined {
   const node = SharedNodeStore.getInstance().getNode(DATABASE_SETTINGS_NODE_ID);
-  const settings = (node?.properties as Record<string, unknown> | undefined)?.['database-settings'];
-  return settings && typeof settings === 'object' ? (settings as DatabaseSettings) : undefined;
+  // The daemon serializes DatabaseSettingsNode with FLAT properties —
+  // `sync_enabled`/`auth_status` sit directly on `properties` (per the Core
+  // schema), not nested under a `database-settings` sub-object. Reading the
+  // wrong (nested) path made `enabled` always false, so the pill could never
+  // resolve to `connected` no matter what merge did.
+  const props = node?.properties;
+  return props && typeof props === 'object' ? (props as DatabaseSettings) : undefined;
 }
 
 /**

--- a/packages/desktop-app/src/lib/services/membership-service.ts
+++ b/packages/desktop-app/src/lib/services/membership-service.ts
@@ -106,7 +106,22 @@ export class MembershipService {
 	async listMembers(collectionId: string): Promise<Member[]> {
 		log.debug('listMembers', { collectionId });
 		const rows = await invoke<RawMember[]>('pro_list_members', { collectionId });
-		return rows.map((r) => ({ personId: r.person_id, permission: r.permission as Permission }));
+		// Collapse duplicate rows for the same person: a person can carry more than
+		// one `member_of` edge (e.g. a role-bearing edge plus a plain membership
+		// edge), so the roster RPC can return the same `person_id` twice. Keep the
+		// highest-privilege permission and emit one row per person — otherwise the
+		// keyed `{#each … (personId)}` roster hits a duplicate-key crash and the
+		// whole Collaboration panel is stuck on "Loading members…".
+		const RANK: Record<Permission, number> = { readOnly: 0, modify: 1, admin: 2 };
+		const byPerson = new Map<string, Member>();
+		for (const r of rows) {
+			const permission = r.permission as Permission;
+			const existing = byPerson.get(r.person_id);
+			if (!existing || (RANK[permission] ?? 0) > (RANK[existing.permission] ?? 0)) {
+				byPerson.set(r.person_id, { personId: r.person_id, permission });
+			}
+		}
+		return [...byPerson.values()];
 	}
 
 	/** Add a member or change their role (admin only, server-gated). */

--- a/packages/desktop-app/src/lib/services/remote-update-policy.ts
+++ b/packages/desktop-app/src/lib/services/remote-update-policy.ts
@@ -87,12 +87,29 @@ export function decideRemoteUpdate(
   const stashVersion =
     typeof incoming.version === 'number' && isPlausibleOwnEcho(incoming, lastSentContent);
 
+  // A database broadcast whose version is NOT ahead of our optimistic local
+  // version is a *stale echo of one of our own earlier writes* looping back
+  // through the daemon — during rapid typing, keystrokes push faster than the
+  // broadcast round-trips, so the echo for an earlier keystroke arrives after
+  // we've typed more and its content no longer matches `lastSentContent`. It is
+  // never a foreign writer getting ahead of us: the daemon assigns a strictly
+  // higher version to any change it applies, so a genuine remote edit always
+  // arrives with a version past ours. Only a strictly-newer version we did not
+  // author (and whose content isn't our own echo) is a real conflict — so a
+  // stale self-echo must not raise a phantom notification on every keystroke.
+  // Missing/uncomparable versions fall back to notifying (the prior behavior).
+  const incomingIsNewer =
+    typeof incoming.version !== 'number' ||
+    typeof existingNode.version !== 'number' ||
+    incoming.version > existingNode.version;
+
   return {
     apply: false,
     stashVersion,
-    // A foreign write (not our own echo) to an actively-edited node is
-    // skipped to protect the optimistic text, but must not be silent.
-    notifyConflict: !stashVersion
+    // A foreign write (not our own echo, and genuinely newer) to an
+    // actively-edited node is skipped to protect the optimistic text, but must
+    // not be silent.
+    notifyConflict: !stashVersion && incomingIsNewer
   };
 }
 

--- a/packages/desktop-app/src/lib/stores/collections.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/collections.svelte.ts
@@ -46,6 +46,22 @@ export interface CollectionMember {
   nodeType: string;
 }
 
+/**
+ * Node types that are NOT user-authored content and so should never appear in a
+ * collection's contents list. `schema`/`person`/`database-settings` are system
+ * definition nodes; `collection` nodes are shown in the collection tree itself;
+ * `horizontal-line` is a purely decorative structural divider. Everything else
+ * (text, header, task, checkbox, code-block, quote-block, ordered-list,
+ * ai-chat, query, prompt, skill, date, …) is genuine content and kept.
+ */
+const NON_CONTENT_NODE_TYPES: ReadonlySet<string> = new Set([
+  'schema',
+  'person',
+  'database-settings',
+  'collection',
+  'horizontal-line',
+]);
+
 export interface CollectionsState {
   /** Currently selected collection ID (for sub-panel display) */
   selectedCollectionId: string | null;
@@ -101,6 +117,24 @@ class CollectionsDataStore {
       const message = err instanceof Error ? err.message : 'Failed to load collections';
       log.error('Failed to load collections', { error: message });
       this.state = { ...this.state, loading: false, error: message };
+    }
+  }
+
+  /**
+   * Create a new collection, then refresh the list so it appears immediately.
+   * Returns the new collection's id, or null on failure (error surfaced in state).
+   */
+  async createCollection(name: string, description?: string): Promise<string | null> {
+    try {
+      const id = await collectionService.createCollection(name, description);
+      log.debug('Created collection', { id, name });
+      await this.loadCollections();
+      return id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create collection';
+      log.error('Failed to create collection', { name, error: message });
+      this.state = { ...this.state, error: message };
+      return null;
     }
   }
 
@@ -208,8 +242,9 @@ class CollectionsStore {
     if (members && members.length > 0) {
       return (
         members
-          // Filter out collection nodes - they're already shown in the collection tree
-          .filter((node) => node.nodeType !== 'collection')
+          // Keep user-authored content only; drop system/definition/decorative
+          // nodes (schema, person, database-settings, collection, horizontal-line).
+          .filter((node) => !NON_CONTENT_NODE_TYPES.has(node.nodeType))
           .map((node) => ({
             id: node.id,
             // Prefer the cleaned title; fall back to the node content with its
@@ -311,6 +346,15 @@ function pruneEmptyCollections(items: CollectionItem[]): CollectionItem[] {
 }
 
 /**
+ * The workspace root/default collection (ADR-053). Every node — including every
+ * other collection — is made `member_of` it for RLS visibility, so it is NOT a
+ * display parent: a collection whose only parent is the root is a TOP-LEVEL
+ * collection, not a sub-collection nested inside "Default Collection". Sub-
+ * collections (member_of a non-root collection) still nest normally.
+ */
+const ROOT_COLLECTION_ID = 'c0000000-0000-0000-0000-000000000001';
+
+/**
  * Transform flat collections into tree structure for UI display.
  * Uses parentCollectionIds to build proper hierarchy.
  */
@@ -333,7 +377,10 @@ function buildCollectionsTree(collections: CollectionInfo[]): CollectionItem[] {
   // Note: A collection can have multiple parents, but for tree display
   // we only show it under the first parent to avoid duplication
   for (const c of collections) {
-    const parentIds = c.parentCollectionIds || [];
+    // Ignore the root/default collection as a parent — every collection is
+    // member_of it for visibility, so counting it would nest all collections
+    // under "Default Collection" instead of showing them as top-level peers.
+    const parentIds = (c.parentCollectionIds || []).filter((p) => p !== ROOT_COLLECTION_ID);
     if (parentIds.length > 0) {
       // Add to first parent only (to avoid showing same collection multiple times)
       const firstParentId = parentIds[0];

--- a/packages/desktop-app/src/lib/stores/membership.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/membership.svelte.ts
@@ -26,6 +26,7 @@ import {
 	type Person
 } from '$lib/services/membership-service';
 import { isProSyncActive } from '$lib/plugins/ui-extensions.svelte';
+import { backendAdapter } from '$lib/services/backend-adapter';
 import { createLogger } from '$lib/utils/logger';
 
 const log = createLogger('MembershipStore');
@@ -51,6 +52,13 @@ class MembershipStore {
 
 	/** The caller's own identity, fetched lazily and cached (cleared on {@link reset}). */
 	currentPerson = $state<Person | null>(null);
+
+	/**
+	 * Resolved display labels for person ids (name → email → id), populated from
+	 * the locally-synced person nodes on roster load and read by {@link displayFor}.
+	 * Reassigned immutably so the reactive roster re-renders when a name lands.
+	 */
+	private personNames = $state<Record<string, string>>({});
 
 	/**
 	 * Collection discovery (browse & join): the collections the caller could join
@@ -116,7 +124,39 @@ class MembershipStore {
 	 * only). Kept here so the view layer has a single call site to upgrade.
 	 */
 	displayFor(personId: string): string {
-		return personId;
+		return this.personNames[personId] ?? personId;
+	}
+
+	/**
+	 * Resolve human-readable labels for the given person ids from their synced
+	 * person nodes and cache them for {@link displayFor}. The daemon FLATTENS the
+	 * type namespace when serving a node, so `name`/`email` come back at the top
+	 * level of `properties` (NOT nested under `person`, which is only the cloud's
+	 * on-disk shape). Prefer name, then email, then fall back to the id (also the
+	 * fallback when the node isn't synced or a non-co-member can't see the email,
+	 * which is `can_see_person`-gated server-side). Best-effort and fire-and-forget.
+	 */
+	private async resolvePersonNames(personIds: string[]): Promise<void> {
+		// Re-attempt ids not yet resolved OR still showing the id fallback (a prior
+		// lookup that failed / raced sync), so a later load self-heals the label.
+		const missing = personIds.filter(
+			(id) => this.personNames[id] === undefined || this.personNames[id] === id
+		);
+		if (missing.length === 0) return;
+		const resolved = await Promise.all(
+			missing.map(async (id) => {
+				try {
+					const node = await backendAdapter.getNode(id);
+					const props = node?.properties as Record<string, unknown> | undefined;
+					const name = typeof props?.['name'] === 'string' ? (props['name'] as string) : '';
+					const email = typeof props?.['email'] === 'string' ? (props['email'] as string) : '';
+					return [id, name || email || id] as const;
+				} catch {
+					return [id, id] as const;
+				}
+			})
+		);
+		this.personNames = { ...this.personNames, ...Object.fromEntries(resolved) };
 	}
 
 	/**
@@ -153,6 +193,9 @@ class MembershipStore {
 			// Commit the roster immediately so a failure of the admin-only listings
 			// below doesn't discard an already-fetched roster (patch merges).
 			this.patch(collectionId, { members, loading: false, error: null });
+			// Resolve display names in the background; the roster shows ids until the
+			// person nodes land, then re-renders (personNames is reactive).
+			void this.resolvePersonNames(members.map((m) => m.personId));
 			if (amAdmin) {
 				const [invites, requests] = await Promise.all([
 					membershipService.listInvites(collectionId),

--- a/packages/desktop-app/src/lib/utils/logger.ts
+++ b/packages/desktop-app/src/lib/utils/logger.ts
@@ -95,6 +95,30 @@ function forwardToFile(level: LogLevel, message: string, data?: unknown): void {
 // NS_FRONTEND_LOG is set (before the first cross-window sync events arrive).
 forwardToFile('info', '[logger] frontend-console capture initialised');
 
+// Global error capture. Thrown exceptions — a Svelte runtime error (e.g. a keyed
+// `{#each}` duplicate-key crash), a synchronous throw, or an unhandled promise
+// rejection — never pass through the logger methods, so without this they land
+// only in the webview devtools console and are invisible to file-based
+// diagnosis. Forward them to the same NDJSON channel. Gated on the channel being
+// enabled (NS_FRONTEND_LOG) inside `forwardToFile`, so normal builds pay nothing.
+if (typeof window !== 'undefined' && !isTest) {
+  window.addEventListener('error', (e) => {
+    const err = e.error as Error | undefined;
+    forwardToFile('error', `[uncaught] ${e.message}`, {
+      filename: e.filename,
+      lineno: e.lineno,
+      colno: e.colno,
+      stack: err?.stack
+    });
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason as { message?: string; stack?: string } | undefined;
+    forwardToFile('error', `[unhandledrejection] ${reason?.message ?? String(e.reason)}`, {
+      stack: reason?.stack
+    });
+  });
+}
+
 export class Logger {
   private config: LoggerConfig;
 

--- a/packages/desktop-app/src/tests/components/pro-sync-pill.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-sync-pill.test.ts
@@ -24,13 +24,17 @@ import { proSync, type SyncState } from '$lib/stores/pro-sync.svelte';
 import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
 import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
 
-/** Seed the active database's settings singleton with the given namespaced props. */
+/**
+ * Seed the active database's settings singleton with the given props. The daemon
+ * serializes DatabaseSettingsNode with FLAT properties (`sync_enabled`/`auth_status`
+ * directly on `properties`), so mirror that shape here.
+ */
 function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
   const node: Node = {
     id: DATABASE_SETTINGS_NODE_ID,
     nodeType: 'database-settings',
     content: '',
-    properties: { 'database-settings': props },
+    properties: props,
     mentions: [],
     createdAt: new Date().toISOString(),
     modifiedAt: new Date().toISOString(),

--- a/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
+++ b/packages/desktop-app/src/tests/plugins/ui-extensions.test.ts
@@ -31,13 +31,17 @@ import {
 } from '$lib/plugins/ui-extensions.svelte';
 import { uiExtensionRegistry, DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
 
-/** Seed the active database's settings singleton with the given namespaced props. */
+/**
+ * Seed the active database's settings singleton with the given props. The daemon
+ * serializes DatabaseSettingsNode with FLAT properties (`sync_enabled`/`auth_status`
+ * directly on `properties`), so mirror that shape here.
+ */
 function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
   const node: Node = {
     id: DATABASE_SETTINGS_NODE_ID,
     nodeType: 'database-settings',
     content: '',
-    properties: { 'database-settings': props },
+    properties: props,
     mentions: [],
     createdAt: new Date().toISOString(),
     modifiedAt: new Date().toISOString(),

--- a/packages/desktop-app/src/tests/services/membership-service.test.ts
+++ b/packages/desktop-app/src/tests/services/membership-service.test.ts
@@ -29,6 +29,24 @@ describe('MembershipService', () => {
 		]);
 	});
 
+	it('listMembers dedupes repeated person rows, keeping the highest permission', async () => {
+		// A person can carry more than one member_of edge (a role-bearing edge plus
+		// a plain membership edge), so the roster RPC can return the same person_id
+		// more than once. Collapse to one row per person at the highest privilege,
+		// regardless of the order the rows arrive in.
+		mockInvoke.mockResolvedValue([
+			{ person_id: 'p1', permission: 'readOnly' },
+			{ person_id: 'p1', permission: 'admin' },
+			{ person_id: 'p2', permission: 'modify' },
+			{ person_id: 'p1', permission: 'modify' }
+		]);
+		const members = await membershipService.listMembers('c1');
+		expect(members).toEqual([
+			{ personId: 'p1', permission: 'admin' },
+			{ personId: 'p2', permission: 'modify' }
+		]);
+	});
+
 	it('setMember forwards camelCase args to pro_set_member', async () => {
 		mockInvoke.mockResolvedValue(undefined);
 		await membershipService.setMember('c1', 'p1', 'modify');

--- a/packages/desktop-app/src/tests/services/remote-update-policy.test.ts
+++ b/packages/desktop-app/src/tests/services/remote-update-policy.test.ts
@@ -139,6 +139,27 @@ describe('decideRemoteUpdate', () => {
     expect(decision.notifyConflict).toBe(true);
   });
 
+  it('does not notify for a stale self-echo whose version is not ahead of the local version', () => {
+    // During rapid typing, one of our own earlier keystrokes echoes back through
+    // the daemon after we've typed further, so its content no longer matches
+    // `lastSentContent` (not a plausible own-echo). But its version is not ahead
+    // of our optimistic local version, so it is not a foreign writer getting
+    // ahead of us either — the daemon assigns a strictly higher version to any
+    // change it applies. It must be dropped silently instead of raising a
+    // phantom conflict notification on every keystroke.
+    const decision = decideRemoteUpdate(
+      makeNode({ content: 'hell', version: 4 }),
+      makeNode({ content: 'hello world', version: 5 }),
+      databaseSource,
+      { isFocused: true, hasPending: false },
+      'hello world'
+    );
+    expect(decision.apply).toBe(false);
+    if (decision.apply) throw new Error('unreachable');
+    expect(decision.stashVersion).toBe(false);
+    expect(decision.notifyConflict).toBe(false);
+  });
+
   it('treats an incoming node with no numeric version as never stash-eligible', () => {
     const decision = decideRemoteUpdate(
       makeNode({ content: 'hello world', version: undefined as unknown as number }),

--- a/packages/desktop-app/src/tests/stores/pro-sync-settings-refresh.test.ts
+++ b/packages/desktop-app/src/tests/stores/pro-sync-settings-refresh.test.ts
@@ -52,12 +52,14 @@ function emit(name: string, payload: unknown) {
   listeners.get(name)?.({ payload });
 }
 
+// The daemon serializes DatabaseSettingsNode with FLAT properties
+// (`sync_enabled`/`auth_status` directly on `properties`), so mirror that shape.
 function settingsNode(props: { sync_enabled?: boolean; auth_status?: string }): Node {
   return {
     id: DATABASE_SETTINGS_NODE_ID,
     nodeType: 'database-settings',
     content: '',
-    properties: { 'database-settings': props },
+    properties: props,
     mentions: [],
     createdAt: new Date().toISOString(),
     modifiedAt: new Date().toISOString(),


### PR DESCRIPTION
Frontend fixes surfaced during live dev-mode validation of Pro sync. Five focused commits.

## What's fixed
1. **Pro-sync pill stuck on "sync off"** — `activeDatabaseSettings()` read the `DatabaseSettingsNode` properties from a nested `['database-settings']` sub-object, but the daemon serializes them **FLAT** (`properties.sync_enabled` / `.auth_status`, per the Core schema). The read now matches the daemon's shape, so the pill can actually resolve to `connected`.
2. **Conflict toast on every keystroke (single writer)** — `decideRemoteUpdate` now only sets `notifyConflict` when the incoming db-broadcast version is **strictly newer** than the local version. A device's own echo (version not ahead) is no longer surfaced as a conflict. (Pairs with the daemon-side self-echo drop in sync#335.)
3. **Collaboration roster: duplicate-key crash + names shown as ids** — `listMembers` dedupes rows by `personId` (keeping the highest permission), and the membership store resolves display names from the locally-synced person node (FLAT `name`/`email`), falling back to the id.
4. **Create-collection UI + collection rendering** — a "+ New collection" inline input in the sidebar; collections that are only `member_of` the root render top-level (not nested under Default); non-content node types are filtered out of the member list, with human-readable type tags / "Untitled …" labels.
5. **Uncaught-error capture** — `window.onerror` / `unhandledrejection` now forward into the debug-log channel (NDJSON), so frontend crashes are captured in dev-mode logs.

## Scope note
The patch was originally authored atop the unmerged `issue-1672-channel-wedge-recover` branch (#1672/#1685) and has been rebased onto clean `main`. The `markSyncEnabledLocally()` FLAT-write correction was **omitted** here because that method lives only on the unmerged #1685 branch — it belongs with #1685. On `main` the pill resolves correctly via the FLAT read plus the existing `refreshDatabaseSettings()` re-pull.

## Verification
- `bun run test` — 166 files, **4106 tests pass** (+2 new: stale-self-echo gate, roster dedupe); zero failures
- `bun run quality:check` — eslint 0/0, svelte-check 0 errors
- Nested→FLAT test fixtures updated in `ui-extensions.test.ts`, `pro-sync-pill.test.ts`, `pro-sync-settings-refresh.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)