### PR TITLE
Add load-time SHA-256 integrity gate for the chat model (#1729)

### DIFF
--- a/packages/agent/src/local_agent/inference.rs
+++ b/packages/agent/src/local_agent/inference.rs
@@ -42,8 +42,17 @@ impl LlamaChatInferenceEngine {
         let engine = ChatEngine::new(config)
             .map_err(|e| InferenceError::Engine(format!("Failed to create ChatEngine: {e}")))?;
 
+        // Look up the pinned digest for this model file so the load-time integrity
+        // gate refuses a swapped-on-disk GGUF before native llama.cpp parses it. A
+        // path outside the catalog (a user-supplied model) resolves to None and
+        // loads without the gate — there is nothing to verify against.
+        let expected_sha256 = std::path::Path::new(model_path)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .and_then(super::model_manager::expected_sha256_for_filename);
+
         engine
-            .load_model(model_path)
+            .load_model(model_path, expected_sha256)
             .map_err(|e| InferenceError::Engine(format!("Failed to load model: {e}")))?;
 
         Ok(Self {

--- a/packages/agent/src/local_agent/model_manager.rs
+++ b/packages/agent/src/local_agent/model_manager.rs
@@ -1010,6 +1010,18 @@ fn find_catalog_entry(model_id: &str) -> Result<&'static CatalogEntry, ModelErro
         .ok_or_else(|| ModelError::NotFound(model_id.to_string()))
 }
 
+/// The pinned SHA-256 for a catalog chat model, looked up by its GGUF file name
+/// (basename). Returns `None` for a file that is not in the catalog — a
+/// user-supplied / custom model with no pinned digest, which the load path then
+/// loads without an integrity gate. Used at load time to hand the expected
+/// digest to the inference engine so a swapped-on-disk GGUF is refused.
+pub fn expected_sha256_for_filename(filename: &str) -> Option<&'static str> {
+    CATALOG
+        .iter()
+        .find(|e| e.filename == filename)
+        .map(|e| e.sha256)
+}
+
 /// Detect total system RAM in bytes using `sysinfo`.
 pub fn detect_system_ram() -> u64 {
     let mut sys = sysinfo::System::new();
@@ -1453,6 +1465,44 @@ mod tests {
             assert!(
                 !entry.sha256.is_empty(),
                 "catalog entry '{}' must carry a sha256",
+                entry.id
+            );
+        }
+    }
+
+    #[test]
+    fn expected_sha256_for_filename_matches_catalog_and_none_for_unknown() {
+        let entry = CATALOG.iter().next().expect("catalog is non-empty");
+        // A real catalog filename resolves to its pinned 64-hex digest — this is
+        // what the chat load gate verifies the on-disk GGUF against.
+        assert_eq!(
+            expected_sha256_for_filename(entry.filename),
+            Some(entry.sha256)
+        );
+        assert_eq!(
+            expected_sha256_for_filename(entry.filename).unwrap().len(),
+            64
+        );
+        // An unknown / user-supplied filename resolves to None — the documented
+        // escape hatch (load without a digest to verify against).
+        assert_eq!(
+            expected_sha256_for_filename("not-a-catalog-model.gguf"),
+            None
+        );
+    }
+
+    #[test]
+    fn every_catalog_model_basename_resolves_to_its_pinned_digest() {
+        // The chat load gate resolves the expected digest from the model file's
+        // basename, and model_path() builds `models_dir.join(entry.filename)` — so
+        // the basename is always the catalog filename. This guards the wiring
+        // invariant: a regression that dropped the lookup (loading a catalog model
+        // unverified) would break here, not slip through.
+        for entry in CATALOG {
+            assert_eq!(
+                expected_sha256_for_filename(entry.filename),
+                Some(entry.sha256),
+                "catalog model '{}' basename must resolve to its pinned digest",
                 entry.id
             );
         }

--- a/packages/nlp-engine/src/chat/error.rs
+++ b/packages/nlp-engine/src/chat/error.rs
@@ -9,6 +9,9 @@ pub enum ChatError {
     #[error("Model loading failed: {0}")]
     ModelLoadError(String),
 
+    #[error("Model integrity check failed: {0}")]
+    IntegrityError(String),
+
     #[error("Tokenization failed: {0}")]
     TokenizationError(String),
 

--- a/packages/nlp-engine/src/chat/mod.rs
+++ b/packages/nlp-engine/src/chat/mod.rs
@@ -180,7 +180,14 @@ impl ChatEngine {
     ///
     /// The model file must exist and be a valid GGUF file with an embedded
     /// chat template. GPU layers are offloaded according to `ChatConfig`.
-    pub fn load_model(&self, model_path: &str) -> Result<()> {
+    ///
+    /// When `expected_sha256` is `Some`, the on-disk file is verified against
+    /// that digest before it is handed to native llama.cpp — closing the
+    /// post-install tamper window (a model correctly downloaded but later
+    /// swapped on disk is refused). `None` is the escape hatch for a
+    /// user-supplied / non-catalog model with no pinned digest: it loads with a
+    /// warning rather than failing, since there is nothing to verify against.
+    pub fn load_model(&self, model_path: &str, expected_sha256: Option<&str>) -> Result<()> {
         #[cfg(feature = "chat-service")]
         {
             tracing::info!("Loading chat model: {}", model_path);
@@ -191,6 +198,24 @@ impl ChatEngine {
                     "Model file not found: {}",
                     model_path
                 )));
+            }
+
+            // Integrity gate: reject a tampered/substituted artifact before native
+            // llama.cpp parses it with full authority. Mirrors the embedding-model
+            // load gate; the digest is the selected catalog entry's pinned SHA-256.
+            match expected_sha256 {
+                Some(expected) => {
+                    crate::config::verify_file_sha256(path, expected)
+                        .map_err(ChatError::IntegrityError)?;
+                    tracing::info!("Chat model integrity verified: {}", model_path);
+                }
+                None => {
+                    tracing::warn!(
+                        "Loading chat model WITHOUT integrity verification (no pinned \
+                         digest for a user-supplied / non-catalog model): {}",
+                        model_path
+                    );
+                }
             }
 
             // Get global backend (shares with embedding service)
@@ -242,6 +267,7 @@ impl ChatEngine {
         #[cfg(not(feature = "chat-service"))]
         {
             let _ = model_path;
+            let _ = expected_sha256;
             tracing::info!("STUB: Chat model load (feature disabled)");
         }
 
@@ -1304,6 +1330,26 @@ mod tests {
             split_all(&["Done.<|channel>I should add the node.<channel|>Added it!"]);
         assert_eq!(answer, "Done.Added it!");
         assert_eq!(reasoning, "I should add the node.");
+    }
+
+    // --- Load-time integrity gate ---
+
+    #[cfg(feature = "chat-service")]
+    #[test]
+    fn load_model_refuses_a_mismatched_digest_before_native_load() {
+        use std::io::Write;
+        let engine = ChatEngine::new(ChatConfig::default()).expect("engine constructs");
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"tampered / substituted model bytes").unwrap();
+        // A wrong expected digest is refused with IntegrityError — this returns
+        // before the file is handed to native llama.cpp (no backend/model needed).
+        let err = engine
+            .load_model(f.path().to_str().unwrap(), Some(&"0".repeat(64)))
+            .expect_err("mismatched digest must be refused");
+        assert!(
+            matches!(err, ChatError::IntegrityError(_)),
+            "expected IntegrityError, got {err:?}"
+        );
     }
 
     #[test]

--- a/packages/nlp-engine/src/config.rs
+++ b/packages/nlp-engine/src/config.rs
@@ -34,13 +34,14 @@ pub fn compute_file_sha256(path: &Path) -> std::io::Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-/// Verify the on-disk model at `path` against the pinned [`EMBEDDING_MODEL_SHA256`].
+/// Verify the on-disk file at `path` against an expected SHA-256 digest.
 ///
 /// Returns `Err` describing the mismatch (or read failure) so the caller can
 /// refuse to load a tampered or corrupt artifact. This closes the post-install
 /// tamper window: even a correctly-downloaded model that is later swapped on
-/// disk is rejected at load time.
-pub fn verify_model_integrity(path: &Path) -> Result<(), String> {
+/// disk is rejected at load time. Shared by the embedding model (fixed pinned
+/// digest) and the chat models (per-catalog-entry digest).
+pub fn verify_file_sha256(path: &Path, expected_sha256: &str) -> Result<(), String> {
     let actual = compute_file_sha256(path).map_err(|e| {
         format!(
             "failed to read model for integrity check {}: {}",
@@ -48,15 +49,23 @@ pub fn verify_model_integrity(path: &Path) -> Result<(), String> {
             e
         )
     })?;
-    if actual != EMBEDDING_MODEL_SHA256 {
+    // Case-insensitive: a hex digest is semantically case-agnostic, so a correctly
+    // pinned digest entered in any case still matches (`actual` is lowercase). This
+    // keeps a legitimate model from being refused over digest casing.
+    if !actual.eq_ignore_ascii_case(expected_sha256) {
         return Err(format!(
             "model integrity check FAILED for {}: expected SHA-256 {}, got {}",
             path.display(),
-            EMBEDDING_MODEL_SHA256,
+            expected_sha256,
             actual
         ));
     }
     Ok(())
+}
+
+/// Verify the on-disk model at `path` against the pinned [`EMBEDDING_MODEL_SHA256`].
+pub fn verify_model_integrity(path: &Path) -> Result<(), String> {
+    verify_file_sha256(path, EMBEDDING_MODEL_SHA256)
 }
 
 /// Configuration for llama.cpp embedding model
@@ -257,5 +266,19 @@ mod tests {
         let result = verify_model_integrity(Path::new("/nonexistent/model.gguf"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("failed to read model"));
+    }
+
+    #[test]
+    fn test_verify_file_sha256_accepts_match_rejects_mismatch() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"chat model bytes").unwrap();
+        let digest = compute_file_sha256(f.path()).unwrap();
+        // Matching digest passes.
+        assert!(verify_file_sha256(f.path(), &digest).is_ok());
+        // A wrong digest is rejected with a descriptive error.
+        let result = verify_file_sha256(f.path(), &"0".repeat(64));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("integrity check FAILED"));
     }
 }


### PR DESCRIPTION
## Summary

The embedding model verifies its GGUF against a pinned SHA-256 before native llama.cpp loads it (ADR-058); the chat/LLM model had no equivalent. Chat models *are* verified at **download** time, but a model correctly downloaded and then **swapped/tampered on disk** was loaded without re-verification — the same post-install tamper window the embedding load gate closes, into C++ with full authority (integrity + memory-safety surface).

## Change

- **`nlp-engine/chat/mod.rs`** — `load_model(model_path, expected_sha256: Option<&str>)`. After the `exists()` check and **before** `backend()` / `load_from_file`, when a digest is present it verifies the on-disk file and returns `ChatError::IntegrityError` on mismatch. `None` is the documented escape hatch for a user-supplied / non-catalog model (loads with a warning — nothing to verify against).
- **`nlp-engine/chat/error.rs`** — new `ChatError::IntegrityError`.
- **`nlp-engine/config.rs`** — extracted a generic `verify_file_sha256(path, expected)` from `verify_model_integrity` (which now delegates to it); comparison is **case-insensitive** so a correctly-pinned digest can't be refused over casing.
- **`agent/model_manager.rs`** — `expected_sha256_for_filename(filename)` resolves the pinned digest from the catalog by GGUF basename.
- **`agent/inference.rs`** — `LlamaChatInferenceEngine::load` resolves the digest from the model file's basename and passes it down, preserving the `agent → nlp-engine` dependency direction (nlp-engine can't import the catalog).

The digest lookup keys off the same `entry.filename` that `model_path()` builds the load path from, so a catalog model's basename always resolves to `Some(digest)` — a wiring-invariant test guards that. The daemon load surface takes a `model_id` (never an arbitrary path), so the `None` branch is unreachable today (future-proofing).

## Acceptance criteria

- [x] Verify the on-disk file against the selected catalog entry's pinned SHA-256 before `load_from_file`, reusing the digests in `model_manager.rs`
- [x] Refuse on mismatch with a clear integrity error (`ChatError::IntegrityError`, mirrors `EmbeddingError::IntegrityError`)
- [x] Handle no-catalog / user-supplied paths explicitly (documented `None` escape hatch: load with a warning)

## Tests

- `verify_file_sha256` accepts match / rejects mismatch
- `expected_sha256_for_filename` resolves a catalog filename / `None` for unknown
- **every catalog model basename resolves to its pinned digest** (guards the load-path wiring)
- `load_model` returns `IntegrityError` on a mismatched digest **before** native load

nlp-engine 99 / agent 301 lib tests pass; clippy clean; full pre-push gate (test:all + `cargo build --bin nodespaced` + test:e2e + `cargo test -p nodespace-app`) green. Independent adversarial review: no bypass / correctness bug / regression.

Closes #1729.

Context: Threat T9, ADR-058 (Model Artifact Integrity Verification). Companion to the embedding-model load gate (#1715).
