### PR TITLE
Consolidate subtree-render + drop dead code + expose skill in nav (part of #1699)

### DIFF
--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use nodespace_core::markdown::NodeTemplate;
 use nodespace_core::models::Node;
-use nodespace_core::services::NodeService;
+use nodespace_core::services::{flatten_subtree_content, NodeService};
 
 use crate::agent_guidance::{NODE_REFERENCE_FORMAT, SCHEMA_CREATION_RULES, TOOL_STRATEGY_RULES};
 use crate::agent_types::ToolDefinition;
@@ -196,37 +196,7 @@ impl PromptAssembler {
         // children, following adjacency_list which is already sorted by
         // fractional order. The prompt node itself is excluded (its content is
         // the short title/label, not prompt body).
-        let mut sections: Vec<String> = Vec::new();
-        let mut stack: Vec<String> = adjacency_list
-            .get(&node.id)
-            .map(|children| children.iter().rev().cloned().collect())
-            .unwrap_or_default();
-
-        while let Some(id) = stack.pop() {
-            if let Some(child) = node_map.get(&id) {
-                sections.push(child.content.clone());
-            } else {
-                // adjacency_list and node_map come from one consolidated
-                // get_subtree_data query, so they should never disagree. If they
-                // ever drift, an id with children but no node would silently drop
-                // its own content while still emitting descendants — a quieter
-                // version of the body-drop bug this method fixes. Surface it.
-                tracing::warn!(
-                    node_id = %id,
-                    "prompt_dump subtree: id in adjacency_list missing from node_map"
-                );
-            }
-            // Push this node's children (reversed so first child is popped first).
-            // The subtree is a single-parent `has_child` tree (acyclic by
-            // construction), so no visited-set is needed.
-            if let Some(grandchildren) = adjacency_list.get(&id) {
-                for gc in grandchildren.iter().rev() {
-                    stack.push(gc.clone());
-                }
-            }
-        }
-
-        sections.join("\n\n")
+        flatten_subtree_content(&node.id, &node_map, &adjacency_list).join("\n\n")
     }
 
     /// Render a Minijinja template with the given context.
@@ -248,39 +218,6 @@ impl PromptAssembler {
                 template_str.to_string()
             }
         }
-    }
-
-    /// Assemble prompt with an active skill context injected.
-    ///
-    /// When a skill is active:
-    /// 1. Graph-only prompt assembly (same as regular)
-    /// 2. Skill header with name and description
-    /// 3. Tool whitelist applied to tool schemas
-    pub async fn assemble_with_skill(
-        &self,
-        template_ctx: &TemplateContext,
-        tools: Vec<ToolDefinition>,
-        skill: &Node,
-    ) -> AssembledPrompt {
-        // Regular assembly first
-        let mut assembled = self.assemble(template_ctx, tools).await;
-
-        // Add skill context
-        let skill_name = &skill.content;
-        let skill_desc = skill
-            .properties
-            .get("description")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        let skill_section = format!(
-            "\n\nACTIVE SKILL: {}\n{}\n\
-             Focus on this skill's capabilities. Use only the tools provided.",
-            skill_name, skill_desc
-        );
-
-        assembled.system_prompt.push_str(&skill_section);
-        assembled
     }
 
     /// Assemble the base system prompt from seed nodes without a database.

--- a/packages/core/src/ops/skill_ops.rs
+++ b/packages/core/src/ops/skill_ops.rs
@@ -3,10 +3,10 @@
 //! Shared logic for skill search used by the local agent's `search_skills`
 //! tool and the MCP `find_skills` handler exposed to external agents.
 
-use crate::models::Node;
-use crate::services::{NodeEmbeddingService, NodeService, SearchNodeFilters};
+use crate::services::{
+    flatten_subtree_content, NodeEmbeddingService, NodeService, SearchNodeFilters,
+};
 use serde_json::{json, Value};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::OpsError;
@@ -75,30 +75,7 @@ async fn render_skill_instructions(node_service: &NodeService, skill_id: &str) -
 
     // One get_subtree_data query per skill. Acceptable under MAX_SKILL_LIMIT = 10;
     // a batch API would eliminate serial round trips if the limit grows.
-    let mut parts: Vec<String> = Vec::with_capacity(node_map.len());
-    render_subtree_dfs(skill_id, &node_map, &adjacency_list, &mut parts);
-    parts.join("\n\n")
-}
-
-/// Depth-first walk of the subtree adjacency list, collecting node content.
-/// Skips the root (skill node itself); visits all descendants in child order.
-fn render_subtree_dfs(
-    parent_id: &str,
-    node_map: &HashMap<String, Node>,
-    adjacency_list: &HashMap<String, Vec<String>>,
-    parts: &mut Vec<String>,
-) {
-    let Some(children) = adjacency_list.get(parent_id) else {
-        return;
-    };
-    for child_id in children {
-        if let Some(node) = node_map.get(child_id) {
-            if !node.content.is_empty() {
-                parts.push(node.content.clone());
-            }
-            render_subtree_dfs(child_id, node_map, adjacency_list, parts);
-        }
-    }
+    flatten_subtree_content(skill_id, &node_map, &adjacency_list).join("\n\n")
 }
 
 /// Search for skill nodes via semantic search and return flat results with
@@ -272,6 +249,7 @@ mod tests {
     use super::*;
     use crate::models::Node;
     use serde_json::json;
+    use std::collections::HashMap;
 
     fn make_node(id: &str, content: &str) -> Node {
         Node {
@@ -290,16 +268,15 @@ mod tests {
     }
 
     #[test]
-    fn render_subtree_dfs_empty_skill() {
+    fn flatten_subtree_content_empty_skill() {
         let node_map: HashMap<String, Node> = HashMap::new();
         let adjacency_list: HashMap<String, Vec<String>> = HashMap::new();
-        let mut parts = Vec::new();
-        render_subtree_dfs("skill-root", &node_map, &adjacency_list, &mut parts);
+        let parts = flatten_subtree_content("skill-root", &node_map, &adjacency_list);
         assert!(parts.is_empty());
     }
 
     #[test]
-    fn render_subtree_dfs_flat_children() {
+    fn flatten_subtree_content_flat_children() {
         let mut node_map = HashMap::new();
         node_map.insert("c1".to_string(), make_node("c1", "Step one"));
         node_map.insert("c2".to_string(), make_node("c2", "Step two"));
@@ -308,13 +285,12 @@ mod tests {
             "skill-root".to_string(),
             vec!["c1".to_string(), "c2".to_string()],
         );
-        let mut parts = Vec::new();
-        render_subtree_dfs("skill-root", &node_map, &adjacency_list, &mut parts);
+        let parts = flatten_subtree_content("skill-root", &node_map, &adjacency_list);
         assert_eq!(parts, vec!["Step one", "Step two"]);
     }
 
     #[test]
-    fn render_subtree_dfs_nested_children() {
+    fn flatten_subtree_content_nested_children() {
         let mut node_map = HashMap::new();
         node_map.insert("c1".to_string(), make_node("c1", "Section header"));
         node_map.insert("c1a".to_string(), make_node("c1a", "Sub-step A"));
@@ -325,8 +301,7 @@ mod tests {
             vec!["c1".to_string(), "c2".to_string()],
         );
         adjacency_list.insert("c1".to_string(), vec!["c1a".to_string()]);
-        let mut parts = Vec::new();
-        render_subtree_dfs("skill-root", &node_map, &adjacency_list, &mut parts);
+        let parts = flatten_subtree_content("skill-root", &node_map, &adjacency_list);
         assert_eq!(
             parts,
             vec!["Section header", "Sub-step A", "Another section"]
@@ -334,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn render_subtree_dfs_skips_empty_content() {
+    fn flatten_subtree_content_skips_empty_content() {
         let mut node_map = HashMap::new();
         node_map.insert("c1".to_string(), make_node("c1", ""));
         node_map.insert("c2".to_string(), make_node("c2", "Has content"));
@@ -343,8 +318,7 @@ mod tests {
             "skill-root".to_string(),
             vec!["c1".to_string(), "c2".to_string()],
         );
-        let mut parts = Vec::new();
-        render_subtree_dfs("skill-root", &node_map, &adjacency_list, &mut parts);
+        let parts = flatten_subtree_content("skill-root", &node_map, &adjacency_list);
         assert_eq!(parts, vec!["Has content"]);
     }
 
@@ -368,10 +342,10 @@ mod tests {
     }
 
     #[test]
-    fn render_subtree_dfs_join_produces_instructions_string() {
-        // Verify the full render_subtree_dfs → join pipeline that produces the
-        // `instructions` value delivered to the model. A regression in either
-        // function (e.g. wrong separator, missing DFS step) breaks this test.
+    fn flatten_subtree_content_join_produces_instructions_string() {
+        // Verify the full flatten_subtree_content → join pipeline that produces the
+        // `instructions` value delivered to the model. A regression in the flatten
+        // logic (e.g. wrong separator, missing DFS step) breaks this test.
         let mut node_map = HashMap::new();
         node_map.insert("c1".to_string(), make_node("c1", "Step one"));
         node_map.insert("c2".to_string(), make_node("c2", "Step two"));
@@ -380,9 +354,8 @@ mod tests {
             "skill-root".to_string(),
             vec!["c1".to_string(), "c2".to_string()],
         );
-        let mut parts = Vec::new();
-        render_subtree_dfs("skill-root", &node_map, &adjacency_list, &mut parts);
-        let instructions = parts.join("\n\n");
+        let instructions =
+            flatten_subtree_content("skill-root", &node_map, &adjacency_list).join("\n\n");
         assert_eq!(instructions, "Step one\n\nStep two");
     }
 }

--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -189,7 +189,8 @@ pub use embedding_service::{NodeEmbeddingService, EMBEDDING_DIMENSION};
 pub use error::NodeServiceError;
 pub use migration_registry::{MigrationRegistry, MigrationTransform};
 pub use node_service::{
-    CompletenessResult, CreateNodeParams, NodeService, SubtreeData, DEFAULT_QUERY_LIMIT,
+    flatten_subtree_content, CompletenessResult, CreateNodeParams, NodeService, SubtreeData,
+    DEFAULT_QUERY_LIMIT,
 };
 pub use query_service::{
     FilterOperator, FilterType, QueryDefinition, QueryFilter, QueryService, RelationshipType,

--- a/packages/core/src/services/node_service/hierarchy.rs
+++ b/packages/core/src/services/node_service/hierarchy.rs
@@ -951,3 +951,38 @@ impl NodeService {
         Ok(false)
     }
 }
+
+/// Flatten a node's child subtree into ordered content sections: a depth-first
+/// pre-order walk of `adjacency_list` (children already in fractional order, then
+/// their descendants), collecting each node's non-empty `content`. The root itself
+/// is excluded. `node_map`/`adjacency_list` come from `get_subtree_data`.
+pub fn flatten_subtree_content(
+    root_id: &str,
+    node_map: &std::collections::HashMap<String, crate::models::Node>,
+    adjacency_list: &std::collections::HashMap<String, Vec<String>>,
+) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut stack: Vec<String> = adjacency_list
+        .get(root_id)
+        .map(|c| c.iter().rev().cloned().collect())
+        .unwrap_or_default();
+    while let Some(id) = stack.pop() {
+        match node_map.get(&id) {
+            Some(node) => {
+                if !node.content.is_empty() {
+                    parts.push(node.content.clone());
+                }
+            }
+            None => tracing::warn!(
+                node_id = %id,
+                "flatten_subtree_content: id in adjacency_list missing from node_map"
+            ),
+        }
+        if let Some(children) = adjacency_list.get(&id) {
+            for c in children.iter().rev() {
+                stack.push(c.clone());
+            }
+        }
+    }
+    parts
+}

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -42,6 +42,8 @@ pub(crate) mod query;
 pub(crate) mod relationship;
 pub(crate) mod schema;
 
+pub use hierarchy::flatten_subtree_content;
+
 /// Reserved ID for the DatabaseSettingsNode singleton instance.
 ///
 /// The `database-settings` schema node stores its own id as the slug

--- a/packages/desktop-app/src/lib/stores/schemas.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/schemas.svelte.ts
@@ -21,7 +21,7 @@ const log = createLogger('SchemasStore');
 // Core schema IDs that are user-queryable and should appear in the sidenav.
 // Structural/inline types (text, date, header, code-block, etc.) are excluded —
 // they are node content primitives, not entity types users browse or filter.
-const SIDENAV_CORE_TYPES = new Set(['task']);
+const SIDENAV_CORE_TYPES = new Set(['task', 'skill']);
 
 class SchemasStore {
   /** Raw schema list */


### PR DESCRIPTION
## Summary

Ships the **non-conflicting subset** of #1699 (ADR-057). Items 2 (skill guidance → markdown children) and 3 (retire the `prompt` type) are **deferred** — see below and the [issue comment](https://github.com/NodeSpaceAI/nodespace-core/issues/1699).

- **Consolidate duplicate subtree-render logic:** `skill_ops::render_skill_instructions` and `PromptAssembler::fetch_prompt_body` carried two independent copies of the same DFS subtree walk. Extracted one shared `flatten_subtree_content` util in `packages/core` (`node_service::hierarchy`, re-exported at `services::`), used by both. `fetch_prompt_body` now also skips empty-content nodes (previously emitted blank `\n\n` sections) — a harmless unification; nested children are still preserved.
- **Delete dead code:** `PromptAssembler::assemble_with_skill()` (zero callers, leftover from the push-based discovery design ADR-038 replaced).
- **Nav:** `'skill'` added to `SIDENAV_CORE_TYPES` — skill nodes browse via the generic path (no new UI; `skill` is already a core schema).

## Why 2 & 3 are deferred

The issue's premise that the `prompt` type has "zero remaining consumers" is **incorrect**: the daemon seeds prompt-typed nodes at startup (`daemon/services/assembly.rs:229`) and `PromptAssembler::fetch_prompt_overrides` queries `node_type == "prompt"` **every agent turn** (`agent_loop.rs:298` → `assemble()`, a live path). Retiring the type would make those internal system-prompt override nodes fall back to the embeddable `CustomNodeBehavior` → search pollution; item 2 has the same embeddability implication. Retiring `prompt` needs a design decision (migrate the override mechanism off the type — the `agent-config` schema the issue gestures at) that's out of scope here. Full detail on the issue.

## Verification

`flatten_subtree_content` is behavior-equivalent to both originals (same pre-order; the only change is the harmless empty-skip). core 973 / agent 301 lib tests pass; clippy clean; the `fetch_prompt_body` body-drop regression test still passes; pre-push gate green. Independent review: sound.

**Part of #1699** (issue stays open for items 2 & 3).
