### PR TITLE
Deterministic cross-turn duplicate-write guard: make the persisted completed_writes enforceable, not advisory

### DIFF
--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -429,6 +429,36 @@ pub struct AgentSession {
     /// Integration tests inject a pre-built prompt without a live database.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt_override: Option<String>,
+
+    /// Writes completed in *earlier* turns of this conversation.
+    ///
+    /// The session is rebuilt from persisted messages on every turn, so this is
+    /// the only channel by which a turn can know what previous turns already
+    /// wrote. The tool-execution path consults it to refuse a repeat
+    /// deterministically, rather than relying on the model to honour a prompt
+    /// note saying the work is done.
+    ///
+    /// Empty for sessions with no prior writes, and for callers that do not
+    /// persist history.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prior_writes: Vec<PriorWrite>,
+}
+
+/// A write completed in an earlier turn, as the duplicate guard sees it.
+///
+/// `tool` plus `canonical_args` is the write's identity; `node_id` and `summary`
+/// exist so a refusal can name what already exists rather than reporting a bare
+/// "duplicate", which the model could not relay usefully to the user.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PriorWrite {
+    /// Tool that performed the write.
+    pub tool: String,
+    /// The call's arguments, canonicalised — see `canonical_args`.
+    pub canonical_args: String,
+    /// Node the write produced, when the tool reported one.
+    pub node_id: Option<String>,
+    /// Short label for the written node, when available.
+    pub summary: Option<String>,
 }
 
 /// Result of a complete agent turn (one round of generation + tool execution).

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -21,6 +21,7 @@ use crate::agent_types::{
 use crate::local_agent::otlp_tracer::TRACER_NAME;
 use crate::local_agent::prompt_templates;
 use crate::local_agent::response_processing::{normalize_response, normalize_response_traced};
+use crate::local_agent::tools::is_cross_turn_guarded_tool;
 use crate::prompt_assembler::{PromptAssembler, TemplateContext, EMERGENCY_FALLBACK_PROMPT};
 
 // ---------------------------------------------------------------------------
@@ -90,28 +91,6 @@ fn duplicate_write_result(prior: &crate::agent_types::PriorWrite) -> serde_json:
             }
         ),
     })
-}
-
-/// Whether a repeat of this tool in a *later turn* is a duplicate to suppress.
-///
-/// Narrower than the set of state-changing tools. The updates are excluded
-/// deliberately: setting a node to the same content, or a task to the same
-/// status, twice is idempotent — the second call is a no-op, not a duplicate,
-/// and blocking it would break a user legitimately re-asserting a value.
-/// `update_schema` is excluded on the same grounds.
-///
-/// The creates are the tools where a repeat produces a second, unwanted copy of
-/// the user's data. `delete_node` is included so a re-issued delete is answered
-/// from the record instead of failing against an already-removed node.
-pub fn is_cross_turn_guarded_tool(tool: &str) -> bool {
-    matches!(
-        tool,
-        "create_node"
-            | "create_nodes_from_markdown"
-            | "create_schema"
-            | "create_relationship"
-            | "delete_node"
-    )
 }
 
 /// Maximum tokens any single inference round may generate.
@@ -869,7 +848,15 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                         // `seen_calls` uses, against writes replayed from the
                         // conversation record.
                         let already_written = if is_cross_turn_guarded_tool(&tc.function_name) {
-                            let incoming = canonical_args(&tc.arguments_json);
+                            // Canonicalised from the *parsed* arguments, not the
+                            // raw text, so this derives from exactly what the
+                            // record side stores (`ToolExecutionRecord.args`).
+                            // Canonicalising the raw string instead would differ
+                            // wherever the two are not textually identical — most
+                            // concretely when empty arguments are read as `{}`
+                            // above, which yields "" here against a stored "{}"
+                            // and a write that could never match itself.
+                            let incoming = canonical_args(&args.to_string());
                             session.prior_writes.iter().find(|w| {
                                 w.tool == tc.function_name && w.canonical_args == incoming
                             })
@@ -4508,5 +4495,43 @@ mod tests {
             .expect("turn should succeed");
 
         assert!(calls.lock().unwrap().iter().any(|c| c == "create_node"));
+    }
+
+    /// The guard's identity must derive from the *parsed* arguments on both
+    /// sides. Empty arguments are read as `{}` before execution, so a
+    /// raw-string comparison would store `"{}"` and compare `""` — a write that
+    /// could never match itself, silently disarming the guard for that call.
+    #[tokio::test]
+    async fn empty_arguments_compare_against_their_parsed_form() {
+        let engine = Arc::new(MockEngine::tool_then_text("create_node", "", "Exists."));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = new_session();
+        // What the daemon would have persisted for an empty-args call: the
+        // canonical form of the parsed `{}`, not the empty string.
+        session.prior_writes = vec![PriorWrite {
+            tool: "create_node".to_string(),
+            canonical_args: canonical_args("{}"),
+            node_id: Some("nodespace://n1".to_string()),
+            summary: Some("Buy milk".to_string()),
+        }];
+
+        agent_loop
+            .run_turn(
+                &mut session,
+                "add it",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            !calls.lock().unwrap().iter().any(|c| c == "create_node"),
+            "an empty-args repeat must still be recognised as the same call"
+        );
     }
 }

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -57,8 +57,12 @@ pub const CANONICAL_ARGS_MAX_CHARS: usize = 4096;
 /// string. Unparseable arguments are returned unchanged: they cannot be
 /// normalised, and an exact-match comparison on the raw text is still correct.
 ///
-/// Shared by the per-turn duplicate detector and the cross-turn write guard so
-/// the two cannot drift into disagreeing about what "the same call" means.
+/// Shared by the per-turn duplicate detector and the cross-turn write guard, so
+/// the normalisation rules cannot drift apart. Note the two feed it different
+/// inputs: the loop-breaker canonicalises the raw emitted text, while the guard
+/// canonicalises the parsed arguments to match what the write record persists.
+/// That difference is deliberate — the loop-breaker only needs to recognise a
+/// stuck model, whereas the guard's comparison must be exact.
 pub fn canonical_args(args_json: &str) -> String {
     serde_json::from_str::<serde_json::Value>(args_json)
         .map(|v| v.to_string())

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -870,10 +870,9 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                         // conversation record.
                         let already_written = if is_cross_turn_guarded_tool(&tc.function_name) {
                             let incoming = canonical_args(&tc.arguments_json);
-                            session
-                                .prior_writes
-                                .iter()
-                                .find(|w| w.tool == tc.function_name && w.canonical_args == incoming)
+                            session.prior_writes.iter().find(|w| {
+                                w.tool == tc.function_name && w.canonical_args == incoming
+                            })
                         } else {
                             None
                         };
@@ -4342,7 +4341,13 @@ mod tests {
 
         let mut session = session_with_prior_create(&canonical_args(args));
         let result = agent_loop
-            .run_turn(&mut session, "add it", |_| {}, |_| {}, CancellationToken::new())
+            .run_turn(
+                &mut session,
+                "add it",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
             .await
             .expect("turn should succeed");
 
@@ -4375,10 +4380,17 @@ mod tests {
         let calls = executor.calls_handle();
         let agent_loop = LocalAgentLoop::new(engine, executor);
 
-        let mut session =
-            session_with_prior_create(&canonical_args(r#"{"content":"Buy milk","node_type":"task"}"#));
+        let mut session = session_with_prior_create(&canonical_args(
+            r#"{"content":"Buy milk","node_type":"task"}"#,
+        ));
         agent_loop
-            .run_turn(&mut session, "add it", |_| {}, |_| {}, CancellationToken::new())
+            .run_turn(
+                &mut session,
+                "add it",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
             .await
             .expect("turn should succeed");
 
@@ -4403,7 +4415,13 @@ mod tests {
 
         let mut session = session_with_prior_create(&canonical_args(r#"{"content":"Buy milk"}"#));
         agent_loop
-            .run_turn(&mut session, "add bread", |_| {}, |_| {}, CancellationToken::new())
+            .run_turn(
+                &mut session,
+                "add bread",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
             .await
             .expect("turn should succeed");
 
@@ -4424,11 +4442,13 @@ mod tests {
             args,
             "Marked done.",
         ));
-        let executor = Arc::new(RecordingToolExecutor::new(MockToolExecutor::new().with_tool(
-            "update_task_status",
-            json!({"type": "object", "properties": {"status": {"type": "string"}}}),
-            json!({"id": "nodespace://t1", "status": "done"}),
-        )));
+        let executor = Arc::new(RecordingToolExecutor::new(
+            MockToolExecutor::new().with_tool(
+                "update_task_status",
+                json!({"type": "object", "properties": {"status": {"type": "string"}}}),
+                json!({"id": "nodespace://t1", "status": "done"}),
+            ),
+        ));
         let calls = executor.calls_handle();
         let agent_loop = LocalAgentLoop::new(engine, executor);
 
@@ -4442,12 +4462,22 @@ mod tests {
         }];
 
         agent_loop
-            .run_turn(&mut session, "mark it done", |_| {}, |_| {}, CancellationToken::new())
+            .run_turn(
+                &mut session,
+                "mark it done",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
             .await
             .expect("turn should succeed");
 
         assert!(
-            calls.lock().unwrap().iter().any(|c| c == "update_task_status"),
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|c| c == "update_task_status"),
             "idempotent updates must not be blocked by the cross-turn guard"
         );
     }
@@ -4467,7 +4497,13 @@ mod tests {
 
         let mut session = new_session();
         agent_loop
-            .run_turn(&mut session, "add milk", |_| {}, |_| {}, CancellationToken::new())
+            .run_turn(
+                &mut session,
+                "add milk",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
             .await
             .expect("turn should succeed");
 

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -38,6 +38,82 @@ const MAX_TOOL_ITERATIONS: usize = 5;
 /// that were about to succeed.
 const MAX_CONSECUTIVE_PARSE_FAILURES: usize = 2;
 
+/// Longest canonical-args string persisted as a completed write's identity.
+///
+/// `create_nodes_from_markdown` carries an entire import in its arguments, so
+/// storing them verbatim would write that content a second time into the chat
+/// node's own message history and grow it without bound. Past this length the
+/// identity is dropped rather than truncated: a truncated string could compare
+/// equal to a *different* call sharing a long prefix, turning a size limit into
+/// a wrong-suppression bug. Dropping it only costs a redundant re-execution.
+pub const CANONICAL_ARGS_MAX_CHARS: usize = 4096;
+
+/// Normalise a tool call's raw JSON arguments so equal calls compare equal.
+///
+/// Round-tripping through serde sorts nothing by itself, but it does normalise
+/// whitespace and re-serialises `serde_json::Value`'s `BTreeMap`-backed objects
+/// in sorted key order, so `{"b":1,"a":2}` and `{"a":2,"b":1}` produce the same
+/// string. Unparseable arguments are returned unchanged: they cannot be
+/// normalised, and an exact-match comparison on the raw text is still correct.
+///
+/// Shared by the per-turn duplicate detector and the cross-turn write guard so
+/// the two cannot drift into disagreeing about what "the same call" means.
+pub fn canonical_args(args_json: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(args_json)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| args_json.to_owned())
+}
+
+/// Build the tool result returned in place of a refused duplicate write.
+///
+/// Deliberately informative rather than a bare failure. A user genuinely
+/// re-asking for the same node is rare but real, so the model must be able to
+/// read this, tell the user the thing already exists, and name it — or, if the
+/// repeat is intended, proceed deliberately with a call that differs.
+fn duplicate_write_result(prior: &crate::agent_types::PriorWrite) -> serde_json::Value {
+    let mut what = prior.tool.clone();
+    if let Some(ref s) = prior.summary {
+        what.push_str(&format!(" \"{s}\""));
+    }
+    serde_json::json!({
+        "skipped": "duplicate_write",
+        "id": prior.node_id,
+        "message": format!(
+            "Not executed: an identical {what} call already completed earlier in this \
+             conversation, so this would create a second copy. The result of that write \
+             still stands{}. Tell the user it already exists rather than repeating the \
+             write. If they explicitly want another, separate copy, say so and issue a \
+             call that differs from the original.",
+            match prior.node_id {
+                Some(ref id) => format!(" ({id})"),
+                None => String::new(),
+            }
+        ),
+    })
+}
+
+/// Whether a repeat of this tool in a *later turn* is a duplicate to suppress.
+///
+/// Narrower than the set of state-changing tools. The updates are excluded
+/// deliberately: setting a node to the same content, or a task to the same
+/// status, twice is idempotent — the second call is a no-op, not a duplicate,
+/// and blocking it would break a user legitimately re-asserting a value.
+/// `update_schema` is excluded on the same grounds.
+///
+/// The creates are the tools where a repeat produces a second, unwanted copy of
+/// the user's data. `delete_node` is included so a re-issued delete is answered
+/// from the record instead of failing against an already-removed node.
+pub fn is_cross_turn_guarded_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "create_node"
+            | "create_nodes_from_markdown"
+            | "create_schema"
+            | "create_relationship"
+            | "delete_node"
+    )
+}
+
 /// Maximum tokens any single inference round may generate.
 ///
 /// Small local models (e.g. Gemma-4-E4B) occasionally open an empty
@@ -732,11 +808,6 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             //
             // Args are round-tripped through serde to normalise JSON key order
             // so {"b":1,"a":2} and {"a":2,"b":1} are treated as the same call.
-            let canonical_args = |args_json: &str| {
-                serde_json::from_str::<serde_json::Value>(args_json)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|_| args_json.to_owned())
-            };
             let all_duplicate = tool_calls.iter().all(|tc| {
                 seen_calls.contains(&(tc.function_name.clone(), canonical_args(&tc.arguments_json)))
             });
@@ -790,11 +861,54 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 let (args, tool_result) = match parsed_args {
                     Ok(args) => {
                         consecutive_parse_failures = 0;
-                        let result = self
-                            .tool_executor
-                            .execute(&tc.function_name, args.clone())
-                            .await;
-                        (args, Some(result))
+                        // Cross-turn duplicate guard. The per-turn `seen_calls`
+                        // set above cannot see this: the session is rebuilt from
+                        // persisted messages every turn, so a repeat of a write
+                        // that landed in an *earlier* turn arrives here looking
+                        // brand new. Comparison is on the same canonical form
+                        // `seen_calls` uses, against writes replayed from the
+                        // conversation record.
+                        let already_written = if is_cross_turn_guarded_tool(&tc.function_name) {
+                            let incoming = canonical_args(&tc.arguments_json);
+                            session
+                                .prior_writes
+                                .iter()
+                                .find(|w| w.tool == tc.function_name && w.canonical_args == incoming)
+                        } else {
+                            None
+                        };
+                        if let Some(prior) = already_written {
+                            tracing::warn!(
+                                session_id = %session.id,
+                                tool = %tc.function_name,
+                                iteration = iteration,
+                                "Cross-turn duplicate write refused — identical call already completed in an earlier turn"
+                            );
+                            // An informative result, not a silent block. A user
+                            // genuinely re-asking for the same node is rare but
+                            // real, so the model needs to be able to tell them it
+                            // already exists — or, if the repeat is deliberate,
+                            // proceed by varying the call.
+                            (
+                                args,
+                                Some(Ok(crate::agent_types::ToolResult {
+                                    tool_call_id: tc.id.clone(),
+                                    name: tc.function_name.clone(),
+                                    result: duplicate_write_result(prior),
+                                    // Not an error: nothing went wrong, and the
+                                    // requested state already holds. Flagging it
+                                    // as a failure would invite a repair retry —
+                                    // the exact loop this guard exists to stop.
+                                    is_error: false,
+                                })),
+                            )
+                        } else {
+                            let result = self
+                                .tool_executor
+                                .execute(&tc.function_name, args.clone())
+                                .await;
+                            (args, Some(result))
+                        }
                     }
                     Err(parse_err) => {
                         consecutive_parse_failures += 1;
@@ -1361,6 +1475,7 @@ impl<E: ChatInferenceEngine + ?Sized + 'static, T: AgentToolExecutor + ?Sized + 
             tool_executions: Vec::new(),
             dynamic_context: None,
             system_prompt_override: None,
+            prior_writes: Vec::new(),
         };
 
         let cancel = CancellationToken::new();
@@ -1384,6 +1499,22 @@ impl<E: ChatInferenceEngine + ?Sized + 'static, T: AgentToolExecutor + ?Sized + 
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(session_id) {
             session.dynamic_context = Some(context);
+        }
+    }
+
+    /// Seed the writes completed by earlier turns of this conversation.
+    ///
+    /// The tool-execution path uses these to refuse a repeat of a write that
+    /// already landed in a prior turn. Callers that do not persist conversation
+    /// history simply never call this.
+    pub async fn set_session_prior_writes(
+        &self,
+        session_id: &str,
+        prior_writes: Vec<crate::agent_types::PriorWrite>,
+    ) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.prior_writes = prior_writes;
         }
     }
 
@@ -1485,7 +1616,9 @@ impl<E: ChatInferenceEngine + ?Sized + 'static, T: AgentToolExecutor + ?Sized + 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_types::{ChatModelSpec, ModelFamily, ToolDefinition, ToolError, ToolResult};
+    use crate::agent_types::{
+        ChatModelSpec, ModelFamily, PriorWrite, ToolDefinition, ToolError, ToolResult,
+    };
     use async_trait::async_trait;
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1716,6 +1849,46 @@ mod tests {
         }
     }
 
+    /// Executor that records every call it actually performs.
+    ///
+    /// The duplicate guard's whole point is that a call never reaches the
+    /// executor, so asserting on the *result* alone is not enough — a guard that
+    /// executed the write and then relabelled the result would pass such a
+    /// check. This records ground truth.
+    struct RecordingToolExecutor {
+        inner: MockToolExecutor,
+        calls: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl RecordingToolExecutor {
+        fn new(inner: MockToolExecutor) -> Self {
+            Self {
+                inner,
+                calls: Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn calls_handle(&self) -> Arc<std::sync::Mutex<Vec<String>>> {
+            Arc::clone(&self.calls)
+        }
+    }
+
+    #[async_trait]
+    impl AgentToolExecutor for RecordingToolExecutor {
+        async fn available_tools(&self) -> Result<Vec<ToolDefinition>, ToolError> {
+            self.inner.available_tools().await
+        }
+
+        async fn execute(
+            &self,
+            name: &str,
+            args: serde_json::Value,
+        ) -> Result<ToolResult, ToolError> {
+            self.calls.lock().unwrap().push(name.to_string());
+            self.inner.execute(name, args).await
+        }
+    }
+
     // -- Helper to create a fresh session --------------------------------
 
     fn new_session() -> AgentSession {
@@ -1728,6 +1901,7 @@ mod tests {
             tool_executions: Vec::new(),
             dynamic_context: None,
             system_prompt_override: None,
+            prior_writes: Vec::new(),
         }
     }
 
@@ -4091,5 +4265,212 @@ mod tests {
     fn empty_response_fallback_is_never_blank() {
         assert!(!EMPTY_RESPONSE_FALLBACK.trim().is_empty());
         assert!(EMPTY_RESPONSE_FALLBACK.contains("try again"));
+    }
+
+    // -- Cross-turn duplicate-write guard --------------------------------
+
+    /// Build a session that already carries one completed `create_node` write,
+    /// as a rebuilt turn N+1 would after loading persisted history.
+    fn session_with_prior_create(canonical: &str) -> AgentSession {
+        let mut session = new_session();
+        session.prior_writes = vec![PriorWrite {
+            tool: "create_node".to_string(),
+            canonical_args: canonical.to_string(),
+            node_id: Some("nodespace://n1".to_string()),
+            summary: Some("Buy milk".to_string()),
+        }];
+        session
+    }
+
+    fn create_node_executor() -> MockToolExecutor {
+        MockToolExecutor::new().with_tool(
+            "create_node",
+            json!({"type": "object", "properties": {"content": {"type": "string"}}}),
+            json!({"id": "nodespace://n2", "created": true}),
+        )
+    }
+
+    /// The acceptance criterion: a repeated write with identical canonical args
+    /// in a later turn must not execute a second time.
+    #[tokio::test]
+    async fn cross_turn_duplicate_write_is_not_executed() {
+        let args = r#"{"content":"Buy milk"}"#;
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_node",
+            args,
+            "It already exists.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_create(&canonical_args(args));
+        let result = agent_loop
+            .run_turn(
+                &mut session,
+                "add a task to buy milk",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            !calls.lock().unwrap().iter().any(|c| c == "create_node"),
+            "the duplicate create must never reach the executor, got {:?}",
+            calls.lock().unwrap()
+        );
+
+        // The model still receives a result, and it is not an error.
+        let rec = result
+            .tool_calls_made
+            .iter()
+            .find(|r| r.name == "create_node")
+            .expect("a tool result must still be produced");
+        assert!(!rec.is_error, "a refused duplicate is not a failure");
+    }
+
+    /// The result must name the already-written node, so the model can tell the
+    /// user the thing exists instead of reporting an opaque refusal.
+    #[tokio::test]
+    async fn refused_duplicate_names_the_existing_node() {
+        let args = r#"{"content":"Buy milk"}"#;
+        let engine = Arc::new(MockEngine::tool_then_text("create_node", args, "Exists."));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_create(&canonical_args(args));
+        let result = agent_loop
+            .run_turn(&mut session, "add it", |_| {}, |_| {}, CancellationToken::new())
+            .await
+            .expect("turn should succeed");
+
+        let rec = result
+            .tool_calls_made
+            .iter()
+            .find(|r| r.name == "create_node")
+            .expect("tool result");
+        let rendered = rec.result.to_string();
+        assert!(
+            rendered.contains("nodespace://n1"),
+            "must name the existing node, got {rendered}"
+        );
+        assert!(
+            rendered.contains("Buy milk"),
+            "must describe what already exists, got {rendered}"
+        );
+    }
+
+    /// Key order must not defeat the guard: the same call re-emitted with
+    /// reordered keys is the same write.
+    #[tokio::test]
+    async fn guard_matches_regardless_of_argument_key_order() {
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_node",
+            r#"{"node_type":"task","content":"Buy milk"}"#,
+            "Exists.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session =
+            session_with_prior_create(&canonical_args(r#"{"content":"Buy milk","node_type":"task"}"#));
+        agent_loop
+            .run_turn(&mut session, "add it", |_| {}, |_| {}, CancellationToken::new())
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            !calls.lock().unwrap().iter().any(|c| c == "create_node"),
+            "reordered keys are the same call and must still be refused"
+        );
+    }
+
+    /// A genuinely different write must still go through. The guard keys on the
+    /// arguments, not merely the tool name.
+    #[tokio::test]
+    async fn a_different_write_still_executes() {
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_node",
+            r#"{"content":"Buy bread"}"#,
+            "Added.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_create(&canonical_args(r#"{"content":"Buy milk"}"#));
+        agent_loop
+            .run_turn(&mut session, "add bread", |_| {}, |_| {}, CancellationToken::new())
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            calls.lock().unwrap().iter().any(|c| c == "create_node"),
+            "a distinct create must not be blocked"
+        );
+    }
+
+    /// Idempotent repeats must survive the guard. Setting the same task status
+    /// twice is a no-op, not a duplicate, and blocking it would break a user
+    /// legitimately re-asserting a value.
+    #[tokio::test]
+    async fn idempotent_update_repeat_is_not_blocked() {
+        let args = r#"{"id":"nodespace://t1","status":"done"}"#;
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "update_task_status",
+            args,
+            "Marked done.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(MockToolExecutor::new().with_tool(
+            "update_task_status",
+            json!({"type": "object", "properties": {"status": {"type": "string"}}}),
+            json!({"id": "nodespace://t1", "status": "done"}),
+        )));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = new_session();
+        // Even with an exact-match record present, an update must execute.
+        session.prior_writes = vec![PriorWrite {
+            tool: "update_task_status".to_string(),
+            canonical_args: canonical_args(args),
+            node_id: Some("nodespace://t1".to_string()),
+            summary: Some("t1".to_string()),
+        }];
+
+        agent_loop
+            .run_turn(&mut session, "mark it done", |_| {}, |_| {}, CancellationToken::new())
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            calls.lock().unwrap().iter().any(|c| c == "update_task_status"),
+            "idempotent updates must not be blocked by the cross-turn guard"
+        );
+    }
+
+    /// A session with no prior writes — every caller that does not persist
+    /// history — must behave exactly as before.
+    #[tokio::test]
+    async fn no_prior_writes_leaves_execution_untouched() {
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_node",
+            r#"{"content":"Buy milk"}"#,
+            "Added.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(create_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = new_session();
+        agent_loop
+            .run_turn(&mut session, "add milk", |_| {}, |_| {}, CancellationToken::new())
+            .await
+            .expect("turn should succeed");
+
+        assert!(calls.lock().unwrap().iter().any(|c| c == "create_node"));
     }
 }

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -847,6 +847,12 @@ pub enum Tool {
 impl Tool {
     /// Every tool in registry order. The order here is the order tools are
     /// presented to the model, so keep retrieval/discovery tools first.
+    ///
+    /// Completeness is compiler-enforced via [`Tool::ALL_IS_COMPLETE`]: a
+    /// variant added to the enum but omitted here fails to build. Without that
+    /// check this list is just another hand-maintained list, and everything
+    /// derived from it — including the duplicate-write guard — would silently
+    /// ignore the missing tool.
     pub const ALL: &'static [Tool] = &[
         Tool::SearchNodes,
         Tool::ResolveQuery,
@@ -863,6 +869,46 @@ impl Tool {
         Tool::DeleteNode,
         Tool::CreateNodesFromMarkdown,
     ];
+
+    /// Compile-time proof that [`Tool::ALL`] lists every variant.
+    ///
+    /// The match is exhaustive, so a new variant must be given a position here;
+    /// the assertion then fails to compile unless that position also holds it
+    /// in `ALL`. A test could only check the variants it was told about, which
+    /// is exactly the blind spot — the omitted one.
+    const ALL_IS_COMPLETE: () = {
+        let mut i = 0;
+        while i < Self::ALL.len() {
+            // Each variant maps to its own index; any duplicate or missing
+            // entry shifts the rest and trips the comparison below.
+            let expected = match Self::ALL[i] {
+                Tool::SearchNodes => 0,
+                Tool::ResolveQuery => 1,
+                Tool::SearchSemantic => 2,
+                Tool::GetNode => 3,
+                Tool::CreateNode => 4,
+                Tool::UpdateNode => 5,
+                Tool::CreateSchema => 6,
+                Tool::UpdateSchema => 7,
+                Tool::UpdateTaskStatus => 8,
+                Tool::CreateRelationship => 9,
+                Tool::GetRelatedNodes => 10,
+                Tool::SearchSkills => 11,
+                Tool::DeleteNode => 12,
+                Tool::CreateNodesFromMarkdown => 13,
+            };
+            assert!(expected == i, "Tool::ALL lists a variant out of order");
+            i += 1;
+        }
+        // The loop above only proves the listed entries sit at their own index;
+        // a variant left out entirely shortens the list without disturbing the
+        // rest. The count is what catches that, and the exhaustive match above
+        // is what forces this number to be revisited when a variant is added.
+        assert!(
+            Self::ALL.len() == 14,
+            "Tool::ALL is missing a variant — every variant must be listed"
+        );
+    };
 
     /// The wire/identifier name the model uses to call this tool.
     pub fn name(self) -> &'static str {
@@ -955,9 +1001,20 @@ impl Tool {
             // to the same status, twice is a no-op — the second call is not a
             // duplicate, and refusing it would break a user legitimately
             // re-asserting a value.
-            Tool::UpdateNode | Tool::UpdateSchema | Tool::UpdateTaskStatus => {
-                WriteSemantics::IdempotentWrite
-            }
+            Tool::UpdateNode | Tool::UpdateTaskStatus => WriteSemantics::IdempotentWrite,
+
+            // Not idempotent, but not guarded either. A repeated `add_fields`
+            // or `add_relationships` rejects the field as already present, and
+            // a repeated `rename_fields` fails because the source name is gone
+            // — so a repeat is self-limiting rather than duplicating data.
+            //
+            // Left unguarded because the guard keys on whole-call arguments,
+            // and `update_schema` batches independent edits: a call repeating
+            // one already-applied rename alongside a new field is not the same
+            // write, yet would be refused wholesale. Refusing a legitimate
+            // schema edit is worse than the error the schema layer already
+            // returns for the redundant part.
+            Tool::UpdateSchema => WriteSemantics::SelfLimitingWrite,
 
             // Writes whose repeat produces a second, unwanted copy of the
             // user's data — or, for a delete, re-attacks a node the record
@@ -984,11 +1041,17 @@ impl Tool {
 /// What a repeat of a tool call means for graph state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteSemantics {
-    /// Does not change state. A repeat wastes an iteration, nothing more.
+    /// Does not change user-visible graph state. A repeat wastes an iteration,
+    /// nothing more. (Reads may still persist internal upkeep such as lazy
+    /// schema migration, which is convergent and invisible to the caller.)
     Read,
     /// Changes state, but a repeat with identical arguments converges on the
     /// same result rather than producing a second copy.
     IdempotentWrite,
+    /// Changes state, and a repeat is rejected by the tool's own validation
+    /// rather than converging or duplicating. Not guarded: the tool already
+    /// refuses the redundant work itself.
+    SelfLimitingWrite,
     /// Changes state, and a repeat with identical arguments produces a second
     /// copy of the user's data. These are what the cross-turn guard refuses.
     DuplicableWrite,
@@ -1010,6 +1073,9 @@ pub fn is_write_tool(tool: &str) -> bool {
 
 /// All tool definitions for the graph executor, derived from the registry.
 pub fn all_tool_definitions() -> Vec<ToolDefinition> {
+    // Force evaluation of the completeness proof; an associated const is only
+    // checked where it is used.
+    const _: () = Tool::ALL_IS_COMPLETE;
     Tool::ALL.iter().map(|t| t.definition()).collect()
 }
 

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -865,7 +865,7 @@ impl Tool {
     ];
 
     /// The wire/identifier name the model uses to call this tool.
-    pub(crate) fn name(self) -> &'static str {
+    pub fn name(self) -> &'static str {
         match self {
             Tool::SearchNodes => "search_nodes",
             Tool::ResolveQuery => "resolve_query",
@@ -887,7 +887,7 @@ impl Tool {
     /// Resolve a wire name back to its registry entry. Returns `None` for any
     /// name not in the registry — used for dispatch and for validating
     /// skill `tool_whitelist` references.
-    pub(crate) fn from_name(name: &str) -> Option<Tool> {
+    pub fn from_name(name: &str) -> Option<Tool> {
         Tool::ALL.iter().copied().find(|t| t.name() == name)
     }
 
@@ -934,6 +934,78 @@ impl Tool {
             Tool::CreateNodesFromMarkdown => "markdown import",
         }
     }
+
+    /// What repeating this tool with identical arguments means.
+    ///
+    /// An exhaustive match rather than a list, so adding a tool cannot silently
+    /// default to "safe to repeat": the compiler makes the author state the
+    /// semantics. Consumers derive their own sets from this — see
+    /// [`Tool::is_write`] and [`Tool::duplicate_is_destructive`].
+    pub fn write_semantics(self) -> WriteSemantics {
+        match self {
+            // Reads. Repeating one is wasteful, never a duplicate.
+            Tool::SearchNodes
+            | Tool::ResolveQuery
+            | Tool::SearchSemantic
+            | Tool::GetNode
+            | Tool::GetRelatedNodes
+            | Tool::SearchSkills => WriteSemantics::Read,
+
+            // Idempotent writes. Setting a node to the same content, or a task
+            // to the same status, twice is a no-op — the second call is not a
+            // duplicate, and refusing it would break a user legitimately
+            // re-asserting a value.
+            Tool::UpdateNode | Tool::UpdateSchema | Tool::UpdateTaskStatus => {
+                WriteSemantics::IdempotentWrite
+            }
+
+            // Writes whose repeat produces a second, unwanted copy of the
+            // user's data — or, for a delete, re-attacks a node the record
+            // already shows removed.
+            Tool::CreateNode
+            | Tool::CreateSchema
+            | Tool::CreateRelationship
+            | Tool::CreateNodesFromMarkdown
+            | Tool::DeleteNode => WriteSemantics::DuplicableWrite,
+        }
+    }
+
+    /// Whether this tool changes graph state.
+    pub fn is_write(self) -> bool {
+        !matches!(self.write_semantics(), WriteSemantics::Read)
+    }
+
+    /// Whether repeating this tool across turns duplicates the user's data.
+    pub fn duplicate_is_destructive(self) -> bool {
+        matches!(self.write_semantics(), WriteSemantics::DuplicableWrite)
+    }
+}
+
+/// What a repeat of a tool call means for graph state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteSemantics {
+    /// Does not change state. A repeat wastes an iteration, nothing more.
+    Read,
+    /// Changes state, but a repeat with identical arguments converges on the
+    /// same result rather than producing a second copy.
+    IdempotentWrite,
+    /// Changes state, and a repeat with identical arguments produces a second
+    /// copy of the user's data. These are what the cross-turn guard refuses.
+    DuplicableWrite,
+}
+
+/// Whether a repeat of this tool in a *later turn* must be refused.
+///
+/// Resolves the wire name through the registry, so the set is computed from
+/// [`Tool::write_semantics`] rather than restated. An unknown name is not
+/// guarded: the guard blocks work, so an unrecognised tool must fail open.
+pub fn is_cross_turn_guarded_tool(tool: &str) -> bool {
+    Tool::from_name(tool).is_some_and(Tool::duplicate_is_destructive)
+}
+
+/// Whether a tool changes graph state, by wire name. Computed from the registry.
+pub fn is_write_tool(tool: &str) -> bool {
+    Tool::from_name(tool).is_some_and(Tool::is_write)
 }
 
 /// All tool definitions for the graph executor, derived from the registry.

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -870,12 +870,55 @@ impl Tool {
         Tool::CreateNodesFromMarkdown,
     ];
 
-    /// Compile-time proof that [`Tool::ALL`] lists every variant.
+    /// The number of variants, counted by walking every one of them.
     ///
-    /// The match is exhaustive, so a new variant must be given a position here;
-    /// the assertion then fails to compile unless that position also holds it
-    /// in `ALL`. A test could only check the variants it was told about, which
-    /// is exactly the blind spot — the omitted one.
+    /// The successor chain is an exhaustive match, so a new variant cannot be
+    /// added without being threaded into it — and threading it in necessarily
+    /// increments this count. That is the whole point: a literal here would be
+    /// satisfied by the very edit it is meant to police, since adding a variant
+    /// changes nothing on the right-hand side of a comparison against a
+    /// constant. `std::mem::variant_count` would say this directly but is still
+    /// nightly-only.
+    const COUNT: usize = {
+        let mut n = 0;
+        let mut v = Tool::SearchNodes;
+        loop {
+            n += 1;
+            v = match v {
+                Tool::SearchNodes => Tool::ResolveQuery,
+                Tool::ResolveQuery => Tool::SearchSemantic,
+                Tool::SearchSemantic => Tool::GetNode,
+                Tool::GetNode => Tool::CreateNode,
+                Tool::CreateNode => Tool::UpdateNode,
+                Tool::UpdateNode => Tool::CreateSchema,
+                Tool::CreateSchema => Tool::UpdateSchema,
+                Tool::UpdateSchema => Tool::UpdateTaskStatus,
+                Tool::UpdateTaskStatus => Tool::CreateRelationship,
+                Tool::CreateRelationship => Tool::GetRelatedNodes,
+                Tool::GetRelatedNodes => Tool::SearchSkills,
+                Tool::SearchSkills => Tool::DeleteNode,
+                Tool::DeleteNode => Tool::CreateNodesFromMarkdown,
+                Tool::CreateNodesFromMarkdown => break,
+            };
+        }
+        n
+    };
+
+    /// Compile-time proof that [`Tool::ALL`] lists every variant, exactly once,
+    /// in enum order.
+    ///
+    /// Two independent failure modes, because neither check catches the other's:
+    /// the index match below catches an entry that is out of order or listed
+    /// twice, while the count catches one omitted entirely — an omission
+    /// shortens the list without disturbing the indices of what remains.
+    ///
+    /// This is worth stating precisely because the obvious version of this
+    /// check does not work. Comparing `ALL.len()` against a literal passes the
+    /// case that actually happens — someone adds a tool — since the exhaustive
+    /// match forces an edit to the *match*, not to the number. The count must
+    /// itself be derived from an exhaustive match ([`Tool::COUNT`]) for the
+    /// proof to bind. Verify any change here by adding a variant, leaving it
+    /// out of `ALL`, and confirming the build fails; inspection is not enough.
     const ALL_IS_COMPLETE: () = {
         let mut i = 0;
         while i < Self::ALL.len() {
@@ -900,12 +943,8 @@ impl Tool {
             assert!(expected == i, "Tool::ALL lists a variant out of order");
             i += 1;
         }
-        // The loop above only proves the listed entries sit at their own index;
-        // a variant left out entirely shortens the list without disturbing the
-        // rest. The count is what catches that, and the exhaustive match above
-        // is what forces this number to be revisited when a variant is added.
         assert!(
-            Self::ALL.len() == 14,
+            Self::ALL.len() == Self::COUNT,
             "Tool::ALL is missing a variant — every variant must be listed"
         );
     };
@@ -1048,9 +1087,15 @@ pub enum WriteSemantics {
     /// Changes state, but a repeat with identical arguments converges on the
     /// same result rather than producing a second copy.
     IdempotentWrite,
-    /// Changes state, and a repeat is rejected by the tool's own validation
-    /// rather than converging or duplicating. Not guarded: the tool already
-    /// refuses the redundant work itself.
+    /// Changes state, and a repeat is either rejected by the tool's own
+    /// validation or is a no-op — never a second copy. Both happen within one
+    /// tool: a repeated `update_schema` add or rename is an error, while a
+    /// repeated remove simply finds nothing left to remove.
+    ///
+    /// Not guarded, for a reason beyond the tool handling redundancy itself:
+    /// the guard keys on whole-call arguments, and a call in this category may
+    /// batch independent edits, so repeating one applied edit alongside a new
+    /// one is not the same write yet would be refused wholesale.
     SelfLimitingWrite,
     /// Changes state, and a repeat with identical arguments produces a second
     /// copy of the user's data. These are what the cross-turn guard refuses.

--- a/packages/core/src/models/ai_chat_node.rs
+++ b/packages/core/src/models/ai_chat_node.rs
@@ -38,9 +38,10 @@ fn default_version() -> i64 {
 /// original instruction alongside a prose claim of completion and no proof the
 /// write occurred — and may repeat it.
 ///
-/// Deliberately narrow: the tool name, the affected node, and a short label.
-/// Full arguments and tool results are not persisted, since the purpose is to
-/// establish *that* the write happened, not to replay it.
+/// Carries the tool name, the affected node, a short label, and the canonical
+/// arguments the call was made with. Tool *results* are not persisted: the
+/// purpose is to establish *that* the write happened and to recognise a later
+/// call as the same write, not to replay its output.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AiChatCompletedWrite {
@@ -54,6 +55,17 @@ pub struct AiChatCompletedWrite {
     /// Short human-readable label for the written node, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+
+    /// The call's arguments, canonicalised (JSON key order normalised). Together
+    /// with `tool` this is the write's identity for the cross-turn duplicate
+    /// guard: a later call matching both is the same write, not a new one.
+    ///
+    /// `None` when the arguments were too large to persist (see
+    /// `CANONICAL_ARGS_MAX_CHARS`). A `None` here never matches, so an
+    /// unrecorded call is executed rather than wrongly suppressed — the guard
+    /// fails open, which is the safe direction for a check that blocks work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_args: Option<String>,
 }
 
 /// A single message in an ai-chat conversation.

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -1457,8 +1457,8 @@ fn completed_writes_from(executions: &[ToolExecutionRecord]) -> Vec<AiChatComple
             // what "the same call" means. Dropped when oversized rather than
             // truncated — see `CANONICAL_ARGS_MAX_CHARS`.
             let canonical = canonical_args(&r.args.to_string());
-            let canonical_args = (canonical.chars().count() <= CANONICAL_ARGS_MAX_CHARS)
-                .then_some(canonical);
+            let canonical_args =
+                (canonical.chars().count() <= CANONICAL_ARGS_MAX_CHARS).then_some(canonical);
 
             AiChatCompletedWrite {
                 tool: r.name.clone(),

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -16,9 +16,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nodespace_agent::agent_types::{
     AgentToolExecutor, ChatInferenceEngine, ChatMessage, InferenceError, InferenceUsage,
-    LocalAgentStatus, ModelManager, ModelStatus, Role, StreamingChunk, ToolExecutionRecord,
+    LocalAgentStatus, ModelManager, ModelStatus, PriorWrite, Role, StreamingChunk,
+    ToolExecutionRecord,
 };
-use nodespace_agent::local_agent::agent_loop::LocalAgentService;
+use nodespace_agent::local_agent::agent_loop::{
+    canonical_args, is_cross_turn_guarded_tool, LocalAgentService, CANONICAL_ARGS_MAX_CHARS,
+};
 use nodespace_agent::local_agent::composite_model_manager::CompositeModelManager;
 use nodespace_agent::local_agent::model_manager::GgufModelManager;
 use nodespace_agent::local_agent::ollama_model_manager::OllamaModelManager;
@@ -376,6 +379,17 @@ impl LocalAgentServiceImpl {
 
         if let Ok(ctx_str) = ctx {
             service.set_session_context(&session_id, ctx_str).await;
+        }
+
+        // Seed the deterministic duplicate guard with what earlier turns wrote.
+        // The prompt note built from the same record tells the model the work is
+        // done; this makes the tool-execution path enforce it regardless of
+        // whether the model heeds that note.
+        let prior_writes = load_prior_writes(&self.inner.node_service, &node_id).await;
+        if !prior_writes.is_empty() {
+            service
+                .set_session_prior_writes(&session_id, prior_writes)
+                .await;
         }
 
         let token_tx = self.inner.token_tx.clone();
@@ -1438,11 +1452,42 @@ fn completed_writes_from(executions: &[ToolExecutionRecord]) -> Vec<AiChatComple
                 None => None,
             };
 
+            // Identity for the cross-turn duplicate guard. Canonicalised through
+            // the same function the per-turn detector uses, so the two agree on
+            // what "the same call" means. Dropped when oversized rather than
+            // truncated — see `CANONICAL_ARGS_MAX_CHARS`.
+            let canonical = canonical_args(&r.args.to_string());
+            let canonical_args = (canonical.chars().count() <= CANONICAL_ARGS_MAX_CHARS)
+                .then_some(canonical);
+
             AiChatCompletedWrite {
                 tool: r.name.clone(),
                 node_id,
                 summary,
+                canonical_args,
             }
+        })
+        .collect()
+}
+
+/// Rebuild the duplicate-guard's view of earlier turns from persisted messages.
+///
+/// Only writes that carry a canonical-args identity can be matched against an
+/// incoming call, so entries without one are skipped: they would match nothing
+/// and only add noise. Filtering to the guarded tools here keeps the set small,
+/// since the execution-path check applies the same restriction anyway.
+fn prior_writes_from_history(messages: &[AiChatMessage]) -> Vec<PriorWrite> {
+    messages
+        .iter()
+        .flat_map(|m| m.completed_writes.iter())
+        .filter(|w| is_cross_turn_guarded_tool(&w.tool))
+        .filter_map(|w| {
+            w.canonical_args.as_ref().map(|args| PriorWrite {
+                tool: w.tool.clone(),
+                canonical_args: args.clone(),
+                node_id: w.node_id.clone(),
+                summary: w.summary.clone(),
+            })
         })
         .collect()
 }
@@ -1483,6 +1528,25 @@ fn completed_writes_message(writes: &[AiChatCompletedWrite]) -> Option<ChatMessa
         Role::System,
         lines.trim_end().to_string(),
     ))
+}
+
+/// Load the writes completed by earlier turns of this chat.
+///
+/// Separate from `load_node_history` because that function's return type is
+/// `ChatMessage`, which has no room for the per-message write record — the very
+/// erasure that let the original duplicate through.
+async fn load_prior_writes(node_service: &Arc<NodeService>, node_id: &str) -> Vec<PriorWrite> {
+    let node = match node_service.get_node(node_id).await {
+        Ok(Some(n)) => n,
+        // A missing or unreadable node is already logged by `load_node_history`,
+        // which runs first on the same node; staying quiet here avoids a
+        // duplicate error line for one underlying failure.
+        _ => return Vec::new(),
+    };
+    match AiChatNode::from_node(node) {
+        Ok(c) => prior_writes_from_history(&c.messages),
+        Err(_) => Vec::new(),
+    }
 }
 
 async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Vec<ChatMessage> {
@@ -2202,5 +2266,158 @@ api_key = "sk-test"
             .expect("a ready event should be emitted");
         assert_eq!(ready_event.engine_swapped, Some(true));
         assert!(events.iter().all(|e| e.event_type != "error"));
+    }
+
+    // -- Cross-turn duplicate-write guard --------------------------------
+
+    /// The guard's identity is `(tool, canonical_args)`, so a write is only
+    /// usable by it if the canonical args survive persistence. Without this the
+    /// whole mechanism degrades to a no-op that still looks wired up.
+    #[tokio::test]
+    async fn completed_writes_record_canonical_args_for_the_guard() {
+        let writes = completed_writes_from(&[exec(
+            "create_node",
+            serde_json::json!({"content": "Buy milk", "node_type": "task"}),
+            serde_json::json!({"id": "nodespace://n1"}),
+        )]);
+        assert_eq!(writes.len(), 1);
+        let canonical = writes[0]
+            .canonical_args
+            .as_deref()
+            .expect("a create must carry its canonical args");
+        assert!(canonical.contains("Buy milk"), "got {canonical:?}");
+    }
+
+    /// Key order is a serialisation artefact, not a difference in intent. If it
+    /// leaked into the identity, the same call re-emitted with reordered keys
+    /// would slip past the guard.
+    #[tokio::test]
+    async fn canonical_args_ignore_key_order() {
+        let a = completed_writes_from(&[exec(
+            "create_node",
+            serde_json::json!({"content": "x", "node_type": "task"}),
+            serde_json::json!({"id": "nodespace://n1"}),
+        )]);
+        let b = completed_writes_from(&[exec(
+            "create_node",
+            serde_json::json!({"node_type": "task", "content": "x"}),
+            serde_json::json!({"id": "nodespace://n1"}),
+        )]);
+        assert_eq!(a[0].canonical_args, b[0].canonical_args);
+    }
+
+    /// Oversized args are dropped, not truncated. A truncated string could
+    /// compare equal to a different call sharing a long prefix, which would turn
+    /// a size limit into a wrongly-blocked write.
+    #[tokio::test]
+    async fn oversized_args_drop_the_identity_rather_than_truncating() {
+        let huge = "#".repeat(CANONICAL_ARGS_MAX_CHARS + 100);
+        let writes = completed_writes_from(&[exec(
+            "create_nodes_from_markdown",
+            serde_json::json!({"markdown": huge}),
+            serde_json::json!({"created": 3}),
+        )]);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(
+            writes[0].canonical_args, None,
+            "oversized args must be dropped so they can never produce a false match"
+        );
+        // The evidence label is unaffected: the write is still reported.
+        assert!(writes[0].summary.is_some());
+    }
+
+    /// The guard reads its state back out of persisted messages. Entries with no
+    /// canonical args cannot match anything and are dropped rather than carried.
+    #[tokio::test]
+    async fn prior_writes_are_rebuilt_from_persisted_messages() {
+        let msgs = vec![AiChatMessage {
+            role: "assistant".to_string(),
+            content: "Added it.".to_string(),
+            timestamp: None,
+            reasoning: None,
+            completed_writes: vec![
+                AiChatCompletedWrite {
+                    tool: "create_node".to_string(),
+                    node_id: Some("nodespace://n1".to_string()),
+                    summary: Some("Buy milk".to_string()),
+                    canonical_args: Some(r#"{"content":"Buy milk"}"#.to_string()),
+                },
+                AiChatCompletedWrite {
+                    tool: "create_node".to_string(),
+                    node_id: Some("nodespace://n2".to_string()),
+                    summary: Some("no identity".to_string()),
+                    canonical_args: None,
+                },
+            ],
+        }];
+
+        let prior = prior_writes_from_history(&msgs);
+        assert_eq!(prior.len(), 1, "the identity-less write must be skipped");
+        assert_eq!(prior[0].tool, "create_node");
+        assert_eq!(prior[0].node_id.as_deref(), Some("nodespace://n1"));
+    }
+
+    /// Updates are idempotent: re-setting the same status or content is a no-op,
+    /// not a duplicate. Carrying them into the guard would block a user
+    /// legitimately re-asserting a value.
+    #[tokio::test]
+    async fn idempotent_updates_are_not_carried_into_the_guard() {
+        let msgs = vec![AiChatMessage {
+            role: "assistant".to_string(),
+            content: "Done.".to_string(),
+            timestamp: None,
+            reasoning: None,
+            completed_writes: vec![
+                AiChatCompletedWrite {
+                    tool: "update_task_status".to_string(),
+                    node_id: Some("nodespace://t1".to_string()),
+                    summary: Some("t1".to_string()),
+                    canonical_args: Some(r#"{"status":"done"}"#.to_string()),
+                },
+                AiChatCompletedWrite {
+                    tool: "update_node".to_string(),
+                    node_id: Some("nodespace://t2".to_string()),
+                    summary: Some("t2".to_string()),
+                    canonical_args: Some(r#"{"content":"x"}"#.to_string()),
+                },
+                AiChatCompletedWrite {
+                    tool: "update_schema".to_string(),
+                    node_id: None,
+                    summary: Some("s1".to_string()),
+                    canonical_args: Some(r#"{"schema_id":"s1"}"#.to_string()),
+                },
+            ],
+        }];
+
+        assert!(
+            prior_writes_from_history(&msgs).is_empty(),
+            "no update tool may be guarded across turns"
+        );
+    }
+
+    /// The guarded set must stay a subset of the tools recognised as writes.
+    /// A tool guarded here but absent from `is_write_tool` would never have its
+    /// args recorded, so the guard would silently never fire for it — the two
+    /// lists are hand-maintained and nothing else forces them to agree.
+    #[tokio::test]
+    async fn every_guarded_tool_is_also_recorded_as_a_write() {
+        for tool in [
+            "create_node",
+            "create_nodes_from_markdown",
+            "create_schema",
+            "create_relationship",
+            "delete_node",
+            "update_node",
+            "update_task_status",
+            "update_schema",
+        ] {
+            if is_cross_turn_guarded_tool(tool) {
+                assert!(
+                    is_write_tool(tool),
+                    "{tool} is guarded across turns but not recorded as a write, \
+                     so its canonical args are never persisted and the guard cannot fire"
+                );
+            }
+        }
     }
 }

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -20,12 +20,14 @@ use nodespace_agent::agent_types::{
     ToolExecutionRecord,
 };
 use nodespace_agent::local_agent::agent_loop::{
-    canonical_args, is_cross_turn_guarded_tool, LocalAgentService, CANONICAL_ARGS_MAX_CHARS,
+    canonical_args, LocalAgentService, CANONICAL_ARGS_MAX_CHARS,
 };
 use nodespace_agent::local_agent::composite_model_manager::CompositeModelManager;
 use nodespace_agent::local_agent::model_manager::GgufModelManager;
 use nodespace_agent::local_agent::ollama_model_manager::OllamaModelManager;
-use nodespace_agent::local_agent::tools::{GraphToolExecutor, SharedEmbeddingService};
+use nodespace_agent::local_agent::tools::{
+    is_cross_turn_guarded_tool, is_write_tool, GraphToolExecutor, SharedEmbeddingService,
+};
 use nodespace_core::models::{
     AiChatCompletedWrite, AiChatMessage, AiChatNode, NodeFilter, NodeUpdate,
 };
@@ -1373,24 +1375,6 @@ fn write_summary_arg(tool: &str) -> Option<&'static [&'static str]> {
     }
 }
 
-/// Whether a tool changes graph state. A repeat of one of these is a real
-/// duplicate; repeating a read is merely wasteful.
-///
-/// Kept exhaustive against the tool set in `packages/agent/src/local_agent/tools.rs`.
-fn is_write_tool(tool: &str) -> bool {
-    matches!(
-        tool,
-        "create_node"
-            | "update_node"
-            | "delete_node"
-            | "create_relationship"
-            | "create_schema"
-            | "update_schema"
-            | "create_nodes_from_markdown"
-            | "update_task_status"
-    )
-}
-
 /// Clip an evidence label, marking it when clipped so a truncated summary is
 /// not mistaken for a complete one.
 fn clip_summary(s: &str) -> String {
@@ -2395,29 +2379,42 @@ api_key = "sk-test"
         );
     }
 
-    /// The guarded set must stay a subset of the tools recognised as writes.
-    /// A tool guarded here but absent from `is_write_tool` would never have its
-    /// args recorded, so the guard would silently never fire for it — the two
-    /// lists are hand-maintained and nothing else forces them to agree.
+    /// The guarded set must stay a subset of the tools recognised as writes:
+    /// a guarded tool absent from `is_write_tool` would never have its args
+    /// recorded, so the guard could never fire for it.
+    ///
+    /// Iterates the registry itself rather than a hardcoded list. A literal
+    /// list would pass vacuously on exactly the change this is meant to catch —
+    /// a newly added tool simply would not appear in it.
     #[tokio::test]
     async fn every_guarded_tool_is_also_recorded_as_a_write() {
-        for tool in [
-            "create_node",
-            "create_nodes_from_markdown",
-            "create_schema",
-            "create_relationship",
-            "delete_node",
-            "update_node",
-            "update_task_status",
-            "update_schema",
-        ] {
-            if is_cross_turn_guarded_tool(tool) {
+        use nodespace_agent::local_agent::tools::Tool;
+
+        for tool in Tool::ALL {
+            let name = tool.name();
+            if is_cross_turn_guarded_tool(name) {
                 assert!(
-                    is_write_tool(tool),
-                    "{tool} is guarded across turns but not recorded as a write, \
+                    is_write_tool(name),
+                    "{name} is guarded across turns but not recorded as a write, \
                      so its canonical args are never persisted and the guard cannot fire"
                 );
             }
+        }
+    }
+
+    /// Every guarded tool must also produce an evidence label, otherwise a
+    /// refusal can only say "duplicate" without naming what already exists.
+    #[tokio::test]
+    async fn every_guarded_tool_can_describe_what_it_wrote() {
+        use nodespace_agent::local_agent::tools::Tool;
+
+        for tool in Tool::ALL.iter().filter(|t| t.duplicate_is_destructive()) {
+            let name = tool.name();
+            assert!(
+                write_summary_arg(name).is_some() || name == "create_relationship",
+                "{name} is guarded but has no way to describe its write, so a \
+                 refusal could not name the existing node"
+            );
         }
     }
 }

--- a/packages/desktop-app/src/lib/types/ai-chat-node.ts
+++ b/packages/desktop-app/src/lib/types/ai-chat-node.ts
@@ -24,6 +24,12 @@ export interface AiChatCompletedWrite {
   nodeId?: string;
   /** Short label for the written node, when available. */
   summary?: string;
+  /**
+   * The call's arguments, canonicalised. With `tool`, this is the write's
+   * identity for the backend's cross-turn duplicate guard. Absent when the
+   * arguments were too large to persist.
+   */
+  canonicalArgs?: string;
 }
 
 export interface AiChatMessage {

--- a/packages/nodespace-types/src/ai_chat.rs
+++ b/packages/nodespace-types/src/ai_chat.rs
@@ -14,6 +14,8 @@ pub struct AiChatCompletedWrite {
     pub node_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_args: Option<String>,
 }
 
 /// A single message in an ai-chat conversation.


### PR DESCRIPTION
Closes #1787