### PR TITLE
Serialize the ops-layer has_child order write under reorder_lock

### DIFF
--- a/packages/core/src/db/sqlite_store/relationships.rs
+++ b/packages/core/src/db/sqlite_store/relationships.rs
@@ -207,9 +207,48 @@ impl SqliteStore {
             .await
     }
 
-    pub async fn get_next_child_order(&self, parent_id: &str) -> Result<f64> {
-        self.get_next_order_for_relationship(parent_id, "has_child", false)
-            .await
+    /// Append a `has_child` edge from `parent_id` to `child_id`, assigning the
+    /// next fractional sibling order — reading the current max order, computing
+    /// the next key, and inserting the edge as ONE atomic unit under
+    /// `reorder_lock`. The ordered `has_child` analogue of `add_to_collection`'s
+    /// `member_of` path.
+    ///
+    /// Splitting the read from the write (a separate "get next order" call
+    /// followed by a generic relationship insert) let a concurrent reorder
+    /// interleave between them, so two appends computed the same order key
+    /// against a now-stale max and collided. Holding `reorder_lock` across the
+    /// read → compute → write serializes this against `move_node`,
+    /// `create_child_node_atomic`, and `move_children_to_parent`, matching their
+    /// discipline. The lock scopes exactly the order read/compute/write — no
+    /// unrelated async work runs under it.
+    ///
+    /// No re-entrancy: `get_next_order_for_relationship` and the raw INSERT take
+    /// no lock, so nothing re-acquires `reorder_lock`. See `reorder_lock`.
+    ///
+    /// Uses `INSERT OR IGNORE` (matching `create_generic_relationship`) so a
+    /// duplicate edge — already guarded by the caller's existence check — is a
+    /// benign no-op rather than a unique-index error. Returns the assigned order
+    /// and the new relationship id.
+    pub async fn append_child_edge(
+        &self,
+        parent_id: &str,
+        child_id: &str,
+    ) -> Result<(f64, String)> {
+        let _reorder_guard = self.reorder_lock.lock().await;
+
+        let new_order = self
+            .get_next_order_for_relationship(parent_id, "has_child", false)
+            .await?;
+
+        let rel_id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let props = serde_json::json!({ "order": new_order }).to_string();
+        self.db.execute(
+            "INSERT OR IGNORE INTO relationship (id, in_node, out_node, relationship_type, properties, version, created_at, modified_at) VALUES (?1, ?2, ?3, 'has_child', ?4, 1, ?5, ?6)",
+            libsql::params![rel_id.clone(), parent_id.to_string(), child_id.to_string(), props, now.clone(), now],
+        ).await.context("Failed to insert has_child edge")?;
+
+        Ok((new_order, rel_id))
     }
 
     /// ADR-059 §2 — a content node may hold a `member_of` edge only when it is a

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1829,6 +1829,159 @@ mod tests {
         (service, temp_dir)
     }
 
+    /// Adding existing nodes as children one at a time appends each after the
+    /// current last sibling, producing strictly increasing order keys — the
+    /// simple single-threaded case for the add-existing-child path.
+    #[tokio::test]
+    async fn add_existing_child_appends_in_order() {
+        let (service, _temp) = create_test_service().await;
+        for id in ["p", "a", "b", "c"] {
+            service
+                .create_node(Node::new_with_id(
+                    id.to_string(),
+                    "text".to_string(),
+                    id.to_string(),
+                    json!({}),
+                ))
+                .await
+                .unwrap();
+        }
+
+        for child in ["a", "b", "c"] {
+            service
+                .create_relationship("p", "has_child", child, json!({}))
+                .await
+                .unwrap();
+        }
+
+        // get_children sorts by the has_child edge order ASC, so insertion order
+        // is preserved: each append landed after the previous max.
+        let kids: Vec<String> = service
+            .get_children("p")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|k| k.id)
+            .collect();
+        assert_eq!(kids, vec!["a", "b", "c"], "appends preserve sibling order");
+
+        let mut orders: Vec<f64> = service
+            .store()
+            .get_relationship_orders("p", "has_child", "in_node")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|o| o.unwrap_or(0.0))
+            .collect();
+        orders.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(orders, vec![1.0, 2.0, 3.0], "strictly appended order keys");
+    }
+
+    /// Regression for the ops-layer add-existing-child order race: many
+    /// `create_relationship("has_child")` appends onto the SAME parent running
+    /// at once — alongside a concurrent reorder of an existing child — must leave
+    /// every sibling with a DISTINCT fractional-order key. The pre-fix code read
+    /// the next child order and wrote the edge as two separate un-serialized
+    /// steps, so concurrent appends computed the same key against a stale max and
+    /// collided. `append_child_edge` does the read → compute → write atomically
+    /// under `reorder_lock`, matching `move_node`'s discipline.
+    ///
+    /// Requires a multi-thread runtime so the appends' read/compute/write can
+    /// actually interleave (mirrors the store-level reorder-race test).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_add_existing_child_keeps_distinct_order() {
+        let (service, _temp) = create_test_service().await;
+        let service = Arc::new(service);
+
+        // Parent seeded with two children: a non-trivial starting max order and a
+        // reorder target for the concurrent move.
+        service
+            .create_node(Node::new_with_id(
+                "p".to_string(),
+                "text".to_string(),
+                "p".to_string(),
+                json!({}),
+            ))
+            .await
+            .unwrap();
+        for seed in ["seed0", "seed1"] {
+            service
+                .create_node(Node::new_with_id(
+                    seed.to_string(),
+                    "text".to_string(),
+                    seed.to_string(),
+                    json!({}),
+                ))
+                .await
+                .unwrap();
+            service
+                .create_relationship("p", "has_child", seed, json!({}))
+                .await
+                .unwrap();
+        }
+
+        // Orphan nodes to attach concurrently.
+        const N: usize = 16;
+        for i in 0..N {
+            service
+                .create_node(Node::new_with_id(
+                    format!("n{i}"),
+                    "text".to_string(),
+                    format!("n{i}"),
+                    json!({}),
+                ))
+                .await
+                .unwrap();
+        }
+
+        let mut handles = Vec::new();
+        // N concurrent add-existing-child appends onto the same parent.
+        for i in 0..N {
+            let service = service.clone();
+            handles.push(tokio::spawn(async move {
+                service
+                    .create_relationship("p", "has_child", &format!("n{i}"), json!({}))
+                    .await
+            }));
+        }
+        // A concurrent reorder contending on the same parent's sibling order.
+        {
+            let service = service.clone();
+            handles.push(tokio::spawn(async move {
+                service
+                    .reorder_child("seed1", crate::services::InsertPosition::Beginning)
+                    .await
+            }));
+        }
+        for h in handles {
+            h.await
+                .expect("task panicked")
+                .expect("add-existing-child / reorder returned an error");
+        }
+
+        // All 2 seed + N appended children are present (none lost/duplicated).
+        let children = service.get_children("p").await.unwrap();
+        assert_eq!(children.len(), N + 2, "lost or duplicated a child");
+
+        // Every has_child edge under the parent carries a DISTINCT order key.
+        let mut orders: Vec<f64> = service
+            .store()
+            .get_relationship_orders("p", "has_child", "in_node")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|o| o.unwrap_or(0.0))
+            .collect();
+        assert_eq!(orders.len(), N + 2, "expected one edge per child");
+        orders.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        for pair in orders.windows(2) {
+            assert!(
+                (pair[1] - pair[0]).abs() > f64::EPSILON,
+                "colliding sibling order keys after concurrent add-existing-child: {orders:?}"
+            );
+        }
+    }
+
     /// The batched edge-sweep primitive (#345) reproduces the sender's sibling order
     /// and is idempotent — it never re-parents a child that already has a parent.
     #[tokio::test]

--- a/packages/core/src/services/node_service/relationship.rs
+++ b/packages/core/src/services/node_service/relationship.rs
@@ -640,29 +640,41 @@ impl NodeService {
             return Ok(());
         }
 
-        // Auto-calculate order for built-in ordered relationships if not provided
-        let final_edge_data = if is_builtin {
-            let mut data = edge_data.as_object().cloned().unwrap_or_default();
+        // Auto-ordered `has_child` with no caller-supplied order: the next
+        // fractional key MUST be read and written as one atomic unit, or a
+        // concurrent reorder can interleave between the read and the write and
+        // collide the order key. The store method does the read → compute →
+        // write under `reorder_lock`. (member_of auto-order is likewise handled
+        // atomically above via add_to_collection.) Explicit-order has_child and
+        // the unordered builtins fall through to the generic path below.
+        if relationship_name == "has_child" && edge_data.get("order").is_none() {
+            let (order, rel_id) = self
+                .store
+                .append_child_edge(source_id, target_id)
+                .await
+                .map_err(|e| {
+                    NodeServiceError::query_failed(format!("Failed to append child edge: {}", e))
+                })?;
 
-            // Auto-calculate order if not provided for ordered relationship types
-            // Note: member_of with auto-order is handled above via atomic add_to_collection
-            if data.get("order").is_none() {
-                let order = match relationship_name {
-                    "has_child" => Some(self.store.get_next_child_order(source_id).await.map_err(
-                        |e| {
-                            NodeServiceError::query_failed(format!(
-                                "Failed to calculate child order: {}",
-                                e
-                            ))
-                        },
-                    )?),
-                    _ => None, // "mentions" doesn't need ordering, member_of handled above
-                };
-                if let Some(ord) = order {
-                    data.insert("order".to_string(), serde_json::json!(ord));
-                }
-            }
-            serde_json::json!(data)
+            self.emit_event(DomainEvent::RelationshipCreated {
+                relationship: crate::db::events::RelationshipEvent::new(
+                    rel_id,
+                    source_id,
+                    target_id,
+                    "has_child",
+                    serde_json::json!({ "order": order }),
+                ),
+            });
+
+            return Ok(());
+        }
+
+        // Remaining relationships carry the caller's edge_data as-is: the two
+        // auto-ordered builtins (member_of, has_child) returned early above, and
+        // mentions / has_role are unordered. Builtins normalize a non-object
+        // payload to an empty object; custom relationships pass through verbatim.
+        let final_edge_data = if is_builtin {
+            serde_json::json!(edge_data.as_object().cloned().unwrap_or_default())
         } else {
             edge_data.clone()
         };


### PR DESCRIPTION
## Summary
The ops-layer add-existing-child path (`NodeService::create_relationship`, `has_child` auto-order) read the next child order and wrote the edge as **two separate** store calls (`get_next_child_order` then a generic insert). A concurrent reorder could interleave between them and collide the fractional order key. #1751 brought the store-internal writers (`move_node`, `create_child_node_atomic`, `move_children_to_parent`) under `reorder_lock`, but this ops-layer read-then-write was still unprotected.

## Change
- New store method `SqliteStore::append_child_edge(parent, child)` reads the max child order, computes the next fractional key, and inserts the `has_child` edge **as one unit under `reorder_lock`** — the ordered analogue of `add_to_collection`'s atomic `member_of` path. `get_next_child_order` (its only caller) is removed.
- `create_relationship` early-returns via `append_child_edge` for auto-ordered `has_child`, mirroring the existing `member_of` early-return. Explicit-order `has_child` and the unordered builtins fall through to the generic path unchanged.
- Bulk paths (`bulk_create_hierarchy`, `bulk_create_has_child`) assign explicit precomputed orders and don't read-then-write, so they aren't exposed to this race; `move_children_to_parent` was already locked by #1751.

**Re-entrancy:** the lock is taken only inside `append_child_edge`, which calls only lock-free code (a plain `SELECT` + a raw insert), so the non-re-entrant `tokio::sync::Mutex` cannot deadlock. Four lock sites total, none nesting another.

## Tests
- `concurrent_add_existing_child_keeps_distinct_order` — 16 concurrent appends onto one parent plus a concurrent reorder; asserts no lost/duplicated child and all order keys distinct. Mutation-checked: removing the lock makes it fail with colliding keys.
- `add_existing_child_appends_in_order` — the simple sequential case.

`cargo test -p nodespace-core` (980 lib + integration incl. the #1751 regression tests), `cargo build --workspace`, clippy `-D warnings`, fmt — all green.

Closes #1750.