### PR TITLE
Cross-turn write guard misses two cases: oversized args exempt create_nodes_from_markdown, and delete_node's node_id alias yields a second identity

### DIFF
--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 
 use opentelemetry::trace::{Span, TraceContextExt, Tracer};
 use opentelemetry::KeyValue;
+use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
@@ -39,15 +40,25 @@ const MAX_TOOL_ITERATIONS: usize = 5;
 /// that were about to succeed.
 const MAX_CONSECUTIVE_PARSE_FAILURES: usize = 2;
 
-/// Longest canonical-args string persisted as a completed write's identity.
+/// Longest canonical-args string stored verbatim as a completed write's identity.
 ///
-/// `create_nodes_from_markdown` carries an entire import in its arguments, so
-/// storing them verbatim would write that content a second time into the chat
-/// node's own message history and grow it without bound. Past this length the
-/// identity is dropped rather than truncated: a truncated string could compare
-/// equal to a *different* call sharing a long prefix, turning a size limit into
-/// a wrong-suppression bug. Dropping it only costs a redundant re-execution.
+/// `create_nodes_from_markdown` carries an entire import in its arguments, and
+/// the identity is persisted into the chat node's own message history — so
+/// storing them verbatim would write that content a second time and grow the
+/// node without bound. Past this length [`canonical_args_identity`] substitutes
+/// a digest, which keeps the identity at constant size.
+///
+/// Note this is a *representation* threshold, not a guard-coverage one: a call
+/// above it is still guarded. Truncation, by contrast, would not be safe — a
+/// truncated string could compare equal to a *different* call sharing a long
+/// prefix, turning a size limit into a wrong-suppression bug. A digest has no
+/// such failure mode, which is why it is the form used above the cap.
 pub const CANONICAL_ARGS_MAX_CHARS: usize = 4096;
+
+/// Prefix marking an identity that is a digest rather than literal canonical
+/// args. Canonical JSON always begins with `{`, so the two forms are mutually
+/// unambiguous and a digest can never be mistaken for a call's real arguments.
+const CANONICAL_ARGS_DIGEST_PREFIX: &str = "sha256:";
 
 /// Normalise a tool call's raw JSON arguments so equal calls compare equal.
 ///
@@ -57,6 +68,14 @@ pub const CANONICAL_ARGS_MAX_CHARS: usize = 4096;
 /// string. Unparseable arguments are returned unchanged: they cannot be
 /// normalised, and an exact-match comparison on the raw text is still correct.
 ///
+/// Also resolves the `node_id` → `id` parameter alias (see the `serde(alias)`
+/// attributes in `tools.rs`). Serde applies that alias when *deserialising into
+/// a params struct*, which happens after this function runs — so without this
+/// step `{"id":"x"}` and `{"node_id":"x"}` would yield two different identities
+/// for one logical call, and a repeat that switched spelling would slip the
+/// guard. Normalising here rather than per-tool means any future tool adopting
+/// the same alias is covered without a matching fix.
+///
 /// Shared by the per-turn duplicate detector and the cross-turn write guard, so
 /// the normalisation rules cannot drift apart. Note the two feed it different
 /// inputs: the loop-breaker canonicalises the raw emitted text, while the guard
@@ -65,8 +84,51 @@ pub const CANONICAL_ARGS_MAX_CHARS: usize = 4096;
 /// stuck model, whereas the guard's comparison must be exact.
 pub fn canonical_args(args_json: &str) -> String {
     serde_json::from_str::<serde_json::Value>(args_json)
-        .map(|v| v.to_string())
+        .map(|mut v| {
+            normalize_param_aliases(&mut v);
+            v.to_string()
+        })
         .unwrap_or_else(|_| args_json.to_owned())
+}
+
+/// Rewrite aliased top-level parameter keys to the name the params struct uses.
+///
+/// Only the top level: a nested `properties` blob is the user's own data, where
+/// a key named `node_id` means whatever the user's schema says and must not be
+/// renamed. When a call carries *both* spellings the object is left untouched —
+/// serde's own precedence decides which wins, and picking one here could make
+/// two genuinely different calls compare equal, which is the one failure this
+/// guard must never have.
+fn normalize_param_aliases(args: &mut serde_json::Value) {
+    let Some(obj) = args.as_object_mut() else {
+        return;
+    };
+    if obj.contains_key("node_id") && !obj.contains_key("id") {
+        if let Some(v) = obj.remove("node_id") {
+            obj.insert("id".to_string(), v);
+        }
+    }
+}
+
+/// The identity persisted for a call's canonical args.
+///
+/// Under [`CANONICAL_ARGS_MAX_CHARS`] this is the canonical JSON verbatim, so a
+/// stored identity stays readable when diagnosing a refusal. Above it, a digest
+/// of that same string — exact-match equality is all the guard needs, so hashing
+/// preserves the guarantee at constant size instead of dropping the identity and
+/// leaving the largest, most costly duplicates unguarded.
+///
+/// Both sides of the comparison must derive the identity through this one
+/// function: the record side when persisting, the execution path when checking.
+/// Deriving either independently is what would let the two drift apart.
+pub fn canonical_args_identity(canonical: &str) -> String {
+    if canonical.chars().count() <= CANONICAL_ARGS_MAX_CHARS {
+        return canonical.to_owned();
+    }
+    format!(
+        "{CANONICAL_ARGS_DIGEST_PREFIX}{:x}",
+        Sha256::digest(canonical.as_bytes())
+    )
 }
 
 /// Build the tool result returned in place of a refused duplicate write.
@@ -860,7 +922,14 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                             // concretely when empty arguments are read as `{}`
                             // above, which yields "" here against a stored "{}"
                             // and a write that could never match itself.
-                            let incoming = canonical_args(&args.to_string());
+                            //
+                            // Reduced to an identity by the same function the
+                            // record side uses, so an oversized call compares
+                            // digest-against-digest. Comparing raw canonical args
+                            // here against a stored digest would never match, and
+                            // would silently unguard exactly the largest writes.
+                            let incoming =
+                                canonical_args_identity(&canonical_args(&args.to_string()));
                             session.prior_writes.iter().find(|w| {
                                 w.tool == tc.function_name && w.canonical_args == incoming
                             })
@@ -4420,6 +4489,259 @@ mod tests {
             calls.lock().unwrap().iter().any(|c| c == "create_node"),
             "a distinct create must not be blocked"
         );
+    }
+
+    /// Build a session carrying one completed markdown import, stored the way
+    /// the record side stores it — through `canonical_args_identity`, so an
+    /// oversized import is held as a digest.
+    fn session_with_prior_import(markdown: &str) -> AgentSession {
+        let mut session = new_session();
+        session.prior_writes = vec![PriorWrite {
+            tool: "create_nodes_from_markdown".to_string(),
+            canonical_args: canonical_args_identity(&canonical_args(
+                &json!({ "markdown": markdown }).to_string(),
+            )),
+            node_id: Some("nodespace://n1".to_string()),
+            summary: Some("Project plan".to_string()),
+        }];
+        session
+    }
+
+    fn import_executor() -> MockToolExecutor {
+        MockToolExecutor::new().with_tool(
+            "create_nodes_from_markdown",
+            json!({"type": "object", "properties": {"markdown": {"type": "string"}}}),
+            json!({"created": 12}),
+        )
+    }
+
+    /// An import large enough to exceed the args cap — the realistic case, since
+    /// any real import does.
+    fn oversized_markdown(topic: &str) -> String {
+        format!(
+            "# {topic}\n{}",
+            "- a task line\n".repeat(CANONICAL_ARGS_MAX_CHARS / 8)
+        )
+    }
+
+    /// The acceptance criterion for the oversized-args gap: a repeated import
+    /// must be refused across turns. This is the tool where a repeat is worst —
+    /// it duplicates an entire subtree — and the one the cap used to exempt
+    /// wholesale, leaving it unguarded in every real case.
+    #[tokio::test]
+    async fn cross_turn_duplicate_oversized_import_is_not_executed() {
+        let markdown = oversized_markdown("Project plan");
+        assert!(
+            markdown.chars().count() > CANONICAL_ARGS_MAX_CHARS,
+            "the fixture must actually exceed the cap"
+        );
+        let args = json!({ "markdown": markdown }).to_string();
+
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_nodes_from_markdown",
+            &args,
+            "It already exists.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(import_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_import(&markdown);
+        agent_loop
+            .run_turn(
+                &mut session,
+                "import my project plan",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            !calls
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|c| c == "create_nodes_from_markdown"),
+            "a repeated import must never reach the executor, got {:?}",
+            calls.lock().unwrap()
+        );
+    }
+
+    /// The negative control for the digest. Refusing a *different* import would
+    /// be a wrong suppression — worse than the missed duplicate this change
+    /// fixes — so the identity must distinguish two large calls, not merely
+    /// recognise that both are large.
+    #[tokio::test]
+    async fn a_different_oversized_import_still_executes() {
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "create_nodes_from_markdown",
+            &json!({ "markdown": oversized_markdown("Recipes") }).to_string(),
+            "Imported.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(import_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_import(&oversized_markdown("Project plan"));
+        agent_loop
+            .run_turn(
+                &mut session,
+                "import my recipes",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .expect("turn should succeed");
+
+        assert!(
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|c| c == "create_nodes_from_markdown"),
+            "a distinct import must not be blocked"
+        );
+    }
+
+    fn delete_node_executor() -> MockToolExecutor {
+        MockToolExecutor::new().with_tool(
+            "delete_node",
+            json!({"type": "object", "properties": {"id": {"type": "string"}}}),
+            json!({"deleted": true}),
+        )
+    }
+
+    /// Build a session carrying one completed `delete_node`, recorded under the
+    /// given key spelling.
+    fn session_with_prior_delete(args: &str) -> AgentSession {
+        let mut session = new_session();
+        session.prior_writes = vec![PriorWrite {
+            tool: "delete_node".to_string(),
+            canonical_args: canonical_args_identity(&canonical_args(args)),
+            node_id: Some("nodespace://n1".to_string()),
+            summary: Some("Old note".to_string()),
+        }];
+        session
+    }
+
+    /// Run a turn where the model re-issues a delete under `incoming`, against a
+    /// prior write recorded under `stored`. Returns whether the executor ran.
+    async fn delete_repeat_reaches_executor(stored: &str, incoming: &str) -> bool {
+        let engine = Arc::new(MockEngine::tool_then_text(
+            "delete_node",
+            incoming,
+            "Already gone.",
+        ));
+        let executor = Arc::new(RecordingToolExecutor::new(delete_node_executor()));
+        let calls = executor.calls_handle();
+        let agent_loop = LocalAgentLoop::new(engine, executor);
+
+        let mut session = session_with_prior_delete(stored);
+        agent_loop
+            .run_turn(
+                &mut session,
+                "delete that node",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .expect("turn should succeed");
+
+        let ran = calls.lock().unwrap().iter().any(|c| c == "delete_node");
+        ran
+    }
+
+    /// The acceptance criterion for the alias gap. `delete_node` takes its target
+    /// under either `id` or `node_id` (serde alias), but serde resolves that only
+    /// when deserialising into the params struct — after canonicalisation. So a
+    /// repeat that switched spelling used to produce a second identity and slip
+    /// the guard. Both directions, since either spelling can be recorded first.
+    #[tokio::test]
+    async fn delete_repeat_is_refused_across_the_node_id_alias() {
+        let id_form = r#"{"id":"nodespace://n1"}"#;
+        let alias_form = r#"{"node_id":"nodespace://n1"}"#;
+
+        assert!(
+            !delete_repeat_reaches_executor(id_form, alias_form).await,
+            "a repeat spelled `node_id` must be recognised as the stored `id` call"
+        );
+        assert!(
+            !delete_repeat_reaches_executor(alias_form, id_form).await,
+            "a repeat spelled `id` must be recognised as the stored `node_id` call"
+        );
+    }
+
+    /// The alias rule must not merge genuinely different deletes: it renames a
+    /// key, it does not ignore the value.
+    #[tokio::test]
+    async fn delete_of_a_different_node_still_executes() {
+        assert!(
+            delete_repeat_reaches_executor(
+                r#"{"id":"nodespace://n1"}"#,
+                r#"{"node_id":"nodespace://n2"}"#
+            )
+            .await,
+            "a delete targeting another node must not be blocked"
+        );
+    }
+
+    /// The alias is resolved at the top level only. A nested `properties` blob is
+    /// the user's own data, where a field named `node_id` means whatever their
+    /// schema says — renaming it would silently rewrite user data into a
+    /// different field for identity purposes.
+    #[test]
+    fn alias_normalisation_does_not_reach_into_nested_user_data() {
+        let canonical = canonical_args(r#"{"properties":{"node_id":"x"},"node_type":"venue"}"#);
+        assert!(
+            canonical.contains("node_id"),
+            "a nested user field must be left alone, got {canonical}"
+        );
+    }
+
+    /// When a call carries both spellings there is no safe rename: serde's own
+    /// precedence decides which wins, and guessing here could make two genuinely
+    /// different calls compare equal — the one failure this guard must not have.
+    #[test]
+    fn alias_normalisation_leaves_ambiguous_calls_untouched() {
+        let canonical = canonical_args(r#"{"id":"a","node_id":"b"}"#);
+        assert!(canonical.contains(r#""id":"a""#), "got {canonical}");
+        assert!(canonical.contains(r#""node_id":"b""#), "got {canonical}");
+    }
+
+    /// Under the cap the identity is the canonical args verbatim, so a stored
+    /// identity stays readable when diagnosing a refusal.
+    #[test]
+    fn identity_is_verbatim_below_the_cap() {
+        let canonical = canonical_args(r#"{"content":"Buy milk"}"#);
+        assert_eq!(canonical_args_identity(&canonical), canonical);
+    }
+
+    /// The two identity forms must be mutually unambiguous: canonical JSON always
+    /// starts with `{`, a digest with `sha256:`. Were they confusable, a call
+    /// whose arguments happened to spell a digest could impersonate another
+    /// call's identity.
+    #[test]
+    fn digest_and_verbatim_identities_cannot_be_confused() {
+        let small = canonical_args_identity(&canonical_args(r#"{"content":"x"}"#));
+        let large = canonical_args_identity(&"x".repeat(CANONICAL_ARGS_MAX_CHARS + 1));
+        assert!(small.starts_with('{'));
+        assert!(large.starts_with("sha256:"));
+        assert_ne!(small, large);
+    }
+
+    /// The digest must be a function of the content: equal args hash equal,
+    /// different args do not. Exact-match equality is the whole guarantee the
+    /// guard needs, and hashing has to preserve it in both directions.
+    #[test]
+    fn digest_identity_is_stable_and_content_sensitive() {
+        let a = "a".repeat(CANONICAL_ARGS_MAX_CHARS + 1);
+        let b = format!("{}b", "a".repeat(CANONICAL_ARGS_MAX_CHARS));
+        assert_eq!(canonical_args_identity(&a), canonical_args_identity(&a));
+        assert_ne!(canonical_args_identity(&a), canonical_args_identity(&b));
     }
 
     /// Idempotent repeats must survive the guard. Setting the same task status

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -93,6 +93,13 @@ pub fn canonical_args(args_json: &str) -> String {
 
 /// Rewrite aliased top-level parameter keys to the name the params struct uses.
 ///
+/// Applied to every tool's arguments rather than per-tool. `node_id` is the only
+/// alias in the tool registry and always means `id`, so a blanket rule is both
+/// correct and self-maintaining — a future tool adopting the same alias needs no
+/// matching fix here. A tool with no such parameter is unaffected in practice,
+/// and even a stray `node_id` is renamed identically on both sides of the
+/// comparison, so the identity stays consistent either way.
+///
 /// Only the top level: a nested `properties` blob is the user's own data, where
 /// a key named `node_id` means whatever the user's schema says and must not be
 /// renamed. When a call carries *both* spellings the object is left untouched —
@@ -4651,6 +4658,8 @@ mod tests {
             .await
             .expect("turn should succeed");
 
+        // Bound, not returned directly: the temporary `MutexGuard` in the
+        // expression would outlive `calls` at the end of the function.
         let ran = calls.lock().unwrap().iter().any(|c| c == "delete_node");
         ran
     }
@@ -4695,9 +4704,19 @@ mod tests {
     /// different field for identity purposes.
     #[test]
     fn alias_normalisation_does_not_reach_into_nested_user_data() {
-        let canonical = canonical_args(r#"{"properties":{"node_id":"x"},"node_type":"venue"}"#);
+        // A realistic `update_node`: the tool's own target under the alias, plus
+        // a user-defined field that happens to be named `node_id` inside the
+        // `properties` blob. The top-level key is renamed; the user's field is
+        // not, and its value must survive untouched.
+        let canonical = canonical_args(
+            r#"{"node_id":"nodespace://n1","properties":{"node_id":"user-value","capacity":10}}"#,
+        );
         assert!(
-            canonical.contains("node_id"),
+            canonical.contains(r#""id":"nodespace://n1""#),
+            "the top-level alias must be resolved, got {canonical}"
+        );
+        assert!(
+            canonical.contains(r#""node_id":"user-value""#),
             "a nested user field must be left alone, got {canonical}"
         );
     }

--- a/packages/core/src/models/ai_chat_node.rs
+++ b/packages/core/src/models/ai_chat_node.rs
@@ -188,10 +188,33 @@ impl AiChatNode {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
+        // Decoded per message, not as one `Vec`. Decoding the whole array at
+        // once means a single unreadable message discards the entire
+        // conversation — and because a caller that then writes the node back
+        // (status updates do) re-serialises from this struct, that loss is
+        // persisted. Per-message decoding contains the damage to the message
+        // actually at fault, and logs it rather than failing silently.
         let messages = props
             .get("messages")
-            .cloned()
-            .map(|v| serde_json::from_value::<Vec<AiChatMessage>>(v).unwrap_or_default())
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(
+                        |m| match serde_json::from_value::<AiChatMessage>(m.clone()) {
+                            Ok(msg) => Some(msg),
+                            Err(e) => {
+                                tracing::error!(
+                                    node_id = %node.id,
+                                    error = %e,
+                                    "dropping unreadable ai-chat message; the rest of the \
+                                     conversation is preserved"
+                                );
+                                None
+                            }
+                        },
+                    )
+                    .collect()
+            })
             .unwrap_or_default();
 
         Ok(Self {

--- a/packages/core/src/models/ai_chat_node.rs
+++ b/packages/core/src/models/ai_chat_node.rs
@@ -56,16 +56,22 @@ pub struct AiChatCompletedWrite {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 
-    /// The call's arguments, canonicalised (JSON key order normalised). Together
-    /// with `tool` this is the write's identity for the cross-turn duplicate
-    /// guard: a later call matching both is the same write, not a new one.
+    /// The call's arguments, canonicalised (JSON key order normalised, parameter
+    /// aliases resolved). Together with `tool` this is the write's identity for
+    /// the cross-turn duplicate guard: a later call matching both is the same
+    /// write, not a new one.
     ///
-    /// `None` when the arguments were too large to persist (see
-    /// `CANONICAL_ARGS_MAX_CHARS`). A `None` here never matches, so an
-    /// unrecorded call is executed rather than wrongly suppressed — the guard
-    /// fails open, which is the safe direction for a check that blocks work.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub canonical_args: Option<String>,
+    /// Two forms, both produced by `canonical_args_identity`: the canonical JSON
+    /// verbatim when it is small enough to store, or `sha256:<hex>` of that same
+    /// string when it is not (see `CANONICAL_ARGS_MAX_CHARS`). The digest keeps
+    /// large writes — an entire markdown import, say — guarded without copying
+    /// their content into this message history a second time. The forms cannot
+    /// be confused: canonical JSON always starts with `{`.
+    ///
+    /// Always present. An identity is what makes a recorded write enforceable,
+    /// so a write recorded without one would be indistinguishable from an
+    /// unguarded tool while still looking wired up.
+    pub canonical_args: String,
 }
 
 /// A single message in an ai-chat conversation.

--- a/packages/core/src/models/ai_chat_node_test.rs
+++ b/packages/core/src/models/ai_chat_node_test.rs
@@ -148,4 +148,89 @@ mod tests {
         assert_eq!(props["ai-chat"]["status"], json!("idle"));
         assert_eq!(props["ai-chat"]["messages"][0]["content"], json!("done"));
     }
+
+    /// One unreadable message must not take the conversation with it.
+    ///
+    /// Decoding the array as a single `Vec` fails wholesale on any one bad
+    /// element, and callers that write the node back — a status update does —
+    /// re-serialise from this struct, so a read that silently yields zero
+    /// messages *persists* as an erased conversation. Per-message decoding keeps
+    /// the loss to the message actually at fault.
+    #[test]
+    fn one_unreadable_message_does_not_erase_the_conversation() {
+        let node = ai_chat_node(json!({
+            "ai-chat": {
+                "status": "idle",
+                "messages": [
+                    { "role": "user", "content": "hello" },
+                    // Malformed: `content` is required and must be a string.
+                    { "role": "assistant", "content": 42 },
+                    { "role": "assistant", "content": "goodbye" }
+                ]
+            }
+        }));
+
+        let chat = AiChatNode::from_node(node).unwrap();
+        assert_eq!(
+            chat.messages.len(),
+            2,
+            "only the unreadable message may be dropped"
+        );
+        assert_eq!(chat.messages[0].content, "hello");
+        assert_eq!(chat.messages[1].content, "goodbye");
+    }
+
+    /// A write record missing its identity is the concrete case that made the
+    /// above reachable: `canonicalArgs` is required, so a legacy write without
+    /// one fails to decode. Its message is dropped; the rest of the conversation
+    /// survives, rather than the whole history decoding to empty.
+    #[test]
+    fn a_write_without_an_identity_does_not_erase_the_conversation() {
+        let node = ai_chat_node(json!({
+            "ai-chat": {
+                "status": "idle",
+                "messages": [
+                    { "role": "user", "content": "add a task" },
+                    {
+                        "role": "assistant",
+                        "content": "Added.",
+                        "completedWrites": [
+                            { "tool": "create_node", "nodeId": "nodespace://n1" }
+                        ]
+                    },
+                    { "role": "user", "content": "thanks" }
+                ]
+            }
+        }));
+
+        let chat = AiChatNode::from_node(node).unwrap();
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(chat.messages[0].content, "add a task");
+        assert_eq!(chat.messages[1].content, "thanks");
+    }
+
+    /// The identity is required, so a well-formed write round-trips with it.
+    #[test]
+    fn completed_write_identity_round_trips() {
+        let node = ai_chat_node(json!({
+            "ai-chat": {
+                "status": "idle",
+                "messages": [{
+                    "role": "assistant",
+                    "content": "Added.",
+                    "completedWrites": [{
+                        "tool": "create_node",
+                        "nodeId": "nodespace://n1",
+                        "canonicalArgs": r#"{"content":"Buy milk"}"#
+                    }]
+                }]
+            }
+        }));
+
+        let chat = AiChatNode::from_node(node).unwrap();
+        assert_eq!(
+            chat.messages[0].completed_writes[0].canonical_args,
+            r#"{"content":"Buy milk"}"#
+        );
+    }
 }

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -2658,7 +2658,10 @@ api_key = "sk-test"
             !identity.contains(&huge),
             "the import must not be re-stored"
         );
-        assert!(identity.len() < 128, "identity must be constant-size");
+        // Exactly "sha256:" plus 64 hex chars. An exact length, not a loose
+        // bound: a bound generous enough to be safe would also pass on a
+        // truncated identity, which is the regression this is here to catch.
+        assert_eq!(identity.len(), 71, "identity must be a full digest");
         // The evidence label is unaffected: the write is still reported.
         assert!(writes[0].summary.is_some());
     }

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -20,7 +20,7 @@ use nodespace_agent::agent_types::{
     ToolExecutionRecord,
 };
 use nodespace_agent::local_agent::agent_loop::{
-    canonical_args, LocalAgentService, CANONICAL_ARGS_MAX_CHARS,
+    canonical_args, canonical_args_identity, LocalAgentService,
 };
 use nodespace_agent::local_agent::composite_model_manager::CompositeModelManager;
 use nodespace_agent::local_agent::model_manager::GgufModelManager;
@@ -407,8 +407,12 @@ impl LocalAgentServiceImpl {
     /// before triggering this turn — writing it again here would re-emit a
     /// nodeUpdated event and cause a re-entry loop.
     async fn run_ai_chat_turn(&self, node_id: String, cancel: CancellationToken) {
-        // Load history from node.
-        let history = load_node_history(&self.inner.node_service, &node_id).await;
+        // One read of the chat node serves both of the things this turn needs
+        // from it: the rendered inference history, and the record of what
+        // earlier turns wrote (which seeds the duplicate guard below).
+        let messages = load_chat_messages(&self.inner.node_service, &node_id).await;
+        let prior_writes = prior_writes_from_history(&messages);
+        let history = node_history_from_messages(messages);
         if history.is_empty() {
             tracing::warn!(node_id, "ai-chat history empty — skipping turn");
             let _ = self.write_ai_chat_status(&node_id, "idle", None).await;
@@ -441,11 +445,11 @@ impl LocalAgentServiceImpl {
             service.set_session_context(&session_id, ctx_str).await;
         }
 
-        // Seed the deterministic duplicate guard with what earlier turns wrote.
-        // The prompt note built from the same record tells the model the work is
-        // done; this makes the tool-execution path enforce it regardless of
-        // whether the model heeds that note.
-        let prior_writes = load_prior_writes(&self.inner.node_service, &node_id).await;
+        // Seed the deterministic duplicate guard with what earlier turns wrote
+        // (read above, alongside the history). The prompt note built from the
+        // same record tells the model the work is done; this makes the
+        // tool-execution path enforce it regardless of whether the model heeds
+        // that note.
         if !prior_writes.is_empty() {
             service
                 .set_session_prior_writes(&session_id, prior_writes)
@@ -1489,11 +1493,11 @@ fn completed_writes_from(executions: &[ToolExecutionRecord]) -> Vec<AiChatComple
 
             // Identity for the cross-turn duplicate guard. Canonicalised through
             // the same function the per-turn detector uses, so the two agree on
-            // what "the same call" means. Dropped when oversized rather than
-            // truncated — see `CANONICAL_ARGS_MAX_CHARS`.
-            let canonical = canonical_args(&r.args.to_string());
-            let canonical_args =
-                (canonical.chars().count() <= CANONICAL_ARGS_MAX_CHARS).then_some(canonical);
+            // what "the same call" means, then reduced to a storable identity —
+            // verbatim when small, a digest when not. The execution path derives
+            // the incoming call's identity the same way; that shared derivation
+            // is what keeps the two comparable.
+            let canonical_args = canonical_args_identity(&canonical_args(&r.args.to_string()));
 
             AiChatCompletedWrite {
                 tool: r.name.clone(),
@@ -1507,22 +1511,19 @@ fn completed_writes_from(executions: &[ToolExecutionRecord]) -> Vec<AiChatComple
 
 /// Rebuild the duplicate-guard's view of earlier turns from persisted messages.
 ///
-/// Only writes that carry a canonical-args identity can be matched against an
-/// incoming call, so entries without one are skipped: they would match nothing
-/// and only add noise. Filtering to the guarded tools here keeps the set small,
-/// since the execution-path check applies the same restriction anyway.
+/// Filtering to the guarded tools here keeps the set small, since the
+/// execution-path check applies the same restriction anyway. Every recorded
+/// write carries an identity, so none are dropped.
 fn prior_writes_from_history(messages: &[AiChatMessage]) -> Vec<PriorWrite> {
     messages
         .iter()
         .flat_map(|m| m.completed_writes.iter())
         .filter(|w| is_cross_turn_guarded_tool(&w.tool))
-        .filter_map(|w| {
-            w.canonical_args.as_ref().map(|args| PriorWrite {
-                tool: w.tool.clone(),
-                canonical_args: args.clone(),
-                node_id: w.node_id.clone(),
-                summary: w.summary.clone(),
-            })
+        .map(|w| PriorWrite {
+            tool: w.tool.clone(),
+            canonical_args: w.canonical_args.clone(),
+            node_id: w.node_id.clone(),
+            summary: w.summary.clone(),
         })
         .collect()
 }
@@ -1565,26 +1566,13 @@ fn completed_writes_message(writes: &[AiChatCompletedWrite]) -> Option<ChatMessa
     ))
 }
 
-/// Load the writes completed by earlier turns of this chat.
+/// Load an ai-chat node's persisted messages.
 ///
-/// Separate from `load_node_history` because that function's return type is
-/// `ChatMessage`, which has no room for the per-message write record — the very
-/// erasure that let the original duplicate through.
-async fn load_prior_writes(node_service: &Arc<NodeService>, node_id: &str) -> Vec<PriorWrite> {
-    let node = match node_service.get_node(node_id).await {
-        Ok(Some(n)) => n,
-        // A missing or unreadable node is already logged by `load_node_history`,
-        // which runs first on the same node; staying quiet here avoids a
-        // duplicate error line for one underlying failure.
-        _ => return Vec::new(),
-    };
-    match AiChatNode::from_node(node) {
-        Ok(c) => prior_writes_from_history(&c.messages),
-        Err(_) => Vec::new(),
-    }
-}
-
-async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Vec<ChatMessage> {
+/// The single read a turn makes of its own chat node. Both things a turn needs
+/// from it — the rendered history and the completed-write record — derive from
+/// these messages, so fetching once and deriving twice avoids a redundant read
+/// per turn. Any failure is logged here, once, and yields no messages.
+async fn load_chat_messages(node_service: &Arc<NodeService>, node_id: &str) -> Vec<AiChatMessage> {
     let node = match node_service.get_node(node_id).await {
         Ok(Some(n)) => n,
         Ok(None) => {
@@ -1597,16 +1585,22 @@ async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Ve
         }
     };
 
-    let ai_chat = match AiChatNode::from_node(node) {
-        Ok(c) => c,
+    match AiChatNode::from_node(node) {
+        Ok(c) => c.messages,
         Err(e) => {
             tracing::warn!(node_id, error = %e, "node is not an ai-chat node");
-            return vec![];
+            vec![]
         }
-    };
+    }
+}
 
-    ai_chat
-        .messages
+/// Render persisted messages as the inference history for this turn.
+///
+/// Separate from `prior_writes_from_history` because `ChatMessage` has no room
+/// for the per-message write record — the very erasure that let the original
+/// duplicate through. Both read the same loaded messages.
+fn node_history_from_messages(messages: Vec<AiChatMessage>) -> Vec<ChatMessage> {
+    messages
         .into_iter()
         .flat_map(|m| {
             let role = match m.role.as_str() {
@@ -1682,8 +1676,17 @@ async fn build_workspace_context(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nodespace_agent::local_agent::agent_loop::CANONICAL_ARGS_MAX_CHARS;
     use nodespace_core::models::Node;
     use nodespace_core::{NodeService as CoreNodeService, SqliteStore};
+
+    /// Load and render a chat node's history, the way a turn does.
+    ///
+    /// A turn splits these steps so one read can also feed the duplicate guard;
+    /// tests that only care about the rendered history compose them back.
+    async fn load_node_history(node_service: &Arc<NodeService>, node_id: &str) -> Vec<ChatMessage> {
+        node_history_from_messages(load_chat_messages(node_service, node_id).await)
+    }
 
     /// Build a `LocalAgentServiceImpl` backed by a temp-dir SqliteStore.
     /// Returns the `TempDir` so it outlives the test body.
@@ -2606,10 +2609,7 @@ api_key = "sk-test"
             serde_json::json!({"id": "nodespace://n1"}),
         )]);
         assert_eq!(writes.len(), 1);
-        let canonical = writes[0]
-            .canonical_args
-            .as_deref()
-            .expect("a create must carry its canonical args");
+        let canonical = &writes[0].canonical_args;
         assert!(canonical.contains("Buy milk"), "got {canonical:?}");
     }
 
@@ -2631,11 +2631,15 @@ api_key = "sk-test"
         assert_eq!(a[0].canonical_args, b[0].canonical_args);
     }
 
-    /// Oversized args are dropped, not truncated. A truncated string could
-    /// compare equal to a different call sharing a long prefix, which would turn
-    /// a size limit into a wrongly-blocked write.
+    /// Oversized args are digested, never truncated and never dropped.
+    ///
+    /// A truncated string could compare equal to a different call sharing a long
+    /// prefix — a size limit turned into a wrongly-blocked write. Dropping the
+    /// identity avoids that but leaves the tool unguarded, and this is the tool
+    /// where a repeat is worst: it duplicates an entire subtree. A digest is the
+    /// form that has neither problem.
     #[tokio::test]
-    async fn oversized_args_drop_the_identity_rather_than_truncating() {
+    async fn oversized_args_are_digested_rather_than_dropped_or_truncated() {
         let huge = "#".repeat(CANONICAL_ARGS_MAX_CHARS + 100);
         let writes = completed_writes_from(&[exec(
             "create_nodes_from_markdown",
@@ -2643,16 +2647,72 @@ api_key = "sk-test"
             serde_json::json!({"created": 3}),
         )]);
         assert_eq!(writes.len(), 1);
-        assert_eq!(
-            writes[0].canonical_args, None,
-            "oversized args must be dropped so they can never produce a false match"
+        let identity = &writes[0].canonical_args;
+        assert!(
+            identity.starts_with("sha256:"),
+            "oversized args must still yield an identity, as a digest: {identity:?}"
         );
+        // The point of the digest: the import itself is not copied back into the
+        // chat node's own history.
+        assert!(
+            !identity.contains(&huge),
+            "the import must not be re-stored"
+        );
+        assert!(identity.len() < 128, "identity must be constant-size");
         // The evidence label is unaffected: the write is still reported.
         assert!(writes[0].summary.is_some());
     }
 
-    /// The guard reads its state back out of persisted messages. Entries with no
-    /// canonical args cannot match anything and are dropped rather than carried.
+    /// The digest must identify the *specific* call, not merely "something big".
+    /// If it collapsed all oversized calls together, a second, genuinely
+    /// different import would be refused — a wrong suppression, the one failure
+    /// mode this guard must not have.
+    #[tokio::test]
+    async fn different_oversized_imports_get_different_identities() {
+        let identity_for = |body: &str| {
+            completed_writes_from(&[exec(
+                "create_nodes_from_markdown",
+                serde_json::json!({ "markdown": body }),
+                serde_json::json!({"created": 3}),
+            )])[0]
+                .canonical_args
+                .clone()
+        };
+        let a = identity_for(&format!(
+            "# Groceries\n{}",
+            "a".repeat(CANONICAL_ARGS_MAX_CHARS)
+        ));
+        let b = identity_for(&format!(
+            "# Recipes\n{}",
+            "a".repeat(CANONICAL_ARGS_MAX_CHARS)
+        ));
+        assert_ne!(a, b, "distinct imports must not share an identity");
+    }
+
+    /// Key-order normalisation must survive the digest — it is applied to the
+    /// canonical form *before* hashing. Were it applied after, the same call with
+    /// reordered keys would hash differently and slip the guard above the cap
+    /// while being caught below it.
+    #[tokio::test]
+    async fn oversized_identity_still_ignores_key_order() {
+        let huge = "#".repeat(CANONICAL_ARGS_MAX_CHARS + 100);
+        let a = completed_writes_from(&[exec(
+            "create_nodes_from_markdown",
+            serde_json::json!({"markdown": huge, "parent_id": "n1"}),
+            serde_json::json!({"created": 3}),
+        )]);
+        let b = completed_writes_from(&[exec(
+            "create_nodes_from_markdown",
+            serde_json::json!({"parent_id": "n1", "markdown": huge}),
+            serde_json::json!({"created": 3}),
+        )]);
+        assert_eq!(a[0].canonical_args, b[0].canonical_args);
+        assert!(a[0].canonical_args.starts_with("sha256:"));
+    }
+
+    /// The guard reads its state back out of persisted messages. Every recorded
+    /// guarded write carries an identity, so every one is replayed — including
+    /// a digested one, which is precisely the case that used to be dropped.
     #[tokio::test]
     async fn prior_writes_are_rebuilt_from_persisted_messages() {
         let msgs = vec![AiChatMessage {
@@ -2665,21 +2725,24 @@ api_key = "sk-test"
                     tool: "create_node".to_string(),
                     node_id: Some("nodespace://n1".to_string()),
                     summary: Some("Buy milk".to_string()),
-                    canonical_args: Some(r#"{"content":"Buy milk"}"#.to_string()),
+                    canonical_args: r#"{"content":"Buy milk"}"#.to_string(),
                 },
                 AiChatCompletedWrite {
-                    tool: "create_node".to_string(),
+                    tool: "create_nodes_from_markdown".to_string(),
                     node_id: Some("nodespace://n2".to_string()),
-                    summary: Some("no identity".to_string()),
-                    canonical_args: None,
+                    summary: Some("big import".to_string()),
+                    canonical_args: "sha256:abc123".to_string(),
                 },
             ],
         }];
 
         let prior = prior_writes_from_history(&msgs);
-        assert_eq!(prior.len(), 1, "the identity-less write must be skipped");
-        assert_eq!(prior[0].tool, "create_node");
+        assert_eq!(prior.len(), 2, "every guarded write must be replayed");
         assert_eq!(prior[0].node_id.as_deref(), Some("nodespace://n1"));
+        assert_eq!(
+            prior[1].canonical_args, "sha256:abc123",
+            "a digested identity must be carried through unchanged"
+        );
     }
 
     /// Updates are idempotent: re-setting the same status or content is a no-op,
@@ -2697,19 +2760,19 @@ api_key = "sk-test"
                     tool: "update_task_status".to_string(),
                     node_id: Some("nodespace://t1".to_string()),
                     summary: Some("t1".to_string()),
-                    canonical_args: Some(r#"{"status":"done"}"#.to_string()),
+                    canonical_args: r#"{"status":"done"}"#.to_string(),
                 },
                 AiChatCompletedWrite {
                     tool: "update_node".to_string(),
                     node_id: Some("nodespace://t2".to_string()),
                     summary: Some("t2".to_string()),
-                    canonical_args: Some(r#"{"content":"x"}"#.to_string()),
+                    canonical_args: r#"{"content":"x"}"#.to_string(),
                 },
                 AiChatCompletedWrite {
                     tool: "update_schema".to_string(),
                     node_id: None,
                     summary: Some("s1".to_string()),
-                    canonical_args: Some(r#"{"schema_id":"s1"}"#.to_string()),
+                    canonical_args: r#"{"schema_id":"s1"}"#.to_string(),
                 },
             ],
         }];

--- a/packages/desktop-app/src/lib/types/ai-chat-node.ts
+++ b/packages/desktop-app/src/lib/types/ai-chat-node.ts
@@ -26,10 +26,14 @@ export interface AiChatCompletedWrite {
   summary?: string;
   /**
    * The call's arguments, canonicalised. With `tool`, this is the write's
-   * identity for the backend's cross-turn duplicate guard. Absent when the
-   * arguments were too large to persist.
+   * identity for the backend's cross-turn duplicate guard.
+   *
+   * Two forms: the canonical JSON verbatim when small enough to store, or
+   * `sha256:<hex>` of it when not — which keeps a large write (an entire
+   * markdown import, say) guarded without copying its content into this
+   * message history a second time. Always present; treat it as opaque.
    */
-  canonicalArgs?: string;
+  canonicalArgs: string;
 }
 
 export interface AiChatMessage {

--- a/packages/nodespace-types/src/ai_chat.rs
+++ b/packages/nodespace-types/src/ai_chat.rs
@@ -14,8 +14,11 @@ pub struct AiChatCompletedWrite {
     pub node_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub canonical_args: Option<String>,
+    /// The write's identity for the cross-turn duplicate guard: canonical JSON
+    /// verbatim, or `sha256:<hex>` of it when too large to store. Always
+    /// present — this is the struct that serialises to the frontend, so making
+    /// it optional here would contradict the TypeScript mirror.
+    pub canonical_args: String,
 }
 
 /// A single message in an ai-chat conversation.

--- a/packages/nodespace-types/src/convert.rs
+++ b/packages/nodespace-types/src/convert.rs
@@ -172,10 +172,19 @@ fn ai_chat_node_to_value(node: Node) -> Result<serde_json::Value, String> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    // Decoded per message, not as one `Vec`: decoding the whole array at once
+    // means a single unreadable message blanks the entire conversation in the
+    // UI. Matches `AiChatNode::from_node`, which contains the same failure the
+    // same way — the invariant has to hold on both paths or the stricter
+    // message type just relocates the problem.
     let messages = props
         .get("messages")
-        .cloned()
-        .map(|v| serde_json::from_value::<Vec<AiChatMessage>>(v).unwrap_or_default())
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| serde_json::from_value::<AiChatMessage>(m.clone()).ok())
+                .collect()
+        })
         .unwrap_or_default();
 
     let lifecycle_status = node.lifecycle_status.clone();
@@ -249,6 +258,42 @@ mod wire_contract {
         assert_eq!(out["messages"][0]["content"], "hi");
         assert!(out["properties"].get("ai-chat").is_none());
         assert!(out["uri"].as_str().unwrap().starts_with("nodespace://"));
+    }
+
+    /// One unreadable message must not blank the whole conversation in the UI.
+    ///
+    /// `canonicalArgs` is required on a completed write, so a record without one
+    /// fails to decode. Decoding the array as a single `Vec` would fail
+    /// wholesale on that one element and send the frontend an empty history for
+    /// a conversation that still has readable messages.
+    #[test]
+    fn ai_chat_one_unreadable_message_does_not_blank_the_conversation() {
+        let node = Node::new(
+            "ai-chat".to_string(),
+            "Chat".to_string(),
+            serde_json::json!({
+                "ai-chat": {
+                    "status": "active",
+                    "messages": [
+                        { "role": "user", "content": "hi" },
+                        {
+                            "role": "assistant",
+                            "content": "Added.",
+                            "completedWrites": [
+                                { "tool": "create_node", "nodeId": "nodespace://n1" }
+                            ]
+                        },
+                        { "role": "user", "content": "thanks" }
+                    ]
+                }
+            }),
+        );
+        let out = node_to_typed_value(node).unwrap();
+
+        let messages = out["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 2, "only the unreadable message may be lost");
+        assert_eq!(messages[0]["content"], "hi");
+        assert_eq!(messages[1]["content"], "thanks");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1798