### PR TITLE
Skill installer: prepend Claude Code frontmatter + honor $CLAUDE_CONFIG_DIR (#1708)

### DIFF
--- a/packages/skill/src/agents.ts
+++ b/packages/skill/src/agents.ts
@@ -4,12 +4,36 @@ import type { AgentConfig } from './types.js';
 
 const home = homedir();
 
+// Claude Code reads its config from $CLAUDE_CONFIG_DIR when set (e.g. a separate
+// `claude-ns` profile), falling back to ~/.claude. Detect + install into the
+// active profile rather than always ~/.claude so the skill lands where the
+// running Claude Code will actually look for it.
+const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
+
+// Claude Code surfaces a skill via its YAML frontmatter (name + description).
+// The shared SKILL.md body is agent-agnostic and carries none, so the installer
+// prepends this Claude-Code-specific frontmatter when writing the skill.
+const CLAUDE_CODE_SKILL_FRONTMATTER = `---
+name: nodespace
+description: >
+  Read and write the NodeSpace knowledge graph — a local-first, synced working
+  memory that persists across sessions and can be shared with a teammate's agent
+  sessions. Use whenever the user wants to remember something for later, recall
+  what was decided or discovered earlier, save notes/tasks/findings/decisions,
+  search prior context at the start of a task, hand off context to a teammate, or
+  asks to "check nodespace" / "what did we save". Drives the \`nodespace\` CLI
+  (create/get/update/query/search/import).
+allowed-tools: Bash(nodespace:*)
+---
+`;
+
 export const AGENTS: AgentConfig[] = [
   {
     name: 'claude-code',
-    detectionDir: join(home, '.claude'),
-    installDir: join(home, '.claude', 'skills', 'nodespace'),
+    detectionDir: claudeConfigDir,
+    installDir: join(claudeConfigDir, 'skills', 'nodespace'),
     shims: ['SKILL.md', 'shims/claude-code/nodespace-hook.ts'],
+    skillFrontmatter: CLAUDE_CODE_SKILL_FRONTMATTER,
   },
   {
     name: 'codex',

--- a/packages/skill/src/installer.ts
+++ b/packages/skill/src/installer.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, copyFileSync, rmSync, readdirSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, rmSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -52,7 +52,13 @@ export function install(targetAgents?: AgentName[], packageRoot = PACKAGE_ROOT):
       const dest = join(config.installDir, basename(shim));
       if (existsSync(src)) {
         mkdirSync(config.installDir, { recursive: true });
-        copyFileSync(src, dest);
+        // SKILL.md gets the agent's frontmatter prepended (Claude Code discovers
+        // a skill by its YAML frontmatter); everything else is copied verbatim.
+        if (config.skillFrontmatter && basename(shim) === 'SKILL.md') {
+          writeFileSync(dest, config.skillFrontmatter + '\n' + readFileSync(src, 'utf8'), 'utf8');
+        } else {
+          copyFileSync(src, dest);
+        }
         installed.push(dest);
       }
     }

--- a/packages/skill/src/tests/installer.test.ts
+++ b/packages/skill/src/tests/installer.test.ts
@@ -11,6 +11,12 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, homedir: () => TMP };
 });
 
+// Isolate from the ambient env: claude-code detection honors $CLAUDE_CONFIG_DIR,
+// so an inherited value (e.g. a `claude-ns` profile) would point the default
+// AGENTS at a real dir and break the mocked-home assumptions below. The dedicated
+// CLAUDE_CONFIG_DIR describe sets it explicitly where it needs to.
+delete process.env.CLAUDE_CONFIG_DIR;
+
 const { install, uninstall, isNodespaceBinaryOnPath } = await import('../installer.js');
 const { AGENTS } = await import('../agents.js');
 
@@ -83,7 +89,27 @@ describe('install', () => {
     expect(results[0].agent).toBe(agentName);
     expect(results[0].installed).toHaveLength(1);
     expect(existsSync(join(config.installDir, 'SKILL.md'))).toBe(true);
-    expect(readFileSync(join(config.installDir, 'SKILL.md'), 'utf8')).toBe(SKILL_MD_CONTENT);
+    const expected = config.skillFrontmatter
+      ? config.skillFrontmatter + '\n' + SKILL_MD_CONTENT
+      : SKILL_MD_CONTENT;
+    expect(readFileSync(join(config.installDir, 'SKILL.md'), 'utf8')).toBe(expected);
+  });
+
+  it('prepends Claude Code frontmatter to SKILL.md but copies verbatim for other agents', () => {
+    const cc = AGENTS.find(a => a.name === 'claude-code')!;
+    expect(cc.skillFrontmatter).toBeTruthy();
+    mkdirSync(cc.detectionDir, { recursive: true });
+    install(['claude-code'], FAKE_PKG_ROOT);
+    const ccContent = readFileSync(join(cc.installDir, 'SKILL.md'), 'utf8');
+    expect(ccContent.startsWith('---\nname: nodespace')).toBe(true);
+    expect(ccContent).toContain('allowed-tools: Bash(nodespace:*)');
+    expect(ccContent).toContain(SKILL_MD_CONTENT);
+
+    const codex = AGENTS.find(a => a.name === 'codex')!;
+    expect(codex.skillFrontmatter).toBeUndefined();
+    mkdirSync(codex.detectionDir, { recursive: true });
+    install(['codex'], FAKE_PKG_ROOT);
+    expect(readFileSync(join(codex.installDir, 'SKILL.md'), 'utf8')).toBe(SKILL_MD_CONTENT);
   });
 
   it('installs all shims (SKILL.md + agent shim) when all source files exist', () => {
@@ -238,5 +264,30 @@ describe('install PATH warning', () => {
     stderrSpy.mockRestore();
     vi.doUnmock('node:child_process');
     vi.resetModules();
+  });
+});
+
+describe('CLAUDE_CONFIG_DIR', () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    vi.resetModules();
+  });
+
+  it('claude-code detects + installs into $CLAUDE_CONFIG_DIR when set', async () => {
+    const custom = join(TMP, 'custom-claude-profile');
+    process.env.CLAUDE_CONFIG_DIR = custom;
+    vi.resetModules();
+    const { AGENTS: A } = await import('../agents.js');
+    const cc = A.find(a => a.name === 'claude-code')!;
+    expect(cc.detectionDir).toBe(custom);
+    expect(cc.installDir).toBe(join(custom, 'skills', 'nodespace'));
+  });
+
+  it('claude-code falls back to ~/.claude when $CLAUDE_CONFIG_DIR is unset', async () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    vi.resetModules();
+    const { AGENTS: A } = await import('../agents.js');
+    const cc = A.find(a => a.name === 'claude-code')!;
+    expect(cc.installDir).toBe(join(TMP, '.claude', 'skills', 'nodespace'));
   });
 });

--- a/packages/skill/src/types.ts
+++ b/packages/skill/src/types.ts
@@ -5,6 +5,13 @@ export interface AgentConfig {
   detectionDir: string;
   installDir: string;
   shims: string[];
+  /**
+   * Frontmatter to prepend to `SKILL.md` when installing for this agent. Claude
+   * Code discovers a skill by the YAML `name` + `description` frontmatter; the
+   * shared SKILL.md body carries none (it is agent-agnostic), so agents that
+   * need it supply it here and the installer writes `frontmatter + body`.
+   */
+  skillFrontmatter?: string;
 }
 
 export interface InstallResult {


### PR DESCRIPTION
Closes #1708.

## Problem
The shipped `packages/skill/SKILL.md` has no Claude Code frontmatter, so the skill installer's copy isn't surfaced by native skill discovery — a session doesn't find NodeSpace on its own, which is the point of the installer. And `agents.ts` hardcodes `~/.claude`, so a separate profile (e.g. `CLAUDE_CONFIG_DIR=~/.claude-ns`) never gets the skill.

## Change
- **`installer.ts`** — when writing `SKILL.md` for an agent that defines `skillFrontmatter`, prepend it (`frontmatter + body`); everything else is copied verbatim. The shared `SKILL.md` source is unchanged (agent-agnostic; the generated schema-rules block is untouched), so other agents still get it as-is.
- **`agents.ts`** — Claude Code `detectionDir`/`installDir` derive from `$CLAUDE_CONFIG_DIR` when set, else `~/.claude`; adds the Claude Code frontmatter constant (`name` + `description` + `allowed-tools: Bash(nodespace:*)`).
- **`types.ts`** — `AgentConfig.skillFrontmatter?: string`.
- **tests** — assert claude-code SKILL.md gets frontmatter while other agents stay verbatim; assert `$CLAUDE_CONFIG_DIR` is honored (and falls back). Isolates the top-level `AGENTS` import from an inherited `$CLAUDE_CONFIG_DIR` so the suite is deterministic. 20/20 pass.

## Validation
Built + ran the installer against a throwaway `CLAUDE_CONFIG_DIR`: SKILL.md starts with the frontmatter, body preserved, installed into the target profile. End-to-end: a headless Claude Code session, given only a natural request (no CLI in the prompt), discovered the installed skill and drove the `nodespace` CLI unprompted.

Follow-up (out of scope): the `nodespace-hook.ts` shim's `hook()` runtime appears unused by current Claude Code; if confirmed dead it can be removed separately.
