### PR TITLE
Flatten typed properties in optimistic updateNode merge (closes #1695)

### DIFF
--- a/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
+++ b/packages/desktop-app/src/lib/components/property-forms/schema-property-form.svelte
@@ -26,7 +26,12 @@
   import { Input } from '$lib/components/ui/input';
   import { backendAdapter } from '$lib/services/backend-adapter';
   import { sharedNodeStore } from '$lib/services/shared-node-store.svelte';
-  import { type SchemaNode, type SchemaField, type EnumValue, isSchemaNode } from '$lib/types/schema-node';
+  import {
+    type SchemaNode,
+    type SchemaField,
+    type EnumValue,
+    isSchemaNode
+  } from '$lib/types/schema-node';
   import type { Node } from '$lib/types';
   import { parseDate, type DateValue } from '@internationalized/date';
   import { createLogger } from '$lib/utils/logger';
@@ -123,7 +128,10 @@
 
     // For strongly-typed nodes (TaskNode, etc.), check top-level fields first
     // Type-specific fields like status, priority, dueDate are at the top level
-    if (fieldName in node && (node as unknown as Record<string, unknown>)[fieldName] !== undefined) {
+    if (
+      fieldName in node &&
+      (node as unknown as Record<string, unknown>)[fieldName] !== undefined
+    ) {
       return (node as unknown as Record<string, unknown>)[fieldName];
     }
 
@@ -184,7 +192,7 @@
       // Look up label from enum values
       if (statusField && status) {
         const enumValues = getEnumValues(statusField);
-        const enumValue = enumValues.find(ev => ev.value === status);
+        const enumValue = enumValues.find((ev) => ev.value === status);
         statusLabel = enumValue?.label || formatEnumLabel(status);
       }
     }
@@ -249,10 +257,13 @@
       ? { title: evaluateTitleTemplate(schema.titleTemplate, migratedNamespace) || null }
       : {};
 
+    // updatedProperties is the full intended bag (the old-format branch above
+    // deliberately drops flat keys), so replace rather than deep-merge.
     sharedNodeStore.updateNode(
       nodeId,
       { properties: updatedProperties, ...titleUpdate },
-      { type: 'viewer', viewerId: 'schema-property-form' }
+      { type: 'viewer', viewerId: 'schema-property-form' },
+      { replaceProperties: true }
     );
   }
 
@@ -392,7 +403,9 @@
                 <!-- Enum Field → shadcn Select Component (Fixed with bind:value) -->
                 {@const enumValues = getEnumValues(field)}
                 {@const currentEnumValue = getEnumValue(field)}
-                {@const currentLabel = enumValues.find(ev => ev.value === currentEnumValue)?.label || formatEnumLabel(currentEnumValue)}
+                {@const currentLabel =
+                  enumValues.find((ev) => ev.value === currentEnumValue)?.label ||
+                  formatEnumLabel(currentEnumValue)}
                 <Select.Root
                   type="single"
                   value={currentEnumValue}

--- a/packages/desktop-app/src/lib/design/components/schema-field-update.ts
+++ b/packages/desktop-app/src/lib/design/components/schema-field-update.ts
@@ -93,10 +93,14 @@ export function updateSchemaField(
         [targetNode.nodeType]: updatedNamespace
       };
 
-  // Persist via sharedNodeStore
+  // Persist via sharedNodeStore. This builds the full intended properties bag
+  // itself (and the old-format branch deliberately drops flat keys), so replace
+  // rather than deep-merge — otherwise the dropped flat keys would reappear on
+  // the local optimistic node.
   sharedNodeStore.updateNode(
     targetNodeId,
     { properties: updatedProperties },
-    { type: 'viewer', viewerId }
+    { type: 'viewer', viewerId },
+    { replaceProperties: true }
   );
 }

--- a/packages/desktop-app/src/lib/services/node-normalize.ts
+++ b/packages/desktop-app/src/lib/services/node-normalize.ts
@@ -18,3 +18,86 @@ export function normalizeNodeData(nodeData: Node): Node {
   }
   return nodeData;
 }
+
+/**
+ * Optimistic-only mirror of the backend's typed-field promotion
+ * (`node_to_typed_value` / `flatten_properties_for_api` in
+ * `packages/nodespace-types/src/convert.rs`). For each node type, lists the
+ * type-specific fields the backend lifts from the stored `properties` bag up to
+ * the TOP LEVEL of the node (the fields viewers actually read).
+ *
+ * Used ONLY so an optimistic (pre-round-trip) `updateNode` reflects these fields
+ * immediately instead of waiting a full RPC round trip. The backend response is
+ * always spread over the node afterward, so any drift between this map and
+ * convert.rs degrades optimistic latency only — never correctness. Keep in sync
+ * with convert.rs when the promoted field set changes.
+ */
+export const OPTIMISTIC_TYPED_FIELDS: Record<string, readonly string[]> = {
+  'ai-chat': ['status', 'provider', 'model', 'messages'],
+  task: ['status', 'priority', 'dueDate', 'assignee', 'startedAt', 'completedAt']
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merge an incoming `properties` patch onto the existing `properties` bag so a
+ * partial write doesn't drop sibling keys. Merges one level, plus one level
+ * deeper into the type namespace (e.g. `properties.task.*`) so a nested patch
+ * like `{ task: { status } }` doesn't clobber `properties.task.priority`.
+ */
+export function deepMergeProperties(
+  existing: Record<string, unknown> | undefined,
+  incoming: Record<string, unknown>,
+  nodeType: string
+): Record<string, unknown> {
+  const base = existing ?? {};
+  const merged: Record<string, unknown> = { ...base, ...incoming };
+
+  const baseNs = base[nodeType];
+  const incomingNs = incoming[nodeType];
+  if (isPlainObject(baseNs) && isPlainObject(incomingNs)) {
+    merged[nodeType] = { ...baseNs, ...incomingNs };
+  }
+
+  return merged;
+}
+
+/**
+ * Compute the top-level typed fields to promote for an optimistic update.
+ *
+ * Only promotes a field that is actually present in this write — either flat
+ * under `properties` (ai-chat stores `properties.model`) or nested under the
+ * type namespace (`properties.task.status`). The "present in this write" guard
+ * is load-bearing: it prevents overwriting an existing top-level value with
+ * `undefined` when a caller omits a field (e.g. sending a message writes
+ * `properties.messages` but not `properties.model`).
+ */
+export function promoteTypedFields(
+  nodeType: string,
+  changesProperties: Record<string, unknown>,
+  mergedProperties: Record<string, unknown>
+): Record<string, unknown> {
+  const fields = OPTIMISTIC_TYPED_FIELDS[nodeType];
+  if (!fields) return {};
+
+  const nestedChanges = changesProperties[nodeType];
+  const nestedMerged = mergedProperties[nodeType];
+  const promoted: Record<string, unknown> = {};
+
+  for (const field of fields) {
+    if (Object.prototype.hasOwnProperty.call(changesProperties, field)) {
+      // Flat shape (e.g. ai-chat: properties.model)
+      promoted[field] = mergedProperties[field];
+    } else if (
+      isPlainObject(nestedChanges) &&
+      Object.prototype.hasOwnProperty.call(nestedChanges, field)
+    ) {
+      // Nested shape (e.g. task schema form: properties.task.status)
+      promoted[field] = isPlainObject(nestedMerged) ? nestedMerged[field] : undefined;
+    }
+  }
+
+  return promoted;
+}

--- a/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
+++ b/packages/desktop-app/src/lib/services/reactive-node-service.svelte.ts
@@ -270,7 +270,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     if (newParentId) {
       // Calculate order: insert right after afterNodeId in the sibling list
       const childrenWithOrder = structureTree.getChildrenWithOrder(newParentId);
-      const afterNodeIndex = childrenWithOrder.findIndex(c => c.nodeId === afterNodeId);
+      const afterNodeIndex = childrenWithOrder.findIndex((c) => c.nodeId === afterNodeId);
 
       let order: number;
       if (insertAtBeginning) {
@@ -303,9 +303,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
         }
       } else {
         // afterNodeId not found in children, append at end
-        order = childrenWithOrder.length > 0
-          ? childrenWithOrder[childrenWithOrder.length - 1].order + 1.0
-          : 1.0;
+        order =
+          childrenWithOrder.length > 0
+            ? childrenWithOrder[childrenWithOrder.length - 1].order + 1.0
+            : 1.0;
       }
 
       structureTree.addInMemoryRelationship(newParentId, nodeId, order);
@@ -333,7 +334,7 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       isExpanded,
       sharedNodeStoreChildren: children.length,
       structureTreeChildren: structureChildren.length,
-      children: children.map(c => c.id),
+      children: children.map((c) => c.id),
       structureIds: structureChildren
     });
 
@@ -342,47 +343,47 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     // 2. Parent has children
     // 3. Parent is EXPANDED (collapsed parents keep their children)
     if (!insertAtBeginning && children.length > 0 && isExpanded) {
-        // OPTIMISTIC UI: Update structure tree IMMEDIATELY for instant visual feedback
-        // This ensures the UI shows the correct hierarchy without waiting for database
-        for (const child of children) {
-          structureTree.moveInMemoryRelationship(afterNodeId, nodeId, child.id);
-        }
+      // OPTIMISTIC UI: Update structure tree IMMEDIATELY for instant visual feedback
+      // This ensures the UI shows the correct hierarchy without waiting for database
+      for (const child of children) {
+        structureTree.moveInMemoryRelationship(afterNodeId, nodeId, child.id);
+      }
 
-        // BACKGROUND PERSISTENCE: Atomically transfer all children in one RPC (C3c).
-        // Structure tree already updated above; this persists to the daemon.
-        Promise.resolve().then(async () => {
-          try {
-            // Wait for newNode to be persisted so children can reference it as parent.
-            await sharedNodeStore.waitForNodeSaves([nodeId]);
+      // BACKGROUND PERSISTENCE: Atomically transfer all children in one RPC (C3c).
+      // Structure tree already updated above; this persists to the daemon.
+      Promise.resolve().then(async () => {
+        try {
+          // Wait for newNode to be persisted so children can reference it as parent.
+          await sharedNodeStore.waitForNodeSaves([nodeId]);
 
-            // Single atomic RPC — all-or-nothing OCC, one transaction in the daemon.
-            const updatedChildren = await backendAdapter.moveChildrenToParent(
-              nodeId,
-              children.map(c => ({ id: c.id, version: c.version }))
+          // Single atomic RPC — all-or-nothing OCC, one transaction in the daemon.
+          const updatedChildren = await backendAdapter.moveChildrenToParent(
+            nodeId,
+            children.map((c) => ({ id: c.id, version: c.version }))
+          );
+
+          // Sync versions from the response (order reconciles via RelationshipUpdated events).
+          for (const updated of updatedChildren) {
+            sharedNodeStore.updateNode(
+              updated.id,
+              { version: updated.version },
+              { type: 'database', reason: 'move-version-sync' },
+              { skipPersistence: true }
             );
-
-            // Sync versions from the response (order reconciles via RelationshipUpdated events).
-            for (const updated of updatedChildren) {
-              sharedNodeStore.updateNode(
-                updated.id,
-                { version: updated.version },
-                { type: 'database', reason: 'move-version-sync' },
-                { skipPersistence: true }
-              );
-            }
-          } catch (error) {
-            // ROLLBACK: Revert optimistic UI changes on failure (preserves the move-rejected notification).
-            log.error('[createNode] Failed to transfer children to database, rolling back:', error);
-            for (const child of children) {
-              structureTree.moveInMemoryRelationship(nodeId, afterNodeId, child.id);
-            }
-            conflictNotifications.add({
-              nodeId,
-              message: "Changes couldn't be saved. Please try again.",
-              conflictType: 'child-transfer-failure'
-            });
           }
-        });
+        } catch (error) {
+          // ROLLBACK: Revert optimistic UI changes on failure (preserves the move-rejected notification).
+          log.error('[createNode] Failed to transfer children to database, rolling back:', error);
+          for (const child of children) {
+            structureTree.moveInMemoryRelationship(nodeId, afterNodeId, child.id);
+          }
+          conflictNotifications.add({
+            nodeId,
+            message: "Changes couldn't be saved. Please try again.",
+            conflictType: 'child-transfer-failure'
+          });
+        }
+      });
     }
 
     // Handle hierarchy positioning
@@ -502,7 +503,6 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     sharedNodeStore.updateNode(nodeId, { mentions: [...mentions] }, viewerSource, {
       skipPersistence: true
     });
-
   }
 
   function updateNodeProperties(
@@ -513,12 +513,15 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
     const node = sharedNodeStore.getNode(nodeId);
     if (!node) return;
 
+    // This function computes the full intended properties bag itself (merged or
+    // replaced), so tell the store to use it as-is rather than deep-merging it
+    // again onto the existing bag.
     sharedNodeStore.updateNode(
       nodeId,
       { properties: merge ? { ...node.properties, ...properties } : { ...properties } },
-      viewerSource
+      viewerSource,
+      { replaceProperties: true }
     );
-
   }
 
   function scheduleContentProcessing(nodeId: string, content: string): void {
@@ -831,7 +834,9 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       // 3. The CREATE will happen with the correct parent - no MOVE needed!
       //
       // This is more efficient and avoids race conditions entirely.
-      log.debug(`[indentNode] Node ${nodeId.substring(0, 8)} not persisted yet, re-triggering CREATE with new parent`);
+      log.debug(
+        `[indentNode] Node ${nodeId.substring(0, 8)} not persisted yet, re-triggering CREATE with new parent`
+      );
 
       // structureTree already updated above — at CREATE time, persistence path will derive
       // parentId from structureTree.getParent(nodeId). Re-trigger setNode to cancel the pending
@@ -881,7 +886,12 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
 
         // Now safe to move the node (with OCC)
         // Backend returns updated node with new version
-        const updatedNode = await backendAdapter.moveNode(nodeId, freshNode.version, targetParentId, null);
+        const updatedNode = await backendAdapter.moveNode(
+          nodeId,
+          freshNode.version,
+          targetParentId,
+          null
+        );
 
         // Sync local version from backend response
         sharedNodeStore.updateNode(
@@ -963,7 +973,9 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
         //
         // This is more efficient and avoids race conditions where the CREATE
         // fires with stale insertAfterNodeId while parentId has been updated.
-        log.debug(`[outdentNode] Node ${nodeId.substring(0, 8)} not persisted yet, re-triggering CREATE with new parent`);
+        log.debug(
+          `[outdentNode] Node ${nodeId.substring(0, 8)} not persisted yet, re-triggering CREATE with new parent`
+        );
 
         // Update structure tree first so persistence path can derive parentId from structureTree
         if (newParentId) {
@@ -978,7 +990,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
             ...updatedNode,
             insertPosition: { type: 'end' } as InsertPosition // clear stale sibling ref — append to new parent
           } as typeof updatedNode & { insertPosition?: InsertPosition | null };
-          sharedNodeStore.setNode(nodeWithClearedInsert, { type: 'database', reason: 'outdent-node' });
+          sharedNodeStore.setNode(nodeWithClearedInsert, {
+            type: 'database',
+            reason: 'outdent-node'
+          });
         }
 
         events.hierarchyChanged();
@@ -988,7 +1003,9 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       } else {
         // CREATE is in-flight! Update structureTree now so the in-flight CREATE closure reads
         // the correct parentId from structureTree.getParent(nodeId) at execution time.
-        log.debug(`[outdentNode] Node ${nodeId.substring(0, 8)} CREATE in-flight, updating structureTree for in-flight CREATE`);
+        log.debug(
+          `[outdentNode] Node ${nodeId.substring(0, 8)} CREATE in-flight, updating structureTree for in-flight CREATE`
+        );
 
         // Update structure tree so in-flight CREATE derives correct parentId
         if (newParentId) {
@@ -998,7 +1015,9 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
         // Clear stale insertPosition on the in-store node (references sibling under OLD parent)
         const currentNode = sharedNodeStore.getNode(nodeId);
         if (currentNode) {
-          (currentNode as typeof currentNode & { insertPosition?: InsertPosition | null }).insertPosition = { type: 'end' } as InsertPosition;
+          (
+            currentNode as typeof currentNode & { insertPosition?: InsertPosition | null }
+          ).insertPosition = { type: 'end' } as InsertPosition;
         }
 
         events.hierarchyChanged();
@@ -1068,7 +1087,12 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
         const outdentPosition: InsertPosition = oldParentId
           ? { type: 'after', siblingId: oldParentId }
           : { type: 'end' };
-        const updatedNode = await backendAdapter.moveNode(nodeId, freshNode.version, newParentId, outdentPosition);
+        const updatedNode = await backendAdapter.moveNode(
+          nodeId,
+          freshNode.version,
+          newParentId,
+          outdentPosition
+        );
 
         // Sync local version from backend response
         sharedNodeStore.updateNode(
@@ -1086,7 +1110,12 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
           const freshSibling = sharedNodeStore.getNode(siblingId);
           if (freshSibling) {
             // Backend returns updated sibling with new version
-            const updatedSibling = await backendAdapter.moveNode(siblingId, freshSibling.version, nodeId, null);
+            const updatedSibling = await backendAdapter.moveNode(
+              siblingId,
+              freshSibling.version,
+              nodeId,
+              null
+            );
             // Sync sibling's version from backend response
             sharedNodeStore.updateNode(
               siblingId,
@@ -1189,9 +1218,8 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       }
 
       // Calculate the depth this child should have
-      const newChildDepth = newParentForChild !== null
-        ? (_uiState[newParentForChild]?.depth ?? 0) + 1
-        : 0;
+      const newChildDepth =
+        newParentForChild !== null ? (_uiState[newParentForChild]?.depth ?? 0) + 1 : 0;
 
       const insertPosition: InsertPosition = insertAfterSiblingId
         ? { type: 'after', siblingId: insertAfterSiblingId }
@@ -1199,7 +1227,8 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
 
       // Use moveNodeCommand to properly update the has_child edge in the backend (with OCC)
       const childVersion = child.version;
-      backendAdapter.moveNode(child.id, childVersion, newParentForChild, insertPosition)
+      backendAdapter
+        .moveNode(child.id, childVersion, newParentForChild, insertPosition)
         .then((updatedChild) => {
           // Sync child's local version from backend response
           sharedNodeStore.updateNode(
@@ -1210,7 +1239,10 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
           );
         })
         .catch((error) => {
-          log.error(`[promoteChildren] Failed to move child ${child.id} to parent ${newParentForChild}:`, error);
+          log.error(
+            `[promoteChildren] Failed to move child ${child.id} to parent ${newParentForChild}:`,
+            error
+          );
         });
 
       // Update ReactiveStructureTree for immediate UI update
@@ -1233,7 +1265,6 @@ export function createReactiveNodeService(events: NodeManagerEvents) {
       updateDescendantDepths(child.id);
     }
   }
-
 
   /**
    * Deletes a node and its entire subtree (cascade).

--- a/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
+++ b/packages/desktop-app/src/lib/services/shared-node-store.svelte.ts
@@ -39,8 +39,11 @@ import type {
   StoreMetrics,
   UpdateOptions
 } from '$lib/types/update-protocol';
-import { conflictNotifications, type ConflictNotification } from '$lib/stores/conflict-notifications.svelte';
-import { normalizeNodeData } from './node-normalize';
+import {
+  conflictNotifications,
+  type ConflictNotification
+} from '$lib/stores/conflict-notifications.svelte';
+import { normalizeNodeData, deepMergeProperties, promoteTypedFields } from './node-normalize';
 import { decideRemoteUpdate, shouldSkipStaleAiChatUpdate } from './remote-update-policy';
 
 const CONFLICT_MESSAGE: Record<ConflictNotification['conflictType'], string> = {
@@ -104,7 +107,10 @@ class SimplePersistenceCoordinator {
   persist(
     nodeId: string,
     operation: () => Promise<void>,
-    options: { mode: 'immediate' | 'debounce'; dependencies?: Array<string | (() => Promise<void>)> } = { mode: 'debounce' }
+    options: {
+      mode: 'immediate' | 'debounce';
+      dependencies?: Array<string | (() => Promise<void>)>;
+    } = { mode: 'debounce' }
   ): { promise: Promise<void> } {
     const opId = ++this.operationCounter;
     const shortNodeId = nodeId.substring(0, 8);
@@ -115,7 +121,7 @@ class SimplePersistenceCoordinator {
 
     coordLog.debug(
       `[op#${opId}] persist() called for ${shortNodeId}: mode=${options.mode}, ` +
-      `hasPending=${hasPending}, isExecuting=${isExecuting}`
+        `hasPending=${hasPending}, isExecuting=${isExecuting}`
     );
 
     // If an operation is already executing for this node, collapse the new
@@ -228,11 +234,17 @@ class SimplePersistenceCoordinator {
           // onDone/onError, which are queued.resolve/reject.
           this.pendingOperations.set(nodeId, {
             nodeId,
-            operation: () => runOperation(queued.operation, queued.options.dependencies, queued.resolve, queued.reject),
+            operation: () =>
+              runOperation(
+                queued.operation,
+                queued.options.dependencies,
+                queued.resolve,
+                queued.reject
+              ),
             resolve: () => {},
             reject: () => {},
             promise: queued.promise,
-            timeoutId: setTimeout(() => {}, 0),
+            timeoutId: setTimeout(() => {}, 0)
           });
           coordLog.debug(
             `[op#${opId}] queued operation taking over for ${shortNodeId} (mode=${queued.options.mode})`
@@ -247,7 +259,12 @@ class SimplePersistenceCoordinator {
           // avoid unbounded stack growth while still running as soon as
           // possible after confirmation, never re-debounced.
           void Promise.resolve().then(() => {
-            void runOperation(queued.operation, queued.options.dependencies, queued.resolve, queued.reject);
+            void runOperation(
+              queued.operation,
+              queued.options.dependencies,
+              queued.resolve,
+              queued.reject
+            );
           });
         }
       }
@@ -270,7 +287,9 @@ class SimplePersistenceCoordinator {
       this.pendingOperations.set(nodeId, pending);
       executeOperation();
     } else {
-      coordLog.debug(`[op#${opId}] scheduling DEBOUNCED (${this.DEBOUNCE_MS}ms) for ${shortNodeId}`);
+      coordLog.debug(
+        `[op#${opId}] scheduling DEBOUNCED (${this.DEBOUNCE_MS}ms) for ${shortNodeId}`
+      );
       const timeoutId = setTimeout(executeOperation, this.DEBOUNCE_MS);
       const pending: PendingOperation = {
         nodeId,
@@ -295,7 +314,7 @@ class SimplePersistenceCoordinator {
       const isExecuting = this.executingOperations.has(nodeId);
       coordLog.debug(
         `[op#${opId ?? '?'}] cancelPending() for ${shortNodeId}: ` +
-        `isExecuting=${isExecuting} (cancel ${isExecuting ? 'INEFFECTIVE' : 'effective'})`
+          `isExecuting=${isExecuting} (cancel ${isExecuting ? 'INEFFECTIVE' : 'effective'})`
       );
       clearTimeout(pending.timeoutId);
       this.pendingOperations.delete(nodeId);
@@ -316,7 +335,9 @@ class SimplePersistenceCoordinator {
     if (queued) {
       coordLog.debug(`Cleared queued operation for ${nodeId.substring(0, 8)} (OCC conflict)`);
       this.queuedOperations.delete(nodeId);
-      queued.reject(new OperationCancelledError('Queued write cancelled: prior write hit an OCC conflict'));
+      queued.reject(
+        new OperationCancelledError('Queued write cancelled: prior write hit an OCC conflict')
+      );
       const pending = this.pendingOperations.get(nodeId);
       if (pending && pending.promise === queued.promise) {
         this.pendingOperations.delete(nodeId);
@@ -353,12 +374,15 @@ class SimplePersistenceCoordinator {
       // data-loss-sensitive moment. Mirror flushAndWaitForNodes: skip the
       // re-execute, but still await the in-flight promise either way.
       if (!this.executingOperations.has(nodeId)) {
-        pending.operation().then(
-          () => pending.resolve(),
-          (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
-        ).finally(() => {
-          this.pendingOperations.delete(nodeId);
-        });
+        pending
+          .operation()
+          .then(
+            () => pending.resolve(),
+            (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
+          )
+          .finally(() => {
+            this.pendingOperations.delete(nodeId);
+          });
       }
       promises.push(pending.promise.catch(() => {})); // Ignore errors, just wait for completion
     }
@@ -378,7 +402,9 @@ class SimplePersistenceCoordinator {
         try {
           await Promise.race([
             pending.promise,
-            new Promise<void>((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeoutMs))
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('Timeout')), timeoutMs)
+            )
           ]);
         } catch {
           failed.add(nodeId);
@@ -416,12 +442,15 @@ class SimplePersistenceCoordinator {
         // This prevents double-execution when the timeout fires just before clearTimeout
         if (!this.executingOperations.has(nodeId)) {
           // Start the operation now
-          pending.operation().then(
-            () => pending.resolve(),
-            (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
-          ).finally(() => {
-            this.pendingOperations.delete(nodeId);
-          });
+          pending
+            .operation()
+            .then(
+              () => pending.resolve(),
+              (error) => pending.reject(error instanceof Error ? error : new Error(String(error)))
+            )
+            .finally(() => {
+              this.pendingOperations.delete(nodeId);
+            });
         }
 
         // Wait for completion with timeout (whether we started it or it was already running)
@@ -797,7 +826,7 @@ export class SharedNodeStore {
     if (!structureTree) return [];
     const cacheKey = parentId ?? '__root__';
     const childIds = structureTree.getChildren(cacheKey);
-    return childIds.map(id => this.nodes.get(id)).filter((n): n is Node => n !== undefined);
+    return childIds.map((id) => this.nodes.get(id)).filter((n): n is Node => n !== undefined);
   }
 
   /**
@@ -986,10 +1015,26 @@ export class SharedNodeStore {
         previousVersion: this.versions.get(nodeId)
       };
 
-      // Apply update optimistically
+      // Apply update optimistically.
+      // A namespaced `properties` patch is deep-merged (so a partial write
+      // doesn't drop sibling keys) and its type-specific fields are promoted to
+      // the top level immediately — mirroring what the backend's
+      // `node_to_typed_value` does on the round-trip response. Without this,
+      // viewers reading top-level fields (e.g. ai-chat's `model`/`messages`)
+      // stay stale until the RPC resolves, making the UI appear to hang.
+      const mergedProperties = changes.properties
+        ? options.replaceProperties
+          ? changes.properties
+          : deepMergeProperties(existingNode.properties, changes.properties, existingNode.nodeType)
+        : existingNode.properties;
+      const promotedFields = changes.properties
+        ? promoteTypedFields(existingNode.nodeType, changes.properties, mergedProperties)
+        : {};
       const updatedNode: Node = {
         ...existingNode,
         ...changes,
+        ...(changes.properties ? { properties: mergedProperties } : {}),
+        ...promotedFields,
         modifiedAt: new Date().toISOString()
       };
 
@@ -1098,7 +1143,9 @@ export class SharedNodeStore {
           const capturedNonContentFields: Record<string, unknown> = {};
           for (const field of changedFields) {
             if (field !== 'content') {
-              capturedNonContentFields[field] = (changes as unknown as Record<string, unknown>)[field];
+              capturedNonContentFields[field] = (changes as unknown as Record<string, unknown>)[
+                field
+              ];
             }
           }
           const handle = PersistenceCoordinator.getInstance().persist(
@@ -1116,7 +1163,9 @@ export class SharedNodeStore {
                   // This ensures we persist the latest content, not stale content from when persist() was called
                   let currentNode = this.nodes.get(nodeId);
                   if (!currentNode) {
-                    log.warn(`Node ${nodeId} no longer exists in store, skipping update persistence`);
+                    log.warn(
+                      `Node ${nodeId} no longer exists in store, skipping update persistence`
+                    );
                     return;
                   }
 
@@ -1125,7 +1174,9 @@ export class SharedNodeStore {
                   // If we UPDATE before the move completes, we'll have a version mismatch.
                   const pendingMove = getPendingMoveOperation(nodeId);
                   if (pendingMove) {
-                    log.debug(`[UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`);
+                    log.debug(
+                      `[UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`
+                    );
                     await pendingMove;
                     // Re-read current node to get updated version after move
                     const refreshedNode = this.nodes.get(nodeId);
@@ -1146,12 +1197,13 @@ export class SharedNodeStore {
 
                   // Debug: Log version being sent
                   const shortNodeId = nodeId.substring(0, 8);
-                  const contentPreview = 'content' in updatePayload
-                    ? `"${String(updatePayload.content).substring(0, 20)}"`
-                    : '(no content)';
+                  const contentPreview =
+                    'content' in updatePayload
+                      ? `"${String(updatePayload.content).substring(0, 20)}"`
+                      : '(no content)';
                   log.debug(
                     `[UPDATE] ${shortNodeId}: sending version=${currentVersion}, ` +
-                    `content=${contentPreview}`
+                      `content=${contentPreview}`
                   );
 
                   try {
@@ -1165,7 +1217,9 @@ export class SharedNodeStore {
                     const nodeType = currentNode?.nodeType;
                     const isNodeTypeChanging = 'nodeType' in updatePayload;
                     const typeUpdater =
-                      nodeType && !isNodeTypeChanging ? pluginRegistry.getNodeUpdater(nodeType) : null;
+                      nodeType && !isNodeTypeChanging
+                        ? pluginRegistry.getNodeUpdater(nodeType)
+                        : null;
 
                     let updatedNodeFromBackend: Node | null = null;
 
@@ -1221,12 +1275,14 @@ export class SharedNodeStore {
                       // clobber a defined local value.
                       const localHasMovedOn =
                         localNode.properties !== currentNode.properties &&
-                        JSON.stringify(localNode.properties) !== JSON.stringify(currentNode.properties);
+                        JSON.stringify(localNode.properties) !==
+                          JSON.stringify(currentNode.properties);
                       const localProperties =
                         localHasMovedOn || updatedNodeFromBackend.properties === undefined
                           ? localNode.properties
                           : updatedNodeFromBackend.properties;
-                      const titleChanged = updatedNodeFromBackend.title !== undefined &&
+                      const titleChanged =
+                        updatedNodeFromBackend.title !== undefined &&
                         updatedNodeFromBackend.title !== localNode.title;
                       Object.assign(localNode, updatedNodeFromBackend, {
                         content: localContent,
@@ -1245,7 +1301,8 @@ export class SharedNodeStore {
                     // If UPDATE fails because node doesn't exist, try CREATE instead
                     // This handles cases where persistedNodeIds is out of sync (page reload, database reset)
                     // Match various error message formats for "node not found"
-                    const errorMsg = updateError instanceof Error ? updateError.message.toLowerCase() : '';
+                    const errorMsg =
+                      updateError instanceof Error ? updateError.message.toLowerCase() : '';
                     const isNodeNotFound =
                       errorMsg.includes('not found') ||
                       errorMsg.includes('does not exist') ||
@@ -1255,15 +1312,16 @@ export class SharedNodeStore {
                       log.warn(
                         `Node ${nodeId} not found in database, creating instead of updating (error: ${updateError.message})`
                       );
-                      const updateFallbackInput: import('$lib/services/backend-adapter').CreateNodeInput = {
-                        id: currentNode.id,
-                        nodeType: currentNode.nodeType,
-                        content: currentNode.content,
-                        properties: currentNode.properties,
-                        mentions: currentNode.mentions,
-                        parentId: this.getParentId(nodeId),
-                        insertPosition: null
-                      };
+                      const updateFallbackInput: import('$lib/services/backend-adapter').CreateNodeInput =
+                        {
+                          id: currentNode.id,
+                          nodeType: currentNode.nodeType,
+                          content: currentNode.content,
+                          properties: currentNode.properties,
+                          mentions: currentNode.mentions,
+                          parentId: this.getParentId(nodeId),
+                          insertPosition: null
+                        };
                       await backendAdapter.createNode(updateFallbackInput);
                       this.persistedNodeIds.add(nodeId); // Now it's persisted
                     } else {
@@ -1276,18 +1334,21 @@ export class SharedNodeStore {
                   // CRITICAL: Read current node state at execution time
                   const currentNode = this.nodes.get(nodeId);
                   if (!currentNode) {
-                    log.warn(`Node ${nodeId} no longer exists in store, skipping create persistence`);
+                    log.warn(
+                      `Node ${nodeId} no longer exists in store, skipping create persistence`
+                    );
                     return;
                   }
-                  const updatePathCreateInput: import('$lib/services/backend-adapter').CreateNodeInput = {
-                    id: currentNode.id,
-                    nodeType: currentNode.nodeType,
-                    content: currentNode.content,
-                    properties: currentNode.properties,
-                    mentions: currentNode.mentions,
-                    parentId: this.getParentId(nodeId),
-                    insertPosition: null
-                  };
+                  const updatePathCreateInput: import('$lib/services/backend-adapter').CreateNodeInput =
+                    {
+                      id: currentNode.id,
+                      nodeType: currentNode.nodeType,
+                      content: currentNode.content,
+                      properties: currentNode.properties,
+                      mentions: currentNode.mentions,
+                      parentId: this.getParentId(nodeId),
+                      insertPosition: null
+                    };
                   await backendAdapter.createNode(updatePathCreateInput);
                   this.persistedNodeIds.add(nodeId); // Track as persisted
 
@@ -1301,7 +1362,6 @@ export class SharedNodeStore {
                       this.nodesSet(nodeId, localNode); // Update local node with backend version
                     }
                   }
-
                 }
 
                 // Update mentionedIn on target nodes after successful persistence
@@ -1325,10 +1385,10 @@ export class SharedNodeStore {
 
                 // Suppress expected errors in in-memory test mode
                 if (shouldLogDatabaseErrors()) {
-                  log.error(
-                    `Database write failed for node ${nodeId}:`,
-                    { error, fullError: dbError }
-                  );
+                  log.error(`Database write failed for node ${nodeId}:`, {
+                    error,
+                    fullError: dbError
+                  });
                 }
 
                 // Always track errors in test environment for verification
@@ -1341,7 +1401,7 @@ export class SharedNodeStore {
                 if (occError) {
                   log.warn(
                     `OCC conflict for node ${nodeId}: ` +
-                    `expected v${occError.conflictData.expected}, got v${occError.conflictData.actual}`
+                      `expected v${occError.conflictData.expected}, got v${occError.conflictData.actual}`
                   );
 
                   // Clear queued operations to prevent stale-version retries
@@ -1354,7 +1414,10 @@ export class SharedNodeStore {
                     this.versions.set(nodeId, currentNode.version ?? 1);
                     this.persistedNodeIds.add(nodeId);
                     this.pendingUpdates.delete(nodeId);
-                    this.notifySubscribers(nodeId, currentNode, { type: 'database', reason: 'occ-resync' });
+                    this.notifySubscribers(nodeId, currentNode, {
+                      type: 'database',
+                      reason: 'occ-resync'
+                    });
                   } else {
                     // Fallback: fetch from server if daemon didn't embed current_node
                     this.resyncNodeFromServer(nodeId).catch((resyncError) => {
@@ -1376,7 +1439,10 @@ export class SharedNodeStore {
               }
             },
             {
-              mode: (isStructuralChange || isPropertyChange || isNodeTypeChange || isTypeSpecificChange) ? 'immediate' : 'debounce',
+              mode:
+                isStructuralChange || isPropertyChange || isNodeTypeChange || isTypeSpecificChange
+                  ? 'immediate'
+                  : 'debounce',
               dependencies: dependencies.length > 0 ? dependencies : undefined
             }
           );
@@ -1470,7 +1536,9 @@ export class SharedNodeStore {
     const hasPending = PersistenceCoordinator.getInstance().hasPending(node.id);
 
     if (shouldSkipStaleAiChatUpdate(node, existingNode, source)) {
-      log.debug(`setNode: skipping ai-chat database update with fewer messages`, { nodeId: node.id });
+      log.debug(`setNode: skipping ai-chat database update with fewer messages`, {
+        nodeId: node.id
+      });
       return;
     }
 
@@ -1549,7 +1617,8 @@ export class SharedNodeStore {
         const dependencies: Array<string | (() => Promise<void>)> = [];
 
         // If this node inserts After a sibling, wait for that sibling to be persisted first
-        const insertPos = (node as Node & { insertPosition?: InsertPosition | null }).insertPosition;
+        const insertPos = (node as Node & { insertPosition?: InsertPosition | null })
+          .insertPosition;
         const afterSiblingId = insertPos?.type === 'after' ? insertPos.siblingId : undefined;
         if (afterSiblingId && !this.persistedNodeIds.has(afterSiblingId)) {
           dependencies.push(afterSiblingId);
@@ -1586,7 +1655,9 @@ export class SharedNodeStore {
                 // If we UPDATE before the move completes, we'll have a version mismatch.
                 const pendingMove = getPendingMoveOperation(nodeId);
                 if (pendingMove) {
-                  log.debug(`[UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`);
+                  log.debug(
+                    `[UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`
+                  );
                   await pendingMove;
                   // Re-read current node to get updated version after move
                   const refreshedNode = this.nodes.get(nodeId);
@@ -1598,7 +1669,11 @@ export class SharedNodeStore {
                 try {
                   // Get current version for optimistic concurrency control.
                   const currentVersion = this.computeOccVersionForUpdate(nodeId);
-                  const updatedFromBackend = await backendAdapter.updateNode(nodeId, currentVersion, currentNode);
+                  const updatedFromBackend = await backendAdapter.updateNode(
+                    nodeId,
+                    currentVersion,
+                    currentNode
+                  );
                   // Sync the backend-assigned version AND typed fields into the
                   // local node. `node_to_typed_value` (the backend's single
                   // flattening authority) promotes type-specific fields — ai-chat's
@@ -1632,7 +1707,8 @@ export class SharedNodeStore {
                     // defined local value.
                     const localHasMovedOn =
                       latestNode.properties !== currentNode.properties &&
-                      JSON.stringify(latestNode.properties) !== JSON.stringify(currentNode.properties);
+                      JSON.stringify(latestNode.properties) !==
+                        JSON.stringify(currentNode.properties);
                     const localProperties =
                       localHasMovedOn || updatedFromBackend.properties === undefined
                         ? latestNode.properties
@@ -1658,15 +1734,16 @@ export class SharedNodeStore {
                     log.warn(
                       `Node ${nodeId} not found in database, creating instead of updating (error: ${errorMessage})`
                     );
-                    const fallbackCreateInput: import('$lib/services/backend-adapter').CreateNodeInput = {
-                      id: currentNode.id,
-                      nodeType: currentNode.nodeType,
-                      content: currentNode.content,
-                      properties: currentNode.properties,
-                      mentions: currentNode.mentions,
-                      parentId: this.getParentId(nodeId),
-                      insertPosition: null
-                    };
+                    const fallbackCreateInput: import('$lib/services/backend-adapter').CreateNodeInput =
+                      {
+                        id: currentNode.id,
+                        nodeType: currentNode.nodeType,
+                        content: currentNode.content,
+                        properties: currentNode.properties,
+                        mentions: currentNode.mentions,
+                        parentId: this.getParentId(nodeId),
+                        insertPosition: null
+                      };
                     await backendAdapter.createNode(fallbackCreateInput);
                     this.persistedNodeIds.add(nodeId);
                   } else {
@@ -1674,8 +1751,13 @@ export class SharedNodeStore {
                   }
                 }
               } else {
-                const nodeWithInsertPos = currentNode as Node & { insertPosition?: InsertPosition | null };
-                if (nodeWithInsertPos.insertPosition?.type === 'after' && nodeWithInsertPos.insertPosition.siblingId) {
+                const nodeWithInsertPos = currentNode as Node & {
+                  insertPosition?: InsertPosition | null;
+                };
+                if (
+                  nodeWithInsertPos.insertPosition?.type === 'after' &&
+                  nodeWithInsertPos.insertPosition.siblingId
+                ) {
                   const siblingId = nodeWithInsertPos.insertPosition.siblingId;
                   const currentParentId = this.getParentId(nodeId);
                   if (this.shouldClearStaleInsertAfter(siblingId, currentParentId)) {
@@ -1717,11 +1799,12 @@ export class SharedNodeStore {
               }
             } catch (dbError) {
               // Properly stringify Tauri errors which come as plain objects
-              const errorMessage = dbError instanceof Error
-                ? dbError.message
-                : typeof dbError === 'object' && dbError !== null
-                  ? JSON.stringify(dbError)
-                  : String(dbError);
+              const errorMessage =
+                dbError instanceof Error
+                  ? dbError.message
+                  : typeof dbError === 'object' && dbError !== null
+                    ? JSON.stringify(dbError)
+                    : String(dbError);
               const error = dbError instanceof Error ? dbError : new Error(errorMessage);
 
               // Suppress expected errors in in-memory test mode
@@ -1970,7 +2053,9 @@ export class SharedNodeStore {
     }
 
     if (existingNode.nodeType !== 'task') {
-      log.warn(`updateTaskNode called on non-task node: ${nodeId} (type: ${existingNode.nodeType})`);
+      log.warn(
+        `updateTaskNode called on non-task node: ${nodeId} (type: ${existingNode.nodeType})`
+      );
       return;
     }
 
@@ -2061,7 +2146,7 @@ export class SharedNodeStore {
           if (occError) {
             log.warn(
               `OCC conflict for task node ${nodeId}: ` +
-              `expected v${occError.conflictData.expected}, got v${occError.conflictData.actual}`
+                `expected v${occError.conflictData.expected}, got v${occError.conflictData.actual}`
             );
             PersistenceCoordinator.getInstance().clearQueued(nodeId);
 
@@ -2071,13 +2156,13 @@ export class SharedNodeStore {
               this.versions.set(nodeId, currentNode.version ?? 1);
               this.persistedNodeIds.add(nodeId);
               this.pendingUpdates.delete(nodeId);
-              this.notifySubscribers(nodeId, currentNode, { type: 'database', reason: 'occ-resync' });
+              this.notifySubscribers(nodeId, currentNode, {
+                type: 'database',
+                reason: 'occ-resync'
+              });
             } else {
               this.resyncNodeFromServer(nodeId).catch((resyncError) => {
-                log.error(
-                  `Failed to resync after OCC error for task node ${nodeId}:`,
-                  resyncError
-                );
+                log.error(`Failed to resync after OCC error for task node ${nodeId}:`, resyncError);
               });
             }
 
@@ -2284,7 +2369,7 @@ export class SharedNodeStore {
       }
 
       const allNodes: Node[] = [];
-      const allRelationships: Array<{parentId: string, childId: string, order: number}> = [];
+      const allRelationships: Array<{ parentId: string; childId: string; order: number }> = [];
       const databaseSource = { type: 'database' as const, reason: 'loaded-from-db' };
 
       // OPTIMIZATION: Add parent node itself to the store
@@ -2304,7 +2389,11 @@ export class SharedNodeStore {
 
       // Helper to recursively process NodeWithChildren and collect nodes + edges
       // OPTIMIZED: Collects all nodes first, then batch adds them
-      const processNode = (nodeWithChildren: import('$lib/types').NodeWithChildren, nodeParentId: string, order: number) => {
+      const processNode = (
+        nodeWithChildren: import('$lib/types').NodeWithChildren,
+        nodeParentId: string,
+        order: number
+      ) => {
         // Extract Node fields (exclude 'children' property)
 
         const { children, ...nodeFields } = nodeWithChildren;
@@ -2593,7 +2682,7 @@ export class SharedNodeStore {
 
         log.warn(
           `Node ${nodeId} resynced from server after OCC error ` +
-          `(server version: ${serverNode.version ?? 1})`
+            `(server version: ${serverNode.version ?? 1})`
         );
       } else {
         log.error(`Failed to resync node ${nodeId}: Node not found on server`);
@@ -2749,15 +2838,15 @@ export class SharedNodeStore {
 
     // Extract mentions from old and new content
     const oldMentions = new Set(
-      contentProcessor.detectNodespaceURIs(oldContent ?? '').map(link => link.nodeId)
+      contentProcessor.detectNodespaceURIs(oldContent ?? '').map((link) => link.nodeId)
     );
     const newMentions = new Set(
-      contentProcessor.detectNodespaceURIs(newContent ?? '').map(link => link.nodeId)
+      contentProcessor.detectNodespaceURIs(newContent ?? '').map((link) => link.nodeId)
     );
 
     // Calculate added and removed mentions
-    const added = [...newMentions].filter(id => !oldMentions.has(id));
-    const removed = [...oldMentions].filter(id => !newMentions.has(id));
+    const added = [...newMentions].filter((id) => !oldMentions.has(id));
+    const removed = [...oldMentions].filter((id) => !newMentions.has(id));
 
     // Skip if no changes
     if (added.length === 0 && removed.length === 0) return;
@@ -2766,14 +2855,17 @@ export class SharedNodeStore {
     // The container is what appears in backlinks - it's the navigable entry point
     const sourceContainer = this.findContainer(sourceNodeId);
     if (!sourceContainer) {
-      log.debug(`Could not find container for source node ${sourceNodeId}, skipping mentionedIn update`);
+      log.debug(
+        `Could not find container for source node ${sourceNodeId}, skipping mentionedIn update`
+      );
       return;
     }
 
     // Build NodeReference for the container
     const containerRef: NodeReference = {
       id: sourceContainer.id,
-      title: sourceContainer.title ?? (stripMarkdown(sourceContainer.content).substring(0, 50) || null),
+      title:
+        sourceContainer.title ?? (stripMarkdown(sourceContainer.content).substring(0, 50) || null),
       nodeType: sourceContainer.nodeType
     };
 
@@ -2786,11 +2878,14 @@ export class SharedNodeStore {
       if (targetNode) {
         const mentionedIn = [...(targetNode.mentionedIn ?? [])];
         // Avoid duplicates (same container can mention via multiple child nodes)
-        if (!mentionedIn.some(ref => ref.id === containerRef.id)) {
+        if (!mentionedIn.some((ref) => ref.id === containerRef.id)) {
           mentionedIn.push(containerRef);
           const updatedTarget = { ...targetNode, mentionedIn };
           this.nodesSet(targetId, updatedTarget);
-          this.notifySubscribers(targetId, updatedTarget, { type: 'database', reason: 'mention-added' });
+          this.notifySubscribers(targetId, updatedTarget, {
+            type: 'database',
+            reason: 'mention-added'
+          });
           log.debug(`Added ${containerRef.id} to mentionedIn of ${targetId}`);
         }
       }
@@ -2803,12 +2898,15 @@ export class SharedNodeStore {
 
       const targetNode = this.nodes.get(targetId);
       if (targetNode?.mentionedIn) {
-        const mentionedIn = targetNode.mentionedIn.filter(ref => ref.id !== containerRef.id);
+        const mentionedIn = targetNode.mentionedIn.filter((ref) => ref.id !== containerRef.id);
         // Only update if actually changed
         if (mentionedIn.length !== targetNode.mentionedIn.length) {
           const updatedTarget = { ...targetNode, mentionedIn };
           this.nodesSet(targetId, updatedTarget);
-          this.notifySubscribers(targetId, updatedTarget, { type: 'database', reason: 'mention-removed' });
+          this.notifySubscribers(targetId, updatedTarget, {
+            type: 'database',
+            reason: 'mention-removed'
+          });
           log.debug(`Removed ${containerRef.id} from mentionedIn of ${targetId}`);
         }
       }
@@ -3224,7 +3322,9 @@ export class SharedNodeStore {
             let currentNode = this.nodes.get(nodeId);
             const pendingMove = getPendingMoveOperation(nodeId);
             if (pendingMove) {
-              log.debug(`[BATCH UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`);
+              log.debug(
+                `[BATCH UPDATE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`
+              );
               await pendingMove;
               // Re-read current node to get updated version after move
               const refreshedNode = this.nodes.get(nodeId);
@@ -3238,7 +3338,11 @@ export class SharedNodeStore {
 
             // CRITICAL: Capture updated node to get new version from backend
             // This prevents version conflicts on subsequent updates
-            const updatedNodeFromBackend = await backendAdapter.updateNode(nodeId, currentVersion, changes);
+            const updatedNodeFromBackend = await backendAdapter.updateNode(
+              nodeId,
+              currentVersion,
+              changes
+            );
 
             // Update local node with backend version
             const localNode = this.nodes.get(nodeId);
@@ -3287,7 +3391,9 @@ export class SharedNodeStore {
                 let raceCurrentNode = this.nodes.get(nodeId);
                 const raceMove = getPendingMoveOperation(nodeId);
                 if (raceMove) {
-                  log.debug(`[BATCH RACE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`);
+                  log.debug(
+                    `[BATCH RACE] Waiting for pending move operation on ${nodeId.substring(0, 8)}`
+                  );
                   await raceMove;
                   const refreshed = this.nodes.get(nodeId);
                   if (refreshed) {
@@ -3295,7 +3401,11 @@ export class SharedNodeStore {
                   }
                 }
                 const currentVersion = raceCurrentNode?.version ?? finalNode.version ?? 1;
-                const updatedNodeFromBackend = await backendAdapter.updateNode(nodeId, currentVersion, changes);
+                const updatedNodeFromBackend = await backendAdapter.updateNode(
+                  nodeId,
+                  currentVersion,
+                  changes
+                );
                 this.persistedNodeIds.add(nodeId);
 
                 // Update local node with backend version
@@ -3314,11 +3424,7 @@ export class SharedNodeStore {
           // This enables immediate backlinks reactivity without requiring navigation
           if (originalContent !== undefined && 'content' in changes) {
             const persistedNode = this.nodes.get(nodeId);
-            this.updateMentionedInOnContentChange(
-              nodeId,
-              originalContent,
-              persistedNode?.content
-            );
+            this.updateMentionedInOnContentChange(nodeId, originalContent, persistedNode?.content);
           }
         } catch (dbError) {
           const error = dbError instanceof Error ? dbError : new Error(String(dbError));

--- a/packages/desktop-app/src/lib/types/update-protocol.ts
+++ b/packages/desktop-app/src/lib/types/update-protocol.ts
@@ -103,6 +103,15 @@ export interface BatchOptions {
 export interface UpdateOptions {
   /** Skip persistence (for temporary UI-only updates) */
   skipPersistence?: boolean;
+  /**
+   * Replace `properties` wholesale instead of deep-merging the incoming patch
+   * onto the existing bag. Default (false/undefined) deep-merges so a partial
+   * `{ properties: {...} }` write doesn't drop sibling keys. Set true when the
+   * caller has already computed the full intended `properties` bag (e.g.
+   * `updateNodeProperties`, which does its own merge) and must not have it
+   * re-merged.
+   */
+  replaceProperties?: boolean;
   /** Force update even if version mismatch (dangerous) */
   force?: boolean;
   /** Notify subscribers even if no actual changes */

--- a/packages/desktop-app/src/tests/services/node-normalize.test.ts
+++ b/packages/desktop-app/src/tests/services/node-normalize.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeNodeData } from '$lib/services/node-normalize';
+import {
+  normalizeNodeData,
+  deepMergeProperties,
+  promoteTypedFields,
+  OPTIMISTIC_TYPED_FIELDS
+} from '$lib/services/node-normalize';
 import type { Node } from '$lib/types/node';
 
 function makeNode(overrides: Partial<Node> = {}): Node {
@@ -65,5 +70,63 @@ describe('normalizeNodeData', () => {
     expect(r.dueDate).toBe('2024-12-31');
     expect(r.id).toBe('test-id');
     expect(r.content).toBe('test content');
+  });
+});
+
+describe('deepMergeProperties', () => {
+  it('merges one level and keeps sibling keys', () => {
+    const merged = deepMergeProperties(
+      { 'capture:x': 'keep', provider: 'native' },
+      { model: 'm1' },
+      'ai-chat'
+    );
+    expect(merged).toEqual({ 'capture:x': 'keep', provider: 'native', model: 'm1' });
+  });
+
+  it('merges one level deeper into the type namespace', () => {
+    const merged = deepMergeProperties(
+      { task: { status: 'open', priority: 'high' } },
+      { task: { status: 'done' } },
+      'task'
+    );
+    expect(merged.task).toEqual({ status: 'done', priority: 'high' });
+  });
+
+  it('treats a missing existing bag as empty', () => {
+    expect(deepMergeProperties(undefined, { model: 'm1' }, 'ai-chat')).toEqual({ model: 'm1' });
+  });
+});
+
+describe('promoteTypedFields', () => {
+  it('promotes only fields present in a flat ai-chat write', () => {
+    const changes = { messages: [{ role: 'user', content: 'hi' }], status: 'processing' };
+    const promoted = promoteTypedFields('ai-chat', changes, changes);
+    // provider/model omitted → not promoted (guards against undefined-clobber)
+    expect(promoted).toEqual({ messages: changes.messages, status: 'processing' });
+    expect('provider' in promoted).toBe(false);
+    expect('model' in promoted).toBe(false);
+  });
+
+  it('promotes nested task fields from the type namespace', () => {
+    const changes = { task: { status: 'done' } };
+    const merged = { task: { status: 'done', priority: 'high' } };
+    const promoted = promoteTypedFields('task', changes, merged);
+    expect(promoted).toEqual({ status: 'done' });
+  });
+
+  it('returns nothing for a node type with no typed-field map', () => {
+    expect(promoteTypedFields('text', { foo: 'bar' }, { foo: 'bar' })).toEqual({});
+  });
+
+  it('promotes an explicit null value (present but null)', () => {
+    const changes = { model: null };
+    const promoted = promoteTypedFields('ai-chat', changes, changes);
+    expect('model' in promoted).toBe(true);
+    expect(promoted.model).toBeNull();
+  });
+
+  it('map stays aligned with the documented promoted types', () => {
+    expect(Object.keys(OPTIMISTIC_TYPED_FIELDS).sort()).toEqual(['ai-chat', 'task']);
+    expect(OPTIMISTIC_TYPED_FIELDS['ai-chat']).toEqual(['status', 'provider', 'model', 'messages']);
   });
 });

--- a/packages/desktop-app/src/tests/services/shared-node-store.test.ts
+++ b/packages/desktop-app/src/tests/services/shared-node-store.test.ts
@@ -52,6 +52,113 @@ describe('SharedNodeStore', () => {
   });
 
   // ========================================================================
+  // Optimistic property flattening (updateNode)
+  // ========================================================================
+
+  describe('Optimistic property flattening (updateNode)', () => {
+    const aiChatNode: Node = {
+      ...mockNode,
+      id: 'ai-chat-1',
+      nodeType: 'ai-chat',
+      properties: {}
+    };
+    const taskNode: Node = {
+      ...mockNode,
+      id: 'task-1',
+      nodeType: 'task',
+      properties: {}
+    };
+    const skip = { skipPersistence: true };
+
+    it('promotes flat ai-chat properties.* to top-level fields synchronously', () => {
+      store.setNode(aiChatNode, viewerSource);
+
+      store.updateNode(
+        aiChatNode.id,
+        { properties: { messages: [], status: 'active', provider: 'native', model: 'm1' } },
+        viewerSource,
+        skip
+      );
+
+      const node = store.getNode(aiChatNode.id) as unknown as Record<string, unknown>;
+      expect(node.provider).toBe('native');
+      expect(node.model).toBe('m1');
+      expect(node.status).toBe('active');
+      expect(Array.isArray(node.messages)).toBe(true);
+    });
+
+    it('preserves top-level provider/model when a later write omits them', () => {
+      store.setNode(aiChatNode, viewerSource);
+      store.updateNode(
+        aiChatNode.id,
+        { properties: { provider: 'native', model: 'm1' } },
+        viewerSource,
+        skip
+      );
+
+      // Sending a message writes messages+status but NOT provider/model
+      store.updateNode(
+        aiChatNode.id,
+        { properties: { messages: [{ role: 'user', content: 'hi' }], status: 'processing' } },
+        viewerSource,
+        skip
+      );
+
+      const node = store.getNode(aiChatNode.id) as unknown as Record<string, unknown>;
+      expect((node.messages as unknown[]).length).toBe(1);
+      expect(node.status).toBe('processing');
+      // The omitted-field guard must leave these intact
+      expect(node.provider).toBe('native');
+      expect(node.model).toBe('m1');
+    });
+
+    it('deep-merges properties so a partial write keeps sibling keys', () => {
+      store.setNode(
+        { ...aiChatNode, properties: { 'capture:x': 'keep', provider: 'native' } },
+        viewerSource
+      );
+
+      store.updateNode(
+        aiChatNode.id,
+        { properties: { messages: [{ role: 'user', content: 'hi' }] } },
+        viewerSource,
+        skip
+      );
+
+      const node = store.getNode(aiChatNode.id) as unknown as Node;
+      expect(node.properties['capture:x']).toBe('keep');
+      expect(node.properties.provider).toBe('native');
+    });
+
+    it('promotes nested task properties.task.* to the top level', () => {
+      store.setNode(taskNode, viewerSource);
+
+      store.updateNode(
+        taskNode.id,
+        { properties: { task: { status: 'done' } } },
+        viewerSource,
+        skip
+      );
+
+      const node = store.getNode(taskNode.id) as unknown as Record<string, unknown>;
+      expect(node.status).toBe('done');
+      expect((node.properties as Record<string, Record<string, unknown>>).task.status).toBe('done');
+    });
+
+    it('leaves non-typed node types unaffected', () => {
+      store.setNode(mockNode, viewerSource); // text node
+
+      store.updateNode(mockNode.id, { properties: { foo: 'bar' } }, viewerSource, skip);
+
+      const node = store.getNode(mockNode.id) as unknown as Record<string, unknown>;
+      expect((node.properties as Record<string, unknown>).foo).toBe('bar');
+      // No typed field was invented on a plain text node
+      expect(node.status).toBeUndefined();
+      expect(node.model).toBeUndefined();
+    });
+  });
+
+  // ========================================================================
   // Singleton Behavior
   // ========================================================================
 
@@ -433,9 +540,7 @@ describe('SharedNodeStore', () => {
         store.setNode(parentNode, viewerSource);
 
         const getNodeSpy = vi.spyOn(backendAdapter, 'getNode');
-        const getChildrenSpy = vi
-          .spyOn(backendAdapter, 'getChildren')
-          .mockResolvedValue([]);
+        const getChildrenSpy = vi.spyOn(backendAdapter, 'getChildren').mockResolvedValue([]);
 
         await store.loadChildrenForParent('parent-already-loaded');
 
@@ -453,12 +558,8 @@ describe('SharedNodeStore', () => {
           content: 'Fetched parent'
         };
 
-        const getNodeSpy = vi
-          .spyOn(backendAdapter, 'getNode')
-          .mockResolvedValue(parentNode);
-        const getChildrenSpy = vi
-          .spyOn(backendAdapter, 'getChildren')
-          .mockResolvedValue([]);
+        const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(parentNode);
+        const getChildrenSpy = vi.spyOn(backendAdapter, 'getChildren').mockResolvedValue([]);
 
         await store.loadChildrenForParent('parent-not-in-store');
 
@@ -479,9 +580,7 @@ describe('SharedNodeStore', () => {
           content: 'Child content'
         };
 
-        const getNodeSpy = vi
-          .spyOn(backendAdapter, 'getNode')
-          .mockResolvedValue(null);
+        const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(null);
         const getChildrenSpy = vi
           .spyOn(backendAdapter, 'getChildren')
           .mockResolvedValue([childNode]);
@@ -520,7 +619,6 @@ describe('SharedNodeStore', () => {
     // Note: hasPendingSave tests removed (PersistenceCoordinator deleted)
 
     // Note: waitForNodeSaves tests removed (PersistenceCoordinator deleted)
-
   });
 
   // ========================================================================
@@ -1459,12 +1557,9 @@ describe('SharedNodeStore', () => {
       store.setNode(mockNode, viewerSource);
 
       // Update with isComputedField should skip persistence and conflict detection
-      store.updateNode(
-        mockNode.id,
-        { mentions: ['node-1', 'node-2'] },
-        viewerSource,
-        { isComputedField: true }
-      );
+      store.updateNode(mockNode.id, { mentions: ['node-1', 'node-2'] }, viewerSource, {
+        isComputedField: true
+      });
 
       const node = store.getNode(mockNode.id);
       expect(node?.mentions).toEqual(['node-1', 'node-2']);
@@ -1473,17 +1568,12 @@ describe('SharedNodeStore', () => {
     it('should handle batch updates with commitImmediately option', () => {
       store.setNode(mockNode, viewerSource);
 
-      store.updateNode(
-        mockNode.id,
-        { content: 'Immediate batch' },
-        viewerSource,
-        {
-          batch: {
-            autoBatch: true,
-            commitImmediately: true
-          }
+      store.updateNode(mockNode.id, { content: 'Immediate batch' }, viewerSource, {
+        batch: {
+          autoBatch: true,
+          commitImmediately: true
         }
-      );
+      });
 
       // Should have updated
       const node = store.getNode(mockNode.id);
@@ -1512,7 +1602,6 @@ describe('SharedNodeStore', () => {
       expect(typeof count).toBe('number');
       expect(count).toBeGreaterThanOrEqual(0);
     });
-
   });
 
   // ========================================================================
@@ -1543,9 +1632,7 @@ describe('SharedNodeStore', () => {
       store.setNode(localNode, viewerSource, true);
 
       // Mock tauriCommands.getNode to return server state
-      const getNodeSpy = vi
-        .spyOn(backendAdapter, 'getNode')
-        .mockResolvedValue(mockServerNode);
+      const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(mockServerNode);
 
       // Trigger resync
       await store.resyncNodeFromServer('test-node-occ');
@@ -1581,9 +1668,7 @@ describe('SharedNodeStore', () => {
       store.setNode(localNode, viewerSource, true);
 
       // Mock tauriCommands.getNode
-      const getNodeSpy = vi
-        .spyOn(backendAdapter, 'getNode')
-        .mockResolvedValue(mockServerNode);
+      const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(mockServerNode);
 
       // Trigger resync
       await store.resyncNodeFromServer('test-node-occ');
@@ -1623,9 +1708,7 @@ describe('SharedNodeStore', () => {
       notificationCount = 0;
 
       // Mock tauriCommands.getNode
-      const getNodeSpy = vi
-        .spyOn(backendAdapter, 'getNode')
-        .mockResolvedValue(mockServerNode);
+      const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(mockServerNode);
 
       // Trigger resync
       await store.resyncNodeFromServer('test-node-occ');
@@ -1657,9 +1740,7 @@ describe('SharedNodeStore', () => {
       store.setNode(localNode, viewerSource, true);
 
       // Mock tauriCommands.getNode to return null (node not found)
-      const getNodeSpy = vi
-        .spyOn(backendAdapter, 'getNode')
-        .mockResolvedValue(null);
+      const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(null);
 
       // Trigger resync - should not throw
       await expect(store.resyncNodeFromServer('test-node-occ')).resolves.not.toThrow();
@@ -1707,20 +1788,15 @@ describe('SharedNodeStore', () => {
       store.setNode(localNode, viewerSource, true);
 
       // Mock tauriCommands.getNode to return server state (version 5)
-      const getNodeSpy = vi
-        .spyOn(backendAdapter, 'getNode')
-        .mockResolvedValue(mockServerNode);
+      const getNodeSpy = vi.spyOn(backendAdapter, 'getNode').mockResolvedValue(mockServerNode);
 
       // Resync to version 5
       await store.resyncNodeFromServer('test-node-occ');
 
       // Now try to update with the correct version (5)
-      store.updateNode(
-        'test-node-occ',
-        { content: 'New edit after resync' },
-        viewerSource,
-        { skipPersistence: true }
-      );
+      store.updateNode('test-node-occ', { content: 'New edit after resync' }, viewerSource, {
+        skipPersistence: true
+      });
 
       // Verify update succeeded
       const updatedNode = store.getNode('test-node-occ');
@@ -2085,12 +2161,9 @@ describe('SharedNodeStore', () => {
         const testNode = createTestNode('conflict-test-1');
         store.setNode(testNode, viewerSource);
 
-        store.updateNode(
-          testNode.id,
-          { content: 'First update' },
-          viewerSource,
-          { skipPersistence: true }
-        );
+        store.updateNode(testNode.id, { content: 'First update' }, viewerSource, {
+          skipPersistence: true
+        });
 
         const currentVersion = store.getVersion(testNode.id);
         expect(currentVersion).toBeGreaterThan(0);
@@ -2112,12 +2185,7 @@ describe('SharedNodeStore', () => {
         const testNode = createTestNode('nodetype-conversion-test');
         store.setNode(testNode, viewerSource);
 
-        store.updateNode(
-          testNode.id,
-          { content: '> ' },
-          viewerSource,
-          { skipPersistence: true }
-        );
+        store.updateNode(testNode.id, { content: '> ' }, viewerSource, { skipPersistence: true });
 
         // NodeType conversion with content — must not conflict
         store.updateNode(
@@ -2183,10 +2251,7 @@ describe('SharedNodeStore', () => {
         const callback = vi.fn();
         store.subscribeAll(callback);
 
-        const nodes = [
-          createTestNode('batch-notify-1'),
-          createTestNode('batch-notify-2')
-        ];
+        const nodes = [createTestNode('batch-notify-1'), createTestNode('batch-notify-2')];
 
         store.batchSetNodes(nodes, viewerSource);
 


### PR DESCRIPTION
## Summary

Fixes an ai-chat UI lag: the optimistic (pre-round-trip) merge in `SharedNodeStore.updateNode()` shallow-spread `changes`, so a namespaced `{ properties: {...} }` write (a) replaced `node.properties` wholesale and (b) never flattened `properties.*` into the top-level fields components read. As a result, selecting a model (textarea gated on top-level `node.model`) and sending a message (list reads top-level `node.messages`) both appeared to hang for one network/IPC round trip, until the backend's already-flattened response arrived.

The backend `node_to_typed_value` (`nodespace-types/src/convert.rs`) remains the single flattening authority; this adds a **minimal, optimistic-only** mirror so the pre-round-trip state reflects the same top-level fields the backend would promote. The backend response always overwrites these, so any drift degrades optimistic latency only — never correctness.

## Changes

- **`node-normalize.ts`** — new `OPTIMISTIC_TYPED_FIELDS` map (the exact per-type fields convert.rs promotes: ai-chat `status/provider/model/messages`, task `status/priority/dueDate/assignee/startedAt/completedAt`), plus `deepMergeProperties` (one-level merge + one level into the `[nodeType]` namespace) and `promoteTypedFields` (promotes a field **only if present in this write** — flat `properties.x` or nested `properties.<type>.x` — so an omitted field never clobbers a top-level value with `undefined`).
- **`shared-node-store.svelte.ts`** — the optimistic merge deep-merges `properties` and spreads the promoted top-level fields into the new node.
- **`update-protocol.ts`** — new `UpdateOptions.replaceProperties` (default deep-merge; `true` = use the incoming bag as-is).
- **`reactive-node-service.svelte.ts`** — `updateNodeProperties()` passes `replaceProperties: true` (it already computes the full merged/replaced bag), preserving its `merge: false` = wholesale-replace contract.
- **`schema-field-update.ts` / `schema-property-form.svelte`** — pass `replaceProperties: true` in their old-format migration paths (which deliberately drop flat keys and build the full bag), so the deep-merge default doesn't re-add the dropped keys to the optimistic node (surfaced by review).

## Anti-divergence

The typed-field list is one tiny table colocated in `node-normalize.ts` with a doc comment pointing at `convert.rs`, and is always overwritten by the authoritative backend echo — so it can never cause a *correctness* divergence, only an optimistic-latency one.

## Verification

- New tests: `node-normalize.test.ts` (+8 — deep-merge sibling/namespace/missing-bag; promote present-only/nested/null/no-map/map-alignment) and `shared-node-store.test.ts` (+5 — flat ai-chat promotion, message-send preserves provider/model via the omitted-field guard, deep-merge keeps sibling keys, nested task promotion, non-typed node untouched). All green.
- Caught + fixed a regression: `updateNodeProperties(merge=false)` expects wholesale replace; now flagged via `replaceProperties: true`.
- **Full frontend suite: 166 files, 4091 tests passing**; `svelte-check`: **0 errors / 1768 files**.
- Independent adversarial review: **CONFIRMED-GOOD**. Key finding: the deep-merge changes only the *local optimistic* node — the persisted wire payload is still built from the raw `changes.properties` (`shared-node-store.svelte.ts` capture path), so the backend stays the flattening authority and no persistence/corruption path is introduced; the backend echo reconciles. All `updateNode({ properties })` call sites audited; the two schema-migration sites above were the only ones needing `replaceProperties`. Content typing (`{ content, nodeType }`, no `properties`) short-circuits the new block entirely, so the real hot path is unaffected.

Closes #1695.
