### PR TITLE
Re-target Pro cloud-sync when switching the active database (ADR-053)

### DIFF
--- a/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
+++ b/packages/desktop-app/src-tauri/proto/nodespace_pro.proto
@@ -45,6 +45,13 @@ service CloudSyncService {
   // can advance from the enable prompt to sign-in. Idempotent.
   rpc EnableSync (EnableSyncRequest) returns (EnableSyncResponse);
 
+  // Switch the cloud-sync session to follow a different local database (ADR-053
+  // single-active sync). The desktop calls this from its switch-database action,
+  // right after re-pointing routing, so switching database also switches which
+  // tenant syncs — not just which one is read/written. An empty database_id
+  // deactivates (local-only). Idempotent for the already-active database.
+  rpc ActivateDatabase (ActivateDatabaseRequest) returns (ActivateDatabaseResponse);
+
   // --- Team membership (M5, #147). Thin adapters over the cloud
   // membership RPCs; the daemon forwards the signed-in user's JWT, so
   // the same admin / last-admin / open-vs-restricted gates apply
@@ -161,6 +168,19 @@ message SignOutResponse {}
 
 message EnableSyncRequest {}
 message EnableSyncResponse {}
+
+message ActivateDatabaseRequest {
+  // Registry id of the database to make the active cloud-sync target. Empty =
+  // deactivate the current session (go local-only).
+  string database_id = 1;
+}
+message ActivateDatabaseResponse {
+  // True when a cloud-sync session was started (the target is bound to a
+  // tenant); false when the target is local-only or sync was deactivated.
+  bool synced = 1;
+  // The tenant schema now syncing; empty when local-only / deactivated.
+  string schema = 2;
+}
 
 // --- Team membership (M5, #147) ----------------------------------
 // permission is "admin" | "modify" | "readOnly". collection_id / person_id are

--- a/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
+++ b/packages/desktop-app/src-tauri/src/commands/pro_sync.rs
@@ -12,11 +12,11 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::services::pro_client::pb::cloud_sync_service_client::CloudSyncServiceClient;
 use crate::services::pro_client::pb::sync_status_event::State as PbState;
 use crate::services::pro_client::pb::{
-    AcceptInviteRequest, ApproveRequestRequest, CreateInviteRequest, EnableSyncRequest,
-    GetIdentityRequest, InitiateOAuthRequest, JoinCollectionRequest, LeaveCollectionRequest,
-    ListInvitesRequest, ListJoinableCollectionsRequest, ListMembersRequest, ListRequestsRequest,
-    RemoveMemberRequest, RequestJoinRequest, RevokeInviteRequest, SetMemberRequest, SignOutRequest,
-    WatchSyncStatusRequest,
+    AcceptInviteRequest, ActivateDatabaseRequest, ApproveRequestRequest, CreateInviteRequest,
+    EnableSyncRequest, GetIdentityRequest, InitiateOAuthRequest, JoinCollectionRequest,
+    LeaveCollectionRequest, ListInvitesRequest, ListJoinableCollectionsRequest, ListMembersRequest,
+    ListRequestsRequest, RemoveMemberRequest, RequestJoinRequest, RevokeInviteRequest,
+    SetMemberRequest, SignOutRequest, WatchSyncStatusRequest,
 };
 use crate::services::{ProClient, ProTier};
 use tonic::transport::Channel;
@@ -235,6 +235,27 @@ pub async fn pro_enable_sync(app: AppHandle) -> Result<(), String> {
         .await
         .map_err(|e| format!("EnableSync failed: {e}"))?;
     tracing::info!("Pro: EnableSync");
+    Ok(())
+}
+
+/// Re-target the Pro cloud-sync session to follow the newly-active database
+/// (ADR-053 single-active sync). The frontend calls this right after
+/// `set_active_database` re-points routing, so switching databases in the app
+/// also switches which tenant syncs — not just which one is read/written. Empty
+/// `database_id` deactivates (local-only). No-ops in community mode (no
+/// `ProClient`), matching the other Pro commands' side-effect-free contract, so
+/// the community database switcher is unaffected.
+#[tauri::command]
+pub async fn pro_activate_database(app: AppHandle, database_id: String) -> Result<(), String> {
+    let Some(pro) = app.try_state::<ProClient>() else {
+        return Ok(());
+    };
+    let mut client = pro.client().await;
+    client
+        .activate_database(ActivateDatabaseRequest { database_id })
+        .await
+        .map_err(|e| format!("ActivateDatabase failed: {e}"))?;
+    tracing::info!("Pro: ActivateDatabase");
     Ok(())
 }
 

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -442,6 +442,7 @@ pub fn run() {
             commands::pro_sync::pro_initiate_oauth,
             commands::pro_sync::pro_signout,
             commands::pro_sync::pro_enable_sync,
+            commands::pro_sync::pro_activate_database,
             commands::pro_sync::pro_set_member,
             commands::pro_sync::pro_remove_member,
             commands::pro_sync::pro_leave_collection,

--- a/packages/desktop-app/src/lib/stores/database.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/database.svelte.ts
@@ -165,6 +165,17 @@ class DatabaseStore {
       if (seq !== this.switchSeq) return;
       this.activeDatabaseId = id;
 
+      // Re-target Pro cloud-sync to follow the newly-active database (ADR-053
+      // single-active sync): switching database in the app switches which tenant
+      // syncs, not just which one is read/written. No-ops in community mode (the
+      // Tauri command returns early without a ProClient). Best-effort — a
+      // re-target failure must not abort the already-committed routing switch.
+      try {
+        await invoke('pro_activate_database', { databaseId: id });
+      } catch (err) {
+        log.warn('Failed to re-target sync to the switched database', { id, error: err });
+      }
+
       // Evict the previous database's cached data. `clearAll()` also bumps the
       // store's database epoch, which closes the in-flight-read window: a read
       // (e.g. loadChildren/getNode) dispatched against the previous database

--- a/packages/desktop-app/src/tests/stores/database.test.ts
+++ b/packages/desktop-app/src/tests/stores/database.test.ts
@@ -193,12 +193,14 @@ describe('Database Store', () => {
     });
 
     it('flushes, switches, clears caches, resets tabs, and reloads', async () => {
-      mockInvoke.mockResolvedValueOnce(undefined); // set_active_database
+      mockInvoke.mockResolvedValue(undefined); // set_active_database + pro_activate_database
 
       await databaseStore.switchTo('b');
 
       expect(flushAllPendingSaves).toHaveBeenCalledOnce();
       expect(mockInvoke).toHaveBeenCalledWith('set_active_database', { id: 'b' });
+      // The switch also re-targets Pro cloud-sync to the new database (ADR-053).
+      expect(mockInvoke).toHaveBeenCalledWith('pro_activate_database', { databaseId: 'b' });
       expect(databaseStore.activeDatabaseId).toBe('b');
       expect(clearAll).toHaveBeenCalledOnce();
       expect(structureTreeClear).toHaveBeenCalledOnce();
@@ -206,6 +208,21 @@ describe('Database Store', () => {
       expect(addTab).toHaveBeenCalledOnce();
       expect(loadCollections).toHaveBeenCalledOnce();
       expect(loadSchemas).toHaveBeenCalledOnce();
+    });
+
+    it('completes the switch even if the Pro sync re-target fails', async () => {
+      mockInvoke
+        .mockResolvedValueOnce(undefined) // set_active_database
+        .mockRejectedValueOnce(new Error('daemon unavailable')); // pro_activate_database
+
+      await databaseStore.switchTo('b');
+
+      // A sync re-target failure is best-effort: the already-committed routing
+      // switch still lands (caches cleared, tabs reset), never left half-done.
+      expect(mockInvoke).toHaveBeenCalledWith('pro_activate_database', { databaseId: 'b' });
+      expect(databaseStore.activeDatabaseId).toBe('b');
+      expect(clearAll).toHaveBeenCalledOnce();
+      expect(clearAllTabs).toHaveBeenCalledOnce();
     });
 
     it('no-ops when switching to the already-active database', async () => {


### PR DESCRIPTION
Closes #1711. Part of the per-database cloud-sync epic (#1535). The daemon-side single-active sync + `ActivateDatabase` RPC are done in nodespace-sync (#350–#358, merged).

> ⚠️ **HOLD — do not merge yet.** Per the author's request this stays open for **on-device validation** first (the switch → sync-retarget → pill behavior needs the running Tauri app). The change is unit-tested + reviewed; only the interactive end-to-end check remains.

## What
`databaseStore.switchTo(id)` re-points the routed gRPC clients via `set_active_database` (the data plane) but never told the Pro daemon to move its cloud-sync session — so switching database in the app changed which database is read/written while the daemon kept syncing the boot tenant. This wires the switch to the daemon's single-active `ActivateDatabase` RPC.

- Mirror the `ActivateDatabase` RPC + messages into the desktop's pro proto copy.
- Add `pro_activate_database(database_id)` Tauri command → `CloudSyncService.ActivateDatabase`; **no-ops in community mode** (no `ProClient`), matching the other `pro_*` commands, so the community DB switcher is unaffected.
- `switchTo` calls it after `set_active_database`, **best-effort**: a re-target failure is logged and does not abort the already-committed routing switch.

Desktop-only.

## Test plan
- `bun run test` — the database-store tests assert the switch re-targets sync (`pro_activate_database` invoked with `{ databaseId }`) **and** still completes when the re-target fails. `nodespace-app` compiles (proto regenerates). Pre-push gate (`test:all` + `cargo build` + `test:e2e`) green.
- **On-device (pending, the reason this is held):** with a Pro daemon + ≥2 bound databases, switching database in the app re-targets sync to the new tenant (Realtime/pill follows). The backend RPC is already headless-validated in nodespace-sync.

## Review
Independently reviewed (adversarial): proto parity byte-for-byte vs the daemon; command no-ops in community; `switchTo` wiring is genuinely best-effort; snake/camel arg convention correct; frontend tests cover both paths. No defects found.

## Scope
The tenant/database **picker UI** + per-DB sync pill (builds on #1536/#1537) are separate — this is only the switch→sync wiring.