### PR TITLE
Add cargo audit / bun audit CI gate (closes #1719)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,44 @@
+name: Dependency audit
+
+# Advisory scanning for known-vulnerable dependencies (Threat T9, supply chain —
+# nodespace-docs/architecture/security-posture.md). The dependency graph is fully
+# pinned (no git/path/wildcard deps; Cargo.lock + bun.lock committed), so this is
+# the missing DETECTION layer: cargo audit (RustSec DB) + bun audit on every PR.
+# A live advisory fails its job here and surfaces as a red check on the PR.
+
+on:
+  pull_request:
+  workflow_dispatch: {}
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit (RustSec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install cargo-audit (prebuilt binary)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: cargo audit
+        run: cargo audit
+
+  bun-audit:
+    name: bun audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+      - name: bun install (frozen lockfile)
+        run: bun install --frozen-lockfile
+      - name: bun audit
+        run: bun audit


### PR DESCRIPTION
## Summary

Adds the missing **detection** layer for supply-chain threat T9. The dependency graph is already fully pinned (no git/path/wildcard deps; `Cargo.lock` + `bun.lock` committed), but nothing scanned those pins against a live advisory database. This adds a `Dependency audit` workflow that runs `cargo audit` (RustSec) and `bun audit` on every PR; a live advisory fails its job and surfaces as a red check.

## Changes

- **`.github/workflows/audit.yml`** (new) — two independent jobs on `ubuntu-latest`:
  - `cargo audit (RustSec)` — installs `cargo-audit` via `taiki-e/install-action@v2`, runs `cargo audit` (reads `Cargo.lock` only, no build/toolchain-target setup needed).
  - `bun audit` — `bun install --frozen-lockfile` then `bun audit`.
- Triggers on `pull_request` (not the dangerous `pull_request_target`, so untrusted PR code runs with a read-only token) + `workflow_dispatch`.
- `permissions: contents: read` (minimal), `concurrency` with `cancel-in-progress`.

## House-style alignment

Matches the repo's existing workflows: `actions/checkout@v7` and `oven-sh/setup-bun@v2` pinned to `bun-version: "1.3.11"` (per an independent review comparing against `release.yml` / `nightly-webkit.yml`).

## Notes

- No `continue-on-error` anywhere — advisories fail hard, as intended.
- To make these **block** merge, add `cargo audit (RustSec)` and `bun audit` as required status checks in branch-protection (a repo-settings concern, outside this YAML).

## Verification

- YAML well-formed; pre-push gate (`test:all` + `cargo build` + `test:e2e`) green.
- Independent adversarial review: CONFIRMED-GOOD — commands resolve, both lockfiles present, no secrets, `pull_request` (not `_target`) is the safe trigger.

Closes #1719.
