### PR TITLE
Fix move_children_to_parent order collision and serialize order writes (#1746)

### DIFF
--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -1221,6 +1221,92 @@ mod tests {
         Ok(())
     }
 
+    /// Moving children into a NON-EMPTY parent must APPEND after its existing
+    /// children, not restart at 1.0, 2.0… The existing children are seeded via
+    /// `create_child_node_atomic` (which appends at 1.0, 2.0), so the old code —
+    /// which assigned the moved children a fresh 1.0, 2.0 ignoring existing
+    /// siblings — collided their order keys. Deterministic, single-threaded.
+    #[tokio::test]
+    async fn move_children_into_non_empty_parent_appends_without_collision() -> Result<()> {
+        let (store, _temp) = create_test_store().await?;
+
+        // new_parent already holds two children at orders 1.0 and 2.0.
+        let new_parent = Node::new("text".to_string(), "New Parent".to_string(), json!({}));
+        let new_parent_id = new_parent.id.clone();
+        store.create_node(new_parent, None, None).await?;
+        for i in 0..2 {
+            store
+                .create_child_node_atomic(
+                    &new_parent_id,
+                    "text",
+                    &format!("existing {i}"),
+                    json!({}),
+                    None,
+                )
+                .await?;
+        }
+
+        // Two children under a source parent, to be moved across.
+        let src = Node::new("text".to_string(), "Src".to_string(), json!({}));
+        let src_id = src.id.clone();
+        store.create_node(src, None, None).await?;
+        let mut moved_ids = Vec::new();
+        let mut moved_vers = Vec::new();
+        for i in 0..2 {
+            let c = Node::new("text".to_string(), format!("moving {i}"), json!({}));
+            let cid = c.id.clone();
+            let ver = c.version;
+            store.create_node(c, None, None).await?;
+            store.move_node(&cid, Some(&src_id), None).await?;
+            moved_ids.push(cid);
+            moved_vers.push(ver);
+        }
+        let pairs: Vec<(&str, i64)> = moved_ids
+            .iter()
+            .zip(moved_vers.iter())
+            .map(|(id, &v)| (id.as_str(), v))
+            .collect();
+        let mut moved_orders = store.move_children_to_parent(&new_parent_id, &pairs).await?;
+
+        // All four children now live under new_parent.
+        let children = store.get_children(&new_parent_id).await?;
+        assert_eq!(children.len(), 4, "new_parent should hold 2 existing + 2 moved");
+
+        // Every sibling order key is distinct — no collision with the existing
+        // children (the old code produced 1.0, 1.0, 2.0, 2.0 here).
+        let mut rows = store
+            .db
+            .query(
+                "SELECT json_extract(properties, '$.order') FROM relationship \
+                 WHERE in_node = ?1 AND relationship_type = 'has_child'",
+                libsql::params![new_parent_id.clone()],
+            )
+            .await?;
+        let mut orders: Vec<f64> = Vec::new();
+        while let Some(r) = rows.next().await? {
+            orders.push(r.get::<f64>(0)?);
+        }
+        assert_eq!(orders.len(), 4);
+        orders.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        for pair in orders.windows(2) {
+            assert!(
+                (pair[1] - pair[0]).abs() > f64::EPSILON,
+                "colliding sibling order keys after move into non-empty parent: {orders:?}"
+            );
+        }
+
+        // The moved children hold the two LARGEST order keys — appended after the
+        // existing children rather than overlapping them.
+        moved_orders.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(
+            moved_orders,
+            vec![orders[2], orders[3]],
+            "moved children should be appended after existing (orders: {orders:?})"
+        );
+
+        Ok(())
+    }
+
     /// two `SqliteStore`s opened against the same file (simulating a dev +
     /// production daemon both holding the DB) must not surface SQLITE_BUSY as a
     /// hard error on the loser of a write race. `busy_timeout` (set by migration 1,

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -75,6 +75,13 @@ impl SqliteStore {
 
         self.validate_no_cycle(parent_id, &node_id).await?;
 
+        // Serialize the sibling-order read → compute → write against move_node and
+        // other order mutations on the shared connection (held until return).
+        // Without it a concurrent create/move under the same parent reads the same
+        // max order and assigns a colliding key. No re-entrancy: this method calls
+        // no other reorder_lock-taking path. See `reorder_lock`.
+        let _reorder_guard = self.reorder_lock.lock().await;
+
         // Get last child order
         let mut rows = self.db.query(
             "SELECT json_extract(r.properties, '$.order') as ord FROM relationship r WHERE r.in_node = ?1 AND r.relationship_type = 'has_child' ORDER BY json_extract(r.properties, '$.order') DESC LIMIT 1",
@@ -1352,12 +1359,35 @@ impl SqliteStore {
 
         let now = Utc::now().to_rfc3339();
 
-        // Compute sequential fractional orders iteratively so each step uses the
-        // previously assigned order as its `prev`, producing a properly spaced
-        // sequence (e.g. [1.0, 2.0, 3.0]) rather than arbitrary constants.
+        // Serialize the sibling-order read → compute → write against move_node and
+        // other order mutations on the shared connection (held until return). No
+        // re-entrancy: the transaction below issues raw DELETE/INSERT and calls no
+        // other reorder_lock-taking path. See `reorder_lock`.
+        let _reorder_guard = self.reorder_lock.lock().await;
+
+        // Append the moved children AFTER new_parent_id's existing children: read
+        // the current max has_child order under the new parent and seed the
+        // sequence from it. Previously this assigned 1.0, 2.0, 3.0… ignoring
+        // existing siblings, so moving into a NON-EMPTY parent collided their
+        // order keys even single-threaded.
+        let existing_max: Option<f64> = {
+            let mut rows = self.db.query(
+                "SELECT json_extract(properties, '$.order') as ord FROM relationship WHERE in_node = ?1 AND relationship_type = 'has_child' ORDER BY json_extract(properties, '$.order') DESC LIMIT 1",
+                libsql::params![new_parent_id.to_string()],
+            ).await.context("Failed to read existing child order for move_children_to_parent")?;
+            if let Some(row) = rows.next().await? {
+                Some(row.get::<Option<f64>>(0)?.unwrap_or(0.0))
+            } else {
+                None
+            }
+        };
+
+        // Compute sequential fractional orders: the first appended after
+        // `existing_max` (or from scratch when the parent is empty), each
+        // subsequent after the previously assigned order.
         let mut orders: Vec<f64> = Vec::with_capacity(children.len());
         for _ in 0..children.len() {
-            let prev = orders.last().copied();
+            let prev = orders.last().copied().or(existing_max);
             orders.push(FractionalOrderCalculator::calculate_order(prev, None));
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #1561. Two fixes to sibling-order writes:

### 1. `move_children_to_parent` — single-threaded order collision (correctness)
It assigned the moved children fresh orders `1.0, 2.0, 3.0…` **without reading the new parent's existing children**, so moving into a **non-empty** parent collided their `has_child` order keys even without concurrency. It now reads the current max order under `new_parent_id` and **appends** the moved children after it (empty parent → unchanged behavior).

### 2. Bring `create_child_node_atomic` + `move_children_to_parent` under `reorder_lock`
#1561 added `reorder_lock` (a non-reentrant `tokio::Mutex`) to `move_node` only. These two other self-contained store paths do a sibling-order read → compute → write on the shared connection and could interleave with a concurrent reorder. They now hold the lock across that sequence.

**No re-entrancy / deadlock:** `reorder_lock` is acquired in exactly three store methods (`move_node`, `create_child_node_atomic`, `move_children_to_parent`) and none calls another (`rebalance_children_for_parent` deliberately doesn't take it); no caller holds the lock (it's private to `SqliteStore`).

## Scope

Deferred (needs a **layered** atomic store method, not a one-line lock) and filed as **#1750**: the ops-layer "add existing node as child" (`get_next_child_order` read → `create_generic_relationship` write, two separate store calls) and `bulk_create_has_child` (inserts pre-computed orders) still write `has_child` orders without the lock.

## Tests

- **New:** `move_children_into_non_empty_parent_appends_without_collision` — seeds the new parent with two children at 1.0/2.0 via `create_child_node_atomic`, moves two more in, asserts all four order keys are distinct and the moved children hold the two largest (appended after). The old code produced `1.0, 1.0, 2.0, 2.0`.
- Existing `test_move_children_to_parent_store_*`, `concurrent_reorders_keep_all_children_with_distinct_order`, and the ops-layer move tests still pass.

968 core lib tests pass; clippy clean; full pre-push gate green (one transient daemon-readiness e2e flake — a startup-timing timeout unrelated to this change — cleared on a longer `E2E_DAEMON_TIMEOUT`; passes cleanly standalone). Independent adversarial review: no deadlock / race / correctness bug / regression.

Closes #1746.
