### PR TITLE
Enforce root-only content membership for member_of edges (store-level, ADR-059 §2)

### DIFF
--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -519,6 +519,158 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_root_only_content_membership_is_enforced() -> Result<()> {
+        // ADR-059 §2: a content node may be `member_of` a collection only when it
+        // is a root node (no `has_child` parent). Enforced in `add_to_collection`,
+        // so every single-add path is gated — including the CLI (which routes
+        // through `ops::collection_ops` → `add_to_collection`).
+        let (store, _t) = create_test_store().await?;
+
+        let coll = Node::new("collection".to_string(), "Coll".to_string(), json!({}));
+        let coll_id = coll.id.clone();
+        store.create_node(coll, None, None).await?;
+
+        // A ROOT content node can be filed. (criterion: root content succeeds)
+        let root_text = Node::new("text".to_string(), "root doc".to_string(), json!({}));
+        let root_id = root_text.id.clone();
+        store.create_node(root_text, None, None).await?;
+        assert!(
+            store.add_to_collection(&root_id, &coll_id).await?.is_some(),
+            "a root content node must be fileable into a collection"
+        );
+
+        // An INTERIOR content node (has a `has_child` parent) is REJECTED. This is
+        // the CLI-path regression: filing an interior node into a (restricted or
+        // any) collection is refused with an actionable, node-naming error.
+        let interior = store
+            .create_child_node_atomic(&root_id, "text", "an interior child", json!({}), None)
+            .await?;
+        let err = store
+            .add_to_collection(&interior.id, &coll_id)
+            .await
+            .expect_err("an interior content node must not be fileable into a collection");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("member_of_not_root") && msg.contains(&interior.id),
+            "rejection must name the node and why it was refused; got: {msg}"
+        );
+
+        // The GENERIC relationship path is gated too. A `member_of` edge created
+        // with an explicit `order` — the CLI `relationship create --edge-data`,
+        // the playbook `add_relationship` action, and
+        // `NodeService::create_relationship`'s non-auto-order fork — routes through
+        // `create_generic_relationship`, which must reject an interior node just as
+        // `add_to_collection` does. (Regression for the bypass where adding one
+        // `order` JSON key skipped the guard.)
+        let err_generic = store
+            .create_generic_relationship(&interior.id, &coll_id, "member_of", &json!({"order": 5.0}))
+            .await
+            .expect_err("member_of via the generic path must reject an interior node");
+        assert!(
+            err_generic.to_string().contains("member_of_not_root"),
+            "generic-path rejection must carry the same reason; got: {err_generic}"
+        );
+        // A non-member_of generic edge is unaffected by the rule.
+        assert!(
+            store
+                .create_generic_relationship(&interior.id, &root_id, "mentions", &json!({}))
+                .await
+                .is_ok(),
+            "the root-only rule must not touch non-member_of generic edges"
+        );
+
+        // Person-node membership is EXEMPT (grantee membership, ADR-037 §4) — even
+        // when the person node is interior.
+        let interior_person = store
+            .create_child_node_atomic(&root_id, "person", "Ada", json!({}), None)
+            .await?;
+        assert!(
+            store
+                .add_to_collection(&interior_person.id, &coll_id)
+                .await
+                .is_ok(),
+            "person-node member_of edges are exempt from the root-only rule"
+        );
+
+        // Collection-to-collection nesting is EXEMPT — even an interior collection.
+        let interior_coll = store
+            .create_child_node_atomic(&root_id, "collection", "Nested", json!({}), None)
+            .await?;
+        assert!(
+            store
+                .add_to_collection(&interior_coll.id, &coll_id)
+                .await
+                .is_ok(),
+            "collection nesting is exempt from the root-only rule"
+        );
+
+        // End-to-end: a restricted task inside an OPEN project still works. The
+        // project ROOT is filed into the open collection; the task lives under it
+        // as an interior node and carries NO membership of its own — its access
+        // rides its root. Creating it must succeed (it is not a membership write).
+        let project = Node::new("project".to_string(), "Open Project".to_string(), json!({}));
+        let project_id = project.id.clone();
+        store.create_node(project, None, None).await?;
+        store.add_to_collection(&project_id, &coll_id).await?; // project root filed
+        let task = store
+            .create_child_node_atomic(&project_id, "task", "a restricted task", json!({}), None)
+            .await?;
+        assert!(
+            store.get_node_memberships(&task.id).await?.is_empty(),
+            "an interior task under a filed project holds no membership of its own"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bulk_root_only_membership_is_enforced() -> Result<()> {
+        // The bulk path (`bulk_add_to_collections`) is what the sync-apply
+        // cold-sweep calls directly, so the same rule must gate incoming edges.
+        let (store, _t) = create_test_store().await?;
+
+        let coll = Node::new("collection".to_string(), "Coll".to_string(), json!({}));
+        let coll_id = coll.id.clone();
+        store.create_node(coll, None, None).await?;
+
+        let r1 = Node::new("text".to_string(), "root 1".to_string(), json!({}));
+        let r1_id = r1.id.clone();
+        store.create_node(r1, None, None).await?;
+        let r2 = Node::new("text".to_string(), "root 2".to_string(), json!({}));
+        let r2_id = r2.id.clone();
+        store.create_node(r2, None, None).await?;
+
+        // An all-root batch applies cleanly.
+        let created = store
+            .bulk_add_to_collections(&[
+                (r1_id.clone(), coll_id.clone()),
+                (r2_id.clone(), coll_id.clone()),
+            ])
+            .await?;
+        assert_eq!(created.len(), 2, "both root memberships must be created");
+
+        // A batch containing ONE interior node is refused (cold-sweep parity): an
+        // incoming non-root membership edge cannot slip in via the bulk path.
+        let interior = store
+            .create_child_node_atomic(&r1_id, "text", "interior child", json!({}), None)
+            .await?;
+        let r3 = Node::new("text".to_string(), "root 3".to_string(), json!({}));
+        let r3_id = r3.id.clone();
+        store.create_node(r3, None, None).await?;
+        let err = store
+            .bulk_add_to_collections(&[
+                (r3_id.clone(), coll_id.clone()),
+                (interior.id.clone(), coll_id.clone()),
+            ])
+            .await
+            .expect_err("a bulk batch with an interior node must be refused");
+        assert!(
+            err.to_string().contains(&interior.id),
+            "the rejection must name the offending interior node; got: {err}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_backfill_fts_reindexes_unindexed_nodes() -> Result<()> {
         // a node present in `node` but missing from `node_fts` (the pre-FTS
         // corpus) must be re-indexed by the one-time backfill.
@@ -1266,11 +1418,17 @@ mod tests {
             .zip(moved_vers.iter())
             .map(|(id, &v)| (id.as_str(), v))
             .collect();
-        let mut moved_orders = store.move_children_to_parent(&new_parent_id, &pairs).await?;
+        let mut moved_orders = store
+            .move_children_to_parent(&new_parent_id, &pairs)
+            .await?;
 
         // All four children now live under new_parent.
         let children = store.get_children(&new_parent_id).await?;
-        assert_eq!(children.len(), 4, "new_parent should hold 2 existing + 2 moved");
+        assert_eq!(
+            children.len(),
+            4,
+            "new_parent should hold 2 existing + 2 moved"
+        );
 
         // Every sibling order key is distinct — no collision with the existing
         // children (the old code produced 1.0, 1.0, 2.0, 2.0 here).

--- a/packages/core/src/db/sqlite_store/relationships.rs
+++ b/packages/core/src/db/sqlite_store/relationships.rs
@@ -212,11 +212,67 @@ impl SqliteStore {
             .await
     }
 
+    /// ADR-059 §2 — a content node may hold a `member_of` edge only when it is a
+    /// **root** node (no `has_child` parent). Collections (nesting) and person
+    /// nodes (grantee membership, ADR-037 §4) are exempt. Enforced at the store's
+    /// three `member_of` INSERT sites (`add_to_collection`,
+    /// `bulk_add_to_collections`, and the generic `create_generic_relationship`
+    /// when its `rel_type` is `member_of`), so every write path is covered without
+    /// a per-path check: CLI, graph import, playbook `add_relationship`, and the
+    /// sync-apply cold-sweep (which calls `bulk_add_to_collections` directly). A
+    /// batched, chunked query keeps the bulk/cold-sweep path a single round trip.
+    /// Members that don't exist yet are left to the INSERT's foreign-key check.
+    async fn assert_root_only_membership(&self, member_ids: &[&str]) -> Result<()> {
+        if member_ids.is_empty() {
+            return Ok(());
+        }
+        let mut unique: Vec<&str> = member_ids.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+
+        // Chunk the `IN (...)` under SQLite's ~999 bound-parameter ceiling.
+        const ID_CHUNK: usize = 900;
+        for chunk in unique.chunks(ID_CHUNK) {
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            let sql = format!(
+                "SELECT n.id, n.node_type, \
+                 EXISTS(SELECT 1 FROM relationship r \
+                        WHERE r.out_node = n.id AND r.relationship_type = 'has_child') \
+                 FROM node n WHERE n.id IN ({})",
+                placeholders.join(", ")
+            );
+            let params: Vec<libsql::Value> = chunk
+                .iter()
+                .map(|id| libsql::Value::Text(id.to_string()))
+                .collect();
+            let mut rows = self
+                .db
+                .query(&sql, params)
+                .await
+                .context("Failed to validate root-only membership")?;
+            while let Some(row) = rows.next().await? {
+                let id: String = row.get(0)?;
+                let node_type: String = row.get(1)?;
+                let has_parent: i64 = row.get(2)?;
+                if has_parent != 0 && node_type != "collection" && node_type != "person" {
+                    return Err(anyhow::anyhow!(
+                        "member_of_not_root: content node '{}' (type '{}') has a parent, so it cannot be a member of a collection directly — file its root node instead",
+                        id,
+                        node_type
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub async fn add_to_collection(
         &self,
         member_id: &str,
         collection_id: &str,
     ) -> Result<Option<String>> {
+        self.assert_root_only_membership(&[member_id]).await?;
+
         let tx = self
             .db
             .transaction()
@@ -507,16 +563,20 @@ impl SqliteStore {
         // system/definition nodes, `collection` members are shown in the tree
         // itself, and `horizontal-line` is a decorative divider. Keep the two lists
         // in sync.
-        let mut rows = self.db.query(
-            "SELECT r.out_node, COUNT(*) \
+        let mut rows = self
+            .db
+            .query(
+                "SELECT r.out_node, COUNT(*) \
              FROM relationship r \
              JOIN node n ON n.id = r.in_node \
              WHERE r.relationship_type = 'member_of' \
                AND n.node_type NOT IN \
                  ('schema', 'person', 'database-settings', 'collection', 'horizontal-line') \
              GROUP BY r.out_node",
-            (),
-        ).await.context("Failed to get member counts")?;
+                (),
+            )
+            .await
+            .context("Failed to get member counts")?;
 
         let mut count_map: HashMap<String, usize> = HashMap::new();
         while let Some(row) = rows.next().await? {
@@ -628,6 +688,12 @@ impl SqliteStore {
         if memberships.is_empty() {
             return Ok(Vec::new());
         }
+
+        let member_ids: Vec<&str> = memberships
+            .iter()
+            .map(|(node_id, _)| node_id.as_str())
+            .collect();
+        self.assert_root_only_membership(&member_ids).await?;
 
         let start = std::time::Instant::now();
 
@@ -829,6 +895,15 @@ impl SqliteStore {
         rel_type: &str,
         properties: &serde_json::Value,
     ) -> Result<String> {
+        // ADR-059 §2 applies to a `member_of` edge no matter which API builds it.
+        // This generic path carries `member_of` whenever a caller supplies an
+        // explicit `order` — `NodeService::create_relationship`'s non-auto-order
+        // fork, the playbook `add_relationship` action, and the CLI
+        // `relationship create --edge-data` — so it must be gated too. (Auto-order
+        // `member_of` goes through `add_to_collection` instead; both are guarded.)
+        if rel_type == "member_of" {
+            self.assert_root_only_membership(&[source_id]).await?;
+        }
         let now = chrono::Utc::now().to_rfc3339();
         let rel_id = uuid::Uuid::new_v4().to_string();
         let props_json = serde_json::to_string(properties).unwrap_or_else(|_| "{}".to_string());


### PR DESCRIPTION
## What

Enforces **root-only content membership** for `member_of` edges (ADR-059 §2): a content node may be a member of a collection only when it is a **root** node (no `has_child` parent). `collection` nodes (nesting) and `person` nodes (grantee membership, ADR-037 §4) are exempt.

The rule is enforced at the **store** level so *every* write path is covered by construction — CLI, graph import, playbook `add_relationship`, and the sync-apply cold-sweep — rather than by a per-path check that a future path could miss.

## How

A new `SqliteStore::assert_root_only_membership(member_ids)` runs before all **three** `member_of` INSERT sites:

- `add_to_collection` (single, auto-order)
- `bulk_add_to_collections` (the path the sync-apply cold-sweep and daemon import call directly)
- `create_generic_relationship` when its `rel_type` is `member_of` — reached when a caller supplies an explicit `order` (`NodeService::create_relationship`'s non-auto-order fork, playbook `add_relationship`, CLI `relationship create --edge-data`)

The bulk check is a single chunked `IN (...)` query (node type + parent presence in one round trip), so the performance-sensitive cold-sweep path stays one query, not 2×N point lookups. Interior nodes are rejected with an actionable, node-naming error (`member_of_not_root: content node '<id>' …`).

## Acceptance criteria (issue #1742)

- ✅ interior content `member_of` write rejected; ✅ root content write succeeds
- ✅ person-node edges unaffected; ✅ collection-to-collection nesting permitted
- ✅ enforced on the sync-apply path (cold-sweep → `bulk_add_to_collections`), not only local writes
- ✅ rejection names the node and why; ✅ CLI path gated (routes through the guarded store methods)
- ✅ regression: interior node cannot be filed into a collection via the generic/explicit-order path
- ✅ regression: a restricted task inside an open project still works (interior task under a filed root holds no membership of its own)
- Criterion 5 (declared in the schema system as a store-aware relationship-validation *kind*) is left to the schema-seam work tracked with #1734; this PR is the enforcement.
- Criterion 8 (reparent transition) split to **#1765** (reject-the-indent); sync permanent-vs-transient apply classification split to **nodespace-sync#378**.

## Tests

Two store-level tests: `test_root_only_content_membership_is_enforced` (root ✓, interior ✗ via both `add_to_collection` and `create_generic_relationship`, person/collection exemptions, restricted-task-in-open-project end-to-end) and `test_bulk_root_only_membership_is_enforced` (all-root batch applies; a batch with one interior node is refused — cold-sweep parity). Full core lib suite: **975 passed / 0 failed**.

## Review

Two independent adversarial reviews. The first caught a real High-severity bypass — `create_generic_relationship` was an unguarded third `member_of` writer reachable by adding one `order` key — which is now fixed and covered by a test. A focused second pass confirmed the fix is complete (exactly three `member_of` writers, all guarded) and introduces no false positives.

Closes #1742
