### PR TITLE
Drop the invitations first-run popup; auto-show only for a signed-in user with no access

### DIFF
--- a/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
+++ b/packages/desktop-app/src/lib/components/collaboration/invitations-inbox.svelte
@@ -1,8 +1,9 @@
 <!--
   InvitationsInbox — onboarding entry point. A modal
-  opened from the Pro account menu (and once, on first sign-in). Lets a user
-  redeem a share-code invite, browse the collections they can join, and join an
-  open one directly / request a restricted one.
+  opened from the Pro account menu (Invitations), and auto-shown for a signed-in
+  user who has no collection access yet. Lets a user redeem a share-code invite,
+  browse the collections they can join, and join an open one directly / request a
+  restricted one.
 
   Email-bound invites are auto-redeemed server-side on reconnect
   (`redeem_my_invites`), so they need no action here — the copy just says so.

--- a/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
+++ b/packages/desktop-app/src/lib/components/pro-sync-pill.svelte
@@ -26,6 +26,7 @@
   import { invoke } from '@tauri-apps/api/core';
   import { proSync, type SyncState } from '$lib/stores/pro-sync.svelte';
   import { membership } from '$lib/stores/membership.svelte';
+  import { collectionsData } from '$lib/stores/collections.svelte';
   import { isProSyncActive } from '$lib/plugins/ui-extensions.svelte';
   import InvitationsInbox from '$lib/components/collaboration/invitations-inbox.svelte';
   import { createLogger } from '$lib/utils/logger';
@@ -64,31 +65,19 @@
   let menuOpen = $state(false);
   let signingOut = $state(false);
 
-  // Invitations inbox (onboarding). Opened from the account menu and,
-  // once per device, automatically on the first sign-in.
+  // Invitations inbox. Opened explicitly from the account menu, and auto-shown
+  // for the one case that genuinely needs it: a signed-in user with sync active
+  // who is a member of no collection yet (nothing to redeem/join otherwise).
   //
-  // `inboxOpenedManually` tracks explicit opens (account menu). The first-run
-  // auto-open is derived from proSync.signedInEpisode instead of pushed by an effect:
-  // when a fresh sign-in episode arrives on a device that hasn't seen the onboarding,
-  // the inbox shows until dismissed — no $effect reading/writing its own seen flag.
+  // `inboxOpenedManually` tracks explicit opens (account menu). There is NO
+  // launch/first-run auto-open — the auto-prompt is derived purely from live
+  // store state (signed-in + no collection access), so it never appears for a
+  // signed-out user and never queries the daemon while signed out.
   let inboxOpenedManually = $state(false);
-  let dismissedSignInEpisode = $state(0);
-
-  const FIRST_RUN_KEY = 'ns:invitations-firstrun-seen';
-  function firstRunSeen(): boolean {
-    try {
-      return typeof localStorage !== 'undefined' && localStorage.getItem(FIRST_RUN_KEY) === '1';
-    } catch {
-      return true; // storage unavailable — don't pester
-    }
-  }
-  function markFirstRunSeen() {
-    try {
-      if (typeof localStorage !== 'undefined') localStorage.setItem(FIRST_RUN_KEY, '1');
-    } catch {
-      /* ignore */
-    }
-  }
+  // Set once the user dismisses the auto-prompt, so it doesn't immediately
+  // reopen while they still have no access this session. Cleared on sign-out so
+  // a later fresh sign-in re-evaluates.
+  let noAccessDismissed = $state(false);
 
   // Signed in = the daemon surfaced an identity. When set, clicking the
   // pill opens the account menu ("signed in as <email>" + Sign out) instead of
@@ -122,22 +111,27 @@
       : proSync.detail || label
   );
 
-  // The inbox is open when explicitly opened, or auto-opened for a fresh, undismissed
-  // first sign-in on a device that hasn't seen onboarding yet.
-  const firstRunAutoOpen = $derived(
+  // Auto-prompt condition: genuinely signed in (realtime session, cleared on
+  // sign-out) AND sync is active for the active database (so redeem/join work)
+  // AND — after collections have actually loaded — the user can see no
+  // collection at all. That last clause is the "no tenant/collection access
+  // yet" case; `collectionsData.hasLoaded` keeps it from flashing during the
+  // pre-load window for users who do have access. Reactive, so it clears the
+  // moment access lands (redeem, join, or sync).
+  const signedInNoAccess = $derived(
     signedIn &&
-      !firstRunSeen() &&
-      proSync.signedInEpisode > 0 &&
-      proSync.signedInEpisode !== dismissedSignInEpisode
+      syncEnabled &&
+      collectionsData.hasLoaded &&
+      collectionsData.collectionsTree.length === 0
   );
-  const inboxOpen = $derived(inboxOpenedManually || firstRunAutoOpen);
+  // The inbox is open when explicitly opened, or auto-shown for a signed-in
+  // user with no access who hasn't dismissed the prompt this session.
+  const inboxOpen = $derived(inboxOpenedManually || (signedInNoAccess && !noAccessDismissed));
 
   function closeInbox() {
     inboxOpenedManually = false;
-    // Dismiss the current first-run episode and remember it device-wide so it
-    // doesn't reopen for this sign-in or on future launches.
-    dismissedSignInEpisode = proSync.signedInEpisode;
-    markFirstRunSeen();
+    // Suppress the auto-prompt for the rest of this session; a sign-out resets it.
+    noAccessDismissed = true;
   }
 
   // A pill click opens a menu — the account menu when signed in, the
@@ -187,6 +181,8 @@
       // Drop cached membership state so the next user doesn't inherit this
       // session's roster/identity (identity is per-session).
       membership.reset();
+      // Re-arm the no-access auto-prompt for whoever signs in next.
+      noAccessDismissed = false;
       log.info('signed out');
     } finally {
       signingOut = false;

--- a/packages/desktop-app/src/lib/stores/collections.svelte.ts
+++ b/packages/desktop-app/src/lib/stores/collections.svelte.ts
@@ -97,6 +97,15 @@ class CollectionsDataStore {
   });
 
   /**
+   * True once `loadCollections` has completed at least one successful fetch.
+   * Lets consumers distinguish "not fetched yet" (empty because unloaded) from
+   * "fetched, genuinely empty" — e.g. the invitations prompt only concludes a
+   * signed-in user has no collection access after a real load has resolved,
+   * never during the pre-load window.
+   */
+  hasLoaded = $state(false);
+
+  /**
    * Transform flat collections into tree structure for UI display.
    * Uses parentCollectionIds to build proper hierarchy. Hides collections with
    * no member nodes visible to the current user.
@@ -113,6 +122,7 @@ class CollectionsDataStore {
       const collections = await collectionService.getAllCollections();
       log.debug('Loaded collections', { count: collections.length });
       this.state = { ...this.state, collections, loading: false };
+      this.hasLoaded = true;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load collections';
       log.error('Failed to load collections', { error: message });
@@ -178,6 +188,7 @@ class CollectionsDataStore {
   /** Clear all cached data */
   reset(): void {
     this.state = { ...initialDataState, members: new Map() };
+    this.hasLoaded = false;
   }
 
   /** Set test data directly (for testing purposes only) */
@@ -188,6 +199,7 @@ class CollectionsDataStore {
       loading: false,
       error: null,
     };
+    this.hasLoaded = true;
   }
 }
 

--- a/packages/desktop-app/src/tests/components/pro-sync-pill-invitations.test.ts
+++ b/packages/desktop-app/src/tests/components/pro-sync-pill-invitations.test.ts
@@ -1,0 +1,195 @@
+/**
+ * pro-sync-pill — invitations auto-prompt (issue #1721).
+ *
+ * The invitations modal must NOT auto-open on launch from local-storage
+ * first-run state. It auto-shows ONLY for the one case that needs it: a
+ * genuinely signed-in user, with sync active, who is a member of no collection
+ * yet. A signed-out or has-access state never triggers it — and it never queries
+ * the daemon (`pro_list_joinable_collections`) while signed out.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import type { Node } from '$lib/types';
+import type { CollectionInfo } from '$lib/services/collection-service';
+
+vi.mock('$lib/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => mockInvoke(...args) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+import ProSyncPill from '$lib/components/pro-sync-pill.svelte';
+import { proSync } from '$lib/stores/pro-sync.svelte';
+import { membership } from '$lib/stores/membership.svelte';
+import { collectionsData } from '$lib/stores/collections.svelte';
+import { SharedNodeStore } from '$lib/services/shared-node-store.svelte';
+import { DATABASE_SETTINGS_NODE_ID } from '$lib/plugins/ui-extensions';
+
+/** The stale first-run localStorage key this change removes — must be inert now. */
+const LEGACY_FIRST_RUN_KEY = 'ns:invitations-firstrun-seen';
+
+/**
+ * Seed the active database's settings singleton (FLAT props, as the daemon
+ * serializes them). `sync_enabled: true` + `auth_status: 'connected'` is the
+ * only combination that makes sync active (isProSyncActive).
+ */
+function seedSettings(props: { sync_enabled?: boolean; auth_status?: string }): void {
+  const node: Node = {
+    id: DATABASE_SETTINGS_NODE_ID,
+    nodeType: 'database-settings',
+    content: '',
+    properties: props,
+    mentions: [],
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1
+  };
+  SharedNodeStore.getInstance().setNode(node, { type: 'database', reason: 'seed' }, true);
+}
+
+function collection(id: string, memberCount: number): CollectionInfo {
+  return {
+    id,
+    content: id,
+    nodeType: 'collection',
+    createdAt: new Date().toISOString(),
+    modifiedAt: new Date().toISOString(),
+    version: 1,
+    properties: {},
+    memberCount,
+    parentCollectionIds: []
+  };
+}
+
+/** Loaded, with a visible collection → the user has access. */
+function seedHasAccess(): void {
+  collectionsData._setTestData([collection('col-1', 3)], new Map());
+}
+
+/** Loaded, but no visible collection → the "no access yet" case. */
+function seedNoAccessLoaded(): void {
+  collectionsData._setTestData([], new Map());
+}
+
+/** Sign the user in with sync active for the active database. */
+function signInWithSync(): void {
+  proSync.tier = 'pro';
+  proSync.state = 'connected';
+  proSync.userEmail = 'mayank@nodespace.dev';
+  seedSettings({ sync_enabled: true, auth_status: 'connected' });
+}
+
+/** The invitations modal is open iff its unique "Redeem an invite code" heading renders. */
+function modalOpen(container: HTMLElement): boolean {
+  return !!Array.from(container.querySelectorAll('h3')).find(
+    (h) => h.textContent === 'Redeem an invite code'
+  );
+}
+
+describe('ProSyncPill — invitations auto-prompt (#1721)', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    // Discovery list resolves empty so the auto-loaded inbox has nothing to error on.
+    mockInvoke.mockResolvedValue([]);
+    SharedNodeStore.resetInstance();
+    collectionsData.reset();
+    membership.reset();
+    localStorage.clear();
+    proSync.tier = 'pro';
+    proSync.state = 'unspecified';
+    proSync.userEmail = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+    proSync.tier = 'unknown';
+    proSync.state = 'unspecified';
+    proSync.userEmail = '';
+    SharedNodeStore.resetInstance();
+    collectionsData.reset();
+    membership.reset();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT auto-open on launch, even with the legacy first-run localStorage flag absent or unset', () => {
+    // Signed-in user WITH access — the common launch case. The old behavior
+    // popped the modal on first run regardless; it must stay closed now.
+    signInWithSync();
+    seedHasAccess();
+    const { container } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(false);
+    // Nothing reads/writes the legacy first-run key anymore.
+    expect(localStorage.getItem(LEGACY_FIRST_RUN_KEY)).toBeNull();
+  });
+
+  it('a pre-existing legacy first-run flag does not force the modal open (key is inert)', () => {
+    localStorage.setItem(LEGACY_FIRST_RUN_KEY, '1');
+    signInWithSync();
+    seedHasAccess();
+    const { container } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(false);
+  });
+
+  it('auto-shows for a signed-in user with sync active and NO collection access', () => {
+    signInWithSync();
+    seedNoAccessLoaded();
+    const { container } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(true);
+  });
+
+  it('does NOT auto-show while collections are still loading (no pre-load flash)', () => {
+    signInWithSync();
+    // collectionsData.reset() in beforeEach leaves hasLoaded=false → not yet known.
+    const { container } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(false);
+  });
+
+  it('does NOT auto-show when the user has collection access', () => {
+    signInWithSync();
+    seedHasAccess();
+    const { container } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(false);
+  });
+
+  it('does NOT auto-show — and never queries list_joinable — while signed out', () => {
+    // Signed out: no identity, sync not active, even if collections read empty.
+    proSync.tier = 'pro';
+    proSync.state = 'auth-required';
+    proSync.userEmail = '';
+    seedSettings({ sync_enabled: false, auth_status: 'local' });
+    seedNoAccessLoaded();
+
+    const { container } = render(ProSyncPill);
+
+    expect(modalOpen(container)).toBe(false);
+    expect(mockInvoke).not.toHaveBeenCalledWith('pro_list_joinable_collections');
+  });
+
+  it('dismissing the auto-prompt keeps it closed for the session (no immediate reopen)', async () => {
+    signInWithSync();
+    seedNoAccessLoaded();
+    const { container, getByText } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(true);
+
+    await fireEvent.click(getByText('Close'));
+    expect(modalOpen(container)).toBe(false);
+  });
+
+  it('the account-menu Invitations entry still opens the modal (Settings path intact)', async () => {
+    // Signed in WITH access → no auto-prompt, but the manual entry must work.
+    signInWithSync();
+    seedHasAccess();
+    const { container, getByText } = render(ProSyncPill);
+    expect(modalOpen(container)).toBe(false);
+
+    // Open the account menu, then the Invitations entry.
+    const pill = container.querySelector('.pro-sync-pill');
+    expect(pill).not.toBeNull();
+    await fireEvent.click(pill!);
+    await fireEvent.click(getByText('Invitations'));
+
+    expect(modalOpen(container)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The invitations modal auto-opened on launch from a local-storage first-run flag, so it appeared for users who didn't need it — and could error (`list_joinable_collections` 401) when the daemon wasn't signed in.

## Change
- **Removed the localStorage-driven auto-open** (`FIRST_RUN_KEY`, `firstRunSeen`/`markFirstRunSeen`, `dismissedSignInEpisode`, the `firstRunAutoOpen` derived) from `pro-sync-pill.svelte`.
- **Auto-prompt derived from live store state**: `signedInNoAccess = signedIn && syncEnabled && collectionsData.hasLoaded && collectionsData.collectionsTree.length === 0` — i.e. a signed-in user (realtime identity) with sync active who, **after collections have loaded**, is a member of no collection (the one case that needs to redeem/request an invite). Dismiss suppresses it for the session; sign-out re-arms it.
- **Added `hasLoaded` to the collections store** so "no access" is only concluded after a real load resolves — prevents the prompt flashing during the pre-load window for users who do have access.
- `proSync.signedInEpisode` preserved (still used by the consent slot); account-menu → Invitations path unchanged.

Nothing queries the daemon on launch or while signed out (every open path now requires a signed-in session).

## Tests
+8 tests (no auto-open with access; legacy localStorage key inert; auto-shows for signed-in + sync-active + no-access; no pre-load flash; no signed-out query/`list_joinable`; dismiss stays closed; account-menu still opens it). `bun run test` = 4104 pass; `svelte-check` 0 errors; lint clean.

Closes #1721.