### PR TITLE
Reject reparenting a collection member into an interior position (ADR-059 §2)

### DIFF
--- a/packages/core/src/db/sqlite_store/mod.rs
+++ b/packages/core/src/db/sqlite_store/mod.rs
@@ -581,7 +581,12 @@ mod tests {
         // `add_to_collection` does. (Regression for the bypass where adding one
         // `order` JSON key skipped the guard.)
         let err_generic = store
-            .create_generic_relationship(&interior.id, &coll_id, "member_of", &json!({"order": 5.0}))
+            .create_generic_relationship(
+                &interior.id,
+                &coll_id,
+                "member_of",
+                &json!({"order": 5.0}),
+            )
             .await
             .expect_err("member_of via the generic path must reject an interior node");
         assert!(
@@ -684,6 +689,92 @@ mod tests {
         assert!(
             err.to_string().contains(&interior.id),
             "the rejection must name the offending interior node; got: {err}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reparent_guard_rejects_moving_a_member_under_a_parent() -> Result<()> {
+        // ADR-059 §2 (reparent side): the store's `move_node` chokepoint rejects
+        // giving a `has_child` parent to a node that holds a `member_of` edge, so
+        // every reparent path (service move_node, upsert_node_with_parent, ...) is
+        // covered. Non-members move freely; move-to-root is allowed; collection and
+        // person nodes are exempt.
+        let (store, _t) = create_test_store().await?;
+
+        let coll = Node::new("collection".to_string(), "Coll".to_string(), json!({}));
+        let coll_id = coll.id.clone();
+        store.create_node(coll, None, None).await?;
+
+        let parent = Node::new("text".to_string(), "parent".to_string(), json!({}));
+        let parent_id = parent.id.clone();
+        store.create_node(parent, None, None).await?;
+
+        // A root member cannot be moved under a parent.
+        let member = Node::new("text".to_string(), "root member".to_string(), json!({}));
+        let member_id = member.id.clone();
+        store.create_node(member, None, None).await?;
+        store.add_to_collection(&member_id, &coll_id).await?;
+        let err = store
+            .move_node(&member_id, Some(&parent_id), None)
+            .await
+            .expect_err("store must reject reparenting a collection member");
+        assert!(
+            err.to_string().contains("member_of_not_root") && err.to_string().contains(&coll_id),
+            "rejection must name the reason and the collection; got: {err}"
+        );
+
+        // Moving the same member to root is allowed (the guard only fires on gaining a parent).
+        assert!(
+            store.move_node(&member_id, None, None).await.is_ok(),
+            "moving a member to root must be allowed"
+        );
+
+        // A non-member node moves under a parent freely.
+        let plain = Node::new("text".to_string(), "plain".to_string(), json!({}));
+        let plain_id = plain.id.clone();
+        store.create_node(plain, None, None).await?;
+        assert!(
+            store
+                .move_node(&plain_id, Some(&parent_id), None)
+                .await
+                .is_ok(),
+            "a non-member node must move under a parent freely"
+        );
+
+        // Person-node membership is exempt: an interior person member is allowed.
+        let person = Node::new("person".to_string(), "Ada".to_string(), json!({}));
+        let person_id = person.id.clone();
+        store.create_node(person, None, None).await?;
+        store.add_to_collection(&person_id, &coll_id).await?;
+        assert!(
+            store
+                .move_node(&person_id, Some(&parent_id), None)
+                .await
+                .is_ok(),
+            "person-node membership is exempt from the reparent rule"
+        );
+
+        // The sync cold-sweep bulk attach path (`bulk_create_has_child`) is gated
+        // too, symmetric with the forward `bulk_add_to_collections` guard: a batch
+        // that would give a parent to a root member is rejected.
+        let bulk_member = Node::new("text".to_string(), "bulk member".to_string(), json!({}));
+        let bulk_member_id = bulk_member.id.clone();
+        store.create_node(bulk_member, None, None).await?;
+        store.add_to_collection(&bulk_member_id, &coll_id).await?;
+        let plain2 = Node::new("text".to_string(), "plain2".to_string(), json!({}));
+        let plain2_id = plain2.id.clone();
+        store.create_node(plain2, None, None).await?;
+        let bulk_err = store
+            .bulk_create_has_child(&[
+                (parent_id.clone(), plain2_id.clone(), 1.0),
+                (parent_id.clone(), bulk_member_id.clone(), 2.0),
+            ])
+            .await
+            .expect_err("bulk_create_has_child must reject attaching a root member to a parent");
+        assert!(
+            bulk_err.to_string().contains("member_of_not_root"),
+            "bulk cold-sweep reparent must be gated; got: {bulk_err}"
         );
         Ok(())
     }

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -1210,6 +1210,63 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// ADR-059 §2 (reparent side of the root-only content-membership rule): a node
+    /// that holds a `member_of` edge is a root member and must not be given a
+    /// `has_child` parent — that would make it a forbidden interior member with no
+    /// `member_of` write for the store's forward guard to catch. Called at BOTH
+    /// store-level sites that attach an *existing* node to a parent — `move_node`
+    /// (the service `move_node` and `upsert_node_with_parent` reparent paths) and
+    /// `bulk_create_has_child` (the sync-apply cold-sweep) — so every reparent
+    /// path is covered, symmetrically with the forward guard `assert_root_only_
+    /// membership` on the `member_of` INSERT sites. (Fresh-node attach sites can't
+    /// pre-hold a membership; `move_children_to_parent` only moves already-interior
+    /// nodes.) Rejects rather than dropping the membership (a node can hold several
+    /// grants, each an independent access path). `collection` (nesting) and
+    /// `person` (grantee, ADR-037 §4) nodes are exempt. A single chunked query
+    /// keeps the bulk/cold-sweep path a single round trip.
+    pub(crate) async fn assert_may_gain_parent(&self, node_ids: &[&str]) -> Result<()> {
+        if node_ids.is_empty() {
+            return Ok(());
+        }
+        let mut unique: Vec<&str> = node_ids.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+
+        // Chunk the `IN (...)` under SQLite's ~999 bound-parameter ceiling.
+        const ID_CHUNK: usize = 900;
+        for chunk in unique.chunks(ID_CHUNK) {
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{}", i)).collect();
+            // Offenders: non-exempt nodes that already hold a `member_of` edge.
+            let sql = format!(
+                "SELECT n.id FROM node n \
+                 WHERE n.id IN ({}) \
+                   AND n.node_type NOT IN ('collection', 'person') \
+                   AND EXISTS(SELECT 1 FROM relationship r \
+                              WHERE r.in_node = n.id AND r.relationship_type = 'member_of')",
+                placeholders.join(", ")
+            );
+            let params: Vec<libsql::Value> = chunk
+                .iter()
+                .map(|id| libsql::Value::Text(id.to_string()))
+                .collect();
+            let mut rows = self
+                .db
+                .query(&sql, params)
+                .await
+                .context("Failed to validate root-only membership on reparent")?;
+            if let Some(row) = rows.next().await? {
+                let offender: String = row.get(0)?;
+                let memberships = self.get_node_memberships(&offender).await?;
+                return Err(anyhow::anyhow!(
+                    "member_of_not_root: node '{}' holds collection membership ({}) and cannot be moved under a parent — only root nodes may hold collection membership (ADR-059 §2). Remove it from the collection(s) first, or move its root instead.",
+                    offender,
+                    memberships.join(", ")
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub async fn move_node(
         &self,
         node_id: &str,
@@ -1236,6 +1293,8 @@ impl SqliteStore {
                 return Err(anyhow::anyhow!("Parent node not found: {}", parent_id));
             }
             self.validate_no_cycle(parent_id, &node_id).await?;
+            // ADR-059 §2: a member cannot be moved into an interior position.
+            self.assert_may_gain_parent(&[node_id.as_str()]).await?;
         }
 
         // Serialize the sibling-order read → fractional-key compute → write-back

--- a/packages/core/src/db/sqlite_store/relationships.rs
+++ b/packages/core/src/db/sqlite_store/relationships.rs
@@ -636,6 +636,13 @@ impl SqliteStore {
             return Ok(Vec::new());
         }
 
+        // ADR-059 §2 (reparent side): this cold-sweep attach path must not give a
+        // `has_child` parent to a node that holds a `member_of` edge — symmetric
+        // with the forward guard on `bulk_add_to_collections`. Run before the tx
+        // (the store shares one connection). See `assert_may_gain_parent`.
+        let child_ids: Vec<&str> = edges.iter().map(|(_, child, _)| child.as_str()).collect();
+        self.assert_may_gain_parent(&child_ids).await?;
+
         let now = Utc::now().to_rfc3339();
         let tx = self
             .db

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -2727,6 +2727,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reparenting_a_collection_member_is_rejected() {
+        // ADR-059 §2 (reparent side): a content node that holds a `member_of` edge
+        // is a root member; moving it under a parent would make it a forbidden
+        // interior member. The store-level guard rejects it on every reparent path
+        // — service `move_node` AND `upsert_node_with_parent` (the gRPC /
+        // save_node_with_parent path) — and must NOT silently drop the membership.
+        // A move to root stays allowed.
+        let (service, _temp) = create_test_service().await;
+
+        let coll = Node::new("collection".to_string(), "Coll".to_string(), json!({}));
+        let coll_id = service.create_node(coll).await.unwrap();
+
+        let root = Node::new("text".to_string(), "root doc".to_string(), json!({}));
+        let root_id = service.create_node(root).await.unwrap();
+        service
+            .create_relationship(&root_id, "member_of", &coll_id, json!({}))
+            .await
+            .unwrap();
+
+        let parent = Node::new("text".to_string(), "a parent".to_string(), json!({}));
+        let parent_id = service.create_node(parent).await.unwrap();
+
+        // Path 1 — service move_node reparent → rejected, naming the collection.
+        let root_node = service.get_node(&root_id).await.unwrap().unwrap();
+        let err = service
+            .move_node(
+                &root_id,
+                root_node.version,
+                Some(&parent_id),
+                crate::services::InsertPosition::End,
+            )
+            .await
+            .expect_err("reparenting a collection member via move_node must be rejected");
+        assert!(
+            err.to_string().contains("member_of_not_root") && err.to_string().contains(&coll_id),
+            "rejection must state the reason and name the collection; got: {err}"
+        );
+
+        // The rejected move did not drop the membership: a second attempt rejects.
+        let root_node = service.get_node(&root_id).await.unwrap().unwrap();
+        let again = service
+            .move_node(
+                &root_id,
+                root_node.version,
+                Some(&parent_id),
+                crate::services::InsertPosition::End,
+            )
+            .await;
+        assert!(
+            again.is_err(),
+            "membership must be intact after a rejected move; got: {:?}",
+            again
+        );
+
+        // Path 2 — upsert_node_with_parent is a DISTINCT reparent path (gRPC
+        // upsert / the save_node_with_parent Tauri command); it must be gated too.
+        let err2 = service
+            .upsert_node_with_parent(&root_id, "root doc", "text", &parent_id, &root_id, None)
+            .await
+            .expect_err("reparenting via upsert_node_with_parent must be rejected");
+        assert!(
+            err2.to_string().contains("member_of_not_root"),
+            "upsert_node_with_parent reparent must be gated; got: {err2}"
+        );
+
+        // Moving a member to root (new_parent = None) is still allowed.
+        let root_node = service.get_node(&root_id).await.unwrap().unwrap();
+        let to_root = service
+            .move_node(
+                &root_id,
+                root_node.version,
+                None,
+                crate::services::InsertPosition::End,
+            )
+            .await;
+        assert!(
+            to_root.is_ok(),
+            "moving a collection member to root must remain allowed; got: {:?}",
+            to_root
+        );
+    }
+
+    #[tokio::test]
     async fn test_create_node_with_parent_rejects_non_container() {
         let (service, _temp) = create_test_service().await;
 


### PR DESCRIPTION
## What

Adds the **reparent side** of the root-only content-membership rule (ADR-059 §2). #1742 enforces it at `member_of` *write* time; this closes the reverse transition — a node that already holds a `member_of` edge (a root member) being moved into an interior position, which would make it a forbidden interior member with no `member_of` write for the forward guard to catch.

## How

The guard is enforced at the **store's two `has_child` attach sites**, symmetric with how #1742 enforced the forward direction at the store's `member_of` INSERT sites. Adversarial review confirmed these are the only two store paths that attach an *existing* node to a parent (the rest create fresh nodes or move already-interior ones), so gating both covers every reparent path by construction:

- **`SqliteStore::move_node`** — the service `NodeService::move_node` (outline drag/indent) and `NodeService::upsert_node_with_parent` (the gRPC upsert / `save_node_with_parent` Tauri command; a *distinct* reparent path the first review caught bypassing a service-only guard).
- **`SqliteStore::bulk_create_has_child`** — the sync-apply cold sweep (`apply_cold_rel_sweep_batched`), mirroring #1742's guard on its sibling `bulk_add_to_collections`.

When a node's type is neither `collection` nor `person` and it holds one or more `member_of` edges, a move that would give it a `has_child` parent is **rejected** with an error naming the collections (a single chunked query on the bulk path).

- **Reject, not drop** — a node can hold several `member_of` grants, each an independent access path; silently dropping them on an indent would revoke access with no record (Michael's decision on the issue's criterion 8).
- **Move to root stays allowed** (`new_parent = None`) — the guard only fires when the node would gain a parent.
- **`collection` (nesting) and `person` (grantee, ADR-037 §4) exempt** — matching the forward guard.

Adversarial review of the first (service-level) attempt found that `upsert_node_with_parent` bypassed a service-only guard; moving the check to the store chokepoint closes that and any future reparent surface.

## Tests

- **Store** `test_reparent_guard_rejects_moving_a_member_under_a_parent`: `store.move_node` rejects reparenting a member; non-member moves freely; move-to-root allowed; person exemption; **and `bulk_create_has_child` rejects a member in a batch** (cold-sweep parity).
- **Service** `test_reparenting_a_collection_member_is_rejected`: rejection via **both** `move_node` and `upsert_node_with_parent`, proof the membership is not dropped (second attempt still rejects), move-to-root still allowed.

All core test targets green — **980 lib + integration + doctests, 0 failed**. Reviewed adversarially three times: the passes caught the `upsert_node_with_parent` bypass and the `bulk_create_has_child` cold-sweep gap in turn, both now closed and tested. The sync side of the cold-sweep rejection (permanent-vs-transient classification, so a bad incoming edge can't wedge the cursor) is tracked in nodespace-sync#378.

Closes #1765
