### PR TITLE
Collections appear empty: content-aware counts + reliable multi-collection membership

### DIFF
--- a/packages/core/src/db/sqlite_store/relationships.rs
+++ b/packages/core/src/db/sqlite_store/relationships.rs
@@ -306,6 +306,46 @@ impl SqliteStore {
         Ok(ids)
     }
 
+    /// Every `member_of` edge belonging to a node that is a member of MORE THAN
+    /// ONE collection, as `(member_id, collection_id)` pairs. A node's first
+    /// membership rides its atomic cloud node insert, so only these SECONDARY
+    /// memberships need a separate push; the cloud-sync membership sweep uses this
+    /// to converge them. Bounding to multi-membership nodes keeps the sweep cheap
+    /// — the single-membership majority (already covered atomically) is never
+    /// enumerated. Idempotent re-push of the one atomic-covered edge among a
+    /// multi-membership node's edges is a benign no-op on the cloud side.
+    ///
+    /// `person` members are excluded: their collection memberships are RBAC state
+    /// managed server-side by the membership RPCs (invite / set_member) and are
+    /// not the sweep's concern — re-asserting them would bypass those gates and
+    /// waste round-trips. Content and nested-collection memberships are kept.
+    pub async fn get_multi_membership_edges(&self) -> Result<Vec<(String, String)>> {
+        let mut rows = self
+            .db
+            .query(
+                "SELECT r.in_node, r.out_node FROM relationship r \
+                 JOIN node n ON n.id = r.in_node \
+                 WHERE r.relationship_type = 'member_of' \
+                   AND n.node_type != 'person' \
+                   AND r.in_node IN ( \
+                     SELECT in_node FROM relationship \
+                     WHERE relationship_type = 'member_of' \
+                     GROUP BY in_node HAVING COUNT(*) > 1 \
+                   )",
+                (),
+            )
+            .await
+            .context("Failed to get multi-membership edges")?;
+
+        let mut edges = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let member: String = row.get(0)?;
+            let collection: String = row.get(1)?;
+            edges.push((member, collection));
+        }
+        Ok(edges)
+    }
+
     pub async fn get_collection_members(&self, collection_id: &str) -> Result<Vec<Node>> {
         let start = std::time::Instant::now();
 
@@ -455,9 +495,26 @@ impl SqliteStore {
             return Ok(vec![]);
         }
 
-        // Count members per collection
+        // Count CONTENT members per collection. This count drives the sidebar's
+        // member badge AND its empty-collection pruning, so it must match what the
+        // collection viewer actually lists — user-authored content only. Counting
+        // raw `member_of` edges instead let a collection whose only members are the
+        // person roster (or other system nodes) report a non-zero count, show in the
+        // sidebar, then open empty because the viewer filters those members out.
+        //
+        // The excluded types mirror the frontend's NON_CONTENT_NODE_TYPES
+        // (collections.svelte.ts): `person`/`schema`/`database-settings` are
+        // system/definition nodes, `collection` members are shown in the tree
+        // itself, and `horizontal-line` is a decorative divider. Keep the two lists
+        // in sync.
         let mut rows = self.db.query(
-            "SELECT out_node, COUNT(*) FROM relationship WHERE relationship_type = 'member_of' GROUP BY out_node",
+            "SELECT r.out_node, COUNT(*) \
+             FROM relationship r \
+             JOIN node n ON n.id = r.in_node \
+             WHERE r.relationship_type = 'member_of' \
+               AND n.node_type NOT IN \
+                 ('schema', 'person', 'database-settings', 'collection', 'horizontal-line') \
+             GROUP BY r.out_node",
             (),
         ).await.context("Failed to get member counts")?;
 
@@ -558,9 +615,18 @@ impl SqliteStore {
         Ok(created)
     }
 
-    pub async fn bulk_add_to_collections(&self, memberships: &[(String, String)]) -> Result<usize> {
+    /// Bulk-insert `member_of` edges, returning the edges actually created
+    /// (skipping ones that already existed) as `(rel_id, node_id, collection_id,
+    /// order)`. Callers that need cloud sync route through
+    /// [`crate::services::NodeService::bulk_add_to_collections_notify`], which
+    /// emits a `RelationshipCreated` event per returned edge — this raw store
+    /// method emits nothing, so on its own the edges never push to cloud.
+    pub async fn bulk_add_to_collections(
+        &self,
+        memberships: &[(String, String)],
+    ) -> Result<Vec<(String, String, String, f64)>> {
         if memberships.is_empty() {
-            return Ok(0);
+            return Ok(Vec::new());
         }
 
         let start = std::time::Instant::now();
@@ -593,7 +659,7 @@ impl SqliteStore {
             .await
             .context("Failed to begin bulk add transaction")?;
 
-        let mut created = 0;
+        let mut created: Vec<(String, String, String, f64)> = Vec::new();
         for (node_id, collection_id, order) in &ordered {
             let mut rows = tx.query(
                 "SELECT id FROM relationship WHERE in_node = ?1 AND out_node = ?2 AND relationship_type = 'member_of' LIMIT 1",
@@ -608,16 +674,16 @@ impl SqliteStore {
             let props = serde_json::json!({"order": order}).to_string();
             tx.execute(
                 "INSERT INTO relationship (id, in_node, out_node, relationship_type, properties, version, created_at, modified_at) VALUES (?1, ?2, ?3, 'member_of', ?4, 1, ?5, ?6)",
-                libsql::params![rel_id, node_id.clone(), collection_id.clone(), props, now.clone(), now.clone()],
+                libsql::params![rel_id.clone(), node_id.clone(), collection_id.clone(), props, now.clone(), now.clone()],
             ).await.context("Failed to insert membership")?;
-            created += 1;
+            created.push((rel_id, node_id.clone(), collection_id.clone(), *order));
         }
 
         tx.commit().await.context("Failed to commit bulk add")?;
 
         tracing::debug!(
             "bulk_add_to_collections: {} memberships in {:?}",
-            created,
+            created.len(),
             start.elapsed()
         );
 

--- a/packages/core/src/ops/collection_ops.rs
+++ b/packages/core/src/ops/collection_ops.rs
@@ -21,6 +21,10 @@ pub struct GetAllCollectionsInput;
 #[derive(Debug)]
 pub struct CollectionEntry {
     pub node: Node,
+    /// Number of **content** members (user-authored nodes) in this collection.
+    /// System/definition/decorative members (person, schema, database-settings,
+    /// nested collection nodes, horizontal-line) are NOT counted, so this matches
+    /// what the collection viewer lists and the sidebar's empty-collection pruning.
     pub member_count: usize,
     pub parent_collection_ids: Vec<String>,
 }

--- a/packages/core/src/services/collection_service.rs
+++ b/packages/core/src/services/collection_service.rs
@@ -1142,4 +1142,91 @@ mod tests {
             "exactly Architecture/Decisions/Alternatives, no duplicates: {names:?}"
         );
     }
+
+    /// `member_count` must reflect CONTENT members only. The sidebar uses it to
+    /// decide whether a collection is empty (and to prune empty ones), so it has
+    /// to agree with what the collection viewer actually lists — user-authored
+    /// content, never the system/roster members the viewer filters out. The
+    /// seeded demo collections held only a `person` roster and so wrongly counted
+    /// as non-empty, then opened blank. Here a decorative `horizontal-line` stands
+    /// in for such a non-content member: it must NOT inflate the count.
+    #[tokio::test]
+    async fn member_count_excludes_non_content_members() {
+        let (ns, _dir) = test_node_service().await;
+        let svc = CollectionService::new(ns.store(), &ns);
+
+        let research = svc.resolve_path("Research").await.unwrap().leaf.id;
+
+        // One genuine content node and one non-content member, both member_of
+        // "Research".
+        let text_id = ns
+            .create_node(Node::new(
+                "text".to_string(),
+                "A research note".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+        let divider_id = ns
+            .create_node(Node::new(
+                "horizontal-line".to_string(),
+                "---".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+        svc.add_to_collection(&text_id, &research).await.unwrap();
+        svc.add_to_collection(&divider_id, &research).await.unwrap();
+
+        let counts = svc.get_all_collections_with_counts().await.unwrap();
+        let (_, research_count, _) = counts
+            .iter()
+            .find(|(node, _, _)| node.id == research)
+            .expect("Research collection present in listing");
+
+        assert_eq!(
+            *research_count, 1,
+            "only the text node counts; the horizontal-line member is excluded"
+        );
+    }
+
+    /// The membership sweep only replicates SECONDARY memberships.
+    /// `get_multi_membership_edges` returns every edge of a node in >1 collection
+    /// and excludes single-membership nodes (their one membership rides the atomic
+    /// node insert), so the sweep stays bounded to the nodes that actually need it.
+    #[tokio::test]
+    async fn get_multi_membership_edges_only_multi_membership_nodes() {
+        let (ns, _dir) = test_node_service().await;
+        let svc = CollectionService::new(ns.store(), &ns);
+        let default = svc.resolve_path("Default").await.unwrap().leaf.id;
+        let topic = svc.resolve_path("Architecture").await.unwrap().leaf.id;
+
+        // Multi-membership node: member_of BOTH collections.
+        let multi = ns
+            .create_node(Node::new("text".to_string(), "multi".to_string(), json!({})))
+            .await
+            .unwrap();
+        svc.add_to_collection(&multi, &default).await.unwrap();
+        svc.add_to_collection(&multi, &topic).await.unwrap();
+        // Single-membership node: member_of only one collection.
+        let single = ns
+            .create_node(Node::new("text".to_string(), "single".to_string(), json!({})))
+            .await
+            .unwrap();
+        svc.add_to_collection(&single, &default).await.unwrap();
+
+        let edges = ns.store().get_multi_membership_edges().await.unwrap();
+        assert_eq!(
+            edges.len(),
+            2,
+            "only the multi-membership node's two edges, not the single node's: {edges:?}"
+        );
+        assert!(
+            edges.iter().all(|(m, _)| m == &multi),
+            "the single-membership node is excluded entirely"
+        );
+        let colls: std::collections::HashSet<&str> =
+            edges.iter().map(|(_, c)| c.as_str()).collect();
+        assert!(colls.contains(default.as_str()) && colls.contains(topic.as_str()));
+    }
 }

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -433,12 +433,21 @@ pub struct CreateNodeParams {
     pub properties: Value,
 }
 
-/// Broadcast channel capacity for domain events.
+/// Broadcast channel capacity for domain events — the LIVE channel `emit_event`
+/// publishes on and every consumer (`subscribe_to_events`) reads, including the
+/// cloud-sync push consumer.
 ///
-/// 128 provides sufficient headroom for burst operations (bulk node creation)
-/// while limiting memory overhead. Observer lag is acceptable - we only track
-/// the current state, not historical events.
-const DOMAIN_EVENT_CHANNEL_CAPACITY: usize = 128;
+/// It must comfortably buffer a bulk import's burst: relationship events are not
+/// node-keyed, so they broadcast immediately (they bypass the batch guard), and
+/// the push consumer replicates each `member_of` edge with its own network
+/// round-trip, so it drains slower than a batch import emits. A broadcast
+/// receiver only misses events if it falls MORE than this many behind, so a burst
+/// larger than the buffer makes the push consumer lag and DROP edges (memberships
+/// then never reach cloud, leaving those collections empty on other devices). 128
+/// overflowed on a ~320-edge collection import; 4096 covers a realistic
+/// multi-collection import while staying tiny in memory (each envelope is a few
+/// small ids).
+const DOMAIN_EVENT_CHANNEL_CAPACITY: usize = 4096;
 
 /// Internal state shared between the store notifier closure and `BatchEmitGuard`.
 ///
@@ -3343,6 +3352,127 @@ mod tests {
         assert!(node_ids.contains(&root_id), "root event missing");
         assert!(node_ids.contains(&child1_id), "child1 event missing");
         assert!(node_ids.contains(&child2_id), "child2 event missing");
+    }
+
+    /// The batch importer assigns collection membership via
+    /// `bulk_add_to_collections_notify`, and each newly created `member_of` edge
+    /// MUST emit a RelationshipCreated event so the cloud-sync push replicates it.
+    /// The raw store insert emits nothing — that gap is why imported collections
+    /// showed up populated only on the importing device and empty on a fresh pull.
+    #[tokio::test]
+    async fn bulk_add_to_collections_notify_emits_push_events() {
+        let (service, _temp) = create_test_service().await;
+
+        // A stand-in collection plus two content nodes. The store bulk-insert does
+        // not type-check the target, so plain nodes suffice to exercise emission.
+        let coll = service
+            .create_node(Node::new(
+                "text".to_string(),
+                "Docs collection".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+        let a = service
+            .create_node(Node::new("text".to_string(), "A".to_string(), json!({})))
+            .await
+            .unwrap();
+        let b = service
+            .create_node(Node::new("text".to_string(), "B".to_string(), json!({})))
+            .await
+            .unwrap();
+
+        // Subscribe after node creation so only the membership events are captured.
+        let mut rx = service.subscribe_to_events();
+
+        let created = service
+            .bulk_add_to_collections_notify(&[(a.clone(), coll.clone()), (b.clone(), coll.clone())])
+            .await
+            .unwrap();
+        assert_eq!(created, 2, "two new memberships created");
+
+        let mut member_of_events = 0;
+        while let Ok(env) = rx.try_recv() {
+            if let DomainEvent::RelationshipCreated { relationship } = &env.event {
+                if relationship.relationship_type == "member_of" {
+                    member_of_events += 1;
+                }
+            }
+        }
+        assert_eq!(
+            member_of_events, 2,
+            "each new member_of edge must emit a RelationshipCreated event so it pushes to cloud",
+        );
+
+        // Idempotent re-assert: an already-present edge creates nothing and, so,
+        // emits nothing (no spurious re-push).
+        let mut rx2 = service.subscribe_to_events();
+        let again = service
+            .bulk_add_to_collections_notify(&[(a.clone(), coll.clone())])
+            .await
+            .unwrap();
+        assert_eq!(again, 0, "existing membership is not recreated");
+        assert!(
+            rx2.try_recv().is_err(),
+            "no event fires for an already-present edge",
+        );
+    }
+
+    /// A bulk import's membership burst must not overflow the domain-event
+    /// broadcast and drop edges — the exact failure that leaves a collection empty
+    /// on other devices. Emit a burst LARGER than the old 128 capacity and assert a
+    /// subscriber receives every event (no `Lagged`). This guards the channel
+    /// capacity: at 128 this burst would drop events; at 4096 it does not.
+    #[tokio::test]
+    async fn bulk_membership_burst_does_not_overflow_the_event_channel() {
+        use tokio::sync::broadcast::error::TryRecvError;
+        let (service, _temp) = create_test_service().await;
+
+        // One collection plus a burst of content nodes, all created BEFORE the
+        // subscription so only the membership events land in the receiver's buffer.
+        let coll = service
+            .create_node(Node::new("text".to_string(), "coll".to_string(), json!({})))
+            .await
+            .unwrap();
+        const BURST: usize = 300; // > 128 (old cap), < 4096 (new cap)
+        let mut memberships = Vec::with_capacity(BURST);
+        for i in 0..BURST {
+            let id = service
+                .create_node(Node::new("text".to_string(), format!("n{i}"), json!({})))
+                .await
+                .unwrap();
+            memberships.push((id, coll.clone()));
+        }
+
+        // Subscribe AFTER node creation → the receiver's buffer starts empty and
+        // only accumulates the membership burst.
+        let mut rx = service.subscribe_to_events();
+        let created = service
+            .bulk_add_to_collections_notify(&memberships)
+            .await
+            .unwrap();
+        assert_eq!(created, BURST, "all memberships created");
+
+        let mut member_of_events = 0usize;
+        loop {
+            match rx.try_recv() {
+                Ok(env) => {
+                    if let DomainEvent::RelationshipCreated { relationship } = &env.event {
+                        if relationship.relationship_type == "member_of" {
+                            member_of_events += 1;
+                        }
+                    }
+                }
+                Err(TryRecvError::Empty | TryRecvError::Closed) => break,
+                Err(TryRecvError::Lagged(n)) => {
+                    panic!("event channel lagged by {n} — capacity too small for the burst")
+                }
+            }
+        }
+        assert_eq!(
+            member_of_events, BURST,
+            "every membership event was buffered — none dropped by a too-small channel",
+        );
     }
 
     /// Single-node creation via `create_node` must still emit immediately (not

--- a/packages/core/src/services/node_service/relationship.rs
+++ b/packages/core/src/services/node_service/relationship.rs
@@ -688,6 +688,53 @@ impl NodeService {
         Ok(())
     }
 
+    /// Bulk-create `member_of` edges AND emit a `RelationshipCreated` event for
+    /// each newly created edge, so the cloud-sync push consumer replicates them.
+    ///
+    /// The raw `store.bulk_add_to_collections` inserts the rows directly and
+    /// emits nothing. That is fine for a purely local write, but the edges then
+    /// never reach cloud: they join nodes that are *already* synced, so the
+    /// node-oriented "unsynced push sweep" skips them, and every other device
+    /// (and any first-time puller) sees those collections empty. Routing the
+    /// batch importer's collection assignment through here puts each membership
+    /// on the exact same event path as [`Self::create_relationship`], so bulk
+    /// import and single-file import replicate identically. Returns the number of
+    /// edges actually created (idempotent hits are skipped and not re-emitted).
+    pub async fn bulk_add_to_collections_notify(
+        &self,
+        memberships: &[(String, String)],
+    ) -> Result<usize, NodeServiceError> {
+        let created = self
+            .store
+            .bulk_add_to_collections(memberships)
+            .await
+            .map_err(|e| NodeServiceError::query_failed(e.to_string()))?;
+
+        // The domain-event broadcast channel is bounded (128 slots). A large
+        // import can create far more `member_of` edges than that; emitting them
+        // all in a tight loop would overflow the channel, making the sync push
+        // consumer lag and DROP edges — which then never reach cloud (defeating
+        // the whole point). Yield every chunk so the consumer drains between
+        // bursts. The chunk stays well under the channel capacity.
+        const EMIT_CHUNK: usize = 50;
+        for (i, (rel_id, node_id, collection_id, order)) in created.iter().enumerate() {
+            self.emit_event(DomainEvent::RelationshipCreated {
+                relationship: crate::db::events::RelationshipEvent::new(
+                    rel_id.clone(),
+                    node_id,
+                    collection_id,
+                    "member_of",
+                    serde_json::json!({ "order": order }),
+                ),
+            });
+            if (i + 1) % EMIT_CHUNK == 0 {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(created.len())
+    }
+
     /// Delete a relationship between two nodes
     ///
     /// Removes the edge between the source and target nodes for the specified relationship.

--- a/packages/daemon/src/services/import_service.rs
+++ b/packages/daemon/src/services/import_service.rs
@@ -694,7 +694,15 @@ async fn run_batch_import(
         .await;
 
         if !bulk_insert_failed && !collection_assignments.is_empty() {
-            match store.bulk_add_to_collections(&collection_assignments).await {
+            // Route through the notifying variant so each new `member_of` edge
+            // emits a RelationshipCreated event and thus PUSHES to cloud. The raw
+            // `store.bulk_add_to_collections` writes the rows but emits nothing, so
+            // the memberships would land only in the local DB — every other device
+            // (and any first-time puller) would then see these collections empty.
+            match node_service_clone
+                .bulk_add_to_collections_notify(&collection_assignments)
+                .await
+            {
                 Ok(count) => tracing::info!("Bulk assigned {} collection memberships", count),
                 Err(e) => {
                     tracing::error!("Failed to bulk add to collections: {:?}", e);
@@ -1546,6 +1554,73 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "collection membership survives replace",
+        );
+    }
+
+    /// The demo-repair case: a document already in the store but MISSING its
+    /// topic-collection membership (its content landed only in the default
+    /// collection) regains that membership from a plain re-import — no
+    /// `--replace`, no duplication. This is the self-heal path the demo re-seed
+    /// relies on: routing is re-derived and every root's membership is
+    /// re-asserted, so a root that lost (or never had) its topic edge gets wired
+    /// up in place.
+    #[tokio::test]
+    async fn reimport_reasserts_missing_collection_membership() {
+        let (ns, dir) = new_service_and_dir().await;
+        let ns = Arc::new(ns);
+        // base_directory is the repo root; the file under architecture/ routes to
+        // the "Architecture" collection.
+        let arch = dir.path().join("architecture");
+        std::fs::create_dir_all(&arch).unwrap();
+        std::fs::write(arch.join("overview.md"), "# Overview\n\nBody.\n").unwrap();
+        let files = vec![arch.join("overview.md").to_str().unwrap().to_string()];
+        let opts = ImportOptions {
+            base_directory: dir.path().to_str().unwrap().to_string(),
+            auto_collection_routing: true,
+            ..Default::default()
+        };
+
+        // First import: the doc root joins its topic collection.
+        run_batch_and_wait(Arc::clone(&ns), files.clone(), opts.clone()).await;
+        let root_id = deterministic_root_id("architecture/overview.md");
+        let memberships_before = ns.store().get_node_memberships(&root_id).await.unwrap();
+        assert!(
+            !memberships_before.is_empty(),
+            "doc routed into a collection on first import",
+        );
+        let topic_coll = memberships_before[0].clone();
+
+        // Simulate the broken demo state: strip the topic membership so the root
+        // is present but orphaned from its collection (unbrowsable there).
+        CollectionService::new(ns.store(), &ns)
+            .remove_from_collection(&root_id, &topic_coll)
+            .await
+            .unwrap();
+        assert!(
+            ns.store()
+                .get_node_memberships(&root_id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "membership removed — the root is now orphaned from its collection",
+        );
+        let headers_before = ns.store().count_nodes_by_type("header").await.unwrap();
+
+        // Plain re-import (no --replace) must re-assert the lost membership and
+        // create no new node.
+        run_batch_and_wait(Arc::clone(&ns), files.clone(), opts.clone()).await;
+        assert!(
+            ns.store()
+                .get_node_memberships(&root_id)
+                .await
+                .unwrap()
+                .contains(&topic_coll),
+            "plain re-import re-asserts the lost topic-collection membership (self-heal)",
+        );
+        assert_eq!(
+            ns.store().count_nodes_by_type("header").await.unwrap(),
+            headers_before,
+            "self-heal adds only the missing edge — it must not duplicate any node",
         );
     }
 }


### PR DESCRIPTION
## What
Fixes "collections appear empty" and makes multi-collection membership replicable (core + daemon half). Closes #1723.

## Changes
- **Content-aware `member_count`** (`get_all_collections_with_member_counts`): counts only content members (excludes person/schema/database-settings/collection/horizontal-line), so the sidebar's count and empty-collection pruning match what the viewer lists — a roster-only collection is no longer a visible click-to-empty.
- **`bulk_add_to_collections`** now returns the created edges; new **`NodeService::bulk_add_to_collections_notify`** emits a `RelationshipCreated` per edge (same push path as `create_relationship`, throttled so a bulk import's burst doesn't overflow the event broadcast). The batch importer routes through it, so imported secondary memberships now reach cloud.
- **`DOMAIN_EVENT_CHANNEL_CAPACITY` 128 → 4096** so a bulk import's edge burst isn't dropped.
- **`SqliteStore::get_multi_membership_edges()`** enumerates secondary (multi-collection) memberships for the cloud-sync membership sweep (excludes `person` — RBAC state is server-managed).

## Testing
`cargo test -p nodespace-core` + `-p nodespace-daemon` green, incl. new: content-count exclusion, event-emission, `get_multi_membership_edges`, and an import self-heal (a present-but-orphaned doc regains its topic membership on a plain re-import). Pre-push gate (test:all + build + e2e) passed.

## Related
Pairs with nodespace-sync#365 (member_of push, merged) and the membership sweep (nodespace-sync#363, which consumes `get_multi_membership_edges`). Follow-ups: nodespace-sync#362, nodespace-cloud#87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
