### PR TITLE
Register project as a built-in frontend node type

### DIFF
--- a/packages/desktop-app/src/lib/design/components/node-type-predicates.ts
+++ b/packages/desktop-app/src/lib/design/components/node-type-predicates.ts
@@ -13,6 +13,7 @@
 export const CORE_NODE_TYPES = new Set([
   'text',
   'task',
+  'project',
   'date',
   'header',
   'code-block',

--- a/packages/desktop-app/src/lib/design/icons/registry.ts
+++ b/packages/desktop-app/src/lib/design/icons/registry.ts
@@ -106,6 +106,17 @@ class IconRegistry {
       hasRingEffect: true // Tasks show ring effects when they have children
     });
 
+    // Project nodes - container that groups tasks/notes; a built-in entity type
+    // like task/date. Reuses the shared circle glyph (as date/entity/user do)
+    // with its own color var, and shows a ring when it has children.
+    this.register('project', {
+      component: CircleIcon,
+      semanticClass: 'node-icon',
+      colorVar: 'hsl(var(--node-project, 200 40% 45%))',
+      hasState: false,
+      hasRingEffect: true // Projects contain child tasks/notes
+    });
+
     // AI Chat nodes - square design with "AI" text
     this.register('ai-chat', {
       component: AIIcon,

--- a/packages/desktop-app/src/lib/stores/schemas.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/schemas.svelte.ts
@@ -21,7 +21,7 @@ const log = createLogger('SchemasStore');
 // Core schema IDs that are user-queryable and should appear in the sidenav.
 // Structural/inline types (text, date, header, code-block, etc.) are excluded —
 // they are node content primitives, not entity types users browse or filter.
-const SIDENAV_CORE_TYPES = new Set(['task', 'skill']);
+const SIDENAV_CORE_TYPES = new Set(['task', 'project', 'skill']);
 
 class SchemasStore {
   /** Raw schema list */

--- a/packages/desktop-app/src/tests/design/icon-registry.test.ts
+++ b/packages/desktop-app/src/tests/design/icon-registry.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Icon registry — built-in node type icon configs.
+ *
+ * `project` is a built-in core node type (backend core#134) and must resolve to
+ * a registered icon config rather than falling back to the default text icon.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { iconRegistry, getIconConfig } from '$lib/design/icons/registry';
+
+describe('icon registry — project', () => {
+  it('resolves a registered icon config for project (not the unknown-type fallback)', () => {
+    expect(iconRegistry.hasConfig('project')).toBe(true);
+    // Sanity: an unregistered type is NOT reported as having its own config.
+    expect(iconRegistry.hasConfig('definitely-not-a-real-node-type')).toBe(false);
+  });
+
+  it('exposes a usable icon component and config for project, mirroring task', () => {
+    const projectConfig = getIconConfig('project');
+    const taskConfig = getIconConfig('task');
+
+    expect(projectConfig.component).toBeTruthy();
+    expect(taskConfig.component).toBeTruthy();
+
+    // Project is a container entity: no per-state icon, shows a ring for children.
+    expect(projectConfig.hasState).toBe(false);
+    expect(projectConfig.hasRingEffect).toBe(true);
+    expect(projectConfig.semanticClass).toBe('node-icon');
+  });
+});

--- a/packages/desktop-app/src/tests/design/node-type-predicates.test.ts
+++ b/packages/desktop-app/src/tests/design/node-type-predicates.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Node type predicates — core vs custom schema type classification.
+ *
+ * `project` is a built-in core node type (backend core#134), so it must be
+ * treated as a core type rather than a custom, UUID-keyed schema type.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CORE_NODE_TYPES, isCustomSchemaType } from '$lib/design/components/node-type-predicates';
+
+describe('node-type-predicates', () => {
+  it('classifies project as a core built-in, like task', () => {
+    expect(CORE_NODE_TYPES.has('project')).toBe(true);
+    expect(CORE_NODE_TYPES.has('task')).toBe(true);
+    expect(isCustomSchemaType('project')).toBe(false);
+    expect(isCustomSchemaType('task')).toBe(false);
+  });
+
+  it('still treats a UUID-keyed schema type as custom', () => {
+    expect(isCustomSchemaType('7b1c2d3e-4f56-7890-abcd-ef1234567890')).toBe(true);
+  });
+});

--- a/packages/desktop-app/src/tests/stores/schemas.test.ts
+++ b/packages/desktop-app/src/tests/stores/schemas.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Schemas store — sidenav built-in filter.
+ *
+ * `builtInSchemas` surfaces core schemas whose id is in the private
+ * SIDENAV_CORE_TYPES set. `project` is a built-in core node type (backend
+ * core#134) and must appear alongside `task`, while non-core schemas and core
+ * schemas outside the set stay excluded.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SchemaNode } from '$lib/types/schema-node';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/services/backend-adapter', () => ({
+  backendAdapter: {
+    getAllSchemas: vi.fn(async () => [])
+  }
+}));
+
+// Neutralize the module-load reconnect registration so importing the store
+// does not touch the real daemon-status service.
+vi.mock('$lib/services/daemon-status', () => ({
+  onDaemonReconnect: vi.fn(() => () => {})
+}));
+
+import { schemasStore } from '$lib/stores/schemas.svelte';
+
+function makeSchema(id: string, isCore: boolean): SchemaNode {
+  return {
+    id,
+    content: id,
+    createdAt: '2026-07-28T00:00:00Z',
+    modifiedAt: '2026-07-28T00:00:00Z',
+    version: 1,
+    isCore,
+    schemaVersion: 1,
+    fields: []
+  };
+}
+
+describe('schemasStore.builtInSchemas — sidenav core types', () => {
+  beforeEach(() => {
+    schemasStore.schemas = [];
+  });
+
+  it('includes the core project schema alongside task and skill', () => {
+    schemasStore.schemas = [
+      makeSchema('task', true),
+      makeSchema('project', true),
+      makeSchema('skill', true),
+      makeSchema('text', true), // core, but not a sidenav core type
+      makeSchema('project', false) // custom schema that happens to share the id
+    ];
+
+    const ids = schemasStore.builtInSchemas.map((s) => s.id);
+
+    expect(ids).toContain('project');
+    expect(ids).toContain('task');
+    expect(ids).toContain('skill');
+    // Structural core types and non-core schemas are excluded.
+    expect(ids).not.toContain('text');
+    // The custom (non-core) project schema is routed to customSchemas instead.
+    expect(schemasStore.builtInSchemas.filter((s) => s.id === 'project')).toHaveLength(1);
+    expect(schemasStore.customSchemas.map((s) => s.id)).toContain('project');
+  });
+});


### PR DESCRIPTION
## Summary
`core#134` (merged) added `project` as a backend core node type + `ProjectNodeBehavior`. This registers it as a **built-in on the frontend** in the three spots the #134 review named, so a project gets built-in treatment (icon + nav) instead of being handled as a custom UUID-keyed schema type.

## Change (scoped to nav/icon — no viewer, no behavior mirror)
- `node-type-predicates.ts`: add `'project'` to `CORE_NODE_TYPES` → `isCustomSchemaType('project')` is now `false`.
- `icons/registry.ts`: register a `project` icon — the shared `CircleIcon` glyph (as `date`/`entity`/`user` do) with its own `--node-project` color var (same `200 40% 45%` fallback as `entity`, so no `app.css` change is needed), `hasRingEffect: true`.
- `stores/schemas.svelte.ts`: add `'project'` to `SIDENAV_CORE_TYPES` so a core project surfaces in the sidenav.

Verified no label map or type switch needs a `project` arm (humanization is dynamic; switches key off `NodeType = string` with a `default` arm).

## Tests
+5 tests (predicates, icon registry, sidenav filter). `bun run test` = 4096 pass; `svelte-check` 0 errors; lint/format clean.

Closes #1754.