### PR TITLE
Set explicit artifact retention on release-workflow uploads (#1748)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,9 @@ jobs:
           name: binaries-macos-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/bundle/
           if-no-files-found: warn
+          # Inspection-only (workflow_dispatch): a short window to download a build
+          # for manual checking, not a deliverable.
+          retention-days: 7
 
       - name: Upload .app bundle for pkg job
         uses: actions/upload-artifact@v7
@@ -124,6 +127,9 @@ jobs:
           name: app-bundle-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/bundle/macos/
           if-no-files-found: error
+          # Job-to-job handoff only — consumed by the pkg job (download-artifact)
+          # within minutes of this run. Never a deliverable, so the minimum: 1 day.
+          retention-days: 1
 
   build-tauri:
     name: Build Tauri (other platforms)
@@ -285,6 +291,8 @@ jobs:
             target/${{ matrix.rust_targets || '' }}/release/bundle/
             target/release/bundle/
           if-no-files-found: warn
+          # Inspection-only (workflow_dispatch): short window for manual download.
+          retention-days: 7
 
   build-pkg-macos:
     name: Build macOS .pkg installer (ARM)
@@ -381,6 +389,10 @@ jobs:
           name: installer-macos-pkg
           path: target/pkg-output/*.pkg
           if-no-files-found: warn
+          # Inspection-only (workflow_dispatch): the distribution path for a real
+          # release is the Release asset (gh release upload above), so the artifact
+          # copy is redundant there — keep it short.
+          retention-days: 7
 
   build-headless:
     strategy:


### PR DESCRIPTION
## Summary

No `upload-artifact` step in `release.yml` set `retention-days`, so every artifact inherited the 90-day repo default — including the job-to-job `.app` handoff bundle (needed for minutes) and artifacts from **failed** runs, which filled the Actions storage quota (1.3 GB).

Set retention per site by what the artifact is for:

| Line | Artifact | retention | Why |
|---|---|---|---|
| app-bundle handoff | `app-bundle-aarch64-apple-darwin` | **1 day** | consumed by the pkg job in the same run; never a deliverable |
| inspection | `binaries-macos-aarch64-apple-darwin` | 7 days | `workflow_dispatch`-only manual-download copy |
| inspection | `binaries-${{ matrix.platform }}-…` | 7 days | `workflow_dispatch`-only |
| installer | `installer-macos-pkg` | 7 days | `workflow_dispatch`-only; real releases attach the `.pkg` via `gh release upload`, so the artifact copy isn't the distribution path |

## Verification

- All **4** `upload-artifact` sites in the repo are covered (only `release.yml` has any; `audit.yml`/`nightly-webkit.yml` have none). `grep retention-days` previously returned nothing.
- YAML re-parses; each `retention-days` sits at the correct indent inside its step's `with:`.
- The `installer-macos-pkg` artifact is `workflow_dispatch`-guarded — on a real `release` event it isn't created at all; the release asset (`gh release upload`, `release`-guarded) is untouched. Shortening it loses no deliverable.
- Independent review: correct, no bad values, no deliverable harmed. Pre-push gate green.

## Out-of-file follow-ups (noted, not in this PR)
- **Repo-level default** (Settings → Actions → Artifact and log retention) is still 90 days — the backstop for future uploads added without an explicit value; should be lowered to ~7–14d by a repo admin.
- **nodespace-sync**'s release workflow (which produced the two failed-run 500 MB artifacts) needs the same audit — separate repo, tracked separately.

Stays within ADR-047 (no test-running workflow added; retention metadata only).

Closes #1748.
