### PR TITLE
Rename the traversal RelationshipDirection enum to TraversalDirection

### DIFF
--- a/packages/core/src/models/mod.rs
+++ b/packages/core/src/models/mod.rs
@@ -60,11 +60,11 @@ pub use ai_chat_node::{AiChatMessage, AiChatNode};
 pub use code_block_node::{CodeBlockNode, CodeBlockValidationError};
 pub use node::{
     DeleteResult, FilterOperator, Node, NodeFilter, NodeQuery, NodeReference, NodeRelationship,
-    NodeUpdate, OrderBy, PropertyFilter, RelationshipDirection, ValidationError,
+    NodeUpdate, OrderBy, PropertyFilter, TraversalDirection, ValidationError,
 };
 pub use ordered_list_node::{OrderedListNode, OrderedListValidationError};
 pub use quote_block_node::{QuoteBlockNode, QuoteBlockValidationError};
-pub use schema::{SchemaField, SchemaProtectionLevel};
+pub use schema::{RelationshipDirection, SchemaField, SchemaProtectionLevel};
 pub use time::{SystemTimeProvider, TimeProvider};
 
 // Export type-safe wrappers

--- a/packages/core/src/models/node.rs
+++ b/packages/core/src/models/node.rs
@@ -45,13 +45,13 @@ pub use nodespace_types::{
     DeleteResult, Node, NodeQuery, NodeReference, NodeUpdate, ValidationError,
 };
 
-/// Direction of a relationship relative to a node
+/// Direction to traverse an edge relative to a node
 ///
 /// - `Out`: The relationship points FROM this node TO another (outgoing)
 /// - `In`: The relationship points FROM another node TO this node (incoming)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum RelationshipDirection {
+pub enum TraversalDirection {
     /// Outgoing relationship: this node -> other node
     Out,
     /// Incoming relationship: other node -> this node
@@ -78,7 +78,7 @@ pub struct NodeRelationship {
     /// The related node's title (for display)
     pub title: Option<String>,
     /// Direction of the relationship relative to the node this is attached to
-    pub direction: RelationshipDirection,
+    pub direction: TraversalDirection,
     /// Type of relationship (e.g., "mentions", "has_child", "member_of")
     pub relationship_type: String,
 }


### PR DESCRIPTION
## Summary
`nodespace_core::models` exposed two distinct enums both named `RelationshipDirection` — the graph-traversal direction (`models/node.rs`, a field on `NodeRelationship`) and the schema relationship declaration (`nodespace-types`, on `SchemaRelationship`). They only avoided a compile clash because `models/mod.rs` selectively re-exported one and left the other reachable by full path — a latent footgun (the two serialize differently, so a multi-word variant added later would silently produce a wire mismatch).

This renames the **traversal** enum to `TraversalDirection` and re-exports both by name, so the correct type is unambiguous at every call site.

## Change
- `models/node.rs`: `RelationshipDirection` → `TraversalDirection` (enum + the `NodeRelationship.direction` field). Keeps `#[serde(rename_all = "lowercase")]` — `Out`/`In` still serialize to `"out"`/`"in"`.
- `models/mod.rs`: re-export `TraversalDirection` by name, and now also re-export the schema `RelationshipDirection` (safe, no clash).
- Schema enum untouched.

Pure rename — no logic or wire-format change.

## Verification
- `cargo build --workspace` green (proves every call site resolves — the traversal enum turned out to be referenced only at its def, its field, and the re-export; the daemon uses a `String` direction and the CLI has its own separate `Direction` enum).
- `cargo test -p nodespace-core` + `-p nodespace-types` pass (wire-format round-trip tests confirm `"out"`/`"in"` unchanged).
- `cargo clippy --workspace --all-targets` clean, no suppression.

Closes #1642.