### PR TITLE
Enforce root-only content membership for member_of edges (#1742)

### DIFF
--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -3356,6 +3356,88 @@ mod tests {
         assert!(node_ids.contains(&child2_id), "child2 event missing");
     }
 
+    /// ADR-059 §2: a content node may hold a `member_of` edge only if it is a
+    /// root. Enforced on every membership-write path; person (grantee) and
+    /// collection (nesting) sources are exempt.
+    #[tokio::test]
+    async fn root_only_content_membership_is_enforced() {
+        let (service, _temp) = create_test_service().await;
+        let coll = service
+            .create_node(Node::new(
+                "collection".to_string(),
+                "Docs".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+
+        // A ROOT content node may be a member.
+        let root_doc = service
+            .create_node(Node::new("text".to_string(), "Root doc".to_string(), json!({})))
+            .await
+            .unwrap();
+        service
+            .create_relationship(&root_doc, "member_of", &coll, json!({}))
+            .await
+            .expect("a root content node may be a collection member");
+
+        // A NON-ROOT content node (has a has_child parent) is rejected.
+        let parent = service
+            .create_node(Node::new("text".to_string(), "Parent".to_string(), json!({})))
+            .await
+            .unwrap();
+        let child = service
+            .create_node(Node::new("text".to_string(), "Child".to_string(), json!({})))
+            .await
+            .unwrap();
+        service
+            .create_relationship(&parent, "has_child", &child, json!({}))
+            .await
+            .unwrap();
+        let err = service
+            .create_relationship(&child, "member_of", &coll, json!({}))
+            .await
+            .expect_err("an interior content node must not hold a member_of edge");
+        assert!(
+            format!("{err}").contains("root"),
+            "error should cite the root-only rule: {err}"
+        );
+
+        // Person `member_of` (grantee membership) is exempt.
+        let person = service
+            .create_node(Node::new("person".to_string(), "Alice".to_string(), json!({})))
+            .await
+            .unwrap();
+        service
+            .create_relationship(&person, "member_of", &coll, json!({}))
+            .await
+            .expect("person member_of (grantee) is exempt");
+
+        // Collection nesting is exempt.
+        let sub = service
+            .create_node(Node::new(
+                "collection".to_string(),
+                "Sub".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+        service
+            .create_relationship(&sub, "member_of", &coll, json!({}))
+            .await
+            .expect("collection nesting is exempt");
+
+        // The bulk import path enforces the same rule.
+        let bulk_err = service
+            .bulk_add_to_collections_notify(&[(child.clone(), coll.clone())])
+            .await
+            .expect_err("bulk import must reject an interior content node");
+        assert!(
+            format!("{bulk_err}").contains("root"),
+            "bulk error should cite the root-only rule: {bulk_err}"
+        );
+    }
+
     /// The batch importer assigns collection membership via
     /// `bulk_add_to_collections_notify`, and each newly created `member_of` edge
     /// MUST emit a RelationshipCreated event so the cloud-sync push replicates it.

--- a/packages/core/src/services/node_service/relationship.rs
+++ b/packages/core/src/services/node_service/relationship.rs
@@ -473,6 +473,30 @@ impl NodeService {
     /// # Ok(())
     /// # }
     /// ```
+    /// Enforce ADR-059 §2 root-only content membership: a content node may hold a
+    /// `member_of` edge only if it is a root (no `has_child` parent). Membership
+    /// carries access classification (ADR-037), so an interior node carrying
+    /// independent classification would make access a property of outline
+    /// position — the conflation ADR-059 exists to remove. Person `member_of`
+    /// edges (grantee membership, ADR-037 §4) and collection nesting are EXEMPT.
+    /// One validation shared by every membership-write path (`create_relationship`
+    /// and the bulk import path), so the invariant can't be broken by whichever
+    /// surface wrote the edge — including a remote edge applied by sync, which
+    /// routes through `create_relationship`.
+    async fn assert_root_only_membership(&self, source: &Node) -> Result<(), NodeServiceError> {
+        if source.node_type == "collection" || source.node_type == "person" {
+            return Ok(());
+        }
+        if !self.is_root_node(&source.id).await? {
+            return Err(NodeServiceError::invalid_update(format!(
+                "content node '{}' has a parent, so it cannot be a collection member; \
+                 only root nodes may hold a member_of edge (ADR-059 root-only membership)",
+                source.id
+            )));
+        }
+        Ok(())
+    }
+
     pub async fn create_relationship(
         &self,
         source_id: &str,
@@ -518,6 +542,9 @@ impl NodeService {
                         .await
                         .map_err(|e| NodeServiceError::collection_cycle(e.to_string()))?;
                 }
+                // Root-only content membership (ADR-059 §2). No-op for collection
+                // (nesting) and person (grantee) sources; enforced for content.
+                self.assert_root_only_membership(&source).await?;
             }
         } else {
             // Custom relationship: validate against source node's schema
@@ -704,6 +731,17 @@ impl NodeService {
         &self,
         memberships: &[(String, String)],
     ) -> Result<usize, NodeServiceError> {
+        // Root-only content membership (ADR-059 §2), same rule the single-add path
+        // enforces. Validate the whole batch before writing any edge so an interior
+        // content node can't be filed into a collection via bulk import.
+        for (node_id, _collection_id) in memberships {
+            let source = self
+                .get_node(node_id)
+                .await?
+                .ok_or_else(|| NodeServiceError::node_not_found(node_id))?;
+            self.assert_root_only_membership(&source).await?;
+        }
+
         let created = self
             .store
             .bulk_add_to_collections(memberships)


### PR DESCRIPTION
## Summary

ADR-059 §2: a **content node may hold a `member_of` edge only if it is a root** (no `has_child` parent). Membership carries access classification (ADR-037), so letting an interior node carry independent classification would make access a property of outline position — the conflation ADR-059 removes. Until now the rule held only by the absence of a UI affordance.

## Fix

A single shared `NodeService::assert_root_only_membership(&source)` — returns Ok for **collection** (nesting) and **person** (grantee membership, ADR-037 §4) sources; for a content source it requires `is_root_node`. Called from **both** `member_of` write paths:

- **`create_relationship`** (uses the source it already fetches) — covers single adds (CLI, `add_to_collection`, playbook `add_relationship`) **and the sync-apply of a remote edge**, which routes through `create_relationship` (`sync/nodespaced-pro/.../cloud_sync/apply.rs:305`) — so sync-apply parity holds with **no sync-repo change**.
- **`bulk_add_to_collections_notify`** (import) — validates the whole batch before writing.

One validation reused by every path, so the invariant can't be silently broken by whichever surface wrote the edge.

## Acceptance criteria
- [x] `member_of` from a content node with a `has_child` parent → rejected
- [x] `member_of` from a root content node → succeeds
- [x] Person-node `member_of` (grantee) unaffected
- [x] Collection→collection `member_of` (nesting) permitted
- [x] Declared as a shared validation, not hardcoded in a single write path

## Note on criterion 5

The rule is a single shared service-level validation reused by every write path (not a per-path check), which satisfies "not hardcoded in one write path." A fuller *schema-system-declared* validation framework (the issue's ideal phrasing, sibling to the seam #1734 gestures at) would be a separate refinement — flagged, not built here, to keep this focused on the enforcement.

## Verification

New test `root_only_content_membership_is_enforced` covers all four criteria + the bulk path. **Live-conflict check clean:** the full core (974) / agent (301) / daemon suites pass — nothing existing (seeds, skill/tool seeding, import) files an interior content node. Clippy clean; pre-push gate green.

Closes #1742.
