### PR TITLE
Serialize concurrent sibling reorders to fix fractional-order race (closes #1561)

### DIFF
--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -127,6 +127,16 @@ pub struct SqliteStore {
     event_tx: broadcast::Sender<crate::db::events::EventEnvelope>,
     valid_node_types: HashSet<String>,
     notifier: Option<StoreNotifier>,
+    /// Serializes `move_node`'s sibling-order read → fractional-key compute →
+    /// write-back. That sequence spans several `await`s on the single shared
+    /// `db` connection, so two concurrent moves would otherwise interleave and
+    /// compute new order keys against the same stale sibling snapshot, corrupting
+    /// the final order. A DB `BEGIN IMMEDIATE` can't serialize them here — every
+    /// task shares one connection, so the second would hit "cannot start a
+    /// transaction within a transaction" rather than waiting — so we serialize at
+    /// the application level. Reorders are infrequent (user-driven), so the
+    /// contention cost is negligible.
+    reorder_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl SqliteStore {
@@ -154,6 +164,7 @@ impl SqliteStore {
             event_tx,
             valid_node_types,
             notifier: None,
+            reorder_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -1271,6 +1282,82 @@ mod tests {
             .await
             .context("writer task panicked")?
             .context("store_b write should retry and succeed, not error with SQLITE_BUSY")?;
+
+        Ok(())
+    }
+
+    /// Regression for the concurrent-reorder race (#1561): many sibling reorders
+    /// running at once must all succeed and leave the parent with exactly N
+    /// children carrying N distinct fractional-order keys. Before `reorder_lock`,
+    /// the read → compute → write-back interleaved across the shared connection,
+    /// so concurrent moves computed order keys against the same stale snapshot —
+    /// producing errored moves and/or colliding order values.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_reorders_keep_all_children_with_distinct_order() -> Result<()> {
+        let (store, _t) = create_test_store().await?;
+
+        let parent = Node::new("text".to_string(), "parent".to_string(), json!({}));
+        let parent_id = parent.id.clone();
+        store.create_node(parent, None, None).await?;
+
+        const N: usize = 16;
+        let mut child_ids = Vec::new();
+        for i in 0..N {
+            let c = Node::new("text".to_string(), format!("c{i}"), json!({}));
+            let cid = c.id.clone();
+            store.create_node(c, None, None).await?;
+            // Wire under the parent (move_node with a None sibling inserts at the
+            // beginning; exact position doesn't matter for this setup).
+            store.move_node(&cid, Some(&parent_id), None).await?;
+            child_ids.push(cid);
+        }
+
+        // Concurrently move every child to the beginning — maximum contention on
+        // the sibling-order read/compute/write.
+        let mut handles = Vec::new();
+        for cid in &child_ids {
+            let store = store.clone();
+            let cid = cid.clone();
+            let parent_id = parent_id.clone();
+            handles.push(tokio::spawn(async move {
+                store.move_node(&cid, Some(&parent_id), None).await
+            }));
+        }
+        for h in handles {
+            h.await
+                .expect("reorder task panicked")
+                .expect("a concurrent reorder returned an error");
+        }
+
+        // No child was lost or duplicated.
+        let children = store.get_children(&parent_id).await?;
+        assert_eq!(
+            children.len(),
+            N,
+            "concurrent reorders lost/duplicated a child"
+        );
+
+        // Every sibling still has a distinct order key (no colliding writes).
+        let mut rows = store
+            .db
+            .query(
+                "SELECT json_extract(properties, '$.order') FROM relationship \
+                 WHERE in_node = ?1 AND relationship_type = 'has_child'",
+                libsql::params![parent_id.clone()],
+            )
+            .await?;
+        let mut orders: Vec<f64> = Vec::new();
+        while let Some(r) = rows.next().await? {
+            orders.push(r.get::<f64>(0)?);
+        }
+        assert_eq!(orders.len(), N, "expected {N} sibling edges");
+        orders.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        for pair in orders.windows(2) {
+            assert!(
+                (pair[1] - pair[0]).abs() > f64::EPSILON,
+                "colliding sibling order keys after concurrent reorders: {orders:?}"
+            );
+        }
 
         Ok(())
     }

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -180,8 +180,7 @@ impl SqliteStore {
         const ID_CHUNK: usize = 900;
         let mut result = HashMap::new();
         for chunk in ids.chunks(ID_CHUNK) {
-            let placeholders: Vec<String> =
-                (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
             let sql = format!(
                 "SELECT * FROM node WHERE id IN ({})",
                 placeholders.join(", ")
@@ -664,8 +663,7 @@ impl SqliteStore {
         // Chunk under SQLite's ~999 bound-parameter ceiling.
         const ID_CHUNK: usize = 900;
         for chunk in ids.chunks(ID_CHUNK) {
-            let placeholders: Vec<String> =
-                (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
             let sql = format!("DELETE FROM node WHERE id IN ({})", placeholders.join(", "));
             let params: Vec<libsql::Value> = chunk
                 .iter()
@@ -1221,6 +1219,13 @@ impl SqliteStore {
             }
             self.validate_no_cycle(parent_id, &node_id).await?;
         }
+
+        // Serialize the sibling-order read → fractional-key compute → write-back
+        // (including any rebalance). Held until the function returns. Without this,
+        // two concurrent same-parent reorders interleave their reads/writes on the
+        // shared connection and compute overlapping order keys against the same
+        // stale snapshot, corrupting the final sibling order. See `reorder_lock`.
+        let _reorder_guard = self.reorder_lock.lock().await;
 
         let new_order = if let Some(ref parent_id) = new_parent_id {
             // Get ordered siblings excluding the moving node


### PR DESCRIPTION
## Summary

Fixes a data-corruption race: two concurrent `reorder_node` operations on distinct siblings under the same parent could produce a corrupted final sibling order. `move_node`'s order logic reads the current sibling order values, computes a new fractional-order key in Rust, and writes it back as **separate, non-transactional `await`ed steps** on the shared DB connection. Two concurrent moves interleave at those `await` points, both reading the same stale snapshot and computing overlapping/inconsistent order keys — so the final order reflects only one of the two moves. Version-based OCC doesn't catch it: it guards the moved node's own row, not the read of its siblings' order values.

## Fix

Serialize the read → compute → write-back with an application-level async mutex (`SqliteStore::reorder_lock`), held across the whole `move_node` order section.

**Why not a DB transaction (as the issue proposed):** the store uses a single shared `Arc<libsql::Connection>` for all tasks. A `BEGIN IMMEDIATE` on that connection can't serialize concurrent moves — the second task would hit *"cannot start a transaction within a transaction"* (nested transaction on the same connection), not wait. An app-level `tokio::sync::Mutex` serializes them deterministically regardless of the connection model, and also protects the cross-parent branch's read-compute-write (its `new_order` is likewise computed from an out-of-transaction read). Reorders are user-driven and infrequent, so the added contention is negligible.

## Changes

- `packages/core/src/db/sqlite_store/mod.rs` — new `reorder_lock: Arc<tokio::sync::Mutex<()>>` field + doc comment; initialized in `new()`.
- `packages/core/src/db/sqlite_store/nodes.rs` — `move_node` acquires `reorder_lock` immediately before the sibling-order read and holds it (through any rebalance) until the write-back completes. `rebalance_children_for_parent` does not take the lock, so there is no re-entrant deadlock.

## Verification

- The existing repro test `concurrent_reorders_of_distinct_nodes_all_succeed` (previously flaky ~1-in-15 under full-suite load) — **30/30 consecutive passes** against a `nodespaced` built with this fix.
- New `concurrent_reorders_keep_all_children_with_distinct_order` (multi-threaded, 16 simultaneous reorders): all moves succeed, all children retained, distinct order keys — 30/30 standalone + 3/3 full-suite passes.
- `cargo test -p nodespace-core --lib`: 967 passed; clippy clean.
- Independent adversarial review: **CONFIRMED-GOOD** — verified the guard covers the full read→compute→write across all three write branches (same-parent, cross-parent tx, make-root) and the rebalance; no deadlock (nothing in the guarded region re-takes the lock); `reorder_lock` is the store's only mutex (no lock-ordering hazard); and the test's distinctness check can't false-fail (serialized beginning-moves stay ~1.0 apart).

**Scope (follow-up #1746):** `reorder_lock` serializes `move_node` against `move_node` — the exact #1561 scenario. Review noted other sibling-order write paths (`create_child_node_atomic` append, `get_next_order_for_relationship`, `bulk_create_has_child`, `move_children_to_parent`) still bypass the lock and can race; those are pre-existing and tracked in #1746.

**Honest note on reproduction:** the race is timing/load-dependent and does not reproduce deterministically in isolation (single shared libsql connection tends to complete each task's statements together; the 1-in-15 flake needs full-suite pressure). Verification therefore rests on the fix's construction (the mutex makes the interleave impossible), the existing repro test passing against the fixed daemon, and the concurrency smoke test — not on a failing-then-passing unit reproduction.

Closes #1561.
