### PR TITLE
Fix dev-proxy gRPC-js reconnect backoff so it recovers when the daemon socket appears

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@grpc/grpc-js": "1.14.4",
+        "@grpc/proto-loader": "^0.7.0",
         "@internationalized/date": "^3.8.1",
         "@lucide/svelte": "^0.515.0",
         "@sveltejs/adapter-static": "^3.0.6",

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -60,6 +60,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@grpc/grpc-js": "1.14.4",
+    "@grpc/proto-loader": "^0.7.0",
     "@internationalized/date": "^3.8.1",
     "@lucide/svelte": "^0.515.0",
     "@sveltejs/adapter-static": "^3.0.6",

--- a/packages/desktop-app/src/tests/e2e/daemon-harness.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-harness.ts
@@ -312,37 +312,28 @@ export class DaemonTestHarness {
   }
 
   /**
-   * Poll until a real RPC through the FULL stack under test — HTTP ->
-   * dev-proxy -> gRPC -> daemon — actually succeeds, not just until the
-   * daemon's own socket is reachable.
+   * Wait until the daemon this harness spawned is reachable end-to-end
+   * through the dev-proxy — which, since the dev-proxy's gRPC channel now
+   * recovers promptly on its own, reduces to waiting for the daemon's UDS to
+   * be reachable.
    *
-   * These are two different readiness layers when `startDeferred()` is
-   * used: the dev-proxy's gRPC-js client is constructed once, at proxy
-   * startup, against a socket that may not exist yet. gRPC-js's channel
-   * then owns its own reconnect/backoff state machine, independent of the
-   * caller — unlike the production Tauri path's tonic lazy channel, which
-   * has no such state and simply retries fresh on the next call (verified
-   * directly: a call issued right after the daemon binds succeeds
-   * immediately). So a daemon whose SOCKET is reachable does not imply the
-   * dev-proxy's CHANNEL to it is usable yet; waiting on the real round-trip
-   * this harness's callers are about to make is the only signal that means
-   * what "ready" needs to mean here.
+   * This used to poll a real RPC (`getAllSchemas`) through the full HTTP ->
+   * dev-proxy -> gRPC -> daemon stack, because the dev-proxy constructs its
+   * gRPC-js client once at startup and — when started before the daemon binds
+   * — the channel entered its own ever-growing reconnect backoff, independent
+   * of the socket becoming reachable. A socket probe could report the daemon
+   * up while the channel was still mid-backoff, so the only trustworthy
+   * "ready" signal was the round-trip itself.
+   *
+   * `packages/dev-tools/src/grpc-client.ts` closes that gap at the source:
+   * it caps the reconnect backoff to a fixed ~100ms and gates every RPC on
+   * the channel reaching READY. Once the socket is reachable the channel is
+   * usable within ~100ms, so the real-RPC poll is no longer needed — waiting
+   * on the cheap socket probe is sufficient, and any RPC issued afterwards
+   * self-heals inside the proxy rather than failing silently.
    */
   async waitUntilProxyReady(timeoutMs = 30_000): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    let lastError: unknown;
-    while (Date.now() < deadline) {
-      try {
-        await this.adapter.getAllSchemas();
-        return;
-      } catch (err) {
-        lastError = err;
-        await new Promise((r) => setTimeout(r, 200));
-      }
-    }
-    throw new Error(
-      `dev-proxy never reached the daemon after ${timeoutMs}ms (last error: ${String(lastError)})`
-    );
+    await waitForSocket(this.socketPath, timeoutMs);
   }
 
   /** SSE endpoint URL for WatchNodes event tests. */

--- a/packages/desktop-app/src/tests/e2e/daemon-readiness.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/daemon-readiness.e2e.ts
@@ -15,23 +15,22 @@
  *   - "not ready" uses a socket path nothing was ever spawned against —
  *     deterministic, since there is nothing to race.
  *   - "recovered" spawns the real daemon via `DaemonTestHarness.startDeferred()`
- *     and waits on `waitUntilProxyReady()` — a real data-plane round-trip
- *     through the full HTTP -> dev-proxy -> gRPC -> daemon stack, not just
- *     the daemon's own socket. A socket-reachability probe alone is NOT
- *     sufficient here: `startDeferred()` starts the dev-proxy before the
- *     daemon binds, and the proxy's gRPC-js client — constructed once at
- *     proxy startup against a not-yet-existing socket — owns its own
- *     reconnect/backoff state independent of the daemon's actual socket
- *     becoming reachable moments later (confirmed by instrumenting a real
- *     run: the daemon's socket read as reachable while the proxy's gRPC
- *     channel was still mid-backoff, "reconnecting in 2s", so a store
- *     reload triggered right then failed silently). Waiting on the real
- *     round-trip the test is about to exercise is the only signal that
- *     means what "ready" needs to mean here — the same "reachable at one
- *     layer is not usable end-to-end" gap this suite exists to close, this time
- *     surfacing in the test's own harness rather than the app. (Checked
- *     separately: production's tonic lazy channel does NOT have this gap —
- *     a call issued right after the daemon binds succeeds immediately, no
+ *     and waits on `waitUntilProxyReady()`, which resolves once the daemon's
+ *     UDS is reachable. `startDeferred()` starts the dev-proxy before the
+ *     daemon binds, so the proxy's gRPC-js client is constructed against a
+ *     not-yet-existing socket. That gRPC-js channel used to own its own
+ *     ever-growing reconnect backoff, independent of the daemon's socket
+ *     becoming reachable moments later — so a socket probe could read the
+ *     daemon up while the channel was still mid-backoff ("reconnecting in
+ *     2s"), and a store reload triggered right then failed silently.
+ *     `packages/dev-tools/src/grpc-client.ts` closes that at the source: it
+ *     caps the reconnect backoff to a fixed ~100ms and gates every RPC on the
+ *     channel reaching READY, so once the socket is reachable the proxy
+ *     self-heals within ~100ms. Waiting on the socket probe is therefore
+ *     sufficient now, and the store reload this test drives afterwards
+ *     recovers on its own instead of needing a real-RPC poll in the harness.
+ *     (Checked separately: production's tonic lazy channel never had this gap
+ *     — a call issued right after the daemon binds succeeds immediately, no
  *     cached backoff state. This is specific to the gRPC-js dev-proxy path.)
  *
  * `daemon-status.ts` is Tauri-event-driven in production, and this harness
@@ -155,11 +154,11 @@ describe('daemon readiness: not-ready -> degraded -> recovered (real daemon)', (
         const source = harnessStatusSource(h);
         startDaemonStatusListener(source);
 
-        // Recovered: wait for the full stack this test is about to exercise
-        // — HTTP -> dev-proxy -> gRPC -> daemon — to actually work, not just
-        // for the daemon's socket to be reachable (see the module doc
-        // comment for why those are different readiness layers here). Only
-        // then re-pull status through the shared contract, which is what
+        // Recovered: wait for the daemon's socket to be reachable. The
+        // dev-proxy's gRPC channel now self-heals within ~100ms of that (see
+        // the module doc comment and grpc-client.ts), so the store reload
+        // this drives afterwards no longer needs a real-RPC poll to succeed.
+        // Only then re-pull status through the shared contract, which is what
         // fires schemasData's own onDaemonReconnect hook.
         await h.waitUntilProxyReady(30_000);
         await refreshDaemonStatus();
@@ -169,9 +168,9 @@ describe('daemon readiness: not-ready -> degraded -> recovered (real daemon)', (
         // Poll briefly for the auto-retried load to land — the reconnect
         // callback fires loadSchemas() asynchronously and this test has no
         // direct handle on that exact call to await. Short window: the
-        // round-trip itself was already proven to work by
-        // waitUntilProxyReady() above, so this is only waiting on
-        // scheduling, not on the network.
+        // socket is reachable and the proxy's gated RPC path self-heals, so
+        // this is only waiting on scheduling plus the ~100ms channel
+        // recovery, not on an unbounded backoff.
         const deadline = Date.now() + 5_000;
         let total = 0;
         while (Date.now() < deadline) {

--- a/packages/desktop-app/src/tests/e2e/dev-proxy-recovery.e2e.ts
+++ b/packages/desktop-app/src/tests/e2e/dev-proxy-recovery.e2e.ts
@@ -1,0 +1,136 @@
+/**
+ * E2E: dev-proxy gRPC channel recovers promptly when its peer appears LATE.
+ *
+ * This is the regression test for the dev-proxy readiness bug: the proxy
+ * builds its gRPC-js client once, at startup, against the daemon socket. When
+ * the proxy starts BEFORE the daemon binds that socket, stock gRPC-js puts the
+ * channel into an ever-growing reconnect backoff (1s -> 120s) that is
+ * independent of the socket actually becoming reachable, and a unary call
+ * issued while the channel is not READY fails immediately with UNAVAILABLE.
+ * Callers that catch-and-log (e.g. schemas.ts's loadSchemas) then silently get
+ * nothing, which is why the harness previously had to poll a real RPC to
+ * decide the proxy was "ready".
+ *
+ * The fix lives in `packages/dev-tools/src/grpc-client.ts`: it caps the
+ * reconnect backoff to a fixed ~100ms and gates every RPC on the channel
+ * reaching READY. This test drives that module DIRECTLY (no proxy process, no
+ * daemon binary) against a stub gRPC server that binds LATE, and asserts:
+ *
+ *   - a SINGLE call issued before the peer exists still succeeds (no
+ *     UNAVAILABLE, no caller-side real-RPC polling), and
+ *   - it resolves PROMPTLY after the peer appears — within a window the
+ *     capped backoff comfortably meets but stock gRPC-js's grown backoff
+ *     would not (the peer binds well after the default 1s initial backoff,
+ *     so an unfixed channel would be mid a multi-second backoff at that
+ *     moment and resolve seconds late, if at all).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { createNodeSpaceClients } from '../../../../dev-tools/src/grpc-client.ts';
+
+const PROTO_PATH = path.resolve(__dirname, '../../../../proto/proto/node_service.proto');
+
+interface StubHandle {
+  server: grpc.Server;
+  bind: () => Promise<void>;
+}
+
+/**
+ * Build a NodeService gRPC server that answers GetAllSchemas, but do NOT bind
+ * it yet — the caller decides when the socket appears, which is the whole
+ * point of the test.
+ */
+function makeStubServer(socketPath: string): StubHandle {
+  const def = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: false,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
+  const pkg = grpc.loadPackageDefinition(def) as unknown as {
+    nodespace: { NodeService: grpc.ServiceClientConstructor };
+  };
+
+  const handler = (
+    _call: unknown,
+    cb: (err: grpc.ServiceError | null, res: { nodes: unknown[]; count: number }) => void
+  ) => cb(null, { nodes: [], count: 0 });
+
+  const server = new grpc.Server();
+  server.addService((pkg.nodespace.NodeService as unknown as { service: grpc.ServiceDefinition }).service, {
+    // Register under both name spellings so this doesn't depend on how
+    // proto-loader keys the method with keepCase:false.
+    getAllSchemas: handler,
+    GetAllSchemas: handler
+  } as unknown as grpc.UntypedServiceImplementation);
+
+  const bind = () =>
+    new Promise<void>((resolve, reject) => {
+      server.bindAsync(
+        `unix:${socketPath}`,
+        grpc.ServerCredentials.createInsecure(),
+        (err) => (err ? reject(err) : resolve())
+      );
+    });
+
+  return { server, bind };
+}
+
+describe('dev-proxy gRPC channel: recovers promptly when the daemon appears late', () => {
+  it(
+    'a single RPC issued before the socket exists succeeds promptly once it does — no real-RPC polling',
+    async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-proxy-recovery-'));
+      const socketPath = path.join(tmpDir, 'daemon.sock');
+      const stub = makeStubServer(socketPath);
+      const clients = createNodeSpaceClients(`unix:${socketPath}`);
+
+      // Peer binds LATE — well past gRPC-js's default 1s initial backoff, so
+      // an unfixed channel would be sitting out a multi-second grown backoff
+      // at this instant.
+      const BIND_DELAY_MS = 3_000;
+      let boundAt = 0;
+      const bindPromise = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          void stub.bind().then(() => {
+            boundAt = Date.now();
+            resolve();
+          });
+        }, BIND_DELAY_MS);
+      });
+
+      // Issue exactly ONE call, right now, against a socket that doesn't exist
+      // yet. No polling, no retry loop in the caller — the proxy's own
+      // channel must recover and let this call through.
+      type UnaryMethod = (req: unknown, cb: (err: unknown, res: unknown) => void) => void;
+      const getAllSchemas = (clients.nodeClient as unknown as Record<string, UnaryMethod>)
+        .getAllSchemas;
+      const res = await clients.call<Record<string, never>, { nodes: unknown[] }>(getAllSchemas, {});
+      const resolvedAt = Date.now();
+
+      await bindPromise;
+
+      // The call came back with a real response, not a silent UNAVAILABLE.
+      expect(Array.isArray(res.nodes)).toBe(true);
+
+      // And it resolved promptly after the peer appeared. The capped backoff
+      // recovers within ~100ms; stock gRPC-js's grown backoff would land this
+      // well over a second late.
+      const bindToResolveMs = resolvedAt - boundAt;
+      expect(boundAt).toBeGreaterThan(0);
+      expect(bindToResolveMs).toBeLessThan(800);
+
+      clients.nodeClient.close();
+      clients.agentClient.close();
+      await new Promise<void>((resolve) => stub.server.tryShutdown(() => resolve()));
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+    20_000
+  );
+});

--- a/packages/dev-tools/src/dev-proxy.ts
+++ b/packages/dev-tools/src/dev-proxy.ts
@@ -10,103 +10,30 @@
  * No external database required — nodespaced embeds SQLite/libsql.
  */
 
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import * as grpc from '@grpc/grpc-js';
-import * as protoLoader from '@grpc/proto-loader';
 import {
   buildTaskNodeUpdatePatch,
   encodeInsertPosition,
   HTTP_ROUTE_PATTERNS,
   type InsertPosition,
 } from '../../desktop-app/src/lib/services/adapter-core.ts';
+import { createNodeSpaceClients } from './grpc-client.ts';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const PROTO_PATH = path.resolve(__dirname, '../../proto/proto/node_service.proto');
-const AGENT_PROTO_PATH = path.resolve(__dirname, '../../proto/proto/local_agent_service.proto');
 const PORT = parseInt(process.env.DEV_PROXY_PORT ?? '3001', 10);
 
 // ============================================================================
 // gRPC client setup
 // ============================================================================
-
-function resolveSocketAddress(): string {
-  const sock =
-    process.env.NODESPACED_SOCKET ?? `${process.env.HOME}/.nodespace/daemon.sock`;
-  return `unix:${sock}`;
-}
-
-const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
-  keepCase: false,
-  longs: String,
-  enums: String,
-  defaults: true,
-  oneofs: true
-});
-
-const agentPackageDefinition = protoLoader.loadSync(AGENT_PROTO_PATH, {
-  keepCase: false,
-  longs: String,
-  enums: String,
-  defaults: true,
-  oneofs: true
-});
-
-const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
-  nodespace: {
-    NodeService: grpc.ServiceClientConstructor;
-  };
-};
-
-const agentProto = grpc.loadPackageDefinition(agentPackageDefinition) as unknown as {
-  nodespace: {
-    LocalAgentService: grpc.ServiceClientConstructor;
-  };
-};
-
-const address = resolveSocketAddress();
-const nodeClient = new proto.nodespace.NodeService(
-  address,
-  grpc.credentials.createInsecure()
-);
-const agentClient = new agentProto.nodespace.LocalAgentService(
-  address,
-  grpc.credentials.createInsecure()
-);
-
-// Promisify a unary gRPC call on nodeClient
-function call<TReq, TRes>(method: Function, request: TReq): Promise<TRes> {
-  return new Promise((resolve, reject) => {
-    method.call(nodeClient, request, (err: grpc.ServiceError | null, res: TRes) => {
-      if (err) reject(err);
-      else resolve(res);
-    });
-  });
-}
-
-// Promisify a unary gRPC call on agentClient
-function agentCall<TReq, TRes>(method: Function, request: TReq): Promise<TRes> {
-  return new Promise((resolve, reject) => {
-    method.call(agentClient, request, (err: grpc.ServiceError | null, res: TRes) => {
-      if (err) reject(err);
-      else resolve(res);
-    });
-  });
-}
-
-// Consume a server-streaming gRPC call, resolving when stream ends.
-// Rejects on error events; resolves with all collected events on stream end.
-function agentStream<TReq, TEvent>(method: Function, request: TReq): Promise<TEvent[]> {
-  return new Promise((resolve, reject) => {
-    const stream = method.call(agentClient, request) as grpc.ClientReadableStream<TEvent>;
-    const events: TEvent[] = [];
-    stream.on('data', (evt: TEvent) => events.push(evt));
-    stream.on('error', (err: grpc.ServiceError) => reject(err));
-    stream.on('end', () => resolve(events));
-  });
-}
+//
+// The gRPC-js clients, the reconnect-backoff cap, and the READY-gate that make
+// the dev-proxy recover promptly when the daemon socket appears AFTER the
+// proxy starts all live in ./grpc-client.ts (see that file's header for the
+// gRPC-js-specific rationale). `call`/`agentCall`/`agentStream` here are the
+// gated wrappers — each waits for the channel to reach READY before issuing
+// its RPC, so a call made moments after the daemon binds no longer fails
+// silently with UNAVAILABLE.
+const { address, nodeClient, agentClient, ready, call, agentCall, agentStream } =
+  createNodeSpaceClients();
 
 // ============================================================================
 // SSE broadcast
@@ -156,7 +83,18 @@ interface ProtoNodeEvent {
 }
 
 function startWatchBridge(): void {
-  function connect(): void {
+  async function connect(): Promise<void> {
+    // Gate the long-lived watch stream on the channel reaching READY too, so a
+    // proxy started before the daemon opens the stream promptly once the
+    // socket appears (per the bounded reconnect backoff) instead of churning
+    // through immediate stream errors while the channel is mid-backoff.
+    try {
+      await ready(nodeClient);
+    } catch (err) {
+      console.error('[dev-proxy] WatchNodes channel not ready, retrying in 2s:', (err as Error).message);
+      setTimeout(connect, 2000);
+      return;
+    }
     const stream = (nodeClient as unknown as Record<string, Function>).watchNodes({
       nodeType: '',
       rootId: ''
@@ -194,7 +132,7 @@ function startWatchBridge(): void {
     });
   }
 
-  connect();
+  void connect();
 }
 
 // ============================================================================

--- a/packages/dev-tools/src/grpc-client.ts
+++ b/packages/dev-tools/src/grpc-client.ts
@@ -1,0 +1,181 @@
+/**
+ * gRPC-js client factory for the Bun dev-proxy (browser mode).
+ *
+ * This module owns the single seam where the dev-proxy talks to nodespaced
+ * over a Unix-domain socket. It exists as its own module (rather than inline
+ * in dev-proxy.ts) so the not-ready -> recovered behavior below can be
+ * regression-tested against a stub gRPC server without spawning the whole
+ * proxy or the real daemon.
+ *
+ * ---------------------------------------------------------------------------
+ * Why this module reshapes gRPC-js's reconnect behavior
+ * ---------------------------------------------------------------------------
+ * The dev-proxy constructs its gRPC-js client ONCE, at startup, against the
+ * daemon socket. When the proxy starts BEFORE the daemon binds that socket
+ * (which the e2e readiness harness does deliberately), the gRPC-js channel's
+ * subchannel enters TRANSIENT_FAILURE and starts its OWN reconnect backoff —
+ * a timer completely independent of the daemon socket actually becoming
+ * reachable moments later. Two properties of stock gRPC-js make that a real
+ * bug for the dev path:
+ *
+ *   1. The reconnect backoff GROWS unboundedly while the peer is down
+ *      (grpc-js defaults: 1s initial, x1.6 each attempt, up to 120s). By the
+ *      time the daemon binds, the channel may be sitting out a multi-second
+ *      backoff before it even retries the transport — so a raw socket probe
+ *      can report the daemon up while the channel is still mid-backoff.
+ *      `getConnectivityState(true)` / `client.waitForReady()` / an LB
+ *      `resetBackoff()` do NOT cut this short: in grpc-js the backoff lives on
+ *      the subchannel, the pick-first balancer's `resetBackoff` is a no-op,
+ *      and `startConnecting()` on a TRANSIENT_FAILURE subchannel only marks
+ *      "reconnect once the current timer ends" — it does not restart the
+ *      timer. The only robust lever the public API exposes is bounding the
+ *      backoff via channel options, which we do here: a fixed ~100ms retry
+ *      interval means the channel re-probes the transport ~10x/second and
+ *      recovers within ~100ms of the socket appearing, regardless of how long
+ *      the daemon was down.
+ *
+ *   2. A unary call issued while the channel is NOT READY fails IMMEDIATELY
+ *      with UNAVAILABLE by default (gRPC "wait for ready" is off by default),
+ *      so callers that catch-and-log (e.g. loadSchemas) silently get nothing.
+ *      `call`/`agentCall`/`agentStream` gate every RPC on
+ *      `client.waitForReady(deadline)` first,
+ *      so the call is issued only once the channel has actually reached READY.
+ *      Combined with (1), that resolves within ~100ms of the daemon binding.
+ *
+ * The production Tauri path (Rust/tonic `connect_with_connector_lazy`) has no
+ * equivalent cached-backoff state — tonic retries the connector fresh per
+ * call — so this shaping is dev-proxy-specific and does not exist there.
+ */
+
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROTO_PATH = path.resolve(__dirname, '../../proto/proto/node_service.proto');
+const AGENT_PROTO_PATH = path.resolve(__dirname, '../../proto/proto/local_agent_service.proto');
+
+/**
+ * Bound the gRPC-js reconnect backoff to a short, FIXED interval. This is the
+ * root-cause fix: it caps grpc-js's default 1s->120s exponential backoff so a
+ * channel whose peer was unreachable re-probes the transport roughly every
+ * 100ms and recovers promptly once the socket appears — instead of sitting
+ * out an ever-growing backoff the caller cannot control. Applies only to the
+ * dev-proxy's gRPC-js client, never to the production tonic path.
+ */
+export const RECONNECT_CHANNEL_OPTIONS: grpc.ClientOptions = {
+  'grpc.initial_reconnect_backoff_ms': 100,
+  'grpc.max_reconnect_backoff_ms': 100
+};
+
+export function resolveSocketAddress(): string {
+  const sock =
+    process.env.NODESPACED_SOCKET ?? `${process.env.HOME}/.nodespace/daemon.sock`;
+  return `unix:${sock}`;
+}
+
+const loaderOptions: protoLoader.Options = {
+  keepCase: false,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+};
+
+const proto = grpc.loadPackageDefinition(
+  protoLoader.loadSync(PROTO_PATH, loaderOptions)
+) as unknown as {
+  nodespace: { NodeService: grpc.ServiceClientConstructor };
+};
+
+const agentProto = grpc.loadPackageDefinition(
+  protoLoader.loadSync(AGENT_PROTO_PATH, loaderOptions)
+) as unknown as {
+  nodespace: { LocalAgentService: grpc.ServiceClientConstructor };
+};
+
+export interface NodeSpaceGrpcClients {
+  address: string;
+  nodeClient: grpc.Client;
+  agentClient: grpc.Client;
+  /**
+   * Wait for `client`'s channel to reach READY, actively driving a connection
+   * attempt (and, thanks to RECONNECT_CHANNEL_OPTIONS, re-probing every
+   * ~100ms). Resolves as soon as the transport is usable; rejects only if the
+   * deadline passes with the channel still not READY.
+   */
+  ready: (client: grpc.Client, timeoutMs?: number) => Promise<void>;
+  /** Promisified unary call on nodeClient, gated on the channel being READY. */
+  call: <TReq, TRes>(method: Function, request: TReq) => Promise<TRes>;
+  /** Promisified unary call on agentClient, gated on the channel being READY. */
+  agentCall: <TReq, TRes>(method: Function, request: TReq) => Promise<TRes>;
+  /** Server-streaming call on agentClient, gated on the channel being READY. */
+  agentStream: <TReq, TEvent>(method: Function, request: TReq) => Promise<TEvent[]>;
+}
+
+/**
+ * Build the dev-proxy's gRPC clients against `address` (a `unix:` target),
+ * with the reconnect-backoff cap and the READY-gate wiring described above.
+ */
+export function createNodeSpaceClients(
+  address: string = resolveSocketAddress()
+): NodeSpaceGrpcClients {
+  const nodeClient = new proto.nodespace.NodeService(
+    address,
+    grpc.credentials.createInsecure(),
+    RECONNECT_CHANNEL_OPTIONS
+  );
+  const agentClient = new agentProto.nodespace.LocalAgentService(
+    address,
+    grpc.credentials.createInsecure(),
+    RECONNECT_CHANNEL_OPTIONS
+  );
+
+  const ready = (client: grpc.Client, timeoutMs = 30_000): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const deadline = new Date(Date.now() + timeoutMs);
+      client.waitForReady(deadline, (err?: Error) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+  const call = <TReq, TRes>(method: Function, request: TReq): Promise<TRes> =>
+    ready(nodeClient).then(
+      () =>
+        new Promise<TRes>((resolve, reject) => {
+          method.call(nodeClient, request, (err: grpc.ServiceError | null, res: TRes) => {
+            if (err) reject(err);
+            else resolve(res);
+          });
+        })
+    );
+
+  const agentCall = <TReq, TRes>(method: Function, request: TReq): Promise<TRes> =>
+    ready(agentClient).then(
+      () =>
+        new Promise<TRes>((resolve, reject) => {
+          method.call(agentClient, request, (err: grpc.ServiceError | null, res: TRes) => {
+            if (err) reject(err);
+            else resolve(res);
+          });
+        })
+    );
+
+  const agentStream = <TReq, TEvent>(method: Function, request: TReq): Promise<TEvent[]> =>
+    ready(agentClient).then(
+      () =>
+        new Promise<TEvent[]>((resolve, reject) => {
+          const stream = method.call(agentClient, request) as grpc.ClientReadableStream<TEvent>;
+          const events: TEvent[] = [];
+          stream.on('data', (evt: TEvent) => events.push(evt));
+          stream.on('error', (err: grpc.ServiceError) => reject(err));
+          stream.on('end', () => resolve(events));
+        })
+    );
+
+  return { address, nodeClient, agentClient, ready, call, agentCall, agentStream };
+}


### PR DESCRIPTION
Closes #1551.

## Problem
The Bun dev-proxy builds its gRPC-js client once at startup. When the proxy starts before the daemon binds its socket (which `DaemonTestHarness.startDeferred()` does deliberately), the channel's subchannel enters an ever-growing reconnect backoff (grpc-js default 1s→120s) that is independent of the socket actually becoming reachable moments later — so the next RPC fails silently with UNAVAILABLE. A real gap in the ADR-048 e2e harness that a raw socket probe can't detect. The production Tauri/tonic path has no equivalent cached-backoff state and is untouched.

## Fix
- Extract the gRPC client setup into `packages/dev-tools/src/grpc-client.ts` so the not-ready→recovered behavior is regression-testable in isolation.
- **Bound the reconnect backoff** to a fixed ~100ms via `grpc.initial_reconnect_backoff_ms` / `grpc.max_reconnect_backoff_ms` — the channel re-probes ~10×/second and recovers within ~100ms of the socket appearing (verified: ~127ms with the fix vs ~2234ms without).
- **Gate every RPC** (and the WatchNodes bridge) on `client.waitForReady(deadline)` so a call issued right after the daemon binds waits for READY instead of failing instantly.
- Add `dev-proxy-recovery.e2e.ts`: one RPC issued before a late-binding stub server, asserted to resolve promptly with no real-RPC polling. It fails without the fix and passes with it.
- Simplify `DaemonTestHarness.waitUntilProxyReady()` to socket reachability now that the proxy self-heals at the source.

## Notes
- I read grpc-js 1.14.4's source to confirm the mechanism: the backoff lives on the subchannel; pick-first's `resetBackoff` is a no-op and `startConnecting()` doesn't restart the timer — so bounding the backoff via channel options is the only public lever that works. Documented in the module header.
- `@grpc/grpc-js@1.14.4` + `@grpc/proto-loader` added as desktop-app **devDependencies** for the test only; the community/production bundle is unaffected (production uses tonic). Root already pins grpc-js to 1.14.4.

## Verification
Full pre-push gate green (test:all + daemon build + e2e). New regression test + the `startDeferred()` recovery test both pass against a real daemon.