### PR TITLE
Protect ai-chat nodes from Backspace deletion/merge (closes #1697)

### DIFF
--- a/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
+++ b/packages/desktop-app/src/lib/design/components/base-node-viewer.svelte
@@ -453,7 +453,6 @@
       if (allNodes.length === 0) {
         // No persisted children - create initial placeholder if needed
         // Note: We already checked cache/DB above, so if allNodes is empty, no persisted children exist
-
         // No children at all - placeholder will be created automatically by viewerPlaceholder derived
         // Removed manual ID creation - getOrCreatePlaceholderId() handles it lazily
         // Focus is handled by BaseNode's onMount when autoFocus=true
@@ -819,6 +818,14 @@
         return;
       }
 
+      // Protect node types whose data lives outside `.content` (e.g. ai-chat,
+      // whose conversation is in properties.messages) from being merged away by
+      // a start-of-node Backspace. Guards the current/event node's own type.
+      const eventNode = nodeManager.nodes.get(eventNodeId);
+      if (eventNode && !pluginRegistry.deletableViaBackspace(eventNode.nodeType)) {
+        return;
+      }
+
       const currentVisibleNodes = visibleNodesFromStores;
       const currentIndex = currentVisibleNodes.findIndex((n) => n.id === eventNodeId);
 
@@ -867,6 +874,14 @@
       // Validate node exists before deletion
       if (!nodeManager.nodes.has(eventNodeId)) {
         log.error('Cannot delete non-existent node:', eventNodeId);
+        return;
+      }
+
+      // Protect node types whose data lives outside `.content` (e.g. ai-chat,
+      // whose conversation is in properties.messages) from being deleted away by
+      // a start-of-node Backspace. Guards the current/event node's own type.
+      const eventNode = nodeManager.nodes.get(eventNodeId);
+      if (eventNode && !pluginRegistry.deletableViaBackspace(eventNode.nodeType)) {
         return;
       }
 
@@ -1303,8 +1318,9 @@
         id="viewer-header-{paneId}-{nodeId ?? 'default'}"
         class="header-input"
         class:header-input--readonly={schemaFormLoader.hasTitleTemplate}
-        value={isHeaderBeingEdited ? (currentViewedNode?.content || '') : headerDisplayValue}
-        oninput={(e) => !schemaFormLoader.hasTitleTemplate && handleHeaderInput(e.currentTarget.value)}
+        value={isHeaderBeingEdited ? currentViewedNode?.content || '' : headerDisplayValue}
+        oninput={(e) =>
+          !schemaFormLoader.hasTitleTemplate && handleHeaderInput(e.currentTarget.value)}
         onfocus={() => {
           if (!schemaFormLoader.hasTitleTemplate) isHeaderBeingEdited = true;
         }}

--- a/packages/desktop-app/src/lib/plugins/core-plugins.ts
+++ b/packages/desktop-app/src/lib/plugins/core-plugins.ts
@@ -61,7 +61,7 @@ export const headerNodePlugin: PluginDefinition = {
   pattern: {
     detect: /^(#{1,6})\s/,
     canRevert: true,
-    revert: /^#{1,6}$/,  // "# " → "#" should revert to text
+    revert: /^#{1,6}$/, // "# " → "#" should revert to text
     onEnter: 'inherit',
     prefixToInherit: (content: string) => content.match(/^(#{1,6})\s/)?.[0],
     splittingStrategy: 'prefix-inheritance',
@@ -146,7 +146,12 @@ export const taskNodePlugin: PluginDefinition = {
   // Type-specific metadata extraction
   // Backend returns TaskNode with status at TOP LEVEL (flat type-specific fields)
   // Also supports generic Node where status is in properties (for SSE events)
-  extractMetadata: (node: { nodeType: string; status?: string; priority?: string | number; properties?: Record<string, unknown> }) => {
+  extractMetadata: (node: {
+    nodeType: string;
+    status?: string;
+    priority?: string | number;
+    properties?: Record<string, unknown>;
+  }) => {
     const properties = node.properties || {};
     // Check top-level status first (TaskNode format), fall back to properties.status
     // TaskNode has status at node.status, generic Node has it at node.properties.status
@@ -190,13 +195,17 @@ export const taskNodePlugin: PluginDefinition = {
       // Convert changes to TaskNodeUpdate format
       // The caller provides type-safe changes, we map to the backend format
       const update: TaskNodeUpdate = {};
-      if ('status' in changes && changes.status !== undefined) update.status = changes.status as TaskNodeUpdate['status'];
+      if ('status' in changes && changes.status !== undefined)
+        update.status = changes.status as TaskNodeUpdate['status'];
       if ('priority' in changes) update.priority = changes.priority as TaskNodeUpdate['priority'];
       if ('dueDate' in changes) update.dueDate = changes.dueDate as TaskNodeUpdate['dueDate'];
       if ('assignee' in changes) update.assignee = changes.assignee as TaskNodeUpdate['assignee'];
-      if ('startedAt' in changes) update.startedAt = changes.startedAt as TaskNodeUpdate['startedAt'];
-      if ('completedAt' in changes) update.completedAt = changes.completedAt as TaskNodeUpdate['completedAt'];
-      if ('content' in changes && changes.content !== undefined) update.content = changes.content as string;
+      if ('startedAt' in changes)
+        update.startedAt = changes.startedAt as TaskNodeUpdate['startedAt'];
+      if ('completedAt' in changes)
+        update.completedAt = changes.completedAt as TaskNodeUpdate['completedAt'];
+      if ('content' in changes && changes.content !== undefined)
+        update.content = changes.content as string;
 
       // Returns TaskNode which has node fields but not properties (flat structure)
       // Cast to Node for interface compatibility - sharedNodeStore will handle appropriately
@@ -292,14 +301,14 @@ export const codeBlockNodePlugin: PluginDefinition = {
   version: '1.0.0',
   // Plugin-owned pattern behavior
   pattern: {
-    detect: /^```\n/,  // Matches ``` followed immediately by newline (language set via dropdown only)
+    detect: /^```\n/, // Matches ``` followed immediately by newline (language set via dropdown only)
     canRevert: true,
-    revert: /^```$/,  // "```" alone should revert to text
-    onEnter: 'none',  // Code blocks don't inherit on Enter
+    revert: /^```$/, // "```" alone should revert to text
+    onEnter: 'none', // Code blocks don't inherit on Enter
     splittingStrategy: 'simple-split',
     cursorPlacement: 'start',
     extractMetadata: () => ({
-      language: 'plaintext'  // Default language; user selects via dropdown
+      language: 'plaintext' // Default language; user selects via dropdown
     })
   },
   config: {
@@ -338,7 +347,7 @@ export const quoteBlockNodePlugin: PluginDefinition = {
   pattern: {
     detect: /^>\s/,
     canRevert: true,
-    revert: /^>$/,  // "> " → ">" should revert to text
+    revert: /^>$/, // "> " → ">" should revert to text
     onEnter: 'inherit',
     prefixToInherit: '> ',
     splittingStrategy: 'prefix-inheritance',
@@ -381,7 +390,7 @@ export const orderedListNodePlugin: PluginDefinition = {
   pattern: {
     detect: /^1\.\s/,
     canRevert: true,
-    revert: /^1\.$/,  // "1. " → "1." should revert to text
+    revert: /^1\.$/, // "1. " → "1." should revert to text
     onEnter: 'inherit',
     prefixToInherit: '1. ',
     splittingStrategy: 'prefix-inheritance',
@@ -614,6 +623,13 @@ export const aiChatNodePlugin: PluginDefinition = {
   name: 'AI Chat',
   description: 'AI conversation node',
   version: '1.0.0',
+  // The conversation lives in properties.messages, not .content — a start-of-node
+  // Backspace must never silently delete or merge it away (enforced in
+  // handleDeleteNode / handleCombineWithPrevious in base-node-viewer.svelte).
+  deletableViaBackspace: false,
+  // ai-chat's .content is not a normal editable text field, so (like code-block /
+  // quote-block) it must not absorb a Backspace-merge from the node below it.
+  acceptsContentMerge: false,
   config: {
     slashCommands: [
       {
@@ -713,9 +729,10 @@ export function registerCorePlugins(registry: import('./plugin-registry').Plugin
         priority: 10, // Default priority
         splittingStrategy: plugin.pattern.splittingStrategy,
         // For headers with function-based prefix, PatternRegistry will extract from regex
-        prefixToInherit: typeof plugin.pattern.prefixToInherit === 'string'
-          ? plugin.pattern.prefixToInherit
-          : undefined,
+        prefixToInherit:
+          typeof plugin.pattern.prefixToInherit === 'string'
+            ? plugin.pattern.prefixToInherit
+            : undefined,
         cursorPlacement: plugin.pattern.cursorPlacement,
         cleanContent: false, // Not used anymore
         extractMetadata: plugin.pattern.extractMetadata

--- a/packages/desktop-app/src/lib/plugins/plugin-registry.ts
+++ b/packages/desktop-app/src/lib/plugins/plugin-registry.ts
@@ -345,9 +345,7 @@ export class PluginRegistry {
       // New: derive PatternDetectionConfig from plugin.pattern
       if (plugin.pattern) {
         // Get slash command for additional config (desiredCursorPosition)
-        const slashCommand = plugin.config.slashCommands.find(
-          cmd => cmd.nodeType === pluginId
-        );
+        const slashCommand = plugin.config.slashCommands.find((cmd) => cmd.nodeType === pluginId);
 
         const derivedConfig: PatternDetectionConfig = {
           pattern: plugin.pattern.detect,
@@ -358,9 +356,10 @@ export class PluginRegistry {
           desiredCursorPosition: slashCommand?.desiredCursorPosition,
           // Only include contentTemplate if desiredCursorPosition is set
           // This indicates auto-completion behavior (e.g., code-block's closing fence)
-          contentTemplate: slashCommand?.desiredCursorPosition !== undefined
-            ? slashCommand.contentTemplate
-            : undefined
+          contentTemplate:
+            slashCommand?.desiredCursorPosition !== undefined
+              ? slashCommand.contentTemplate
+              : undefined
         };
         patterns.push(derivedConfig);
       }
@@ -386,11 +385,11 @@ export class PluginRegistry {
     // Get all plugins with patterns, sorted by explicit priority (higher = checked first)
     // Uses the same priority system as getAllPatternDetectionConfigs for consistency
     const pluginsWithPatterns = Array.from(this.plugins.values())
-      .filter(p => this.enabledPlugins.has(p.id) && p.pattern)
+      .filter((p) => this.enabledPlugins.has(p.id) && p.pattern)
       .sort((a, b) => {
         // Use explicit priority from slash command config, fallback to default
-        const aSlashCmd = a.config.slashCommands.find(cmd => cmd.nodeType === a.id);
-        const bSlashCmd = b.config.slashCommands.find(cmd => cmd.nodeType === b.id);
+        const aSlashCmd = a.config.slashCommands.find((cmd) => cmd.nodeType === a.id);
+        const bSlashCmd = b.config.slashCommands.find((cmd) => cmd.nodeType === b.id);
         const aPriority = aSlashCmd?.priority ?? DEFAULT_PATTERN_PRIORITY;
         const bPriority = bSlashCmd?.priority ?? DEFAULT_PATTERN_PRIORITY;
         return bPriority - aPriority;
@@ -407,9 +406,7 @@ export class PluginRegistry {
         // Get slash command for additional config (desiredCursorPosition)
         // NOTE: contentTemplate is NOT used for pattern detection when canRevert is true
         // because we want to preserve the user's typed content for bidirectional conversion
-        const slashCommand = plugin.config.slashCommands.find(
-          cmd => cmd.nodeType === plugin.id
-        );
+        const slashCommand = plugin.config.slashCommands.find((cmd) => cmd.nodeType === plugin.id);
 
         // Create backward-compatible PatternDetectionConfig
         // NOTE: contentTemplate should NEVER be used for pattern detection.
@@ -511,6 +508,24 @@ export class PluginRegistry {
       return true; // Default to true for unknown or disabled plugins
     }
     return plugin.acceptsContentMerge ?? true; // Default to true if not specified
+  }
+
+  /**
+   * Check if a node type may be deleted or merged away by a start-of-node Backspace
+   * Returns true by default if plugin not found or deletableViaBackspace not specified
+   *
+   * Protects node types whose data lives outside `.content` (e.g. ai-chat) from
+   * silent whole-node loss when Backspace is pressed at the start of the node.
+   *
+   * @param nodeType - Node type to check
+   * @returns true if the node type may be deleted via Backspace, false otherwise
+   */
+  deletableViaBackspace(nodeType: string): boolean {
+    const plugin = this.plugins.get(nodeType);
+    if (!plugin || !this.enabledPlugins.has(nodeType)) {
+      return true; // Default to true for unknown or disabled plugins
+    }
+    return plugin.deletableViaBackspace ?? true; // Default to true if not specified
   }
 
   /**

--- a/packages/desktop-app/src/lib/plugins/types.ts
+++ b/packages/desktop-app/src/lib/plugins/types.ts
@@ -288,6 +288,18 @@ export interface PluginDefinition {
   acceptsContentMerge?: boolean;
 
   /**
+   * Whether this node type may be deleted or merged away by a Backspace at the
+   * start of the node (the node acting as the *current* node, not the target).
+   * Protects node types whose data lives outside `.content` — e.g. ai-chat,
+   * whose conversation is stored in `properties.messages` — from silent
+   * whole-node loss.
+   *
+   * Default: true (most nodes can be deleted via Backspace)
+   * Set to false for nodes that must not be destroyed by a start-of-node Backspace
+   */
+  deletableViaBackspace?: boolean;
+
+  /**
    * Compute this node's tab title. Only needed when the title isn't derivable from the
    * node's own stored fields (node.title / node.content) — e.g. date nodes, whose display
    * title ("Today", "Tomorrow", a date string) is computed from parsing the node's id, not

--- a/packages/desktop-app/src/tests/plugins/core-plugins.test.ts
+++ b/packages/desktop-app/src/tests/plugins/core-plugins.test.ts
@@ -95,6 +95,11 @@ describe('Core Plugins Integration', () => {
       expect(aiChatNodePlugin.config.slashCommands).toHaveLength(1);
       expect(aiChatNodePlugin.config.canHaveChildren).toBe(false);
       expect(aiChatNodePlugin.config.canBeChild).toBe(true);
+      // Conversation lives in properties.messages, not .content — must be
+      // protected from a start-of-node Backspace deleting the whole node, and
+      // from absorbing a Backspace-merge from the node below.
+      expect(aiChatNodePlugin.deletableViaBackspace).toBe(false);
+      expect(aiChatNodePlugin.acceptsContentMerge).toBe(false);
       expect(aiChatNodePlugin.viewer).toBeDefined();
       expect(aiChatNodePlugin.viewer?.lazyLoad).toBeDefined();
       expect(aiChatNodePlugin.reference).toBeDefined();
@@ -551,7 +556,15 @@ describe('Core Plugins Integration', () => {
 
       // Verify currently implemented reference types have references
       // Note: 'user' and 'document' are not yet implemented - will be added when reference system is built
-      const expectedReferenceTypes = ['text', 'task', 'date', 'header', 'code-block', 'quote-block', 'ordered-list'];
+      const expectedReferenceTypes = [
+        'text',
+        'task',
+        'date',
+        'header',
+        'code-block',
+        'quote-block',
+        'ordered-list'
+      ];
 
       for (const referenceType of expectedReferenceTypes) {
         expect(registry.hasReferenceComponent(referenceType)).toBe(true);
@@ -579,7 +592,7 @@ describe('Core Plugins Integration', () => {
       'horizontal-line': false,
       table: false,
       query: false,
-      'ai-chat': false,
+      'ai-chat': false
     };
 
     it('every registered core plugin canHaveChildren matches Rust can_have_children()', () => {
@@ -587,7 +600,10 @@ describe('Core Plugins Integration', () => {
 
       for (const [nodeType, rustValue] of Object.entries(RUST_CAN_HAVE_CHILDREN)) {
         const frontendValue = registry.canHaveChildren(nodeType);
-        expect(frontendValue, `canHaveChildren parity failed for '${nodeType}': frontend=${frontendValue} rust=${rustValue}`).toBe(rustValue);
+        expect(
+          frontendValue,
+          `canHaveChildren parity failed for '${nodeType}': frontend=${frontendValue} rust=${rustValue}`
+        ).toBe(rustValue);
       }
     });
   });

--- a/packages/desktop-app/src/tests/plugins/plugin-registry.test.ts
+++ b/packages/desktop-app/src/tests/plugins/plugin-registry.test.ts
@@ -1006,7 +1006,10 @@ describe('PluginRegistry - Core Functionality', () => {
         version: '1.0.0',
         config: { slashCommands: [] },
         node: {
-          lazyLoad: () => Promise.resolve({ default: MockViewerComponent as unknown as import('$lib/plugins/types').NodeComponent }),
+          lazyLoad: () =>
+            Promise.resolve({
+              default: MockViewerComponent as unknown as import('$lib/plugins/types').NodeComponent
+            }),
           priority: 1
         }
       };
@@ -1080,7 +1083,11 @@ describe('PluginRegistry - Core Functionality', () => {
     });
 
     it('should cache loaded node components', async () => {
-      const lazyLoad = vi.fn().mockResolvedValue({ default: MockViewerComponent as unknown as import('$lib/plugins/types').NodeComponent });
+      const lazyLoad = vi
+        .fn()
+        .mockResolvedValue({
+          default: MockViewerComponent as unknown as import('$lib/plugins/types').NodeComponent
+        });
       const plugin: PluginDefinition = {
         id: 'cached-node',
         name: 'Cached Node',
@@ -1555,7 +1562,10 @@ describe('PluginRegistry - Core Functionality', () => {
       registry.register(plugin);
 
       // createTestNode() doesn't copy `title` from options, so set it directly.
-      const node = { ...createTestNode({ nodeType: 'task', content: 'raw content' }), title: 'Interpolated Title' };
+      const node = {
+        ...createTestNode({ nodeType: 'task', content: 'raw content' }),
+        title: 'Interpolated Title'
+      };
       const title = registry.getNodeTitle(node);
 
       expect(title).toBe('Interpolated Title');
@@ -1677,6 +1687,80 @@ describe('PluginRegistry - Core Functionality', () => {
       registry.setEnabled('disabled-merge', false);
 
       expect(registry.acceptsContentMerge('disabled-merge')).toBe(true);
+    });
+  });
+
+  describe('Backspace Deletion Protection', () => {
+    it('should return false for plugins with deletableViaBackspace: false', () => {
+      const plugin: PluginDefinition = {
+        id: 'ai-chat',
+        name: 'AI Chat',
+        description: 'AI conversation node',
+        version: '1.0.0',
+        config: {
+          slashCommands: []
+        },
+        deletableViaBackspace: false
+      };
+
+      registry.register(plugin);
+
+      expect(registry.deletableViaBackspace('ai-chat')).toBe(false);
+    });
+
+    it('should return true for plugins with deletableViaBackspace: true', () => {
+      const plugin: PluginDefinition = {
+        id: 'text',
+        name: 'Text Node',
+        description: 'Text node',
+        version: '1.0.0',
+        config: {
+          slashCommands: []
+        },
+        deletableViaBackspace: true
+      };
+
+      registry.register(plugin);
+
+      expect(registry.deletableViaBackspace('text')).toBe(true);
+    });
+
+    it('should return true by default when deletableViaBackspace is not specified', () => {
+      const plugin: PluginDefinition = {
+        id: 'default-deletable',
+        name: 'Default Deletable',
+        description: 'Node without deletableViaBackspace specified',
+        version: '1.0.0',
+        config: {
+          slashCommands: []
+        }
+      };
+
+      registry.register(plugin);
+
+      expect(registry.deletableViaBackspace('default-deletable')).toBe(true);
+    });
+
+    it('should return true for unknown/unregistered plugins', () => {
+      expect(registry.deletableViaBackspace('unknown-plugin')).toBe(true);
+    });
+
+    it('should return true for disabled plugins', () => {
+      const plugin: PluginDefinition = {
+        id: 'disabled-deletable',
+        name: 'Disabled Deletable',
+        description: 'A disabled plugin',
+        version: '1.0.0',
+        config: {
+          slashCommands: []
+        },
+        deletableViaBackspace: false
+      };
+
+      registry.register(plugin);
+      registry.setEnabled('disabled-deletable', false);
+
+      expect(registry.deletableViaBackspace('disabled-deletable')).toBe(true);
     });
   });
 
@@ -1903,7 +1987,7 @@ describe('PluginRegistry - Core Functionality', () => {
 
       // Matches both "Create Task" (name contains 't') and cmd1 (shortcut 't')
       expect(filtered.length).toBeGreaterThanOrEqual(1);
-      expect(filtered.some(cmd => cmd.shortcut === 't')).toBe(true);
+      expect(filtered.some((cmd) => cmd.shortcut === 't')).toBe(true);
     });
 
     it('should handle whitespace-only query', () => {


### PR DESCRIPTION
## Summary

Fixes a data-loss bug: pressing Backspace at the start of an ai-chat node deleted or merged it away exactly like a plain text node, silently discarding the entire conversation. An ai-chat's messages live in `properties.messages` (ADR-028), separate from `.content`, so `combineNodes()` — which only concatenates `.content` strings and deletes the current node — destroyed the whole conversation with no protection or confirmation.

The existing `acceptsContentMerge` flag only guards the **previous** (target) node from *receiving* a merge; nothing guarded a node from being deleted/merged away as the **current** node.

## Change

Adds a new plugin flag `deletableViaBackspace`, mirroring `acceptsContentMerge` exactly:

- **`types.ts`** — optional `deletableViaBackspace?: boolean` on `PluginDefinition`, default `true` (existing types unaffected).
- **`plugin-registry.ts`** — `deletableViaBackspace(nodeType)` returning `true` for unknown/disabled/unspecified, `false` only when a registered+enabled plugin opts out.
- **`core-plugins.ts`** — `deletableViaBackspace: false` on the ai-chat plugin. Also sets `acceptsContentMerge: false` (like code-block/quote-block) so a node *below* an ai-chat can't Backspace-merge its text into ai-chat's `.content` and consume itself — the symmetric guard surfaced in review.
- **`base-node-viewer.svelte`** — both `handleCombineWithPrevious` and `handleDeleteNode` now check the flag against the **current/event** node's own type (`nodeManager.nodes.get(eventNodeId).nodeType`) right after the existence check, and no-op when it's `false`. (Previously the only type check was against the *previous* node.)

## Acceptance criteria

- [x] Backspace at the start of an empty ai-chat node does not delete it
- [x] Backspace at the start of a non-empty ai-chat node does not merge/delete it
- [x] Other node types' Backspace behavior unchanged (default-true; full suite green)
- [x] Flag documented consistently with `acceptsContentMerge` (JSDoc in-code + nodespace-docs PR #70)
- [x] `bun run test` passes
- [x] Passes lint/format

## Verification

- New unit tests mirror the existing `acceptsContentMerge` registry block: `plugin-registry.test.ts` (+5 — false/true/default/unknown/disabled) and `core-plugins.test.ts` (+1 asserting the real ai-chat plugin sets the flag). All green.
- Full frontend suite: **167 files, 4115 tests passing**; `svelte-check`: **0 errors / 1769 files**.
- Docs: `nodespace-docs` PR #70 adds the flag to `creating-node-types.md` alongside `acceptsContentMerge`.
- Independent adversarial review: CONFIRMED-GOOD. Verified the two guarded handlers are the *only* Backspace-at-start delete/merge paths (`MergeNodesCommand` → `deleteNode`/`combineWithPrevious`, no Cmd+Backspace or select-all bypass); `nodeType` is the correct field on the `Map<string, Node>`; default-true preserves all other types; and ai-chat reaches these handlers via node-row's fallback `BaseNode` branch (it has a viewer but no inline node component). The companion `acceptsContentMerge: false` was added per the review's secondary finding.

Closes #1697.
