### PR TITLE
Verify model artifact SHA-256 at download and load time (closes #1715)

### DIFF
--- a/packages/nlp-engine/Cargo.toml
+++ b/packages/nlp-engine/Cargo.toml
@@ -26,6 +26,9 @@ sysinfo = { version = "0.33", optional = true }
 # Caching layer
 lru = "0.12"
 
+# SHA-256 for load-time model-integrity verification (ADR-058)
+sha2 = "0.10"
+
 # Workspace dependencies
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/nlp-engine/src/config.rs
+++ b/packages/nlp-engine/src/config.rs
@@ -1,10 +1,63 @@
 /// Configuration for the embedding service using llama.cpp
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 
 /// Offload all model layers to GPU. This is the llama.cpp convention
 /// where any value >= total layers offloads everything.
 pub const GPU_OFFLOAD_ALL_LAYERS: u32 = 99;
+
+/// SHA-256 of the pinned embedding model `nomic-embed-text-v1.5.Q8_0.gguf`
+/// (HuggingFace `nomic-ai/nomic-embed-text-v1.5-GGUF`, commit
+/// `0188c9bf409793f810680a5a431e7b899c46104c`), lowercase hex.
+///
+/// This is the load-time half of the model-integrity gate (ADR-058); the
+/// build-time download in `scripts/download-models.ts` pins the SAME digest.
+/// Rotating the model MUST update both constants in the same change.
+pub const EMBEDDING_MODEL_SHA256: &str =
+    "3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7";
+
+/// Compute the SHA-256 of the file at `path`, streaming in 64 KB chunks so a
+/// ~146 MB GGUF does not balloon memory. Returns the lowercase-hex digest.
+pub fn compute_file_sha256(path: &Path) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Verify the on-disk model at `path` against the pinned [`EMBEDDING_MODEL_SHA256`].
+///
+/// Returns `Err` describing the mismatch (or read failure) so the caller can
+/// refuse to load a tampered or corrupt artifact. This closes the post-install
+/// tamper window: even a correctly-downloaded model that is later swapped on
+/// disk is rejected at load time.
+pub fn verify_model_integrity(path: &Path) -> Result<(), String> {
+    let actual = compute_file_sha256(path).map_err(|e| {
+        format!(
+            "failed to read model for integrity check {}: {}",
+            path.display(),
+            e
+        )
+    })?;
+    if actual != EMBEDDING_MODEL_SHA256 {
+        return Err(format!(
+            "model integrity check FAILED for {}: expected SHA-256 {}, got {}",
+            path.display(),
+            EMBEDDING_MODEL_SHA256,
+            actual
+        ));
+    }
+    Ok(())
+}
 
 /// Configuration for llama.cpp embedding model
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +102,13 @@ impl EmbeddingConfig {
     /// Uses centralized data directory pattern:
     /// - macOS/Linux: ~/.nodespace/models/nomic-embed-text-v1.5.Q8_0.gguf
     /// - Windows: %USERPROFILE%\.nodespace\models\nomic-embed-text-v1.5.Q8_0.gguf
+    ///
+    /// Resolution matches on filename only; the caller then enforces
+    /// [`verify_model_integrity`] against [`EMBEDDING_MODEL_SHA256`] before
+    /// loading. Only the pinned Q8_0 *bytes* pass that gate, so a different
+    /// quantization (e.g. the `.f16` fallback) or a custom `model_path` pointing
+    /// at some other model resolves here but is then rejected at load time —
+    /// this is deliberate, so nothing but the pinned artifact reaches llama.cpp.
     pub fn resolve_model_path(&self) -> Result<PathBuf, std::io::Error> {
         if let Some(path) = &self.model_path {
             if path.exists() {
@@ -157,5 +217,45 @@ mod tests {
         assert_eq!(sanitize_model_name("nomic/embed"), "nomic-embed");
         assert_eq!(sanitize_model_name("model:v1"), "model-v1");
         assert_eq!(sanitize_model_name("normal-name"), "normal-name");
+    }
+
+    #[test]
+    fn test_pinned_digest_is_lowercase_hex_64() {
+        assert_eq!(EMBEDDING_MODEL_SHA256.len(), 64);
+        assert!(EMBEDDING_MODEL_SHA256
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn test_compute_file_sha256_known_vector() {
+        use std::io::Write;
+        // NIST SHA-256 test vector: sha256("abc").
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"abc").unwrap();
+        let digest = compute_file_sha256(f.path()).unwrap();
+        assert_eq!(
+            digest,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_verify_model_integrity_rejects_mismatch() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"not the real model bytes").unwrap();
+        let result = verify_model_integrity(f.path());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("integrity check FAILED"));
+        assert!(msg.contains(EMBEDDING_MODEL_SHA256));
+    }
+
+    #[test]
+    fn test_verify_model_integrity_read_failure_is_error() {
+        let result = verify_model_integrity(Path::new("/nonexistent/model.gguf"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("failed to read model"));
     }
 }

--- a/packages/nlp-engine/src/embedding.rs
+++ b/packages/nlp-engine/src/embedding.rs
@@ -367,6 +367,15 @@ impl EmbeddingService {
 
             tracing::info!("Model path resolved to: {:?}", model_path);
 
+            // Load-time integrity gate (ADR-058): refuse to load a model whose
+            // bytes don't match the pinned SHA-256. This closes the post-install
+            // tamper window — a swapped GGUF is parsed by native llama.cpp with
+            // full daemon authority, so a hostile artifact must never reach it.
+            crate::config::verify_model_integrity(&model_path).map_err(|e| {
+                tracing::error!("{}", e);
+                EmbeddingError::IntegrityError(e)
+            })?;
+
             // Initialize llama.cpp backend (uses global singleton)
             // BackendGuard holds the Mutex lock for the duration of model loading
             let backend = get_or_init_backend().map_err(EmbeddingError::ModelLoadError)?;

--- a/packages/nlp-engine/src/error.rs
+++ b/packages/nlp-engine/src/error.rs
@@ -27,6 +27,9 @@ pub enum EmbeddingError {
     #[error("Model file not found at path: {0}")]
     ModelNotFound(String),
 
+    #[error("Model integrity verification failed: {0}")]
+    IntegrityError(String),
+
     #[error("Device initialization failed: {0}")]
     DeviceError(String),
 }

--- a/scripts/download-models.ts
+++ b/scripts/download-models.ts
@@ -8,12 +8,36 @@
  */
 
 import { $ } from "bun";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
 const MODEL_FILE = "nomic-embed-text-v1.5.Q8_0.gguf";
-const MODEL_URL = `https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/${MODEL_FILE}`;
+
+// Model artifact integrity (ADR-058, Threat T9 supply chain). This build-time
+// download bakes the model into the signed, notarized bundle, so a substituted
+// artifact would ship as authentic. The pinned SHA-256 below is the
+// authoritative integrity gate; the pinned HuggingFace commit stops `main` from
+// moving under us. Rotating the model MUST update BOTH the commit and the digest
+// here AND the matching `EMBEDDING_MODEL_SHA256` in
+// `packages/nlp-engine/src/config.rs`.
+const MODEL_HF_COMMIT = "0188c9bf409793f810680a5a431e7b899c46104c";
+const MODEL_SHA256 =
+  "3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7";
+const MODEL_URL = `https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/${MODEL_HF_COMMIT}/${MODEL_FILE}`;
+
+/**
+ * Compute the SHA-256 of a file, streaming it through the hasher so a ~146 MB
+ * GGUF doesn't get buffered whole in memory. Returns the lowercase-hex digest.
+ */
+async function sha256File(path: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha256");
+  const stream = Bun.file(path).stream();
+  for await (const chunk of stream) {
+    hasher.update(chunk);
+  }
+  return hasher.digest("hex");
+}
 
 // Determine target directory based on --bundle flag
 const isBundleMode = process.argv.includes("--bundle");
@@ -30,14 +54,35 @@ async function downloadModels() {
   mkdirSync(MODELS_DIR, { recursive: true });
 
   if (existsSync(MODEL_PATH)) {
-    console.log("✅ Model already downloaded");
-    return;
+    console.log("🔍 Verifying existing model...");
+    const existing = await sha256File(MODEL_PATH);
+    if (existing === MODEL_SHA256) {
+      console.log("✅ Model already downloaded and verified");
+      return;
+    }
+    console.warn(
+      `⚠️  Existing model failed integrity check (expected ${MODEL_SHA256}, got ${existing}); re-downloading.`,
+    );
+    rmSync(MODEL_PATH, { force: true });
   }
 
   console.log(`⬇️  Downloading ${MODEL_FILE}...`);
-  await $`curl -L --progress-bar -o ${MODEL_PATH} ${MODEL_URL}`;
+  // HTTPS with normal cert validation and hard failure on HTTP errors. The
+  // pinned digest verified below is the authoritative gate regardless of where
+  // any redirect ultimately points.
+  await $`curl -fL --proto =https --progress-bar -o ${MODEL_PATH} ${MODEL_URL}`;
 
-  console.log(`✅ Model downloaded to ${MODEL_PATH}`);
+  console.log("🔍 Verifying SHA-256...");
+  const digest = await sha256File(MODEL_PATH);
+  if (digest !== MODEL_SHA256) {
+    rmSync(MODEL_PATH, { force: true });
+    throw new Error(
+      `❌ Model integrity check FAILED: expected SHA-256 ${MODEL_SHA256}, got ${digest}. ` +
+        `Deleted the downloaded file — refusing to bundle an unverified model.`,
+    );
+  }
+
+  console.log(`✅ Model downloaded and verified: ${MODEL_PATH}`);
 
   const size = await $`du -sh ${MODEL_PATH}`.text();
   console.log(`📊 Model size: ${size.trim()}`);


### PR DESCRIPTION
## Summary

Closes the last unmet leg of the T9 supply-chain bar (ADR-058): the **build-time** model download did `curl -L` with **no SHA-256 verification**, so a substituted `nomic-embed-text-v1.5.Q8_0.gguf` (compromised upstream, redirect hijack, MITM on a CI runner, malicious mirror) would be code-signed and notarized as authentic, then parsed by native llama.cpp inside the daemon with full authority. This adds digest verification at **both** the download and the load site.

The runtime chat-model download (`model_manager.rs`) was already hardened (#1543); this is the separate build/bundle path it never touched, plus the companion load-time check.

## Changes

**Build-time — `scripts/download-models.ts`**
- Pin the HuggingFace commit in the URL (`resolve/0188c9bf…/`) so `main` can't move under us, and pin `MODEL_SHA256`.
- `curl -fL --proto =https` (fail-hard on HTTP errors, HTTPS-only). The digest is the authoritative gate regardless of redirect target.
- Streaming `sha256File()` (Bun.CryptoHasher) verifies the artifact **after** download; on mismatch it **deletes the file and throws** — never bundles an unverified model.
- Also verifies an already-present file; a stale/mismatched one is re-downloaded rather than trusted.

**Load-time — `packages/nlp-engine/`**
- `config.rs`: pinned `EMBEDDING_MODEL_SHA256` (single source of truth, kept in lockstep with the script), a streaming `compute_file_sha256()` (64 KB chunks — a 146 MB GGUF never buffers whole), and `verify_model_integrity()`.
- `embedding.rs`: right after the model path resolves and **before** `LlamaModel::load_from_file`, verify the on-disk bytes; refuse to load on mismatch. This closes the post-install tamper window — a model swapped on disk after install is rejected.
- `error.rs`: new `EmbeddingError::IntegrityError` so the failure is legible (not folded into a generic load error).
- `Cargo.toml`: `sha2 = "0.10"`.

**Digest rotation** is a single-change contract: rotating the model updates the commit + digest in the script AND the `EMBEDDING_MODEL_SHA256` const together (called out in both comments).

## Acceptance criteria

- [x] Pin an expected SHA-256 next to `MODEL_URL` + a matching constant at the Rust load site
- [x] After download, compute the digest and fail hard + delete the file on mismatch
- [x] Verify the on-disk model against the pinned digest at load time; refuse to load on mismatch
- [x] Download over HTTPS with normal cert validation (digest remains authoritative)
- [x] Rotating the model updates the pinned digest in the same change

## Verification

- Authoritative HF LFS digest for the pinned commit == the pinned constant (`3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7`); the shipped local model matches it.
- Ran the script live: verifies the real 146 MB model in ~0.2 s → "already downloaded and verified".
- New Rust unit tests (all green): NIST `sha256("abc")` vector, mismatch rejection, unreadable-file error, digest-format invariant.
- `cargo clippy -p nodespace-nlp-engine` clean; `cargo test --lib` green. No fake-model test exists, and integration tests skip when the model is absent / use the real default config, so the load gate introduces no test breakage.

Closes #1715.
