### PR TITLE
Fix model-store tests leaking Tauri env across the parallel suite

### DIFF
--- a/packages/desktop-app/src/tests/stores/model-store.test.ts
+++ b/packages/desktop-app/src/tests/stores/model-store.test.ts
@@ -40,11 +40,18 @@ vi.mock('@tauri-apps/api/event', () => ({
 
 function mockTauriEnvironment(isTauri: boolean) {
   interface WindowWithTauri extends Window {
+    __TAURI__?: Record<string, unknown>;
     __TAURI_INTERNALS__?: Record<string, unknown>;
   }
   if (isTauri) {
     (window as WindowWithTauri).__TAURI_INTERNALS__ = {};
   } else {
+    // Clear BOTH markers `isTauri()` checks. Under vitest's `forks` pool the
+    // environment is reused across test files, so another file that set either
+    // marker (and didn't clear it) would otherwise leak into these mock-path
+    // tests and flip them onto the Tauri branch — the cause of the parallel-suite
+    // flakiness where refreshModels()/downloadModel() take the unmocked Tauri path.
+    delete (window as WindowWithTauri).__TAURI__;
     delete (window as WindowWithTauri).__TAURI_INTERNALS__;
   }
 }
@@ -52,6 +59,10 @@ function mockTauriEnvironment(isTauri: boolean) {
 describe('ModelStore', () => {
   beforeEach(() => {
     modelStore.reset();
+    // Establish the non-Tauri (mock) environment deterministically so these tests
+    // don't depend on the absence of Tauri globals a prior test file may have left
+    // on the shared window. The Tauri sub-block below opts back into Tauri mode.
+    mockTauriEnvironment(false);
     vi.useFakeTimers();
   });
 


### PR DESCRIPTION
Closes #1712.

## Problem
`packages/desktop-app/src/tests/stores/model-store.test.ts` mock-path tests (`recommendedModel`, `downloadModel`) pass **27/27 in isolation** but fail **4 assertions** under the full parallel `test:all` run — blocking the ADR-047 pre-push gate for **unrelated** changes.

## Root cause (a real test-isolation bug)
`isTauri()` returns `'__TAURI__' in window || '__TAURI_INTERNALS__' in window`. These mock-path tests never establish the non-Tauri environment — they rely on **both** markers being absent. Under vitest's `pool: 'forks'` the environment is reused across files, and several other test files (`free-user-guardrail`, `tauri-sync-listener`, `daemon-reconnect-retry`, `database`, `settings`) set `__TAURI__` / `__TAURI_INTERNALS__` on the shared `window` without clearing them. When one runs before this file, `isTauri()` flips **true**, so `refreshModels()` / `downloadModel()` take the **Tauri** branch and call `chatModelList` / `chatModelDownload` (unmocked here). The fallback leaves `systemRamGb = 0` — so `recommendedModel` picks the largest model *overall* instead of the largest that fits in 8 GB — and the download never reaches `ready`. Exactly the 4 failures.

## Fix
Make the file self-sufficient: the outer `beforeEach` establishes the non-Tauri environment (`mockTauriEnvironment(false)`), and `mockTauriEnvironment(false)` clears **both** markers (previously only `__TAURI_INTERNALS__`, missing `__TAURI__` leaked by other files). Test-only; deterministic regardless of fork order.

## Verification
Full frontend suite green across repeated runs (was `1 file / 4 tests failed`); the pre-push gate (`test:all` + `cargo build` + `test:e2e`) passed on this branch.