### PR TITLE
Content-only edits forced immediate (non-debounced) persistence via redundant nodeType, and property-only updates never synced typed fields back from the backend

### DIFF
--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -1090,10 +1090,10 @@ export class SharedNodeStore {
         const isStructuralChange = false; // Structural changes now handled via backend moveNode()
         const isContentChange = 'content' in changes;
         // A VALUE comparison, not mere presence: `updateNodeContent` always
-        // bundles the current nodeType alongside content on every keystroke
-        // (see reactive-node-service.svelte.ts — issue #424 fix, so a
+        // bundles the current (unchanged) nodeType alongside content on every
+        // keystroke (see reactive-node-service.svelte.ts), so an in-flight
         // slash-command type conversion can't race a content update and get
-        // silently reverted). Treating that presence alone as "changing type"
+        // silently reverted. Treating that presence alone as "changing type"
         // forced immediate (non-debounced) persistence on every keystroke,
         // which raced the broadcast against the next keystroke and produced
         // spurious "conflicted with a remote change" toasts + content
@@ -1252,17 +1252,49 @@ export class SharedNodeStore {
                       );
                     }
 
-                    // Update local node with backend version and any backend-computed fields
-                    // (e.g. title recomputed from title_template after property changes)
+                    // Update local node with the backend's version AND typed
+                    // fields. `node_to_typed_value` (the backend's single
+                    // flattening authority) promotes type-specific fields —
+                    // ai-chat's `provider`/`model`, task's `status`/`priority`,
+                    // etc. — from the namespaced storage shape to genuinely
+                    // top-level fields on this response. `updatePayload` above
+                    // sends the UN-flattened `{ properties: {...} }` shape
+                    // (matching storage, not the wire contract), so viewers
+                    // reading those top-level fields directly (e.g.
+                    // AiChatNodeViewer's `node?.provider`) never saw them
+                    // become defined until a later daemon broadcast happened
+                    // to re-hydrate the node via `setNode()`. Spread the full
+                    // response over the local node so every type-specific
+                    // top-level field is corrected immediately, but re-assert
+                    // `content` and `properties` from the local node
+                    // afterward if they've moved on since `currentNode` was
+                    // read for this RPC — a user (or another in-flight write)
+                    // may have changed either while this request was in
+                    // flight, and blindly applying the response for that
+                    // older send would clobber the newer local state.
                     const localNode = this.nodes.get(nodeId);
                     if (localNode && updatedNodeFromBackend) {
                       const oldVersion = localNode.version;
-                      localNode.version = updatedNodeFromBackend.version;
+                      const localContent = localNode.content;
+                      // Only take the backend's properties if it actually
+                      // returned some — some type-specific responses (e.g.
+                      // TaskNode, or a task-updater response for a
+                      // properties-only change it doesn't map) carry no
+                      // `properties` field at all, and `undefined` must never
+                      // clobber a defined local value.
+                      const localHasMovedOn =
+                        localNode.properties !== currentNode.properties &&
+                        JSON.stringify(localNode.properties) !== JSON.stringify(currentNode.properties);
+                      const localProperties =
+                        localHasMovedOn || updatedNodeFromBackend.properties === undefined
+                          ? localNode.properties
+                          : updatedNodeFromBackend.properties;
                       const titleChanged = updatedNodeFromBackend.title !== undefined &&
                         updatedNodeFromBackend.title !== localNode.title;
-                      if (updatedNodeFromBackend.title !== undefined) {
-                        localNode.title = updatedNodeFromBackend.title;
-                      }
+                      Object.assign(localNode, updatedNodeFromBackend, {
+                        content: localContent,
+                        properties: localProperties
+                      });
                       this.nodesSet(nodeId, localNode);
                       // Notify subscribers if title changed (e.g. title_template recomputed)
                       if (titleChanged) {
@@ -1672,14 +1704,30 @@ export class SharedNodeStore {
                   //
                   // Spread the full response over the local node so every
                   // type-specific top-level field is corrected, but re-assert
-                  // `content` from the local node afterward — a user may have kept
-                  // typing while this RPC was in flight, and clobbering their newer
-                  // local edit with the response for an older send would lose
-                  // keystrokes.
+                  // `content` and `properties` from the local node afterward if
+                  // they've moved on since `currentNode` was snapshotted for this
+                  // RPC — a user (or another in-flight write) may have changed
+                  // either while this request was in flight, and blindly applying
+                  // the response for that older send would clobber the newer local
+                  // state. `properties` is compared shallowly since callers replace
+                  // it wholesale rather than patching individual keys.
                   const latestNode = this.nodes.get(nodeId);
                   if (latestNode && updatedFromBackend) {
                     const localContent = latestNode.content;
-                    Object.assign(latestNode, updatedFromBackend, { content: localContent });
+                    // Only take the backend's properties if it actually
+                    // returned some — `undefined` must never clobber a
+                    // defined local value.
+                    const localHasMovedOn =
+                      latestNode.properties !== currentNode.properties &&
+                      JSON.stringify(latestNode.properties) !== JSON.stringify(currentNode.properties);
+                    const localProperties =
+                      localHasMovedOn || updatedFromBackend.properties === undefined
+                        ? latestNode.properties
+                        : updatedFromBackend.properties;
+                    Object.assign(latestNode, updatedFromBackend, {
+                      content: localContent,
+                      properties: localProperties
+                    });
                     this.nodesSet(nodeId, latestNode);
                   }
                 } catch (updateError) {

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -1089,7 +1089,18 @@ export class SharedNodeStore {
         // The persistence whitelist now includes type-specific property changes
         const isStructuralChange = false; // Structural changes now handled via backend moveNode()
         const isContentChange = 'content' in changes;
-        const isNodeTypeChange = 'nodeType' in changes;
+        // A VALUE comparison, not mere presence: `updateNodeContent` always
+        // bundles the current nodeType alongside content on every keystroke
+        // (see reactive-node-service.svelte.ts — issue #424 fix, so a
+        // slash-command type conversion can't race a content update and get
+        // silently reverted). Treating that presence alone as "changing type"
+        // forced immediate (non-debounced) persistence on every keystroke,
+        // which raced the broadcast against the next keystroke and produced
+        // spurious "conflicted with a remote change" toasts + content
+        // corruption under fast typing. Only a genuine type change should
+        // skip the debounce.
+        const isNodeTypeChange =
+          'nodeType' in changes && changes.nodeType !== existingNode.nodeType;
         const isPropertyChange = 'properties' in changes;
         // Check for type-specific property changes (status, priority, dueDate, assignee, etc.)
         // These are persisted via type-specific updaters registered in the plugin system
@@ -1643,11 +1654,32 @@ export class SharedNodeStore {
                   // an own-echo (see `isPlausibleOwnEcho`).
                   this.lastPersistedContent.set(nodeId, currentNode.content ?? '');
                   const updatedFromBackend = await backendAdapter.updateNode(nodeId, currentVersion, currentNode);
-                  // Sync the backend-assigned version into the local node so the next
-                  // OCC uses a fresh version rather than the now-stale pre-update value.
+                  // Sync the backend-assigned version AND typed fields into the
+                  // local node. `node_to_typed_value` (the backend's single
+                  // flattening authority) promotes type-specific fields — ai-chat's
+                  // `provider`/`model`, task's `status`/`priority`, etc. — from the
+                  // namespaced storage shape to genuinely top-level fields on this
+                  // response. The optimistic write above sent the UN-flattened
+                  // `{ properties: {...} }` shape client-side (matching storage, not
+                  // the wire contract), so the local node's top-level typed fields —
+                  // read directly by viewers like AiChatNodeViewer's
+                  // `node?.provider` — never got corrected to match. Previously only
+                  // `.version` was synced here, so e.g. an ai-chat model selection
+                  // persisted correctly server-side but the local node never
+                  // observed `provider`/`model` becoming defined, leaving the UI
+                  // stuck on "Choose a model to get started" even after the write
+                  // succeeded.
+                  //
+                  // Spread the full response over the local node so every
+                  // type-specific top-level field is corrected, but re-assert
+                  // `content` from the local node afterward — a user may have kept
+                  // typing while this RPC was in flight, and clobbering their newer
+                  // local edit with the response for an older send would lose
+                  // keystrokes.
                   const latestNode = this.nodes.get(nodeId);
                   if (latestNode && updatedFromBackend) {
-                    latestNode.version = updatedFromBackend.version;
+                    const localContent = latestNode.content;
+                    Object.assign(latestNode, updatedFromBackend, { content: localContent });
                     this.nodesSet(nodeId, latestNode);
                   }
                 } catch (updateError) {

--- a/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
@@ -151,8 +151,8 @@ describe('Node content persistence regression (#1307)', () => {
     // Regression for a "conflicted with a remote change" toast firing on
     // effectively every keystroke. Root cause: reactive-node-service.svelte's
     // updateNodeContent() always bundles the CURRENT (unchanged) nodeType
-    // alongside content on every keystroke (issue #424 fix, to keep a
-    // slash-command type conversion from racing a content update). But
+    // alongside content on every keystroke, to keep a slash-command type
+    // conversion from racing a content update. But
     // isNodeTypeChange used to be `'nodeType' in changes` — mere presence,
     // not a value comparison — so that redundant nodeType forced
     // mode: 'immediate' on every keystroke instead of 'debounce'. Immediate
@@ -236,5 +236,51 @@ describe('Node content persistence regression (#1307)', () => {
     expect(store.getNode(nodeId)?.content).toBe(userTyped);
 
     await store.flushAllPendingSaves(3000);
+  }, 5000);
+
+  it("a properties-only update syncs the backend's flattened top-level fields back into the local node", async () => {
+    // Regression for the ai-chat viewer getting stuck on "Choose a model to
+    // get started" after selecting a model. Root cause: this store's
+    // updateNode() only copied `.version` from the backend's response back
+    // into the local node. The optimistic write sends the un-flattened
+    // `{ properties: { provider, model } }` shape (matching storage), but
+    // `node_to_typed_value` on the backend promotes type-specific fields like
+    // ai-chat's provider/model to genuinely top-level fields on its response.
+    // Viewers read those top-level fields directly (e.g. `node?.provider`),
+    // so without syncing the full response back, they stayed undefined
+    // forever even though the write succeeded server-side.
+    const nodeId = 'persist-regression-properties-flatten';
+    const initialNode = makeNode(nodeId, '', 1);
+    // Mark the node persisted so updateNode() takes the UPDATE path (not
+    // CREATE) — setNode() only marks a node persisted for a database-sourced
+    // load when the store has already seen it once (see setNode's
+    // existingNode guard), so this simulates the node having been loaded on
+    // a prior sync rather than freshly created in this test.
+    store.setNode(initialNode, dbSource);
+    store.setNode(initialNode, dbSource);
+
+    vi.spyOn(backendAdapter, 'updateNode').mockResolvedValueOnce({
+      ...initialNode,
+      version: 2,
+      properties: { provider: 'native', model: 'gemma-4-e4b-q4km' },
+      // Simulates node_to_typed_value's flattening: promoted to top-level,
+      // as the backend does for ai-chat's provider/model, task's
+      // status/priority, etc.
+      provider: 'native',
+      model: 'gemma-4-e4b-q4km'
+    } as unknown as Node);
+
+    store.updateNode(
+      nodeId,
+      { properties: { provider: 'native', model: 'gemma-4-e4b-q4km' } },
+      viewerSource
+    );
+
+    await store.flushAllPendingSaves(3000);
+
+    const stored = store.getNode(nodeId) as Node & { provider?: string; model?: string };
+    expect(stored?.version).toBe(2);
+    expect(stored?.provider).toBe('native');
+    expect(stored?.model).toBe('gemma-4-e4b-q4km');
   }, 5000);
 });

--- a/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
+++ b/packages/desktop-app/src/tests/services/node-content-persistence-regression.test.ts
@@ -147,6 +147,71 @@ describe('Node content persistence regression (#1307)', () => {
     expect(writeFailure?.nodeId).toBe(nodeId);
   }, 5000);
 
+  it('rapid content edits with nodeType redundantly bundled (real updateNodeContent shape) debounce into one write, no spurious conflict toast', async () => {
+    // Regression for a "conflicted with a remote change" toast firing on
+    // effectively every keystroke. Root cause: reactive-node-service.svelte's
+    // updateNodeContent() always bundles the CURRENT (unchanged) nodeType
+    // alongside content on every keystroke (issue #424 fix, to keep a
+    // slash-command type conversion from racing a content update). But
+    // isNodeTypeChange used to be `'nodeType' in changes` — mere presence,
+    // not a value comparison — so that redundant nodeType forced
+    // mode: 'immediate' on every keystroke instead of 'debounce'. Immediate
+    // mode fires an RPC per keystroke, and the broadcast echo for an early
+    // keystroke can land after later keystrokes have moved the local content
+    // on, misclassifying the echo as a foreign write and firing a conflict
+    // notification (and, under fast enough typing, corrupting content).
+    //
+    // This test exercises the EXACT payload shape the real call site sends
+    // (content + unchanged nodeType together) — the other tests in this file
+    // send `{ content }` alone, which never exercised this path.
+    const nodeId = 'persist-regression-nodetype-bundle';
+    const initialNode = makeNode(nodeId, '', 1);
+
+    let updateCallCount = 0;
+    vi.spyOn(backendAdapter, 'updateNode').mockImplementation(async (_id, _v, node) => {
+      updateCallCount++;
+      return {
+        id: nodeId,
+        nodeType: node.nodeType ?? 'text',
+        content: node.content ?? '',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        modifiedAt: new Date().toISOString(),
+        version: 1 + updateCallCount,
+        properties: node.properties ?? {}
+      };
+    });
+
+    store.setNode(initialNode, dbSource);
+
+    // Simulate keystroke-by-keystroke typing, each call bundling the
+    // unchanged nodeType exactly as updateNodeContent() does in production.
+    // flushAllPendingSaves force-fires debounce timers early, so it can't
+    // distinguish immediate vs. debounced mode — the distinguishing signal is
+    // synchronous: `mode: 'immediate'` calls executeOperation() (and thus the
+    // mocked backendAdapter.updateNode) SYNCHRONOUSLY within persist(), before
+    // any await; `mode: 'debounce'` schedules a setTimeout and calls nothing
+    // until it fires. Check the call count BEFORE any flush/await.
+    const keystrokes = ['a', 'ab', 'abc', 'abcd', 'abcde'];
+    for (const partial of keystrokes) {
+      store.updateNode(nodeId, { content: partial, nodeType: 'text' }, viewerSource);
+    }
+
+    // Immediate mode would have fired at least the first keystroke's RPC
+    // synchronously by now; debounce mode has fired none yet.
+    expect(updateCallCount).toBe(0);
+
+    await store.flushAllPendingSaves(3000);
+
+    // No spurious version-mismatch conflict notification from the redundant
+    // nodeType forcing immediate mode.
+    const spuriousConflicts = conflictNotifications.notifications.filter(
+      (n) => n.nodeId === nodeId && n.conflictType === 'version-mismatch'
+    );
+    expect(spuriousConflicts).toHaveLength(0);
+
+    expect(store.getNode(nodeId)?.content).toBe('abcde');
+  }, 5000);
+
   it('database broadcast does not clobber an actively-edited node', async () => {
     const nodeId = 'persist-regression-5';
     const initialNode = makeNode(nodeId, 'Server state', 1);


### PR DESCRIPTION
Closes #1690