### PR TITLE
Implement ProjectNodeBehavior and the project core schema (#134)

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -744,6 +744,150 @@ impl NodeBehavior for TaskNodeBehavior {
     }
 }
 
+/// True if `s` is an ISO calendar date `YYYY-MM-DD` (zero-padded), so plain
+/// string comparison orders two such dates correctly. Anything else returns
+/// false, in which case the project date-range check is skipped (per spec:
+/// enforce only when both dates parse as ISO).
+fn is_iso_date(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() == 10
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && b.iter().enumerate().all(|(i, &c)| {
+            if i == 4 || i == 7 {
+                c == b'-'
+            } else {
+                c.is_ascii_digit()
+            }
+        })
+}
+
+/// Built-in behavior for project nodes
+///
+/// A ProjectNode (`node_type = "project"`) is a container for tasks, milestones,
+/// and related work. Its name is the node `content` (like Collection and Task);
+/// typed data lives under the `properties.project.*` namespace. Children are real
+/// graph nodes attached via `has_child` edges, and ownership/membership are graph
+/// edges — never property blobs (Universal Graph model).
+///
+/// Validation split (matches `TaskNodeBehavior`): this behavior does TYPE checks
+/// plus the cross-field `start_date <= end_date` rule; the schema system validates
+/// enum membership and values, so enum-value checks are not duplicated here.
+///
+/// # Examples
+///
+/// ```rust
+/// use nodespace_core::behaviors::{NodeBehavior, ProjectNodeBehavior};
+/// use nodespace_core::models::Node;
+/// use serde_json::json;
+///
+/// let behavior = ProjectNodeBehavior;
+/// let node = Node::new(
+///     "project".to_string(),
+///     "Launch v1".to_string(),
+///     json!({ "project": { "status": "active" } }),
+/// );
+/// assert!(behavior.validate(&node).is_ok());
+/// ```
+pub struct ProjectNodeBehavior;
+
+impl NodeBehavior for ProjectNodeBehavior {
+    fn type_name(&self) -> &'static str {
+        "project"
+    }
+
+    fn validate(&self, node: &Node) -> Result<(), NodeValidationError> {
+        // Project name is the node content — required.
+        if node.content.trim().is_empty() {
+            return Err(NodeValidationError::MissingField(
+                "content (project name)".to_string(),
+            ));
+        }
+
+        // Typed fields live under `properties.project.*`. TYPE checks only —
+        // the schema system validates enum membership and allowed values.
+        if let Some(props) = node.properties.get("project") {
+            // status / priority must be strings if present.
+            for field in ["status", "priority"] {
+                if let Some(v) = props.get(field) {
+                    if !v.is_string() && !v.is_null() {
+                        return Err(NodeValidationError::InvalidProperties(format!(
+                            "{} must be a string",
+                            field
+                        )));
+                    }
+                }
+            }
+
+            // start_date / end_date must be strings if present; when both are
+            // present and both parse as ISO YYYY-MM-DD, enforce start <= end
+            // (string comparison is valid for zero-padded ISO dates).
+            let read_date = |name: &str| -> Result<Option<String>, NodeValidationError> {
+                match props.get(name) {
+                    None | Some(serde_json::Value::Null) => Ok(None),
+                    Some(v) => match v.as_str() {
+                        Some(s) => Ok(Some(s.to_string())),
+                        None => Err(NodeValidationError::InvalidProperties(format!(
+                            "{} must be a string",
+                            name
+                        ))),
+                    },
+                }
+            };
+            let start = read_date("start_date")?;
+            let end = read_date("end_date")?;
+            if let (Some(s), Some(e)) = (&start, &end) {
+                if is_iso_date(s) && is_iso_date(e) && s > e {
+                    return Err(NodeValidationError::InvalidProperties(
+                        "start_date must be on or before end_date".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn can_have_children(&self) -> bool {
+        true // Projects contain tasks, milestones, and related work
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true // Projects carry rich descriptions
+    }
+
+    fn default_metadata(&self) -> serde_json::Value {
+        serde_json::json!({
+            "project": {
+                "status": "planning",
+                "start_date": null,
+                "end_date": null,
+                "priority": null
+            }
+        })
+    }
+
+    /// Projects carry semantic content (their name/description) worth embedding as
+    /// a standalone root — unlike Task, which overrides these to `None`. This is an
+    /// intentional divergence, so it is stated explicitly here rather than left to
+    /// the trait default.
+    fn get_embeddable_content(&self, node: &Node) -> Option<String> {
+        if node.content.trim().is_empty() {
+            None
+        } else {
+            Some(node.content.clone())
+        }
+    }
+
+    fn get_parent_contribution(&self, node: &Node) -> Option<String> {
+        if node.content.trim().is_empty() {
+            None
+        } else {
+            Some(node.content.clone())
+        }
+    }
+}
+
 /// Built-in behavior for code block nodes
 ///
 /// Code block nodes contain code snippets with language selection.
@@ -2254,6 +2398,7 @@ impl NodeBehaviorRegistry {
         registry.register(Arc::new(TextNodeBehavior));
         registry.register(Arc::new(HeaderNodeBehavior));
         registry.register(Arc::new(TaskNodeBehavior));
+        registry.register(Arc::new(ProjectNodeBehavior));
         registry.register(Arc::new(CodeBlockNodeBehavior));
         registry.register(Arc::new(QuoteBlockNodeBehavior));
         registry.register(Arc::new(OrderedListNodeBehavior));
@@ -2704,6 +2849,107 @@ mod tests {
     }
 
     #[test]
+    fn test_project_node_behavior_valid() {
+        let behavior = ProjectNodeBehavior;
+        assert_eq!(behavior.type_name(), "project");
+        assert!(behavior.can_have_children());
+        assert!(behavior.supports_markdown());
+
+        // Full project: name + all typed fields, valid date range.
+        let full = Node::new(
+            "project".to_string(),
+            "Launch v1".to_string(),
+            json!({
+                "project": {
+                    "status": "active",
+                    "priority": "high",
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-06-30"
+                }
+            }),
+        );
+        assert!(behavior.validate(&full).is_ok());
+
+        // Minimal project: name only (no properties).
+        let minimal = Node::new("project".to_string(), "Untitled project".to_string(), json!({}));
+        assert!(behavior.validate(&minimal).is_ok());
+
+        // Equal start/end dates are allowed (start <= end).
+        let same_day = Node::new(
+            "project".to_string(),
+            "One-day sprint".to_string(),
+            json!({ "project": { "start_date": "2026-03-03", "end_date": "2026-03-03" } }),
+        );
+        assert!(behavior.validate(&same_day).is_ok());
+
+        // Projects are embeddable roots (unlike Task): content is returned.
+        assert_eq!(behavior.get_embeddable_content(&full), Some("Launch v1".to_string()));
+    }
+
+    #[test]
+    fn test_project_node_behavior_rejects_empty_name() {
+        let behavior = ProjectNodeBehavior;
+        let node = Node::new(
+            "project".to_string(),
+            "   ".to_string(),
+            json!({ "project": { "status": "planning" } }),
+        );
+        assert!(matches!(
+            behavior.validate(&node),
+            Err(NodeValidationError::MissingField(_))
+        ));
+    }
+
+    #[test]
+    fn test_project_node_behavior_rejects_non_string_fields() {
+        let behavior = ProjectNodeBehavior;
+        for bad in [
+            json!({ "project": { "status": 3 } }),
+            json!({ "project": { "priority": true } }),
+            json!({ "project": { "start_date": 20260101 } }),
+        ] {
+            let node = Node::new("project".to_string(), "P".to_string(), bad);
+            assert!(matches!(
+                behavior.validate(&node),
+                Err(NodeValidationError::InvalidProperties(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_project_node_behavior_rejects_inverted_date_range() {
+        let behavior = ProjectNodeBehavior;
+        let node = Node::new(
+            "project".to_string(),
+            "Time-travel project".to_string(),
+            json!({ "project": { "start_date": "2026-06-30", "end_date": "2026-01-01" } }),
+        );
+        assert!(matches!(
+            behavior.validate(&node),
+            Err(NodeValidationError::InvalidProperties(_))
+        ));
+
+        // Non-ISO dates skip the range check (spec: enforce only when both parse).
+        let non_iso = Node::new(
+            "project".to_string(),
+            "Loose dates".to_string(),
+            json!({ "project": { "start_date": "June 2026", "end_date": "Jan 2026" } }),
+        );
+        assert!(behavior.validate(&non_iso).is_ok());
+    }
+
+    #[test]
+    fn test_project_node_behavior_default_metadata() {
+        let behavior = ProjectNodeBehavior;
+        let meta = behavior.default_metadata();
+        let p = &meta["project"];
+        assert_eq!(p["status"], json!("planning"));
+        assert_eq!(p["start_date"], json!(null));
+        assert_eq!(p["end_date"], json!(null));
+        assert_eq!(p["priority"], json!(null));
+    }
+
+    #[test]
     fn test_task_node_behavior_validation() {
         let behavior = TaskNodeBehavior;
 
@@ -2969,7 +3215,8 @@ mod tests {
         assert!(types.contains(&"tool".to_string()));
         assert!(types.contains(&"person".to_string()));
         assert!(types.contains(&"database-settings".to_string()));
-        assert_eq!(types.len(), 18);
+        assert!(types.contains(&"project".to_string()));
+        assert_eq!(types.len(), 19);
     }
 
     #[test]

--- a/packages/core/src/models/core_schemas.rs
+++ b/packages/core/src/models/core_schemas.rs
@@ -171,6 +171,117 @@ pub fn get_core_schemas() -> Vec<SchemaNode> {
             title_template: None,
             properties_header_summary_template: None,
         },
+        // Project schema - container for tasks, milestones, related work.
+        // Name is the node `content`; ownership/membership are graph edges, not
+        // properties (Universal Graph). Enum values validated by the schema system.
+        SchemaNode {
+            id: "project".to_string(),
+            content: "Project".to_string(),
+            version: 1,
+            created_at: now,
+            modified_at: now,
+            is_core: true,
+            schema_version: 1,
+            fields: vec![
+                SchemaField {
+                    name: "status".to_string(),
+                    field_type: "enum".to_string(),
+                    protection: SchemaProtectionLevel::Core,
+                    core_values: Some(vec![
+                        EnumValue {
+                            value: "planning".to_string(),
+                            label: "Planning".to_string(),
+                        },
+                        EnumValue {
+                            value: "active".to_string(),
+                            label: "Active".to_string(),
+                        },
+                        EnumValue {
+                            value: "completed".to_string(),
+                            label: "Completed".to_string(),
+                        },
+                        EnumValue {
+                            value: "archived".to_string(),
+                            label: "Archived".to_string(),
+                        },
+                        EnumValue {
+                            value: "cancelled".to_string(),
+                            label: "Cancelled".to_string(),
+                        },
+                    ]),
+                    user_values: Some(vec![]),
+                    indexed: true,
+                    required: Some(true),
+                    extensible: Some(true),
+                    default: Some(serde_json::json!("planning")),
+                    description: Some("Project status".to_string()),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+                SchemaField {
+                    name: "priority".to_string(),
+                    field_type: "enum".to_string(),
+                    protection: SchemaProtectionLevel::User,
+                    core_values: Some(vec![
+                        EnumValue {
+                            value: "low".to_string(),
+                            label: "Low".to_string(),
+                        },
+                        EnumValue {
+                            value: "medium".to_string(),
+                            label: "Medium".to_string(),
+                        },
+                        EnumValue {
+                            value: "high".to_string(),
+                            label: "High".to_string(),
+                        },
+                    ]),
+                    user_values: Some(vec![]),
+                    indexed: true,
+                    required: Some(false),
+                    extensible: Some(true),
+                    default: None,
+                    description: Some("Project priority".to_string()),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+                SchemaField {
+                    name: "start_date".to_string(),
+                    field_type: "date".to_string(),
+                    protection: SchemaProtectionLevel::User,
+                    core_values: None,
+                    user_values: None,
+                    indexed: false,
+                    required: Some(false),
+                    extensible: None,
+                    default: None,
+                    description: Some("Project start date".to_string()),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+                SchemaField {
+                    name: "end_date".to_string(),
+                    field_type: "date".to_string(),
+                    protection: SchemaProtectionLevel::User,
+                    core_values: None,
+                    user_values: None,
+                    indexed: false,
+                    required: Some(false),
+                    extensible: None,
+                    default: None,
+                    description: Some("Project end date".to_string()),
+                    item_type: None,
+                    fields: None,
+                    item_fields: None,
+                },
+            ],
+            relationships: vec![],
+            title_template: None,
+            properties_header_summary_template: None,
+        },
         // Text schema - plain text content (no extra fields)
         SchemaNode {
             id: "text".to_string(),
@@ -1054,7 +1165,7 @@ mod tests {
     #[test]
     fn test_get_core_schemas_returns_all() {
         let schemas = get_core_schemas();
-        assert_eq!(schemas.len(), 17);
+        assert_eq!(schemas.len(), 18);
     }
 
     #[test]

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -568,8 +568,8 @@ async fn test_create_schema_description_not_in_properties() {
     handle_create_schema(
         &svc,
         json!({
-            "name": "Project",
-            "description": "Organizes work into milestones and tasks.",
+            "name": "Campaign",
+            "description": "Organizes outreach into phases and channels.",
             "fields": []
         }),
     )
@@ -577,7 +577,7 @@ async fn test_create_schema_description_not_in_properties() {
     .expect("create_schema should succeed");
 
     let node = svc
-        .get_node("project")
+        .get_node("campaign")
         .await
         .expect("get_node failed")
         .expect("schema node not found");


### PR DESCRIPTION
## Summary

Adds `project` as a core node type (Universal Graph model): a `project` `SchemaNode` in `core_schemas.rs` + a `ProjectNodeBehavior` registered in `NodeBehaviorRegistry::new()`.

- **Schema:** `status` (enum, Core, default `planning`, indexed, required), `priority` (enum, User, indexed, optional), `start_date`/`end_date` (date, User, optional). `is_core: true`. Mirrors the `task` schema.
- **Behavior:** name is the node `content`; typed data under `properties.project.*`; children are `has_child` edges; ownership/membership are graph edges — **no side table, no owner_id/team_members blob**.
- **Validation split (as `TaskNodeBehavior`):** the behavior TYPE-checks fields and enforces the cross-field `start_date <= end_date` rule (only when both parse as ISO `YYYY-MM-DD`); the schema system validates enum membership/values (not duplicated here). Empty name → `MissingField`; non-string `status`/`priority`/date → `InvalidProperties`.
- `can_have_children` → true, `supports_markdown` → true, `default_metadata` seeds `project.status = "planning"`. Projects are **embeddable roots** (name/description) — `get_embeddable_content`/`get_parent_contribution` return the content, unlike Task which returns `None` (intentional divergence, stated explicitly).

## Tests

5 behavior tests + a doctest: valid full project, minimal (name only), empty-name rejection, non-string field rejection, inverted date range rejection (+ non-ISO dates skip the range check, equal dates allowed), and `default_metadata` shape. Updated the enumeration tests (`test_registry_get_all_types` 18→19, `test_get_core_schemas_returns_all` 17→18) and renamed a `schema_test` example from "Project"→"Campaign", since `project` is now a reserved core type a user schema can't shadow.

973 core lib tests pass; clippy clean; doctest passes; pre-push gate green.

## Scope
Type only — no project UI/viewers, no status-transition workflows (#334), no `on_delete` (the trait has none). Per ADR corrections in the issue (Universal Graph; no `projects` table).

Closes #134.
