### PR TITLE
Description-only create_schema always fails: namespaced field names contain ':' which the field-name validator rejects

### DIFF
--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -1250,11 +1250,17 @@ pub struct SchemaNodeBehavior;
 /// the bare name must be non-empty and contain only alphanumerics and underscores.
 ///
 /// Namespace prefixes are part of the stored field name, not a separate layer
-/// applied afterwards: user-defined fields are namespaced (`custom:`, `org:`,
-/// `plugin:`) before the schema node is validated and persisted, so validation
-/// must accept the prefixed form. Both schema-creation paths agree on this —
-/// the description path applies `custom:` during field inference, and the
-/// explicit-fields path passes through names the caller already namespaced.
+/// applied afterwards: fields are namespaced (`custom:`, `org:`, `plugin:`)
+/// before the schema node is validated and persisted, so validation must accept
+/// the prefixed form. The same stored-name convention is assumed downstream —
+/// CEL strips the prefix, the graph resolver matches on it, and identifier
+/// validation in the query path permits it.
+///
+/// This function decides only whether a name is *well-formed*, not whether it is
+/// namespaced. Both are accepted, because the two schema-creation paths differ:
+/// the description path applies `custom:` during field inference, while the
+/// explicit-fields path stores caller-supplied names verbatim and does not
+/// namespace them. Requiring a prefix here would reject the latter.
 fn validate_schema_field_name(name: &str) -> Result<(), NodeValidationError> {
     let invalid = |reason: &str| {
         Err(NodeValidationError::InvalidProperties(format!(
@@ -3771,6 +3777,142 @@ mod tests {
         assert!(
             behavior.validate(&namespaced_node).is_ok(),
             "Namespaced field names should pass validation"
+        );
+    }
+
+    #[test]
+    fn test_schema_node_validates_namespaced_names_at_nesting_depth() {
+        let behavior = SchemaNodeBehavior;
+
+        // Name validation recurses through `fields` and `item_fields`, so the
+        // namespace rule must hold at depth, not just on top-level fields.
+        let nested = Node::new(
+            "schema".to_string(),
+            "venue".to_string(),
+            json!({
+                "isCore": false,
+                "version": 1,
+                "fields": [
+                    {
+                        "name": "custom:address",
+                        "type": "object",
+                        "protection": "user",
+                        "indexed": false,
+                        "fields": [
+                            {
+                                "name": "custom:postal_code",
+                                "type": "string",
+                                "protection": "user",
+                                "indexed": false
+                            }
+                        ]
+                    },
+                    {
+                        "name": "custom:sessions",
+                        "type": "array",
+                        "protection": "user",
+                        "indexed": false,
+                        "item_fields": [
+                            {
+                                "name": "custom:room",
+                                "type": "string",
+                                "protection": "user",
+                                "indexed": false
+                            }
+                        ]
+                    }
+                ]
+            }),
+        );
+
+        assert!(
+            behavior.validate(&nested).is_ok(),
+            "Namespaced nested and item field names should pass validation"
+        );
+
+        // A malformed nested name must still be rejected at depth.
+        let bad_nested = Node::new(
+            "schema".to_string(),
+            "venue".to_string(),
+            json!({
+                "isCore": false,
+                "version": 1,
+                "fields": [
+                    {
+                        "name": "custom:address",
+                        "type": "object",
+                        "protection": "user",
+                        "indexed": false,
+                        "fields": [
+                            {
+                                "name": "custom:a:b",
+                                "type": "string",
+                                "protection": "user",
+                                "indexed": false
+                            }
+                        ]
+                    }
+                ]
+            }),
+        );
+
+        assert!(
+            behavior.validate(&bad_nested).is_err(),
+            "Malformed nested field names should still be rejected"
+        );
+    }
+
+    #[test]
+    fn test_schema_node_title_template_resolves_namespaced_field() {
+        let behavior = SchemaNodeBehavior;
+
+        // Templates are checked against the STORED field names, so a schema
+        // created from a description must reference the namespaced form.
+        let resolved = Node::new(
+            "schema".to_string(),
+            "venue".to_string(),
+            json!({
+                "isCore": false,
+                "version": 1,
+                "titleTemplate": "{custom:contact_email}",
+                "fields": [
+                    {
+                        "name": "custom:contact_email",
+                        "type": "string",
+                        "protection": "user",
+                        "indexed": false
+                    }
+                ]
+            }),
+        );
+
+        assert!(
+            behavior.validate(&resolved).is_ok(),
+            "titleTemplate referencing a namespaced field should validate"
+        );
+
+        // The bare name is a different key and must not resolve.
+        let unresolved = Node::new(
+            "schema".to_string(),
+            "venue".to_string(),
+            json!({
+                "isCore": false,
+                "version": 1,
+                "titleTemplate": "{contact_email}",
+                "fields": [
+                    {
+                        "name": "custom:contact_email",
+                        "type": "string",
+                        "protection": "user",
+                        "indexed": false
+                    }
+                ]
+            }),
+        );
+
+        assert!(
+            behavior.validate(&unresolved).is_err(),
+            "Bare name must not resolve against a namespaced field"
         );
     }
 

--- a/packages/core/src/behaviors/mod.rs
+++ b/packages/core/src/behaviors/mod.rs
@@ -1232,7 +1232,8 @@ impl NodeBehavior for DateNodeBehavior {
 /// Validation includes:
 /// - Non-empty content (schema name)
 /// - Properties must be valid JSON object
-/// - Field names must be unique (alphanumeric and underscores only)
+/// - Field names must be unique (alphanumeric and underscores, with an optional
+///   `<namespace>:` prefix — see [`validate_schema_field_name`])
 /// - Enum fields must have at least one value defined (in core_values or user_values)
 ///
 /// # Strongly-Typed Validation
@@ -1242,15 +1243,60 @@ impl NodeBehavior for DateNodeBehavior {
 /// validation internally converts to SchemaNode for type-safe validation.
 pub struct SchemaNodeBehavior;
 
+/// Validate a schema field name.
+///
+/// A field name is either a bare name (`capacity`) or a namespaced name carrying
+/// exactly one `<namespace>:` prefix (`custom:capacity`). Both the namespace and
+/// the bare name must be non-empty and contain only alphanumerics and underscores.
+///
+/// Namespace prefixes are part of the stored field name, not a separate layer
+/// applied afterwards: user-defined fields are namespaced (`custom:`, `org:`,
+/// `plugin:`) before the schema node is validated and persisted, so validation
+/// must accept the prefixed form. Both schema-creation paths agree on this —
+/// the description path applies `custom:` during field inference, and the
+/// explicit-fields path passes through names the caller already namespaced.
+fn validate_schema_field_name(name: &str) -> Result<(), NodeValidationError> {
+    let invalid = |reason: &str| {
+        Err(NodeValidationError::InvalidProperties(format!(
+            "Invalid field name '{}': {}",
+            name, reason
+        )))
+    };
+
+    let is_valid_segment =
+        |s: &str| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_');
+
+    let mut parts = name.split(':');
+    // `split` always yields at least one element, so this cannot panic.
+    let bare_name = match (parts.next(), parts.next(), parts.next()) {
+        // Bare name: `capacity`
+        (Some(bare), None, _) => bare,
+        // Namespaced name: `custom:capacity`
+        (Some(namespace), Some(bare), None) => {
+            if !is_valid_segment(namespace) {
+                return invalid(
+                    "namespace prefix must contain only alphanumeric characters and underscores",
+                );
+            }
+            bare
+        }
+        // More than one ':' — e.g. `custom:a:b`
+        _ => return invalid("must contain at most one ':' namespace prefix"),
+    };
+
+    if !is_valid_segment(bare_name) {
+        return invalid(
+            "must contain only alphanumeric characters and underscores, \
+             optionally preceded by a '<namespace>:' prefix",
+        );
+    }
+
+    Ok(())
+}
+
 /// Validate a single schema field (standalone function for recursive validation)
 fn validate_schema_field(field: &SchemaField) -> Result<(), NodeValidationError> {
-    // Validate field name characters (alphanumeric and underscores only)
-    if !field.name.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        return Err(NodeValidationError::InvalidProperties(format!(
-            "Invalid field name '{}': must contain only alphanumeric characters and underscores",
-            field.name
-        )));
-    }
+    validate_schema_field_name(&field.name)?;
 
     // Enum fields must have at least one value defined
     if field.field_type == "enum" {
@@ -2871,7 +2917,11 @@ mod tests {
         assert!(behavior.validate(&full).is_ok());
 
         // Minimal project: name only (no properties).
-        let minimal = Node::new("project".to_string(), "Untitled project".to_string(), json!({}));
+        let minimal = Node::new(
+            "project".to_string(),
+            "Untitled project".to_string(),
+            json!({}),
+        );
         assert!(behavior.validate(&minimal).is_ok());
 
         // Equal start/end dates are allowed (start <= end).
@@ -2883,7 +2933,10 @@ mod tests {
         assert!(behavior.validate(&same_day).is_ok());
 
         // Projects are embeddable roots (unlike Task): content is returned.
-        assert_eq!(behavior.get_embeddable_content(&full), Some("Launch v1".to_string()));
+        assert_eq!(
+            behavior.get_embeddable_content(&full),
+            Some("Launch v1".to_string())
+        );
     }
 
     #[test]
@@ -3652,6 +3705,73 @@ mod tests {
             Err(NodeValidationError::InvalidProperties(ref msg))
                 if msg.contains("duplicate field names")
         ));
+    }
+
+    #[test]
+    fn test_schema_field_name_accepts_bare_and_namespaced() {
+        for name in [
+            "capacity",
+            "contact_email",
+            "field1",
+            "custom:capacity",
+            "custom:contact_email",
+            "org:cost_center",
+            "plugin:external_id",
+        ] {
+            assert!(
+                validate_schema_field_name(name).is_ok(),
+                "'{}' should be a valid field name",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_field_name_rejects_malformed_names() {
+        for name in [
+            "",                // empty
+            "custom:",         // empty bare name
+            ":capacity",       // empty namespace
+            "custom:a:b",      // more than one prefix
+            "custom capacity", // space
+            "custom.capacity", // dot is not a namespace separator
+            "custom:has space",
+        ] {
+            assert!(
+                validate_schema_field_name(name).is_err(),
+                "'{}' should be rejected",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_node_accepts_namespaced_field_names() {
+        let behavior = SchemaNodeBehavior;
+
+        // Namespaced field names are what the description-inference path produces,
+        // so validation must accept them.
+        let namespaced_node = Node::new(
+            "schema".to_string(),
+            "venue".to_string(),
+            json!({
+                "isCore": false,
+                "version": 1,
+                "fields": [
+                    {
+                        "name": "custom:contact_email",
+                        "type": "string",
+                        "protection": "user",
+                        "indexed": false
+                    }
+                ]
+            }),
+        );
+
+        assert!(
+            behavior.validate(&namespaced_node).is_ok(),
+            "Namespaced field names should pass validation"
+        );
     }
 
     #[test]

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -1072,3 +1072,61 @@ async fn test_update_schema_title_template_may_reference_preexisting_fields() {
         result
     );
 }
+
+// ============================================================================
+// create_schema from a description (no explicit fields)
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_schema_from_description_only() {
+    let (svc, _tmp) = create_test_service().await;
+
+    // No `fields` array: fields are inferred from the description and namespaced
+    // with `custom:` before the schema node is validated and persisted.
+    let result = handle_create_schema(
+        &svc,
+        json!({ "name": "Venue", "description": "contact email and capacity number" }),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Description-only create_schema should succeed: {:?}",
+        result
+    );
+
+    let val = result.expect("description-only create_schema should return Ok");
+    assert_eq!(val["schemaId"], "venue");
+
+    let field_names: Vec<&str> = val["fields"]
+        .as_array()
+        .expect("fields should be an array")
+        .iter()
+        .map(|f| f["name"].as_str().expect("field name should be a string"))
+        .collect();
+
+    assert!(
+        !field_names.is_empty(),
+        "Description should infer at least one field"
+    );
+    assert!(
+        field_names.iter().all(|n| n.starts_with("custom:")),
+        "Inferred fields should be namespaced: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&"custom:contact_email"),
+        "Expected 'custom:contact_email' among {:?}",
+        field_names
+    );
+
+    // The schema must be readable back from storage, not merely returned.
+    let stored = svc
+        .get_schema_node("venue")
+        .await
+        .expect("get_schema_node should succeed");
+    assert!(
+        stored.is_some(),
+        "Schema should be persisted and retrievable"
+    );
+}


### PR DESCRIPTION
Closes #1777