### PR TITLE
Serialize the nlp-engine model-loading tests and bound model load with a timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ dependencies = [
  "lru",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sysinfo",
  "tempfile",

--- a/packages/nlp-engine/Cargo.toml
+++ b/packages/nlp-engine/Cargo.toml
@@ -50,6 +50,9 @@ tokio-test = { workspace = true }
 criterion = { workspace = true }
 tempfile = "3.0"
 futures = "0.3"
+# Serializes the model-loading integration tests so concurrent first-time
+# llama.cpp/Metal backend initialization cannot happen under the parallel harness.
+serial_test = "3.2"
 
 [features]
 default = ["embedding-service", "chat-service"]

--- a/packages/nlp-engine/src/embedding.rs
+++ b/packages/nlp-engine/src/embedding.rs
@@ -171,6 +171,69 @@ impl std::ops::Deref for BackendGuard {
     }
 }
 
+/// Maximum time to wait for the process-global backend to initialize and the
+/// model to load onto the GPU.
+///
+/// A normal load completes in a few seconds. A genuinely stuck first-time
+/// backend/Metal init would otherwise hang the process at 0% CPU forever.
+/// Exceeding this budget returns an error so the caller fails fast with a
+/// diagnostic instead of hanging silently. The budget is generous so it never
+/// trips on a slow-but-progressing load on a cold or constrained machine.
+#[cfg(feature = "embedding-service")]
+const MODEL_LOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Initialize the global backend (if needed) and load a model from `model_path`,
+/// bounded by `timeout`.
+///
+/// The blocking backend-init + model-load runs on a dedicated worker thread so a
+/// genuinely stuck load fails fast with an error instead of hanging the process
+/// at 0% CPU. The worker acquires the global backend Mutex via
+/// [`get_or_init_backend`] — serializing loads across services exactly as
+/// before — and returns the loaded `LlamaModel`, which is `Send`. The backend
+/// `MutexGuard` is created and dropped entirely within the worker thread, so it
+/// never crosses a thread boundary.
+///
+/// NOTE: if a load genuinely deadlocks, the abandoned worker thread still holds
+/// the backend Mutex, so subsequent loads in the same process would block on it.
+/// That is an acceptable tradeoff for this pathological case — the point is that
+/// the *first* stuck load returns an error instead of hanging the process
+/// forever at 0% CPU.
+#[cfg(feature = "embedding-service")]
+fn load_model_with_timeout(
+    model_path: std::path::PathBuf,
+    n_gpu_layers: u32,
+    timeout: std::time::Duration,
+) -> std::result::Result<LlamaModel, String> {
+    use std::sync::mpsc;
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("llama-model-load".to_string())
+        .spawn(move || {
+            let result = (|| {
+                // Holds the backend Mutex for the duration of the load.
+                let backend = get_or_init_backend()?;
+                let model_params = LlamaModelParams::default().with_n_gpu_layers(n_gpu_layers);
+                LlamaModel::load_from_file(&backend, &model_path, &model_params)
+                    .map_err(|e| format!("Model load failed: {}", e))
+            })();
+            // Receiver may have already timed out and dropped; ignore send errors.
+            let _ = tx.send(result);
+        })
+        .map_err(|e| format!("Failed to spawn model-load thread: {}", e))?;
+
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(format!(
+            "Model load timed out after {}s (possible Metal/GPU backend deadlock)",
+            timeout.as_secs()
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("Model-load thread terminated without returning a result".to_string())
+        }
+    }
+}
+
 /// Explicitly release the global llama backend to prevent SIGABRT on process exit.
 ///
 /// This drops the `LlamaBackend` while we still have full control of the process,
@@ -376,16 +439,13 @@ impl EmbeddingService {
                 EmbeddingError::IntegrityError(e)
             })?;
 
-            // Initialize llama.cpp backend (uses global singleton)
-            // BackendGuard holds the Mutex lock for the duration of model loading
-            let backend = get_or_init_backend().map_err(EmbeddingError::ModelLoadError)?;
-
-            // Load model with GPU offloading
-            let model_params =
-                LlamaModelParams::default().with_n_gpu_layers(self.config.n_gpu_layers);
-
-            let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
-                .map_err(|e| EmbeddingError::ModelLoadError(format!("Model load failed: {}", e)))?;
+            // Initialize the llama.cpp backend (global singleton) and load the
+            // model onto the GPU. This runs on a dedicated worker thread bounded
+            // by a timeout so a genuinely stuck first-time Metal/GPU init fails
+            // fast with an error instead of hanging the process at 0% CPU.
+            let model =
+                load_model_with_timeout(model_path, self.config.n_gpu_layers, MODEL_LOAD_TIMEOUT)
+                    .map_err(EmbeddingError::ModelLoadError)?;
 
             // Get actual embedding dimension from model
             self.embedding_dimension = model.n_embd() as usize;

--- a/packages/nlp-engine/tests/integration_tests.rs
+++ b/packages/nlp-engine/tests/integration_tests.rs
@@ -4,6 +4,13 @@
 #[cfg(all(test, feature = "embedding-service"))]
 mod integration_tests {
     use nodespace_nlp_engine::{EmbeddingConfig, EmbeddingService, EMBEDDING_DIMENSION};
+    use serial_test::serial;
+
+    // These tests each build an embedding service and load a real GGUF onto the
+    // GPU, racing to initialize the process-global llama.cpp/Metal backend. Under
+    // the parallel test harness that race deadlocks (0% CPU hang). `#[serial]`
+    // forces them to run one at a time so first-time backend init never races,
+    // letting the whole binary run in parallel with other test binaries.
 
     fn model_exists() -> bool {
         let config = EmbeddingConfig::default();
@@ -11,6 +18,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_service_initialization() {
         if !model_exists() {
             eprintln!(
@@ -29,6 +37,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_single_embedding_generation() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -60,6 +69,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_asymmetric_embeddings() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -89,6 +99,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_batch_embedding_generation() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -117,6 +128,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_cache_functionality() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -155,6 +167,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_semantic_similarity() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -194,6 +207,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_blob_roundtrip() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -227,6 +241,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_empty_text_handling() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -243,6 +258,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_long_text_handling() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -264,6 +280,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_device_info() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");
@@ -285,6 +302,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_concurrent_requests() {
         if !model_exists() {
             eprintln!("Skipping test: model not found");


### PR DESCRIPTION
## Summary
`cargo test -p nodespace-nlp-engine` hung indefinitely at 0% CPU: the parallel harness ran the 11 model-loading integration tests concurrently, racing to initialize the process-global llama.cpp/Metal backend and deadlocking. `--test-threads=1` passed all 11 in ~13s.

## Change
- **Serialize the model-loading tests** with `serial_test`'s `#[serial]` (added as a dev-dependency) on all 11 integration tests, so first-time backend init can no longer race under the parallel harness. The 3 stub tests are untouched.
- **Bound the load with a timeout**: `load_model_with_timeout` runs the blocking backend-init + model-load on a dedicated worker thread with a 120s budget, returning an error instead of hanging forever if a first-time Metal/GPU init genuinely stalls.

The deliberate `Mutex<Option<LlamaBackend>>` drop-at-exit design is unchanged — the backend `MutexGuard` is created and dropped entirely inside the worker thread and never crosses a thread boundary; only the `Send` `LlamaModel` is returned. Loads across services stay serialized exactly as before.

## Verification
- **Before:** parallel run hung at 0% CPU (killed after ~4 min); serial passed 11/11.
- **After:** `cargo test -p nodespace-nlp-engine` (no `--test-threads`) passes — 108 lib + 11 integration tests, process pinned at ~95% CPU (the decisive contrast with the 0% hang).
- `cargo clippy -p nodespace-nlp-engine --all-targets -- -D warnings` + `cargo fmt --check` clean, no suppression.

Closes #1761.