### PR TITLE
Playbook rule class + save-time invariant eligibility gate (ADR-060 Slice A)

### DIFF
--- a/packages/core/src/playbook/cel.rs
+++ b/packages/core/src/playbook/cel.rs
@@ -337,6 +337,18 @@ fn build_condition_context_with_resolved<'a>(
 // Custom CEL Functions
 // ---------------------------------------------------------------------------
 
+/// CEL functions that read wall-clock time and are therefore **non-deterministic**
+/// across devices: two devices evaluating the same condition at different moments
+/// can disagree.
+///
+/// ADR-060 §2 forbids these in an invariant rule's conditions (see
+/// [`crate::playbook::validation`]). Keep this list in sync with the functions
+/// registered in [`build_condition_context_with_resolved`] — it is the single
+/// source of truth for "which CEL functions are non-deterministic". There is no
+/// random-value function registered, so wall-clock reads are the only
+/// non-deterministic surface CEL can express today.
+pub const NON_DETERMINISTIC_FUNCTIONS: &[&str] = &["today", "days_since", "days_until"];
+
 /// `days_since(date_string)` — Parse ISO 8601 date and return days elapsed.
 ///
 /// Returns negative for future dates. Returns error for invalid input.

--- a/packages/core/src/playbook/cron_runner.rs
+++ b/packages/core/src/playbook/cron_runner.rs
@@ -203,7 +203,7 @@ fn synthetic_cron_envelope(node_id: &str) -> EventEnvelope {
 mod tests {
     use super::*;
     use crate::playbook::types::{
-        ActionType, CronEntry, OrderedRuleRef, ParsedAction, ParsedRule, ParsedTrigger,
+        ActionType, CronEntry, OrderedRuleRef, ParsedAction, ParsedRule, ParsedTrigger, RuleClass,
     };
     use chrono::Utc;
     use std::sync::Arc;
@@ -212,6 +212,7 @@ mod tests {
     fn make_cron_entry(cron_expr: &str, node_type: &str) -> CronEntry {
         let rule = Arc::new(ParsedRule {
             name: "test-cron-rule".to_string(),
+            class: RuleClass::Reactive,
             trigger: ParsedTrigger::Scheduled {
                 cron: cron_expr.to_string(),
                 node_type: node_type.to_string(),
@@ -300,6 +301,7 @@ mod tests {
         // (deduplication is structural — same cron+node_type = one CronEntry)
         let rule_a = Arc::new(ParsedRule {
             name: "rule-a".to_string(),
+            class: RuleClass::Reactive,
             trigger: ParsedTrigger::Scheduled {
                 cron: "0 * * * * * *".to_string(),
                 node_type: "task".to_string(),
@@ -310,6 +312,7 @@ mod tests {
 
         let rule_b = Arc::new(ParsedRule {
             name: "rule-b".to_string(),
+            class: RuleClass::Reactive,
             trigger: ParsedTrigger::Scheduled {
                 cron: "0 * * * * * *".to_string(),
                 node_type: "task".to_string(),

--- a/packages/core/src/playbook/lifecycle.rs
+++ b/packages/core/src/playbook/lifecycle.rs
@@ -633,6 +633,7 @@ mod tests {
             created_at: Utc::now(),
             rules: vec![Arc::new(ParsedRule {
                 name: "r1".to_string(),
+                class: RuleClass::Reactive,
                 trigger: ParsedTrigger::GraphEvent {
                     on: GraphEventType::NodeCreated,
                     node_type: "task".to_string(),
@@ -659,6 +660,7 @@ mod tests {
             created_at: Utc::now(),
             rules: vec![Arc::new(ParsedRule {
                 name: "r1".to_string(),
+                class: RuleClass::Reactive,
                 trigger: ParsedTrigger::GraphEvent {
                     on: GraphEventType::NodeCreated,
                     node_type: "task".to_string(),

--- a/packages/core/src/playbook/path_extractor.rs
+++ b/packages/core/src/playbook/path_extractor.rs
@@ -60,6 +60,83 @@ pub fn extract_paths(expr: &str) -> Result<ExtractionResult, String> {
     Ok(result)
 }
 
+/// Collect the names of every function called in a CEL expression.
+///
+/// Used by save-time validation to detect non-deterministic functions
+/// (wall-clock reads like `today`, `days_since`, `days_until`) inside an
+/// invariant rule's conditions (ADR-060 §2).
+///
+/// Notes on the CEL AST surface this walks:
+/// - Named function calls (`today()`, `days_since(x)`, `size(x)`) appear as
+///   `Expr::Call` with `func_name` set — these are what we collect.
+/// - Macros (`.any`/`.all`/`.exists`) are desugared into `Comprehension` nodes,
+///   not calls, so their sub-expressions are walked but contribute no call name.
+/// - Binary/unary operators appear as calls with sentinel names like `_==_`,
+///   `_&&_`, `_+_` — harmless here, they never match a wall-clock function.
+pub fn extract_function_names(expr: &str) -> Result<Vec<String>, String> {
+    let parsed = cel_parser::Parser::new()
+        .parse(expr)
+        .map_err(|e| format!("CEL parse error: {}", e))?;
+    let mut names = Vec::new();
+    collect_function_names(&parsed, &mut names);
+    Ok(names)
+}
+
+/// Recursively collect `func_name` from every `Expr::Call` in the AST.
+fn collect_function_names(expr: &IdedExpr, names: &mut Vec<String>) {
+    match &expr.expr {
+        Expr::Call(call) => {
+            names.push(call.func_name.clone());
+            if let Some(target) = &call.target {
+                collect_function_names(target, names);
+            }
+            for arg in &call.args {
+                collect_function_names(arg, names);
+            }
+        }
+        Expr::Select(sel) => collect_function_names(&sel.operand, names),
+        Expr::Comprehension(comp) => {
+            collect_function_names(&comp.iter_range, names);
+            collect_function_names(&comp.accu_init, names);
+            collect_function_names(&comp.loop_cond, names);
+            collect_function_names(&comp.loop_step, names);
+            collect_function_names(&comp.result, names);
+        }
+        Expr::List(list) => {
+            for elem in &list.elements {
+                collect_function_names(elem, names);
+            }
+        }
+        Expr::Map(map) => {
+            for entry in &map.entries {
+                match &entry.expr {
+                    cel_parser::ast::EntryExpr::MapEntry(me) => {
+                        collect_function_names(&me.key, names);
+                        collect_function_names(&me.value, names);
+                    }
+                    cel_parser::ast::EntryExpr::StructField(sf) => {
+                        collect_function_names(&sf.value, names);
+                    }
+                }
+            }
+        }
+        Expr::Struct(s) => {
+            for entry in &s.entries {
+                match &entry.expr {
+                    cel_parser::ast::EntryExpr::MapEntry(me) => {
+                        collect_function_names(&me.key, names);
+                        collect_function_names(&me.value, names);
+                    }
+                    cel_parser::ast::EntryExpr::StructField(sf) => {
+                        collect_function_names(&sf.value, names);
+                    }
+                }
+            }
+        }
+        Expr::Ident(_) | Expr::Literal(_) | Expr::Unspecified => {}
+    }
+}
+
 /// Recursively walk the AST, collecting paths.
 fn walk_expr(expr: &IdedExpr, active_iter_vars: &[String], result: &mut ExtractionResult) {
     match &expr.expr {
@@ -395,5 +472,33 @@ mod tests {
             .paths
             .iter()
             .any(|p| p.segments == vec!["node", "tasks"]));
+    }
+
+    // -- extract_function_names --
+
+    #[test]
+    fn extract_function_names_finds_named_calls() {
+        let names =
+            extract_function_names("days_since(node.created) > 7 && size(node.tags) > 0").unwrap();
+        assert!(names.contains(&"days_since".to_string()));
+        assert!(names.contains(&"size".to_string()));
+    }
+
+    #[test]
+    fn extract_function_names_finds_nested_call() {
+        // `today()` nested as an argument of `size(...)` is still collected.
+        let names = extract_function_names("size(today()) == 10").unwrap();
+        assert!(names.contains(&"today".to_string()));
+    }
+
+    #[test]
+    fn extract_function_names_ignores_macros_and_plain_paths() {
+        // `.exists` desugars to a comprehension, not a named call.
+        let names = extract_function_names("node.tasks.exists(t, t.status == 'done')").unwrap();
+        assert!(!names.contains(&"exists".to_string()));
+
+        // A plain property comparison references no wall-clock function.
+        let names = extract_function_names("node.status == 'open'").unwrap();
+        assert!(!names.iter().any(|n| n == "today" || n == "days_since"));
     }
 }

--- a/packages/core/src/playbook/tests.rs
+++ b/packages/core/src/playbook/tests.rs
@@ -65,6 +65,7 @@ mod playbook_tests {
     fn test_parse_graph_event_node_created() {
         let def = RuleDefinition {
             name: "test rule".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("node_created".to_string()),
@@ -97,6 +98,7 @@ mod playbook_tests {
     fn test_parse_graph_event_property_changed() {
         let def = RuleDefinition {
             name: "status watcher".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("property_changed".to_string()),
@@ -130,6 +132,7 @@ mod playbook_tests {
     fn test_parse_scheduled_trigger() {
         let def = RuleDefinition {
             name: "daily check".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "scheduled".to_string(),
                 on: None,
@@ -155,6 +158,7 @@ mod playbook_tests {
     fn test_parse_invalid_trigger_type() {
         let def = RuleDefinition {
             name: "bad".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "webhook".to_string(),
                 on: None,
@@ -176,6 +180,7 @@ mod playbook_tests {
     fn test_parse_invalid_event_type() {
         let def = RuleDefinition {
             name: "bad".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("node_exploded".to_string()),
@@ -197,6 +202,7 @@ mod playbook_tests {
     fn test_parse_missing_node_type() {
         let def = RuleDefinition {
             name: "bad".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("node_created".to_string()),
@@ -218,6 +224,7 @@ mod playbook_tests {
     fn test_parse_invalid_cel_condition() {
         let def = RuleDefinition {
             name: "bad condition".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("node_created".to_string()),
@@ -239,6 +246,7 @@ mod playbook_tests {
     fn test_parse_condition_compiles_program_once() {
         let def = RuleDefinition {
             name: "compiled rule".to_string(),
+            class: RuleClass::Reactive,
             trigger: TriggerDefinition {
                 trigger_type: "graph_event".to_string(),
                 on: Some("node_created".to_string()),
@@ -300,6 +308,70 @@ mod playbook_tests {
         };
         let parsed = super::super::types::parse_action(&def).unwrap();
         assert_eq!(parsed.for_each, Some("trigger.node.tasks".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Rule class parsing (ADR-060)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rule_class_defaults_to_reactive() {
+        // A rule definition with no `class` field parses as Reactive, keeping
+        // every previously-authored rule's semantics unchanged.
+        let def = RuleDefinition {
+            name: "no class".to_string(),
+            class: RuleClass::default(),
+            trigger: TriggerDefinition {
+                trigger_type: "graph_event".to_string(),
+                on: Some("node_created".to_string()),
+                node_type: Some("task".to_string()),
+                property_key: None,
+                cron: None,
+            },
+            conditions: vec![],
+            actions: vec![],
+        };
+        assert_eq!(RuleClass::default(), RuleClass::Reactive);
+        assert_eq!(parse_rule(&def).unwrap().class, RuleClass::Reactive);
+    }
+
+    #[test]
+    fn test_rule_class_missing_field_deserializes_as_reactive() {
+        // JSON without a `class` key → Reactive via `#[serde(default)]`.
+        let defs: Vec<RuleDefinition> = serde_json::from_value(json!([{
+            "name": "r1",
+            "trigger": {"type": "graph_event", "on": "node_created", "node_type": "task"},
+            "conditions": [],
+            "actions": []
+        }]))
+        .unwrap();
+        assert_eq!(defs[0].class, RuleClass::Reactive);
+        assert_eq!(parse_rule(&defs[0]).unwrap().class, RuleClass::Reactive);
+    }
+
+    #[test]
+    fn test_rule_class_parses_invariant_and_reactive() {
+        let defs: Vec<RuleDefinition> = serde_json::from_value(json!([
+            {
+                "name": "inv",
+                "class": "invariant",
+                "trigger": {"type": "graph_event", "on": "node_created", "node_type": "task"},
+                "conditions": [],
+                "actions": []
+            },
+            {
+                "name": "react",
+                "class": "reactive",
+                "trigger": {"type": "graph_event", "on": "node_created", "node_type": "task"},
+                "conditions": [],
+                "actions": []
+            }
+        ]))
+        .unwrap();
+        assert_eq!(defs[0].class, RuleClass::Invariant);
+        assert_eq!(defs[1].class, RuleClass::Reactive);
+        assert_eq!(parse_rule(&defs[0]).unwrap().class, RuleClass::Invariant);
+        assert_eq!(parse_rule(&defs[1]).unwrap().class, RuleClass::Reactive);
     }
 
     #[test]

--- a/packages/core/src/playbook/types.rs
+++ b/packages/core/src/playbook/types.rs
@@ -119,10 +119,33 @@ pub enum PlaybookStatus {
     Disabled,
 }
 
+/// Execution class of a playbook rule (ADR-060).
+///
+/// - `Reactive` is today's behavior: the rule runs asynchronously, post-commit,
+///   on every device that observes the triggering event.
+/// - `Invariant` rules run synchronously inside the creating transaction,
+///   fail-closed, on the originating device only. They are subject to the
+///   save-time eligibility checks in [`crate::playbook::validation`] (ADR-060 §2).
+///
+/// The class is a property of the rule, declared in the playbook and validated at
+/// save time. It defaults to `Reactive` so every rule authored before this class
+/// existed keeps its current semantics unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleClass {
+    /// Synchronous, in-transaction, origin-device-only, fail-closed.
+    Invariant,
+    /// Asynchronous, post-commit, every device. The default.
+    #[default]
+    Reactive,
+}
+
 /// A single parsed rule from a playbook's `rules` array.
 #[derive(Debug, Clone)]
 pub struct ParsedRule {
     pub name: String,
+    /// Execution class (ADR-060). Defaults to `Reactive`.
+    pub class: RuleClass,
     pub trigger: ParsedTrigger,
     pub conditions: Vec<CompiledCondition>,
     pub actions: Vec<ParsedAction>,
@@ -168,6 +191,41 @@ pub enum ActionType {
     UpdateNode,
     AddRelationship,
     RemoveRelationship,
+}
+
+impl ActionType {
+    /// The canonical JSON name for this action type (the value parsed from a
+    /// rule's `action_type` field).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::CreateNode => "create_node",
+            Self::UpdateNode => "update_node",
+            Self::AddRelationship => "add_relationship",
+            Self::RemoveRelationship => "remove_relationship",
+        }
+    }
+
+    /// Whether this action performs only a local graph write.
+    ///
+    /// ADR-060 §2 requires an invariant rule's actions to be **local writes
+    /// only**: a transaction cannot await an LLM call, a network request, a PTY,
+    /// or any external service, and holding a write transaction across an
+    /// unbounded wait is a correctness and liveness hazard.
+    ///
+    /// Every v1 action type is a pure local graph mutation, so this returns
+    /// `true` for all current variants. It is written as an exhaustive `match`
+    /// rather than a blanket `true` deliberately: adding a non-local action type
+    /// later (LLM/network/PTY/external) will fail to compile until it is
+    /// classified here, so such an action can never silently become eligible for
+    /// an invariant rule.
+    pub fn is_local_write(&self) -> bool {
+        match self {
+            Self::CreateNode
+            | Self::UpdateNode
+            | Self::AddRelationship
+            | Self::RemoveRelationship => true,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +283,10 @@ pub type CronRegistry = Vec<CronEntry>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleDefinition {
     pub name: String,
+    /// Execution class (ADR-060). Omitted in JSON → `Reactive`, so every
+    /// existing rule definition keeps today's async, post-commit semantics.
+    #[serde(default)]
+    pub class: RuleClass,
     pub trigger: TriggerDefinition,
     #[serde(default)]
     pub conditions: Vec<String>,
@@ -308,6 +370,7 @@ pub fn parse_rule(def: &RuleDefinition) -> Result<ParsedRule, PlaybookParseError
 
     Ok(ParsedRule {
         name: def.name.clone(),
+        class: def.class,
         trigger,
         conditions,
         actions,

--- a/packages/core/src/playbook/validation.rs
+++ b/packages/core/src/playbook/validation.rs
@@ -19,7 +19,9 @@
 
 use crate::models::SchemaNode;
 use crate::playbook::path_extractor;
-use crate::playbook::types::{ActionType, ParsedAction, ParsedRule, ParsedTrigger};
+use crate::playbook::types::{
+    ActionType, GraphEventType, ParsedAction, ParsedRule, ParsedTrigger, RuleClass,
+};
 use crate::services::NodeService;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -66,6 +68,31 @@ pub enum PlaybookValidationError {
     InvalidCronExpression {
         cron: String,
         message: String,
+        location: String,
+    },
+    /// An invariant rule (ADR-060) contains an action that is not a local graph
+    /// write. Invariant rules run inside the creating transaction, which cannot
+    /// await an LLM call, network request, PTY, or external service.
+    InvariantNonLocalAction { action: String, location: String },
+    /// An invariant rule's condition uses a non-deterministic function (a
+    /// wall-clock read such as `today`/`days_since`/`days_until`). Two devices
+    /// reasoning about the same node must agree on what the invariant requires.
+    InvariantNonDeterministic { function: String, location: String },
+    /// An invariant rule's action addresses a node outside the trigger's graph
+    /// scope — a literal/arbitrary node id rather than a binding derived from the
+    /// trigger node or a prior action's output.
+    InvariantOutOfScopeTarget {
+        action: String,
+        param: String,
+        value: String,
+        location: String,
+    },
+    /// An invariant rule's own action would re-satisfy its own trigger, forming a
+    /// chain. Invariant rules must be non-chaining (depth 1) — unbounded
+    /// recursion inside a transaction is unacceptable.
+    InvariantChaining {
+        action: String,
+        trigger: String,
         location: String,
     },
 }
@@ -119,6 +146,40 @@ impl std::fmt::Display for PlaybookValidationError {
                 f,
                 "invalid cron expression '{}' at {}: {}",
                 cron, location, message
+            ),
+            Self::InvariantNonLocalAction { action, location } => write!(
+                f,
+                "invariant rule action '{}' at {} is not a local write \
+                 (invariant rules may not call an LLM, the network, a PTY, or an external service)",
+                action, location
+            ),
+            Self::InvariantNonDeterministic { function, location } => write!(
+                f,
+                "invariant rule uses non-deterministic function '{}' at {} \
+                 (invariant rules must be deterministic — no wall-clock reads or random values)",
+                function, location
+            ),
+            Self::InvariantOutOfScopeTarget {
+                action,
+                param,
+                value,
+                location,
+            } => write!(
+                f,
+                "invariant rule action '{}' at {} targets an out-of-scope node via {} = '{}' \
+                 (invariant actions may only address the trigger node or nodes it references, \
+                 not a literal/arbitrary node id)",
+                action, location, param, value
+            ),
+            Self::InvariantChaining {
+                action,
+                trigger,
+                location,
+            } => write!(
+                f,
+                "invariant rule action '{}' at {} would re-satisfy its own '{}' trigger \
+                 (invariant rules must be non-chaining, depth 1)",
+                action, location, trigger
             ),
         }
     }
@@ -230,6 +291,16 @@ pub async fn validate_playbook(
                 &mut errors,
             )
             .await;
+        }
+
+        // -- Validate invariant-rule eligibility (ADR-060 §2) --
+        //
+        // Only invariant rules are gated; reactive rules (the default, and every
+        // rule authored so far) are unaffected. All checks are static — they
+        // inspect the parsed rule, not the schema graph — so no DB lookup is
+        // needed here.
+        if rule.class == RuleClass::Invariant {
+            validate_invariant_eligibility(rule, rule_idx, &mut errors);
         }
     }
 
@@ -528,6 +599,195 @@ async fn validate_relationship_action(
 }
 
 // ---------------------------------------------------------------------------
+// Invariant-rule eligibility (ADR-060 §2)
+// ---------------------------------------------------------------------------
+
+/// Validate that an invariant rule provably terminates inside a transaction, per
+/// ADR-060 §2. Any violation is pushed to `errors`, naming the offending action
+/// or function. All checks are static (they read the parsed rule only).
+///
+/// # What is enforced statically here vs. deferred to the runtime guard
+///
+/// - **Local writes only** — fully enforced via [`ActionType::is_local_write`].
+///   Every current action type is a local write, so this passes today; it is a
+///   forward-looking gate that rejects any future non-local action type (LLM,
+///   network, PTY, external) added to an invariant rule.
+/// - **Deterministic** — fully enforced against the only surface that can
+///   express non-determinism today: wall-clock CEL functions in the rule's
+///   conditions (`today`/`days_since`/`days_until`, see
+///   [`crate::playbook::cel::NON_DETERMINISTIC_FUNCTIONS`]). Action params are
+///   pure `{binding}` data references (see `actions.rs`) with no function-call
+///   surface, and no random-value function is registered anywhere, so conditions
+///   are the complete non-deterministic surface.
+/// - **Same-graph scope** — enforced by requiring every action *target* node id
+///   (`node_id`, `source_id`, `target_id`) to be a `{binding}` derived from the
+///   trigger node or a prior action, rejecting a literal/arbitrary node id.
+/// - **Non-chaining, depth 1** — the statically decidable *self-chaining* case
+///   is enforced here: an action that would re-satisfy the rule's **own**
+///   trigger. The fully general form — an action output matching a *different*
+///   rule's trigger (in this or another playbook), and multi-device causal
+///   cycles — needs whole-corpus analysis plus the causal depth carried on the
+///   event, so it is deferred to the runtime causal-depth guard (ADR-060 §5),
+///   built in a later slice. `validate_playbook` sees only the rules of the
+///   playbook being saved, so cross-playbook chains are not even visible here.
+fn validate_invariant_eligibility(
+    rule: &ParsedRule,
+    rule_idx: usize,
+    errors: &mut Vec<PlaybookValidationError>,
+) {
+    // Local writes only.
+    for (action_idx, action) in rule.actions.iter().enumerate() {
+        if !action.action_type.is_local_write() {
+            errors.push(PlaybookValidationError::InvariantNonLocalAction {
+                action: action.action_type.as_str().to_string(),
+                location: format!("rule[{}].action[{}]", rule_idx, action_idx),
+            });
+        }
+    }
+
+    // Deterministic — no wall-clock reads in conditions.
+    for (cond_idx, condition) in rule.conditions.iter().enumerate() {
+        // `condition.source` already compiled successfully to reach a
+        // `ParsedRule`, so a parse error here is not expected; if it somehow
+        // occurs we simply skip (the determinism check adds no false positives).
+        if let Ok(functions) = path_extractor::extract_function_names(&condition.source) {
+            for function in functions {
+                if crate::playbook::cel::NON_DETERMINISTIC_FUNCTIONS.contains(&function.as_str()) {
+                    errors.push(PlaybookValidationError::InvariantNonDeterministic {
+                        function,
+                        location: format!("rule[{}].condition[{}]", rule_idx, cond_idx),
+                    });
+                }
+            }
+        }
+    }
+
+    // Same-graph scope — action targets must be trigger-derived bindings.
+    for (action_idx, action) in rule.actions.iter().enumerate() {
+        let location = format!("rule[{}].action[{}]", rule_idx, action_idx);
+        for param in target_id_params(&action.action_type) {
+            if let Some(value) = action.params.get(param).and_then(|v| v.as_str()) {
+                if !is_binding_template(value) {
+                    errors.push(PlaybookValidationError::InvariantOutOfScopeTarget {
+                        action: action.action_type.as_str().to_string(),
+                        param: param.to_string(),
+                        value: value.to_string(),
+                        location: location.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Non-chaining, depth 1 — self-trigger detection (statically checkable part).
+    check_invariant_self_chaining(rule, rule_idx, errors);
+}
+
+/// The action params that name an *existing* node the action addresses.
+///
+/// `create_node` addresses no existing node (it makes one), so it contributes no
+/// target and cannot violate same-graph scope through a target id.
+fn target_id_params(action_type: &ActionType) -> &'static [&'static str] {
+    match action_type {
+        ActionType::CreateNode => &[],
+        ActionType::UpdateNode => &["node_id"],
+        ActionType::AddRelationship | ActionType::RemoveRelationship => &["source_id", "target_id"],
+    }
+}
+
+/// Whether a param value references graph state via a `{dot.path}` binding.
+///
+/// Bindings are rooted at `trigger`, `actions`, or `item` (see `actions.rs`) —
+/// all derived from the trigger node or the rule's own prior outputs, so a
+/// binding stays within the trigger's graph scope. A plain literal id addresses
+/// an arbitrary node whose presence depends on sync state, which ADR-060 §2
+/// forbids for invariant rules.
+fn is_binding_template(value: &str) -> bool {
+    value.contains('{') && value.contains('}')
+}
+
+/// Detect the statically checkable case of ADR-060 §2's "non-chaining, depth 1":
+/// an invariant rule whose own action re-satisfies its own graph-event trigger.
+///
+/// Scheduled triggers are not re-satisfied by graph writes, so they are exempt.
+/// The general cross-rule / multi-device chaining case is deferred to the runtime
+/// causal-depth guard (see [`validate_invariant_eligibility`] docs).
+fn check_invariant_self_chaining(
+    rule: &ParsedRule,
+    rule_idx: usize,
+    errors: &mut Vec<PlaybookValidationError>,
+) {
+    let ParsedTrigger::GraphEvent { on, node_type, .. } = &rule.trigger else {
+        return;
+    };
+
+    for (action_idx, action) in rule.actions.iter().enumerate() {
+        let re_satisfies = match (on, &action.action_type) {
+            // Creating a node of the trigger's own type re-fires `node_created`.
+            (GraphEventType::NodeCreated, ActionType::CreateNode) => {
+                action_creates_node_type(action, node_type)
+            }
+            // Updating the trigger node re-fires `property_changed` on it. This is
+            // conservative: it flags any update to the trigger node regardless of
+            // which property the update touches, because the whole-object
+            // `properties` param (with bindings) cannot be statically matched
+            // against the trigger's watched `property_key`.
+            (GraphEventType::PropertyChanged, ActionType::UpdateNode) => {
+                action_targets_trigger_node(action, "node_id")
+            }
+            // Adding/removing a relationship whose source is the trigger node
+            // re-fires the relationship trigger (which matches on source type).
+            (GraphEventType::RelationshipAdded, ActionType::AddRelationship) => {
+                action_targets_trigger_node(action, "source_id")
+            }
+            (GraphEventType::RelationshipRemoved, ActionType::RemoveRelationship) => {
+                action_targets_trigger_node(action, "source_id")
+            }
+            _ => false,
+        };
+
+        if re_satisfies {
+            errors.push(PlaybookValidationError::InvariantChaining {
+                action: action.action_type.as_str().to_string(),
+                trigger: graph_event_name(on).to_string(),
+                location: format!("rule[{}].action[{}]", rule_idx, action_idx),
+            });
+        }
+    }
+}
+
+/// Whether a `create_node` action creates a node of `node_type` — either as a
+/// literal `node_type` param, or via the binding that resolves to the trigger
+/// node's own type (accepted in both `snake_case` and `camelCase` spellings).
+fn action_creates_node_type(action: &ParsedAction, node_type: &str) -> bool {
+    match action.params.get("node_type").and_then(|v| v.as_str()) {
+        Some(nt) => {
+            nt == node_type || nt == "{trigger.node.node_type}" || nt == "{trigger.node.nodeType}"
+        }
+        None => false,
+    }
+}
+
+/// Whether an action's `param` targets the trigger node itself via the
+/// `{trigger.node.id}` binding.
+fn action_targets_trigger_node(action: &ParsedAction, param: &str) -> bool {
+    matches!(
+        action.params.get(param).and_then(|v| v.as_str()),
+        Some("{trigger.node.id}")
+    )
+}
+
+/// The JSON name of a graph event type, for error messages.
+fn graph_event_name(on: &GraphEventType) -> &'static str {
+    match on {
+        GraphEventType::NodeCreated => "node_created",
+        GraphEventType::PropertyChanged => "property_changed",
+        GraphEventType::RelationshipAdded => "relationship_added",
+        GraphEventType::RelationshipRemoved => "relationship_removed",
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Schema Change Impact Analysis (Phase 2)
 // ---------------------------------------------------------------------------
 
@@ -689,7 +949,7 @@ mod tests {
     use super::*;
     use crate::playbook::cel::compile_condition;
     use crate::playbook::types::{
-        ActionType, GraphEventType, ParsedAction, ParsedRule, ParsedTrigger,
+        ActionType, GraphEventType, ParsedAction, ParsedRule, ParsedTrigger, RuleClass,
     };
 
     // -- CEL condition validation tests (no NodeService needed) --
@@ -708,6 +968,7 @@ mod tests {
     ) -> Arc<ParsedRule> {
         Arc::new(ParsedRule {
             name: "test-rule".to_string(),
+            class: RuleClass::Reactive,
             trigger: ParsedTrigger::GraphEvent {
                 on: GraphEventType::NodeCreated,
                 node_type: node_type.to_string(),
@@ -721,6 +982,7 @@ mod tests {
     fn make_scheduled_rule(cron: &str, node_type: &str, conditions: Vec<&str>) -> Arc<ParsedRule> {
         Arc::new(ParsedRule {
             name: "test-scheduled-rule".to_string(),
+            class: RuleClass::Reactive,
             trigger: ParsedTrigger::Scheduled {
                 cron: cron.to_string(),
                 node_type: node_type.to_string(),
@@ -1752,6 +2014,392 @@ mod tests {
                 msg.contains("Playbook validation failed"),
                 "error should indicate validation failure: {}",
                 msg
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Invariant-rule eligibility (ADR-060 §2)
+    // -----------------------------------------------------------------------
+
+    mod invariant_eligibility {
+        use super::*;
+        use serde_json::json;
+        use std::sync::Arc;
+
+        /// Build an invariant graph-event rule for eligibility testing.
+        fn invariant_rule(
+            on: GraphEventType,
+            node_type: &str,
+            property_key: Option<&str>,
+            conditions: Vec<&str>,
+            actions: Vec<ParsedAction>,
+        ) -> ParsedRule {
+            ParsedRule {
+                name: "inv".to_string(),
+                class: RuleClass::Invariant,
+                trigger: ParsedTrigger::GraphEvent {
+                    on,
+                    node_type: node_type.to_string(),
+                    property_key: property_key.map(str::to_string),
+                },
+                conditions: compile_conditions(conditions),
+                actions,
+            }
+        }
+
+        fn create_action(node_type: &str) -> ParsedAction {
+            ParsedAction {
+                action_type: ActionType::CreateNode,
+                params: json!({ "node_type": node_type, "content": "x" }),
+                for_each: None,
+            }
+        }
+
+        fn update_action(node_id: &str) -> ParsedAction {
+            ParsedAction {
+                action_type: ActionType::UpdateNode,
+                params: json!({ "node_id": node_id, "properties": { "custom:tag": "v" } }),
+                for_each: None,
+            }
+        }
+
+        fn add_rel_action(source_id: &str, target_id: &str) -> ParsedAction {
+            ParsedAction {
+                action_type: ActionType::AddRelationship,
+                params: json!({
+                    "source_id": source_id,
+                    "relationship_type": "linked_to",
+                    "target_id": target_id,
+                }),
+                for_each: None,
+            }
+        }
+
+        fn eligibility_errors(rule: &ParsedRule) -> Vec<PlaybookValidationError> {
+            let mut errors = Vec::new();
+            validate_invariant_eligibility(rule, 0, &mut errors);
+            errors
+        }
+
+        // -- Local writes only --
+
+        #[test]
+        fn all_current_action_types_are_local_writes() {
+            // ADR-060 §2 "local writes only" is a forward-looking gate: every v1
+            // action type IS a local write, so an invariant rule passes it today.
+            // The classification is an explicit exhaustive match (not a hardcoded
+            // `true` at the call site), so a future non-local action type will
+            // fail to compile until it is classified here.
+            for at in [
+                ActionType::CreateNode,
+                ActionType::UpdateNode,
+                ActionType::AddRelationship,
+                ActionType::RemoveRelationship,
+            ] {
+                assert!(at.is_local_write(), "{:?} should be a local write", at);
+            }
+        }
+
+        // -- Valid invariant rule --
+
+        #[test]
+        fn valid_invariant_rule_has_no_eligibility_errors() {
+            // Canonical invariant: on task creation, stamp a property on the
+            // trigger node inside the txn. Local write, deterministic, in-scope
+            // (targets the trigger node), and does not re-fire `node_created`.
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec!["node.status == 'open'"],
+                vec![update_action("{trigger.node.id}")],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(errors.is_empty(), "expected no errors, got {:?}", errors);
+        }
+
+        // -- Deterministic --
+
+        #[test]
+        fn invariant_non_deterministic_condition_rejected() {
+            for (expr, func) in [
+                ("days_since(node.created_date) > 7", "days_since"),
+                ("days_until(node.due_date) < 3", "days_until"),
+                ("size(today()) == 10", "today"),
+            ] {
+                let rule = invariant_rule(
+                    GraphEventType::NodeCreated,
+                    "task",
+                    None,
+                    vec![expr],
+                    vec![],
+                );
+                let errors = eligibility_errors(&rule);
+                assert!(
+                    errors.iter().any(|e| matches!(
+                        e,
+                        PlaybookValidationError::InvariantNonDeterministic { function, .. }
+                            if function == func
+                    )),
+                    "expected non-deterministic '{}' error for `{}`, got {:?}",
+                    func,
+                    expr,
+                    errors
+                );
+            }
+        }
+
+        #[test]
+        fn invariant_deterministic_condition_accepted() {
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec!["node.priority == 'high' && node.amount > 1000"],
+                vec![],
+            );
+            assert!(eligibility_errors(&rule).is_empty());
+        }
+
+        // -- Same-graph scope --
+
+        #[test]
+        fn invariant_literal_update_target_rejected() {
+            // update_node with a literal node_id addresses an arbitrary node.
+            let rule = invariant_rule(
+                GraphEventType::PropertyChanged,
+                "task",
+                Some("status"),
+                vec![],
+                vec![update_action("some-fixed-node-id")],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantOutOfScopeTarget { action, param, .. }
+                        if action == "update_node" && param == "node_id"
+                )),
+                "expected out-of-scope node_id error, got {:?}",
+                errors
+            );
+        }
+
+        #[test]
+        fn invariant_literal_relationship_target_rejected() {
+            // Binding source, but a literal target_id addresses an arbitrary node.
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec![],
+                vec![add_rel_action("{trigger.node.id}", "collection-hr")],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantOutOfScopeTarget { param, value, .. }
+                        if param == "target_id" && value == "collection-hr"
+                )),
+                "expected out-of-scope target_id error, got {:?}",
+                errors
+            );
+        }
+
+        #[test]
+        fn invariant_trigger_derived_bindings_accepted() {
+            // Both relationship endpoints are trigger-derived bindings, and the
+            // trigger event (node_created) is not re-satisfied by add_relationship.
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec![],
+                vec![add_rel_action(
+                    "{trigger.node.id}",
+                    "{trigger.node.owner_id}",
+                )],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(errors.is_empty(), "expected no errors, got {:?}", errors);
+        }
+
+        // -- Non-chaining, depth 1 (self-trigger detection) --
+
+        #[test]
+        fn invariant_self_chaining_create_same_type_rejected() {
+            // node_created(task) + create_node(task) re-fires the same trigger.
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec![],
+                vec![create_action("task")],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantChaining { action, trigger, .. }
+                        if action == "create_node" && trigger == "node_created"
+                )),
+                "expected chaining error, got {:?}",
+                errors
+            );
+        }
+
+        #[test]
+        fn invariant_create_different_type_not_chaining() {
+            let rule = invariant_rule(
+                GraphEventType::NodeCreated,
+                "task",
+                None,
+                vec![],
+                vec![create_action("audit_log")],
+            );
+            assert!(
+                !eligibility_errors(&rule)
+                    .iter()
+                    .any(|e| matches!(e, PlaybookValidationError::InvariantChaining { .. })),
+                "creating a different node type must not self-chain"
+            );
+        }
+
+        #[test]
+        fn invariant_self_chaining_property_update_of_trigger_node_rejected() {
+            let rule = invariant_rule(
+                GraphEventType::PropertyChanged,
+                "task",
+                Some("status"),
+                vec![],
+                vec![update_action("{trigger.node.id}")],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantChaining { action, trigger, .. }
+                        if action == "update_node" && trigger == "property_changed"
+                )),
+                "expected chaining error, got {:?}",
+                errors
+            );
+        }
+
+        #[test]
+        fn invariant_self_chaining_add_relationship_from_trigger_rejected() {
+            let rule = invariant_rule(
+                GraphEventType::RelationshipAdded,
+                "task",
+                None,
+                vec![],
+                vec![add_rel_action(
+                    "{trigger.node.id}",
+                    "{trigger.node.owner_id}",
+                )],
+            );
+            let errors = eligibility_errors(&rule);
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantChaining { action, trigger, .. }
+                        if action == "add_relationship" && trigger == "relationship_added"
+                )),
+                "expected chaining error, got {:?}",
+                errors
+            );
+        }
+
+        // -- End-to-end through validate_playbook: reactive bypass + invariant gate --
+
+        async fn create_test_service() -> (Arc<crate::services::NodeService>, tempfile::TempDir) {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let db_path = temp_dir.path().join("test.db");
+            let mut store: Arc<crate::db::SqliteStore> =
+                Arc::new(crate::db::SqliteStore::new(db_path).await.unwrap());
+            let node_service =
+                Arc::new(crate::services::NodeService::new(&mut store).await.unwrap());
+            (node_service, temp_dir)
+        }
+
+        async fn create_schema(node_service: &crate::services::NodeService, type_name: &str) {
+            let schema_node = crate::models::Node::new_with_id(
+                type_name.to_string(),
+                "schema".to_string(),
+                type_name.to_string(),
+                json!({
+                    "isCore": false,
+                    "schemaVersion": 1,
+                    "description": format!("{} schema", type_name),
+                    "fields": [{ "name": "status", "type": "string" }],
+                    "relationships": []
+                }),
+            );
+            node_service.create_node(schema_node).await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn reactive_rule_bypasses_invariant_gate() {
+            let (svc, _tmp) = create_test_service().await;
+            create_schema(&svc, "vi_react").await;
+
+            // A REACTIVE rule (default class) that would violate §2 if invariant:
+            // non-deterministic condition + self-chaining create_node of the same
+            // type. Reactive rules are not gated → accepted.
+            let rule = Arc::new(invariant_rule(
+                GraphEventType::NodeCreated,
+                "vi_react",
+                None,
+                vec!["days_since(node.created) > 7"],
+                vec![create_action("vi_react")],
+            ));
+            let reactive = Arc::new(ParsedRule {
+                class: RuleClass::Reactive,
+                ..(*rule).clone()
+            });
+            let result = validate_playbook(&[reactive], &svc).await;
+            assert!(
+                result.is_ok(),
+                "reactive rule must bypass the §2 gate: {:?}",
+                result
+            );
+        }
+
+        #[tokio::test]
+        async fn invariant_rule_gated_through_validate_playbook() {
+            let (svc, _tmp) = create_test_service().await;
+            create_schema(&svc, "vi_inv").await;
+
+            // Same rule as above, but INVARIANT → the §2 gate fires with both a
+            // non-determinism and a self-chaining error, proving the gate is wired
+            // into validate_playbook.
+            let rule = Arc::new(invariant_rule(
+                GraphEventType::NodeCreated,
+                "vi_inv",
+                None,
+                vec!["days_since(node.created) > 7"],
+                vec![create_action("vi_inv")],
+            ));
+            let errors = validate_playbook(&[rule], &svc).await.unwrap_err();
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantNonDeterministic { function, .. }
+                        if function == "days_since"
+                )),
+                "expected non-determinism error, got {:?}",
+                errors
+            );
+            assert!(
+                errors.iter().any(|e| matches!(
+                    e,
+                    PlaybookValidationError::InvariantChaining { action, .. }
+                        if action == "create_node"
+                )),
+                "expected chaining error, got {:?}",
+                errors
             );
         }
     }


### PR DESCRIPTION
**Part of #1739** — Slice A of 4 implementing ADR-060 (invariant vs reactive playbook rules). This slice is **behavior-neutral**: it adds the rule class and a save-time validation gate, with **no execution change** (and no invariant rules are seeded yet).

## Change
- `RuleClass { Invariant, Reactive }` on the rule model, **default `Reactive`** (`#[serde(default)]`), so every existing rule and stored definition is unchanged.
- Save-time eligibility gate (`validation.rs`), run **only** for invariant rules, rejecting a rule that violates ADR-060 §2 and naming the offending action:
  - **Local writes only** — exhaustive `ActionType::is_local_write()` (a future non-local type won't compile until classified, so it can't silently become invariant-eligible).
  - **Deterministic** — rejects a condition using a wall-clock CEL function; `NON_DETERMINISTIC_FUNCTIONS` is exactly the set CEL registers (`today`/`days_since`/`days_until`), the only non-deterministic surface (action params are pure `{binding}` data refs; no random fn exists).
  - **Same-graph scope** — rejects a literal target node id (addresses an arbitrary, sync-state-dependent node); trigger-derived `{binding}` targets are in scope.
  - **Non-chaining depth-1** — enforces the statically-decidable *self-chaining* case; the general cross-rule/multi-device case is deferred to the runtime causal-depth guard (ADR-060 §5, Slice B), documented in the validator.

## Tests
+16 tests: class parse/default, each rejection path (naming the action/function), a valid invariant rule accepted, and the same rule accepted as Reactive but rejected as Invariant (reactive-unaffected). `cargo test -p nodespace-core` = 996 lib + integration green; clippy `-D warnings` + fmt clean.

## Next slices (own PRs)
B = synchronous pre-commit invariant execution in the create transaction; C = repair-and-log for remote violations (§7); D = seeded-playbook protection (§8). §6 (DB-side enforcement) is a separate cloud task.