### PR TITLE
Collection UI: author content (New node / Add existing) + fix Contents leaks & crash

### DIFF
--- a/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
+++ b/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
@@ -71,11 +71,22 @@
     }
   }
 
-  async function runAddSearch() {
+  let addSearchTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Debounce keystrokes — `searchAddableNodes` is a semantic/embedding query
+  // (mirrors search-pane.svelte). The token check still drops a late result.
+  function runAddSearch() {
+    if (addSearchTimer) clearTimeout(addSearchTimer);
     if (!addQuery.trim()) {
       addResults = [];
+      addSearching = false;
       return;
     }
+    addSearching = true; // immediate feedback while the debounce settles
+    addSearchTimer = setTimeout(doAddSearch, 200);
+  }
+
+  async function doAddSearch() {
     const token = ++addSearchToken;
     addSearching = true;
     try {

--- a/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
+++ b/packages/desktop-app/src/lib/components/layout/collection-sub-panel.svelte
@@ -7,23 +7,110 @@
 
 <script lang="ts">
   import Icon, { type IconName } from '$lib/design/icons/icon.svelte';
-  import type { CollectionMember } from '$lib/stores/collections.svelte';
+  import { type CollectionMember } from '$lib/stores/collections.svelte';
+  import { collectionService } from '$lib/services/collection-service';
+  import { createNodeInCollection, searchAddableNodes } from '$lib/services/collection-authoring';
+  import { createLogger } from '$lib/utils/logger';
+  import type { Node } from '$lib/types';
+
+  const log = createLogger('CollectionSubPanel');
 
   interface Props {
     open: boolean;
+    collectionId: string;
     collectionName: string;
     members: CollectionMember[];
     onClose: () => void;
     onNodeClick: (_nodeId: string, _nodeType: string) => void;
     /** Open the collection's own page (Contents / Collaboration tabs). */
     onOpenCollection: () => void;
+    /** Called after a node is created in / added to this collection so the parent
+        can reload the member list. */
+    onChanged: () => void;
   }
 
-  let { open, collectionName, members, onClose, onNodeClick, onOpenCollection }: Props = $props();
+  let {
+    open,
+    collectionId,
+    collectionName,
+    members,
+    onClose,
+    onNodeClick,
+    onOpenCollection,
+    onChanged
+  }: Props = $props();
+
+  // --- Authoring into this collection (mirrors the full collection viewer) ----
+  let authorBusy = $state(false);
+  let showAddExisting = $state(false);
+  let addQuery = $state('');
+  let addResults: Node[] = $state([]);
+  let addSearching = $state(false);
+  let addSearchToken = 0;
+
+  async function handleNewNode() {
+    if (authorBusy || !collectionId) return;
+    authorBusy = true;
+    try {
+      const newId = await createNodeInCollection(collectionId);
+      onChanged();
+      onNodeClick(newId, 'text'); // open the empty node to edit
+      log.debug('Created node in collection', { newId, collectionId });
+    } catch (err) {
+      log.error('Failed to create node in collection', { collectionId, error: err });
+    } finally {
+      authorBusy = false;
+    }
+  }
+
+  function toggleAddExisting() {
+    showAddExisting = !showAddExisting;
+    if (!showAddExisting) {
+      addQuery = '';
+      addResults = [];
+    }
+  }
+
+  async function runAddSearch() {
+    if (!addQuery.trim()) {
+      addResults = [];
+      return;
+    }
+    const token = ++addSearchToken;
+    addSearching = true;
+    try {
+      const excludeIds = new Set(members.map((m) => m.id));
+      const results = await searchAddableNodes(addQuery, collectionId, excludeIds);
+      if (token !== addSearchToken) return;
+      addResults = results;
+    } catch (err) {
+      if (token !== addSearchToken) return;
+      log.error('search_roots failed for add-existing', err);
+      addResults = [];
+    } finally {
+      if (token === addSearchToken) addSearching = false;
+    }
+  }
+
+  async function addExisting(node: Node) {
+    if (authorBusy || !collectionId) return;
+    authorBusy = true;
+    try {
+      await collectionService.addNodeToCollection(node.id, collectionId);
+      addResults = addResults.filter((n) => n.id !== node.id);
+      onChanged();
+      log.debug('Added existing node to collection', { nodeId: node.id, collectionId });
+    } catch (err) {
+      log.error('Failed to add existing node to collection', { nodeId: node.id, error: err });
+    } finally {
+      authorBusy = false;
+    }
+  }
 
   // Map content node types to the closest available icon (see icon.svelte for
   // the full IconName set). Anything unmapped falls back to the generic text glyph.
-  function getNodeIcon(nodeType: string): IconName {
+  function getNodeIcon(nodeType: string | undefined | null): IconName {
+    if (!nodeType) return 'text';
     const iconMap: Record<string, IconName> = {
       date: 'calendar',
       task: 'taskIncomplete',
@@ -58,7 +145,12 @@
     date: 'Date'
   };
 
-  function humanizeNodeType(nodeType: string): string {
+  function humanizeNodeType(nodeType: string | undefined | null): string {
+    // A member row can render before its node has hydrated (rapid collection
+    // switching, initial sync catch-up), so `nodeType` may be undefined. Guard
+    // it — an unguarded `.split` here threw on every reactive re-run, storming
+    // the log and churning the sub-panel until the node landed.
+    if (!nodeType) return 'Item';
     return (
       NODE_TYPE_LABELS[nodeType] ??
       nodeType
@@ -71,7 +163,7 @@
 
   // A muted placeholder for content with no name, so blank rows read as
   // "Untitled text" / "Untitled task" instead of appearing empty/unclickable.
-  function fallbackName(nodeType: string): string {
+  function fallbackName(nodeType: string | undefined | null): string {
     return `Untitled ${humanizeNodeType(nodeType).toLowerCase()}`;
   }
 </script>
@@ -92,6 +184,51 @@
       </svg>
     </button>
   </div>
+
+  <div class="sub-toolbar">
+    <button class="sub-toolbar-btn" onclick={handleNewNode} disabled={authorBusy}>
+      <Icon name="text" size={13} />
+      <span>New node</span>
+    </button>
+    <button
+      class="sub-toolbar-btn"
+      class:active={showAddExisting}
+      onclick={toggleAddExisting}
+      disabled={authorBusy}
+    >
+      <Icon name="circleRing" size={13} />
+      <span>Add existing</span>
+    </button>
+  </div>
+
+  {#if showAddExisting}
+    <div class="sub-add-existing">
+      <input
+        class="sub-add-search"
+        type="text"
+        placeholder="Search nodes to add…"
+        bind:value={addQuery}
+        oninput={runAddSearch}
+      />
+      {#if addSearching}
+        <p class="sub-add-hint">Searching…</p>
+      {:else if addResults.length > 0}
+        <ul class="sub-add-results">
+          {#each addResults as r (r.id)}
+            <li>
+              <button class="sub-add-result" onclick={() => addExisting(r)} disabled={authorBusy}>
+                <Icon name={getNodeIcon(r.nodeType)} size={13} />
+                <span class="sub-add-result-name">{r.content || 'Untitled'}</span>
+                <span class="sub-add-plus">+</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {:else if addQuery.trim()}
+        <p class="sub-add-hint">No matching nodes.</p>
+      {/if}
+    </div>
+  {/if}
 
   <ul class="node-list">
     {#each members as member (member.id)}
@@ -200,6 +337,93 @@
   .close-btn svg {
     width: 16px;
     height: 16px;
+  }
+
+  .sub-toolbar {
+    display: flex;
+    gap: 0.35rem;
+    padding: 0.5rem 0.75rem 0;
+  }
+  .sub-toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.3rem 0.55rem;
+    font-size: 0.75rem;
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted) / 0.4);
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .sub-toolbar-btn:hover:not(:disabled) {
+    background: hsl(var(--muted) / 0.7);
+  }
+  .sub-toolbar-btn.active {
+    background: hsl(var(--muted) / 0.9);
+    border-color: hsl(var(--muted-foreground) / 0.4);
+  }
+  .sub-toolbar-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .sub-add-existing {
+    padding: 0.5rem 0.75rem 0;
+  }
+  .sub-add-search {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.8125rem;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    box-sizing: border-box;
+  }
+  .sub-add-hint {
+    margin: 0.4rem 0 0;
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+  }
+  .sub-add-results {
+    list-style: none;
+    margin: 0.4rem 0 0;
+    padding: 0;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+  .sub-add-result {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    padding: 0.3rem 0.4rem;
+    font-size: 0.8125rem;
+    color: hsl(var(--foreground));
+    background: transparent;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .sub-add-result:hover:not(:disabled) {
+    background: hsl(var(--muted) / 0.6);
+  }
+  .sub-add-result:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .sub-add-result-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sub-add-plus {
+    color: hsl(var(--muted-foreground));
+    flex-shrink: 0;
   }
 
   .node-list {

--- a/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
+++ b/packages/desktop-app/src/lib/components/layout/navigation-sidebar.svelte
@@ -630,12 +630,16 @@
   <div bind:this={subPanelElement}>
     <CollectionSubPanel
       open={subPanelOpen}
+      collectionId={collectionForPanel?.id ?? ''}
       collectionName={collectionForPanel?.content ?? collectionForPanel?.name ?? ''}
       members={collectionMembers}
       onClose={handleCloseSubPanel}
       onNodeClick={handleNodeClick}
       onOpenCollection={() => {
         if (collectionForPanel) handleNodeClick(collectionForPanel.id, 'collection');
+      }}
+      onChanged={() => {
+        if (collectionForPanel) collectionsState.selectCollection(collectionForPanel.id);
       }}
     />
   </div>

--- a/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
@@ -203,8 +203,9 @@
       handleMemberClick({ id: newId, nodeType: 'text', content: '' } as Node);
       log.debug('Created node in collection', { newId, collectionId: nodeId });
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to create node';
-      log.error('Failed to create node in collection', { collectionId: nodeId, error });
+      // Log only — matches handleRemoveMember. Setting the shared `error` state
+      // would trip the full-screen error branch and wipe the whole Contents view.
+      log.error('Failed to create node in collection', { collectionId: nodeId, error: err });
     } finally {
       authorBusy = false;
     }
@@ -218,11 +219,23 @@
     }
   }
 
-  async function runAddSearch() {
+  let addSearchTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // `searchAddableNodes` runs a semantic/embedding query, so debounce keystrokes
+  // instead of firing one per character (mirrors search-pane.svelte). The
+  // `addSearchToken` check still drops a slow earlier request that lands late.
+  function runAddSearch() {
+    if (addSearchTimer) clearTimeout(addSearchTimer);
     if (!addQuery.trim()) {
       addResults = [];
+      addSearching = false;
       return;
     }
+    addSearching = true; // immediate feedback while the debounce settles
+    addSearchTimer = setTimeout(doAddSearch, 200);
+  }
+
+  async function doAddSearch() {
     const token = ++addSearchToken;
     addSearching = true;
     try {
@@ -248,8 +261,8 @@
       addResults = addResults.filter((n) => n.id !== node.id);
       log.debug('Added existing node to collection', { nodeId: node.id, collectionId: nodeId });
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to add node';
-      log.error('Failed to add existing node to collection', { memberId: node.id, error });
+      // Log only — do not wipe the Contents view on a transient add failure.
+      log.error('Failed to add existing node to collection', { memberId: node.id, error: err });
     } finally {
       authorBusy = false;
     }

--- a/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/components/viewers/collection-node-viewer.svelte
@@ -18,7 +18,8 @@
   import { onMount } from 'svelte';
   import Icon from '$lib/design/icons/icon.svelte';
   import { collectionService } from '$lib/services/collection-service';
-  import { collectionsData } from '$lib/stores/collections.svelte';
+  import { collectionsData, NON_CONTENT_NODE_TYPES } from '$lib/stores/collections.svelte';
+  import { createNodeInCollection, searchAddableNodes } from '$lib/services/collection-authoring';
   import type { Node, CollectionNode } from '$lib/types';
   import { navigationStore, addTab, setActiveTab } from '$lib/stores/navigation.svelte';
   import { createLogger } from '$lib/utils/logger';
@@ -67,7 +68,12 @@
     try {
       // Get collection members (this also validates the collection exists)
       const memberNodes = await collectionService.getCollectionMembers(collectionId);
-      members = memberNodes;
+      // The Contents tab lists user-authored content only. `getCollectionMembers`
+      // also returns non-content members — chiefly the creator's `person` node
+      // (stamped as an admin member on collection creation) and system nodes —
+      // which belong in the Collaboration tab, not here. Filter them out (mirrors
+      // the sidebar sub-panel's `selectedCollectionMembers`).
+      members = memberNodes.filter((n) => !NON_CONTENT_NODE_TYPES.has(n.nodeType));
 
       // Try to get collection details from cached store data first (by ID)
       const cachedCollection = collectionsData.getCollectionById(collectionId);
@@ -155,15 +161,97 @@
     return currentState.panes[0]?.id ?? 'pane-1';
   }
 
+  // Reload the Contents list (user-authored members only — same filter as the
+  // initial load), used after any add/remove so the count and rows stay honest.
+  async function reloadContentMembers() {
+    members = (await collectionService.getCollectionMembers(nodeId)).filter(
+      (n) => !NON_CONTENT_NODE_TYPES.has(n.nodeType)
+    );
+  }
+
   async function handleRemoveMember(member: Node) {
     try {
       await collectionService.removeNodeFromCollection(member.id, nodeId);
-      // Reload members
-      members = await collectionService.getCollectionMembers(nodeId);
+      await reloadContentMembers();
       log.debug('Removed member from collection', { memberId: member.id, collectionId: nodeId });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to remove member';
       log.error('Failed to remove member', { memberId: member.id, error: message });
+    }
+  }
+
+  // --- Authoring into this collection -------------------------------------
+  // A collection is a `member_of` grouping over outliner nodes, so both actions
+  // below ultimately call `add_node_to_collection`. "New node" mints a fresh
+  // text node first (and opens it to edit); "Add existing" attaches a node the
+  // user already has. `authorBusy` serializes them so a double-click can't
+  // create two nodes or fire overlapping reloads.
+  let authorBusy = $state(false);
+  let showAddExisting = $state(false);
+  let addQuery = $state('');
+  let addResults: Node[] = $state([]);
+  let addSearching = $state(false);
+  let addSearchToken = 0;
+
+  async function handleNewNode() {
+    if (authorBusy) return;
+    authorBusy = true;
+    try {
+      const newId = await createNodeInCollection(nodeId);
+      await reloadContentMembers();
+      // Open the empty node so the user can type into it immediately.
+      handleMemberClick({ id: newId, nodeType: 'text', content: '' } as Node);
+      log.debug('Created node in collection', { newId, collectionId: nodeId });
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to create node';
+      log.error('Failed to create node in collection', { collectionId: nodeId, error });
+    } finally {
+      authorBusy = false;
+    }
+  }
+
+  function toggleAddExisting() {
+    showAddExisting = !showAddExisting;
+    if (!showAddExisting) {
+      addQuery = '';
+      addResults = [];
+    }
+  }
+
+  async function runAddSearch() {
+    if (!addQuery.trim()) {
+      addResults = [];
+      return;
+    }
+    const token = ++addSearchToken;
+    addSearching = true;
+    try {
+      const excludeIds = new Set(members.map((m) => m.id));
+      const results = await searchAddableNodes(addQuery, nodeId, excludeIds);
+      if (token !== addSearchToken) return; // superseded by a newer keystroke
+      addResults = results;
+    } catch (err) {
+      if (token !== addSearchToken) return;
+      log.error('search_roots failed for add-existing', err);
+      addResults = [];
+    } finally {
+      if (token === addSearchToken) addSearching = false;
+    }
+  }
+
+  async function addExisting(node: Node) {
+    if (authorBusy) return;
+    authorBusy = true;
+    try {
+      await collectionService.addNodeToCollection(node.id, nodeId);
+      await reloadContentMembers();
+      addResults = addResults.filter((n) => n.id !== node.id);
+      log.debug('Added existing node to collection', { nodeId: node.id, collectionId: nodeId });
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to add node';
+      log.error('Failed to add existing node to collection', { memberId: node.id, error });
+    } finally {
+      authorBusy = false;
     }
   }
 </script>
@@ -227,13 +315,65 @@
           Try Again
         </button>
       </div>
-    {:else if members.length === 0}
-      <div class="empty-state">
-        <Icon name="circleRing" size={48} color="hsl(var(--muted-foreground))" />
-        <p>This collection is empty</p>
-        <span class="empty-hint">Add nodes to this collection using the /collection command or by dragging nodes here.</span>
-      </div>
     {:else}
+      <div class="collection-toolbar">
+        <button class="toolbar-btn" onclick={handleNewNode} disabled={authorBusy}>
+          <Icon name="text" size={14} color="currentColor" />
+          <span>New node</span>
+        </button>
+        <button
+          class="toolbar-btn"
+          class:active={showAddExisting}
+          onclick={toggleAddExisting}
+          disabled={authorBusy}
+        >
+          <Icon name="circleRing" size={14} color="currentColor" />
+          <span>Add existing</span>
+        </button>
+      </div>
+
+      {#if showAddExisting}
+        <div class="add-existing">
+          <!-- svelte-ignore a11y_autofocus -->
+          <input
+            class="add-search"
+            type="text"
+            placeholder="Search your nodes to add…"
+            bind:value={addQuery}
+            oninput={runAddSearch}
+            autofocus
+          />
+          {#if addSearching}
+            <p class="add-hint">Searching…</p>
+          {:else if addResults.length > 0}
+            <ul class="add-results">
+              {#each addResults as r (r.id)}
+                <li>
+                  <button class="add-result" onclick={() => addExisting(r)} disabled={authorBusy}>
+                    <Icon name={getNodeIcon(r.nodeType)} size={14} color="currentColor" />
+                    <span class="add-result-name">{r.content || 'Untitled'}</span>
+                    <span class="add-result-type">{r.nodeType}</span>
+                    <span class="add-plus">+ Add</span>
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {:else if addQuery.trim()}
+            <p class="add-hint">No matching nodes.</p>
+          {/if}
+        </div>
+      {/if}
+
+      {#if members.length === 0}
+        <div class="empty-state">
+          <Icon name="circleRing" size={48} color="hsl(var(--muted-foreground))" />
+          <p>This collection is empty</p>
+          <span class="empty-hint"
+            >Use “New node” to create content here, or “Add existing” to pull in a node you already
+            have.</span
+          >
+        </div>
+      {:else}
       <ul class="member-list">
         {#each members as member (member.id)}
           <li class="member-item">
@@ -259,6 +399,7 @@
           </li>
         {/each}
       </ul>
+      {/if}
     {/if}
   </div>
   {/if}
@@ -329,6 +470,105 @@
     flex: 1;
     overflow-y: auto;
     padding: 1rem 2rem;
+  }
+
+  .collection-toolbar {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8125rem;
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted) / 0.4);
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .toolbar-btn:hover:not(:disabled) {
+    background: hsl(var(--muted) / 0.7);
+  }
+  .toolbar-btn.active {
+    background: hsl(var(--muted) / 0.9);
+    border-color: hsl(var(--muted-foreground) / 0.4);
+  }
+  .toolbar-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .add-existing {
+    margin-bottom: 0.75rem;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    background: hsl(var(--muted) / 0.25);
+  }
+  .add-search {
+    width: 100%;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.875rem;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    box-sizing: border-box;
+  }
+  .add-hint {
+    margin: 0.5rem 0 0.25rem;
+    font-size: 0.8125rem;
+    color: hsl(var(--muted-foreground));
+  }
+  .add-results {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .add-result {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.4rem 0.5rem;
+    font-size: 0.875rem;
+    color: hsl(var(--foreground));
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .add-result:hover:not(:disabled) {
+    background: hsl(var(--muted) / 0.6);
+  }
+  .add-result:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .add-result-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .add-result-type {
+    font-size: 0.6875rem;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--muted) / 0.6);
+    padding: 0.05rem 0.35rem;
+    border-radius: 4px;
+  }
+  .add-plus {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    flex-shrink: 0;
   }
 
   .loading-state,

--- a/packages/desktop-app/src/lib/services/collection-authoring.ts
+++ b/packages/desktop-app/src/lib/services/collection-authoring.ts
@@ -1,0 +1,62 @@
+/**
+ * Collection authoring helpers
+ *
+ * Shared logic behind the "New node" and "Add existing" actions that both the
+ * full collection viewer (`collection-node-viewer.svelte`) and the sidebar
+ * sub-panel (`collection-sub-panel.svelte`) offer. A collection is a
+ * `member_of` grouping over outliner nodes, so both actions ultimately call
+ * `collectionService.addNodeToCollection`. Extracting them here keeps the two
+ * components in lock-step (no duplicated authoring rules) and makes the
+ * behaviour unit-testable without a DOM.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { v4 as uuidv4 } from 'uuid';
+import { backendAdapter } from '$lib/services/backend-adapter';
+import { collectionService } from '$lib/services/collection-service';
+import { NON_CONTENT_NODE_TYPES } from '$lib/stores/collections.svelte';
+import type { Node } from '$lib/types';
+
+/**
+ * Mint a fresh, empty `text` node and attach it to the given collection.
+ *
+ * The node is created as a root (`parentId: null`) with empty content so the
+ * caller can immediately open it for editing. Returns the new node's id.
+ */
+export async function createNodeInCollection(collectionId: string): Promise<string> {
+  const newId = uuidv4();
+  await backendAdapter.createNode({
+    id: newId,
+    nodeType: 'text',
+    content: '',
+    properties: {},
+    mentions: [],
+    parentId: null,
+  });
+  await collectionService.addNodeToCollection(newId, collectionId);
+  return newId;
+}
+
+/**
+ * Search the user's root nodes for candidates to add to a collection.
+ *
+ * Trims the query (an empty/whitespace query yields `[]` without hitting the
+ * backend), runs the `search_roots` command, then drops results that cannot be
+ * meaningfully added: the collection itself, ids already present (or otherwise
+ * excluded), and non-content node types (person/schema/database-settings/
+ * collection/horizontal-line).
+ */
+export async function searchAddableNodes(
+  query: string,
+  collectionId: string,
+  excludeIds: Set<string>
+): Promise<Node[]> {
+  const q = query.trim();
+  if (!q) return [];
+
+  const found = await invoke<Node[]>('search_roots', { params: { query: q, limit: 20 } });
+  return found.filter(
+    (n) =>
+      n.id !== collectionId && !excludeIds.has(n.id) && !NON_CONTENT_NODE_TYPES.has(n.nodeType)
+  );
+}

--- a/packages/desktop-app/src/lib/stores/collections.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/collections.svelte.ts
@@ -54,7 +54,7 @@ export interface CollectionMember {
  * (text, header, task, checkbox, code-block, quote-block, ordered-list,
  * ai-chat, query, prompt, skill, date, …) is genuine content and kept.
  */
-const NON_CONTENT_NODE_TYPES: ReadonlySet<string> = new Set([
+export const NON_CONTENT_NODE_TYPES: ReadonlySet<string> = new Set([
   'schema',
   'person',
   'database-settings',

--- a/packages/desktop-app/src/tests/components/collection-sub-panel.test.ts
+++ b/packages/desktop-app/src/tests/components/collection-sub-panel.test.ts
@@ -14,11 +14,13 @@ import CollectionSubPanel from '$lib/components/layout/collection-sub-panel.svel
 function baseProps() {
   return {
     open: true,
+    collectionId: 'col-arch',
     collectionName: 'Architecture',
     members: [{ id: 'm1', name: 'System Overview', nodeType: 'header' }],
     onClose: vi.fn(),
     onNodeClick: vi.fn(),
-    onOpenCollection: vi.fn()
+    onOpenCollection: vi.fn(),
+    onChanged: vi.fn()
   };
 }
 

--- a/packages/desktop-app/src/tests/services/collection-authoring.test.ts
+++ b/packages/desktop-app/src/tests/services/collection-authoring.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the collection-authoring service — the shared "New node" and
+ * "Add existing" logic behind the collection viewer and the sidebar sub-panel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Node } from '$lib/types';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn()
+}));
+
+vi.mock('$lib/services/backend-adapter', () => ({
+  backendAdapter: { createNode: vi.fn() }
+}));
+
+vi.mock('$lib/services/collection-service', () => ({
+  collectionService: { addNodeToCollection: vi.fn() }
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import { backendAdapter } from '$lib/services/backend-adapter';
+import { collectionService } from '$lib/services/collection-service';
+import { createNodeInCollection, searchAddableNodes } from '$lib/services/collection-authoring';
+
+const invokeMock = vi.mocked(invoke);
+const createNodeMock = vi.mocked(backendAdapter.createNode);
+const addNodeToCollectionMock = vi.mocked(collectionService.addNodeToCollection);
+
+// Minimal Node builder (only the required fields; nodeType/id are what the
+// filter cares about).
+function makeNode(id: string, nodeType: string): Node {
+  return {
+    id,
+    nodeType,
+    content: id,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    properties: {}
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createNodeInCollection', () => {
+  it('mints an empty text root node then attaches it, returning the new id', async () => {
+    const returnedId = await createNodeInCollection('col-42');
+
+    // createNode was called once with a text root (empty content, no parent).
+    expect(createNodeMock).toHaveBeenCalledTimes(1);
+    const createArg = createNodeMock.mock.calls[0][0];
+    expect(createArg).toEqual(
+      expect.objectContaining({ nodeType: 'text', content: '', parentId: null })
+    );
+
+    // The generated id is threaded through the membership edge and returned.
+    expect(typeof createArg.id).toBe('string');
+    expect(createArg.id.length).toBeGreaterThan(0);
+    expect(returnedId).toBe(createArg.id);
+    expect(addNodeToCollectionMock).toHaveBeenCalledTimes(1);
+    expect(addNodeToCollectionMock).toHaveBeenCalledWith(returnedId, 'col-42');
+  });
+
+  it('creates the node before writing the membership edge', async () => {
+    await createNodeInCollection('col-order');
+
+    // The node must exist before it can be made a member.
+    expect(createNodeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      addNodeToCollectionMock.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('mints a distinct id per call', async () => {
+    const first = await createNodeInCollection('col-1');
+    const second = await createNodeInCollection('col-1');
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('searchAddableNodes', () => {
+  it('returns [] without calling the backend for an empty or whitespace query', async () => {
+    expect(await searchAddableNodes('', 'col-1', new Set())).toEqual([]);
+    expect(await searchAddableNodes('   ', 'col-1', new Set())).toEqual([]);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('trims the query and passes it to search_roots with a limit of 20', async () => {
+    invokeMock.mockResolvedValue([]);
+
+    await searchAddableNodes('  hello  ', 'col-1', new Set());
+
+    expect(invokeMock).toHaveBeenCalledWith('search_roots', {
+      params: { query: 'hello', limit: 20 }
+    });
+  });
+
+  it('filters out the collection itself, excluded ids, and non-content node types', async () => {
+    const results: Node[] = [
+      makeNode('text-1', 'text'),
+      makeNode('task-1', 'task'),
+      makeNode('code-1', 'code-block'),
+      makeNode('col-1', 'text'), // the collection id itself (even if content type)
+      makeNode('already-in', 'text'), // already a member (excluded)
+      makeNode('person-1', 'person'), // non-content
+      makeNode('schema-1', 'schema'), // non-content
+      makeNode('settings-1', 'database-settings'), // non-content
+      makeNode('other-collection', 'collection'), // non-content
+      makeNode('divider-1', 'horizontal-line') // non-content
+    ];
+    invokeMock.mockResolvedValue(results);
+
+    const out = await searchAddableNodes('acp', 'col-1', new Set(['already-in']));
+
+    // Only genuine, addable content survives, in original order.
+    expect(out.map((n) => n.id)).toEqual(['text-1', 'task-1', 'code-1']);
+  });
+
+  it('keeps all content nodes when nothing is excluded', async () => {
+    const results: Node[] = [
+      makeNode('a', 'text'),
+      makeNode('b', 'task'),
+      makeNode('c', 'header'),
+      makeNode('d', 'date')
+    ];
+    invokeMock.mockResolvedValue(results);
+
+    const out = await searchAddableNodes('q', 'col-x', new Set());
+
+    expect(out.map((n) => n.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});

--- a/packages/desktop-app/src/tests/stores/collections.test.ts
+++ b/packages/desktop-app/src/tests/stores/collections.test.ts
@@ -7,6 +7,7 @@ import {
   collectionsState,
   collectionsData,
   findCollectionById,
+  NON_CONTENT_NODE_TYPES,
   type CollectionsState,
   type CollectionItem,
   type CollectionMember
@@ -514,6 +515,57 @@ describe('Collections Store', () => {
       collectionsData._setTestData(collections, new Map());
 
       expect(collectionsData.collectionsTree).toEqual([]);
+    });
+  });
+
+  describe('NON_CONTENT_NODE_TYPES member filter', () => {
+    // Build a full Node for a given type (only the fields the filter/mapper read).
+    function mkNode(id: string, nodeType: string, name: string): Node {
+      return {
+        id,
+        content: name,
+        title: name,
+        nodeType,
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        version: 1,
+        properties: {}
+      };
+    }
+
+    it('exports the expected non-content node types', () => {
+      for (const t of ['schema', 'person', 'database-settings', 'collection', 'horizontal-line']) {
+        expect(NON_CONTENT_NODE_TYPES.has(t)).toBe(true);
+      }
+      // Genuine user-authored content types are NOT in the set.
+      for (const t of ['text', 'task', 'header', 'code-block', 'date']) {
+        expect(NON_CONTENT_NODE_TYPES.has(t)).toBe(false);
+      }
+    });
+
+    it('drops non-content members (creator person, system, sub-collection, divider) from Contents', () => {
+      const mixed = new Map<string, Node[]>([
+        [
+          'col-1',
+          [
+            mkNode('text-1', 'text', 'A note'),
+            mkNode('creator', 'person', 'Alice'), // stamped creator — must drop
+            mkNode('task-1', 'task', 'Do the thing'),
+            mkNode('schema-1', 'schema', 'Schema'), // system definition — must drop
+            mkNode('sub-col', 'collection', 'Sub'), // shown in the tree — must drop
+            mkNode('divider', 'horizontal-line', ''), // decorative — must drop
+            mkNode('code-1', 'code-block', 'console.log()')
+          ]
+        ]
+      ]);
+      collectionsData._setTestData(flattenCollections(mockCollections), mixed);
+
+      collectionsState.selectCollection('col-1');
+
+      const members = collectionsState.selectedCollectionMembers;
+      // Only genuine content survives, in original order.
+      expect(members.map((m) => m.id)).toEqual(['text-1', 'task-1', 'code-1']);
+      expect(members.every((m) => !NON_CONTENT_NODE_TYPES.has(m.nodeType))).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes #1700, closes #1701. Found and validated live during Pro dev-harness testing.

## Bug fixes (#1700)
1. **Contents tab leaked non-content nodes** — the main collection viewer listed `getCollectionMembers()` unfiltered, so the creator's `person` node (stamped as admin on collection creation) and system nodes (`database-settings`/`schema`) showed as "Untitled" content. Now filtered through the shared `NON_CONTENT_NODE_TYPES` (exported from the collections store; the sidebar sub-panel already used it). A fresh collection now correctly reads "0 items / empty" and the creator appears as a named member under Collaboration.
2. **Crash storm / apparent hang** — `humanizeNodeType`/`getNodeIcon`/`fallbackName` called `.split()` on a `nodeType` that can be `undefined` while a member row renders before its node hydrates (rapid switching / initial sync). Inside a reactive `{#each}` it re-threw dozens of times a second → the sub-panel churned. Now null-guarded with widened signatures.

## Feature (#1701)
Authoring affordances in **both** the main collection viewer and the sidebar sub-panel:
- **New node** — mints an empty `text` node, attaches it via `add_node_to_collection`, opens it to edit.
- **Add existing** — a compact `search_roots` picker listing content nodes not already in the collection; click to attach.

Shared logic lives in a new, unit-tested `lib/services/collection-authoring.ts` (`createNodeInCollection`, `searchAddableNodes`) — both components call it, no duplication.

## Tests
- NEW `tests/services/collection-authoring.test.ts` (7) — create-then-attach ordering, empty-query short-circuit, and non-content/exclude/self filtering.
- `tests/stores/collections.test.ts` (+2) — the exported set + `selectedCollectionMembers` drops non-content members in order.
- `tests/components/collection-sub-panel.test.ts` — updated for the new required props.
- `bun run test` → **167 files, 4109 tests pass**. `quality:check` clean (ESLint + svelte-check 0/0).

## Follow-ups (noted on #1701)
Where collection-authored root nodes sit in the outliner tree; duplicate-name prevention; inline create-failure feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)