### PR TITLE
Exclude ai-chat nodes from embedding/vectorization (closes #1696)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,6 +3862,7 @@ dependencies = [
  "lru",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -407,8 +407,8 @@ fn def_search_semantic() -> ToolDefinition {
                 },
                 "scope": {
                     "type": "string",
-                    "enum": ["knowledge", "conversations", "everything"],
-                    "description": "Search scope: 'knowledge' (default, searches text/header/code/schema nodes), 'conversations' (searches conversation messages), 'everything' (all node types). Use 'conversations' when the user asks about past chats or conversation history."
+                    "enum": ["knowledge", "everything"],
+                    "description": "Search scope: 'knowledge' (default, searches text/header/code/schema nodes) or 'everything' (all embedded node types). Note: ai-chat conversations are not embedded, so they are never returned by search regardless of scope."
                 },
                 "include_archived": {
                     "type": "boolean",

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -257,7 +257,6 @@ FETCH ADDITIONAL CONTENT: Only call get_node with format=markdown if you need fu
 PARAMETER GUIDANCE:
 - Use 'collection' to narrow search to a namespace/folder (e.g. collection="Architecture").
 - Use 'node_types' to filter by type (e.g. node_types=["task"]) — prefer over 'collection' for type-based filtering.
-- Use 'scope'="conversations" when the user asks about past chats or conversation history.
 - Use 'threshold' to tune precision: default 0.3. Lower to 0.1-0.2 for broader recall when results are sparse.
 - Use 'include_archived'=true only when the user explicitly asks for archived or historical content.
 - Use 'exclude_collections' to suppress noisy collections (e.g. exclude_collections=["Archived"]).

--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -1490,8 +1490,8 @@ impl NodeBehavior for CollectionNodeBehavior {
 ///
 /// AI chat nodes store conversations (user messages, assistant responses, tool calls)
 /// as nested properties following the same pattern as playbook `rules[]`.
-/// Conversations are stored as nodes to enable semantic search, Stamped ACL
-/// permissions, cloud sync, and development traceability.
+/// Conversations are stored as nodes for Stamped ACL permissions, cloud sync,
+/// and development traceability. They are deliberately NOT embedded (see below).
 ///
 /// # Storage Architecture (ADR-028)
 ///
@@ -1501,10 +1501,10 @@ impl NodeBehavior for CollectionNodeBehavior {
 /// - **Tool calls**: Stored as messages with role "tool_call", result_summary preserved,
 ///   full result nulled at write time for storage efficiency
 ///
-/// # Embedding (ADR-029)
+/// # Embedding (ADR-029, as revised)
 ///
-/// `get_embeddable_content()` extracts user + assistant text from `properties.messages[]`,
-/// skipping tool_call messages. This enables semantic search over chat history.
+/// `get_embeddable_content()` always returns `None`: ai-chat conversations are
+/// never embedded or made semantically searchable.
 ///
 /// # Examples
 ///
@@ -1600,27 +1600,15 @@ impl NodeBehavior for AiChatNodeBehavior {
         })
     }
 
-    /// Extract user and assistant message content for semantic search embedding.
+    /// AI-chat nodes are intentionally NOT embedded.
     ///
-    /// Iterates over `properties.messages[]`, includes only messages with
-    /// role "user" or "assistant", and joins their content with double newlines.
-    /// Tool call messages (role "tool_call") are skipped as they contain
-    /// structured data rather than semantic text.
-    fn get_embeddable_content(&self, node: &Node) -> Option<String> {
-        let messages = node.properties.get("messages")?.as_array()?;
-        let text: Vec<&str> = messages
-            .iter()
-            .filter_map(|m| match m.get("role")?.as_str()? {
-                "user" | "assistant" => m.get("content")?.as_str(),
-                _ => None,
-            })
-            .filter(|s| !s.trim().is_empty())
-            .collect();
-        if text.is_empty() {
-            None
-        } else {
-            Some(text.join("\n\n"))
-        }
+    /// Conversations are not general knowledge and must never surface in
+    /// semantic search, so this always returns `None` — no embedding is ever
+    /// produced for an ai-chat node regardless of its messages. This reverses
+    /// the original ADR-029 decision (which embedded chat text but hid it from
+    /// default search); `SearchScope::Conversations` is consequently a no-op.
+    fn get_embeddable_content(&self, _node: &Node) -> Option<String> {
+        None
     }
 
     /// AI chat nodes don't contribute to parent embeddings.
@@ -4276,58 +4264,38 @@ mod tests {
     }
 
     #[test]
-    fn test_ai_chat_node_embeddable_content() {
+    fn test_ai_chat_node_never_embeddable() {
         let behavior = AiChatNodeBehavior;
 
-        // Node with user and assistant messages
+        // Rich conversation with user + assistant messages: still not embeddable.
         let node = Node::new(
             "ai-chat".to_string(),
             "Chat about webhooks".to_string(),
             json!({
                 "messages": [
                     {"role": "user", "content": "Help me implement the webhook handler"},
-                    {"role": "tool_call", "tool": "search_semantic", "result_summary": "Found 3 nodes"},
                     {"role": "assistant", "content": "Based on the spec, here is my approach"},
                     {"role": "user", "content": "Looks good, please proceed"}
                 ]
             }),
         );
-        let content = behavior.get_embeddable_content(&node).unwrap();
-        assert!(content.contains("Help me implement the webhook handler"));
-        assert!(content.contains("Based on the spec, here is my approach"));
-        assert!(content.contains("Looks good, please proceed"));
-        // Tool call messages should be excluded
-        assert!(!content.contains("search_semantic"));
-        assert!(!content.contains("Found 3 nodes"));
-    }
+        assert!(
+            behavior.get_embeddable_content(&node).is_none(),
+            "ai-chat with messages must not be embeddable"
+        );
 
-    #[test]
-    fn test_ai_chat_node_embeddable_content_empty_messages() {
-        let behavior = AiChatNodeBehavior;
-
-        // Empty messages array
-        let node = Node::new(
-            "ai-chat".to_string(),
-            "Empty chat".to_string(),
+        // Empty messages array, tool-only messages, and no messages property are
+        // all likewise never embeddable.
+        for props in [
             json!({"messages": []}),
-        );
-        assert!(behavior.get_embeddable_content(&node).is_none());
-
-        // Only tool call messages (no user/assistant text)
-        let node = Node::new(
-            "ai-chat".to_string(),
-            "Tool-only chat".to_string(),
-            json!({
-                "messages": [
-                    {"role": "tool_call", "tool": "search_semantic", "result_summary": "Found 3 nodes"}
-                ]
-            }),
-        );
-        assert!(behavior.get_embeddable_content(&node).is_none());
-
-        // No messages property
-        let node = Node::new("ai-chat".to_string(), "No messages".to_string(), json!({}));
-        assert!(behavior.get_embeddable_content(&node).is_none());
+            json!({"messages": [
+                {"role": "tool_call", "tool": "search_semantic", "result_summary": "Found 3 nodes"}
+            ]}),
+            json!({}),
+        ] {
+            let node = Node::new("ai-chat".to_string(), "Chat".to_string(), props);
+            assert!(behavior.get_embeddable_content(&node).is_none());
+        }
     }
 
     #[test]
@@ -4462,7 +4430,7 @@ mod tests {
             "schema nodes with content should be embeddable"
         );
 
-        // ai-chat: extracts user/assistant messages from properties
+        // ai-chat: conversations are deliberately NOT embedded, even with messages
         let chat_node = Node::new(
             "ai-chat".to_string(),
             "Chat about webhooks".to_string(),
@@ -4478,12 +4446,9 @@ mod tests {
             .unwrap()
             .get_embeddable_content(&chat_node);
         assert!(
-            chat_content.is_some(),
-            "ai-chat with messages should be embeddable"
+            chat_content.is_none(),
+            "ai-chat should never be embeddable, even with messages"
         );
-        let chat_text = chat_content.unwrap();
-        assert!(chat_text.contains("How do I implement webhooks?"));
-        assert!(chat_text.contains("Here is an approach..."));
 
         // --- Types that should NOT be embeddable (return None) ---
 
@@ -4559,7 +4524,7 @@ mod tests {
             "collection nodes should NOT be embeddable"
         );
 
-        // --- Edge case: ai-chat with no messages returns None ---
+        // --- ai-chat with no messages also returns None (never embeddable) ---
         let empty_chat = Node::new("ai-chat".to_string(), "Empty".to_string(), json!({}));
         assert!(
             registry
@@ -4567,7 +4532,7 @@ mod tests {
                 .unwrap()
                 .get_embeddable_content(&empty_chat)
                 .is_none(),
-            "ai-chat without messages property should NOT be embeddable"
+            "ai-chat is never embeddable, with or without messages"
         );
     }
 

--- a/packages/core/src/services/embedding_service.rs
+++ b/packages/core/src/services/embedding_service.rs
@@ -838,6 +838,9 @@ impl NodeEmbeddingService {
                 node_type,
                 "text" | "header" | "code-block" | "schema" | "table"
             ),
+            // ai-chat nodes are no longer embedded (ADR-029, as revised), so no
+            // ai-chat rows exist in the vector index — this scope is effectively
+            // a no-op that returns no results.
             SearchScope::Conversations => node_type == "ai-chat",
             SearchScope::Everything => true,
             SearchScope::Custom {
@@ -1260,8 +1263,7 @@ mod tests {
 
     /// Verify that extract_content_for_embedding respects behavior decisions:
     /// - Embeddable types (text, header, code-block) return Some
-    /// - Non-embeddable types (task, date, collection) return None
-    /// - ai-chat extracts messages, not node content
+    /// - Non-embeddable types (task, date, collection, ai-chat) return None
     #[tokio::test]
     async fn test_behavior_driven_embedding_decision() {
         let _accessor = Arc::new(MockNodeAccessor::new());
@@ -1345,7 +1347,7 @@ mod tests {
             "collection should NOT be embeddable — behavior returns None"
         );
 
-        // --- ai-chat: message-based extraction ---
+        // --- ai-chat: never embeddable (conversations excluded from vectorization) ---
 
         let chat_node = Node::new(
             "ai-chat".to_string(),
@@ -1359,23 +1361,9 @@ mod tests {
             }),
         );
         let chat_behavior = behaviors.get("ai-chat").unwrap();
-        let chat_content = chat_behavior.get_embeddable_content(&chat_node);
         assert!(
-            chat_content.is_some(),
-            "ai-chat with messages should be embeddable"
-        );
-        let text = chat_content.unwrap();
-        assert!(
-            text.contains("How do I write tests?"),
-            "Should include user message"
-        );
-        assert!(
-            text.contains("Here is a testing guide."),
-            "Should include assistant message"
-        );
-        assert!(
-            !text.contains("search"),
-            "Should exclude tool_call messages"
+            chat_behavior.get_embeddable_content(&chat_node).is_none(),
+            "ai-chat should never be embeddable, even with messages"
         );
 
         // --- CustomNodeBehavior fallback ---


### PR DESCRIPTION
## Summary

AI-chat conversation nodes were embedded and made semantically searchable. This stops that: ai-chat nodes are never vectorized. Conversations are not general knowledge and must not surface in semantic search.

This reverses the per-type decision in **ADR-029** (embeddable-but-hidden) to **not embeddable at all**. The behavior-owned embedding mechanism itself is unchanged — only ai-chat's `get_embeddable_content()` result changes.

## Changes

- **`behaviors/mod.rs`** — `AiChatNodeBehavior::get_embeddable_content()` now returns `None` unconditionally (was: extract user/assistant text from `properties.messages[]`). Updated the method + struct doc comments. Consolidated the two now-obsolete extraction tests into one `test_ai_chat_node_never_embeddable` (asserts `None` for rich, empty, tool-only, and no-messages shapes); flipped the `get_embeddable_content` matrix assertion to `is_none()`.
- **`embedding_service.rs`** — flipped the ai-chat assertion in `test_behavior_driven_embedding_decision` to `is_none()`; updated its doc comment; added a clarifying comment at `matches_scope` noting `SearchScope::Conversations` (`node_type == "ai-chat"`) is now a no-op (no ai-chat rows exist in the vector index). The enum variant is retained for API stability.
- **`agent/local_agent/tools.rs` + `agent/skill_pipeline.rs`** — removed `conversations` from the `search_nodes` tool's advertised `scope` options and dropped the skill guidance that steered the model to `scope="conversations"` for past chats. Without this, the model would keep calling a scope that now returns nothing and report "searched conversations, found nothing." The core `SearchScope::Conversations` enum variant is retained (documented no-op) for API stability.
- **`nodespace-docs` ADR-029** (committed directly to docs `main` per that repo's workflow) — added a Revision note, updated the per-type behavior table (ai-chat → `None`) and the SearchScope section (Conversations/Everything surface no ai-chat content).
- **`Cargo.lock`** — adds the `sha2` entry for `nodespace-nlp-engine` that was missing (its `Cargo.toml` gained the dep in #1715 but the root lockfile was never committed alongside it, leaving `--locked` builds inconsistent). Drive-by correction.

## Notes

- Per CLAUDE.md's decision tree, embeddability for built-in types is behavior-trait-owned (no schema flag), so this is a Core hardcoded-behavior change.
- Existing ai-chat embeddings are cleaned up by the normal pipeline: `get_embeddable_content()` returning `None` triggers the embedding service's "don't embed me → clean up existing embeddings" path on reprocess (greenfield: no migration needed).
- `NON_EMBEDDABLE_CONTAINER_TYPES` unchanged (ai-chat isn't a container type).

## Verification

- `cargo test -p nodespace-core --lib`: **966 passed, 0 failed**; `cargo clippy -p nodespace-core`: clean.
- Independent adversarial review (crate-wide + other packages): confirmed no test breaks and container-parity holds. It surfaced one real behavioral gap — the agent still steered the LLM to the now-dead `conversations` scope — which this PR fixes (tools.rs + skill_pipeline.rs above).
- `cargo test -p nodespace-agent --lib` (scope + skill tests): green; `cargo clippy -p nodespace-agent`: clean.

Closes #1696.
