### PR TITLE
Restrict lifecycle_status writes to active/archived at the storage boundary

### DIFF
--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -284,6 +284,24 @@ impl SqliteStore {
         ))
     }
 
+    /// Reject any `lifecycle_status` outside the supported allow-list before it
+    /// reaches a SQL write. The only supported values are `"active"` and
+    /// `"archived"` (local deletion is a hard delete, so there is no `"deleted"`
+    /// state). Guarding here — the single point every INSERT/UPDATE of the column
+    /// flows through — structurally prevents an unsupported value (e.g. from a
+    /// playbook action or API caller) from letting hidden nodes resurface in
+    /// full-text and semantic search.
+    fn validate_lifecycle_status(status: &str) -> Result<()> {
+        if crate::models::is_valid_lifecycle_status(status) {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!(
+            "Invalid lifecycle_status '{}'. Valid values: {:?}",
+            status,
+            crate::models::LIFECYCLE_STATUSES
+        ))
+    }
+
     pub(crate) fn add_to_schema_cache(&mut self, type_name: String) {
         self.valid_node_types.insert(type_name);
     }

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -18,6 +18,8 @@ impl SqliteStore {
             }
         }
 
+        Self::validate_lifecycle_status(&node.lifecycle_status)?;
+
         let properties = if node.properties.is_null() {
             serde_json::json!({})
         } else {
@@ -217,6 +219,10 @@ impl SqliteStore {
         update: NodeUpdate,
         source: Option<String>,
     ) -> Result<Node> {
+        if let Some(ref status) = update.lifecycle_status {
+            Self::validate_lifecycle_status(status)?;
+        }
+
         let current = self
             .get_node(id)
             .await?
@@ -358,6 +364,10 @@ impl SqliteStore {
         source: Option<String>,
         playbook_context: Option<crate::db::events::PlaybookExecutionContext>,
     ) -> Result<Option<Node>> {
+        if let Some(ref status) = update.lifecycle_status {
+            Self::validate_lifecycle_status(status)?;
+        }
+
         let current = self
             .get_node(id)
             .await?
@@ -408,6 +418,7 @@ impl SqliteStore {
     }
 
     pub async fn update_lifecycle_status(&self, id: &str, status: &str) -> Result<()> {
+        Self::validate_lifecycle_status(status)?;
         self.db
             .execute(
                 "UPDATE node SET lifecycle_status = ?1 WHERE id = ?2",
@@ -1593,6 +1604,10 @@ impl SqliteStore {
             .context("Failed to begin bulk update transaction")?;
 
         for (id, update) in &updates {
+            if let Some(ref status) = update.lifecycle_status {
+                Self::validate_lifecycle_status(status)?;
+            }
+
             let props_json = update
                 .properties
                 .as_ref()

--- a/packages/core/src/models/mod.rs
+++ b/packages/core/src/models/mod.rs
@@ -78,3 +78,8 @@ pub use text_node::TextNode;
 // node_to_typed_value and nodes_to_typed_values are the single canonical
 // implementations in nodespace-types, re-exported here for all entry points.
 pub use nodespace_types::{node_to_typed_value, nodes_to_typed_values};
+
+// The lifecycle-status allow-list and its validator live in nodespace-types
+// (owner of the `Node`/`NodeUpdate` types), re-exported here as the single
+// source of truth for the storage-layer write guard.
+pub use nodespace_types::{is_valid_lifecycle_status, LIFECYCLE_STATUSES};

--- a/packages/core/src/ops/node_ops.rs
+++ b/packages/core/src/ops/node_ops.rs
@@ -26,7 +26,8 @@ pub struct CreateNodeInput {
     pub properties: Value,
     /// Optional collection path (e.g. "hr:policy:vacation")
     pub collection: Option<String>,
-    /// Optional lifecycle status ("active", "archived", "deleted")
+    /// Optional lifecycle status. Only `"active"` and `"archived"` are supported;
+    /// any other value is rejected at the storage boundary.
     pub lifecycle_status: Option<String>,
 }
 

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -2455,6 +2455,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_rejects_unsupported_lifecycle_status() {
+        let (service, _temp) = create_test_service().await;
+
+        let node = Node::new("text".to_string(), "Original".to_string(), json!({}));
+        let id = service.create_node(node).await.unwrap();
+
+        // Writing an unsupported lifecycle_status ("deleted") must be rejected —
+        // there is no soft-delete state, only "active"/"archived".
+        let bad = NodeUpdate::new().with_lifecycle_status("deleted".to_string());
+        let err = service
+            .update_node(&id, 1, bad)
+            .await
+            .expect_err("update with lifecycle_status 'deleted' must be rejected");
+        assert!(
+            err.to_string().contains("lifecycle_status"),
+            "error should name the offending field, got: {err}"
+        );
+
+        // The rejected write must leave the persisted row untouched (still active, v1).
+        let unchanged = service.get_node(&id).await.unwrap().unwrap();
+        assert_eq!(unchanged.lifecycle_status, "active");
+        assert_eq!(unchanged.version, 1);
+    }
+
+    #[tokio::test]
+    async fn test_active_archived_lifecycle_transitions_succeed() {
+        let (service, _temp) = create_test_service().await;
+
+        let node = Node::new("text".to_string(), "Original".to_string(), json!({}));
+        let id = service.create_node(node).await.unwrap();
+
+        // active -> archived
+        let archived = service
+            .update_node(
+                &id,
+                1,
+                NodeUpdate::new().with_lifecycle_status("archived".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(archived.lifecycle_status, "archived");
+        assert_eq!(archived.version, 2);
+
+        // archived -> active
+        let reactivated = service
+            .update_node(
+                &id,
+                2,
+                NodeUpdate::new().with_lifecycle_status("active".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(reactivated.lifecycle_status, "active");
+        assert_eq!(reactivated.version, 3);
+    }
+
+    #[tokio::test]
+    async fn test_all_store_write_paths_reject_unsupported_lifecycle_status() {
+        let (service, _temp) = create_test_service().await;
+        let node = Node::new("text".to_string(), "Original".to_string(), json!({}));
+        let id = service.create_node(node).await.unwrap();
+        let store = service.store();
+
+        // Direct single-column write path.
+        assert!(
+            store.update_lifecycle_status(&id, "deleted").await.is_err(),
+            "update_lifecycle_status must reject 'deleted'"
+        );
+        // A supported value on the same path still succeeds.
+        store
+            .update_lifecycle_status(&id, "archived")
+            .await
+            .expect("update_lifecycle_status must accept 'archived'");
+
+        // Batch write path.
+        assert!(
+            store
+                .bulk_update(vec![(
+                    id.clone(),
+                    NodeUpdate::new().with_lifecycle_status("deleted".to_string()),
+                )])
+                .await
+                .is_err(),
+            "bulk_update must reject 'deleted'"
+        );
+
+        // Insert write path.
+        let mut bad_new = Node::new("text".to_string(), "Bad".to_string(), json!({}));
+        bad_new.lifecycle_status = "deleted".to_string();
+        assert!(
+            store.create_node(bad_new, None, None).await.is_err(),
+            "create_node must reject 'deleted'"
+        );
+    }
+
+    #[tokio::test]
     async fn test_delete_with_cascade() {
         let (service, _temp) = create_test_service().await;
 

--- a/packages/nodespace-types/src/helpers.rs
+++ b/packages/nodespace-types/src/helpers.rs
@@ -1,3 +1,12 @@
+/// The complete set of supported node lifecycle states.
+///
+/// Local deletion is a hard delete, so there is deliberately no `"deleted"`
+/// state: a node is either live (`"active"`) or hidden from default views and
+/// search (`"archived"`). Persisting any other value would let hidden nodes leak
+/// back into full-text and semantic search, so writes are validated against this
+/// set at the storage boundary.
+pub const LIFECYCLE_STATUSES: [&str; 2] = ["active", "archived"];
+
 pub(crate) fn default_lifecycle_status() -> String {
     "active".to_string()
 }
@@ -8,4 +17,9 @@ pub(crate) fn default_version() -> i64 {
 
 pub(crate) fn is_active_lifecycle(s: &str) -> bool {
     s == "active"
+}
+
+/// Returns `true` if `status` is one of the [`LIFECYCLE_STATUSES`].
+pub fn is_valid_lifecycle_status(status: &str) -> bool {
+    LIFECYCLE_STATUSES.contains(&status)
 }

--- a/packages/nodespace-types/src/lib.rs
+++ b/packages/nodespace-types/src/lib.rs
@@ -20,6 +20,7 @@ mod task;
 
 pub use ai_chat::{AiChatMessage, AiChatNode};
 pub use convert::{node_to_typed_value, nodes_to_typed_values};
+pub use helpers::{is_valid_lifecycle_status, LIFECYCLE_STATUSES};
 pub use node::{DeleteResult, Node, NodeQuery, NodeReference, NodeUpdate, ValidationError};
 pub use schema::{
     EdgeField, EnumValue, RelationshipCardinality, RelationshipDirection, SchemaField, SchemaNode,


### PR DESCRIPTION
## Summary
`lifecycle_status` was a free-form, unvalidated `String` in the write path, so a playbook action or API caller could persist an unsupported value (e.g. `"deleted"`) — which would silently resurface hidden nodes in FTS/BM25 and semantic search (the guarding filters were removed as dead code once nothing wrote that value). Local deletion is a hard delete; the only supported states are `"active"` and `"archived"`.

## Change
- Single allow-list + validator in `nodespace-types` (`LIFECYCLE_STATUSES`, `is_valid_lifecycle_status`) — the crate that owns the `Node`/`NodeUpdate` types — re-exported through `crate::models`.
- `SqliteStore::validate_lifecycle_status` guards **every** SQL write of the column at the storage boundary (the lowest choke point all writes pass through): `create_node`, `update_node`, `update_node_with_version_check`, `update_lifecycle_status`, `bulk_update`. Both the ops/API path and the playbook `update_node` action funnel through these; the bulk path is a separate service choke point a service-layer-only guard would have missed.
- Fixed a stale doc comment that listed `"deleted"` as valid.

## Tests
- `"deleted"` update via `NodeService::update_node` is rejected and the persisted row is untouched (still `active`, v1).
- `active → archived → active` transitions succeed with correct version bumps.
- All three store write paths (`update_lifecycle_status`, `bulk_update`, `create_node`) reject `"deleted"` directly.

Verified `cargo test -p nodespace-core` (incl. the new tests) + `cargo build --workspace` + clippy clean. Playbook "disabled" state is an in-memory engine status (nodes are disabled via `archived`), so `[active, archived]` is the correct closed set.

Closes #1615.