### PR TITLE
Make the create_schema eval assertions able to see a failed schema creation (#1799)

### DIFF
--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -933,10 +933,22 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                     ),
                 };
 
+                // Field count from the tool RESULT, not its arguments: the result is the
+                // executor's report of what it persisted, while args are only the model's
+                // report of what it asked for. Logged as a bare integer because both
+                // previews truncate at 300 chars — a realistic create_schema payload
+                // exceeds that, so a parser reading them would fail on exactly the
+                // well-formed calls it is meant to pass.
+                let result_field_count = result_value
+                    .get("fields")
+                    .and_then(|f| f.as_array())
+                    .map(|a| a.len());
+
                 tracing::info!(
                     tool = %tc.function_name,
                     is_error,
                     duration_ms,
+                    result_field_count,
                     args_preview = %args.to_string().chars().take(300).collect::<String>(),
                     result_preview = %result_value.to_string().chars().take(300).collect::<String>(),
                     "Tool executed"

--- a/scripts/aichat.ts
+++ b/scripts/aichat.ts
@@ -157,11 +157,13 @@ function reportTurnLog(sinceByte: number): void {
     const tool = l.match(/tool="?([a-z_]+)"?/)?.[1] ?? "?";
     const args = l.match(/args_preview="?([^"]*?)"? result_preview/)?.[1] ?? "";
     const err = /is_error=true/.test(l) ? " [ERROR]" : "";
-    // Field count of the persisted result. tracing omits the field entirely when
-    // it is None, so "absent" (not a schema-creating tool) stays distinguishable
-    // from "=0" (a schema persisted with no properties) — the latter is a real
-    // failure that looks identical to success by tool name alone. Emitted before
-    // the args, which are free-form and truncated and so must stay last.
+    // Field count of the persisted result, emitted by any tool whose result
+    // carries a top-level `fields` array. tracing omits the field entirely when
+    // it is None, so "absent" (the result reports no fields) stays
+    // distinguishable from "=0" (a schema persisted with no properties) — the
+    // latter is a real failure that looks identical to success by tool name
+    // alone. Emitted before the args, which are free-form and truncated at the
+    // source and so must stay last on the line.
     const fields = l.match(/result_field_count=(\d+)/)?.[1];
     const fieldPart = fields === undefined ? "" : ` [fields=${fields}]`;
     console.log(`[tool] ${tool}${err}${fieldPart} ${args}`);

--- a/scripts/aichat.ts
+++ b/scripts/aichat.ts
@@ -30,7 +30,8 @@ import { fileURLToPath } from "node:url";
 
 const WORKTREE = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const NS_BIN = process.env.NS_BIN ?? join(WORKTREE, "target/release/nodespace");
-const SOCKET = process.env.NODESPACED_SOCKET ?? "/tmp/nodespaced-test/daemon.sock";
+const SOCKET =
+  process.env.NODESPACED_SOCKET ?? "/tmp/nodespaced-test/daemon.sock";
 const NS_LOG = process.env.NS_LOG ?? "/tmp/nodespaced-test/daemon.log";
 const NS_MODEL = process.env.NS_MODEL ?? "gemma-4-e4b-q4km";
 const TIMEOUT_MS = Number(process.env.NS_TIMEOUT_MS ?? 180_000);
@@ -44,10 +45,13 @@ interface AiChat {
 
 /** Run the nodespace CLI with --json and parse stdout. Throws on non-zero exit. */
 function ns(args: string[]): unknown {
-  const result = Bun.spawnSync([NS_BIN, "--socket", SOCKET, "--json", ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  const result = Bun.spawnSync(
+    [NS_BIN, "--socket", SOCKET, "--json", ...args],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
   const stdout = result.stdout.toString();
   if (result.exitCode !== 0) {
     throw new Error(
@@ -84,14 +88,25 @@ function defaultAiChat(): AiChat {
   return { provider: "native", model: NS_MODEL, status: "idle", messages: [] };
 }
 
-function batchUpdateProps(id: string, version: number | null, props: Record<string, unknown>): void {
+function batchUpdateProps(
+  id: string,
+  version: number | null,
+  props: Record<string, unknown>,
+): void {
   const item: Record<string, unknown> = { node_id: id, properties: props };
   if (version !== null) item.version = version;
   nsRaw(["node", "batch-update", "--updates", JSON.stringify([item])]);
 }
 
 function cmdNew(): string {
-  const created = ns(["node", "create", "--type", "ai-chat", "--content", "CLI test chat"]) as {
+  const created = ns([
+    "node",
+    "create",
+    "--type",
+    "ai-chat",
+    "--content",
+    "CLI test chat",
+  ]) as {
     id: string;
   };
   if (!created?.id) throw new Error("create returned no id");
@@ -113,7 +128,14 @@ function reportTurnLog(sinceByte: number): void {
   try {
     const buf = Bun.file(NS_LOG);
     // Read only the bytes appended during this turn.
-    slice = stripAnsi(Bun.spawnSync(["tail", "-c", `+${sinceByte + 1}`, NS_LOG]).stdout.toString());
+    slice = stripAnsi(
+      Bun.spawnSync([
+        "tail",
+        "-c",
+        `+${sinceByte + 1}`,
+        NS_LOG,
+      ]).stdout.toString(),
+    );
     if (!slice && buf) slice = "";
   } catch {
     return;
@@ -124,7 +146,9 @@ function reportTurnLog(sinceByte: number): void {
     const m = offered.match(/selected_tools="?([^"]*)"?/);
     if (m) console.log(`[tools offered] ${m[1]}`);
   }
-  const prepared = lines.filter((l) => l.includes("system prompt and tools prepared")).pop();
+  const prepared = lines
+    .filter((l) => l.includes("system prompt and tools prepared"))
+    .pop();
   if (prepared) {
     const m = prepared.match(/tool_names="?([^"]*?)"? system_prompt_len/);
     if (m) console.log(`[tools available] ${m[1]}`);
@@ -133,14 +157,23 @@ function reportTurnLog(sinceByte: number): void {
     const tool = l.match(/tool="?([a-z_]+)"?/)?.[1] ?? "?";
     const args = l.match(/args_preview="?([^"]*?)"? result_preview/)?.[1] ?? "";
     const err = /is_error=true/.test(l) ? " [ERROR]" : "";
-    console.log(`[tool] ${tool}${err} ${args}`);
+    // Field count of the persisted result. tracing omits the field entirely when
+    // it is None, so "absent" (not a schema-creating tool) stays distinguishable
+    // from "=0" (a schema persisted with no properties) — the latter is a real
+    // failure that looks identical to success by tool name alone. Emitted before
+    // the args, which are free-form and truncated and so must stay last.
+    const fields = l.match(/result_field_count=(\d+)/)?.[1];
+    const fieldPart = fields === undefined ? "" : ` [fields=${fields}]`;
+    console.log(`[tool] ${tool}${err}${fieldPart} ${args}`);
   }
 }
 
 async function cmdSend(id: string, message: string): Promise<void> {
   const node = getNode(id);
   const aichat: AiChat = node.properties["ai-chat"] ?? defaultAiChat();
-  const beforeAssistant = aichat.messages.filter((m) => m.role === "assistant").length;
+  const beforeAssistant = aichat.messages.filter(
+    (m) => m.role === "assistant",
+  ).length;
 
   const logSize = (() => {
     try {
@@ -150,7 +183,11 @@ async function cmdSend(id: string, message: string): Promise<void> {
     }
   })();
 
-  aichat.messages.push({ role: "user", content: message, timestamp: new Date().toISOString() });
+  aichat.messages.push({
+    role: "user",
+    content: message,
+    timestamp: new Date().toISOString(),
+  });
   aichat.status = "processing";
   batchUpdateProps(id, node.version, { "ai-chat": aichat });
 
@@ -160,7 +197,9 @@ async function cmdSend(id: string, message: string): Promise<void> {
     await sleep(1000);
     const cur = getNode(id);
     latest = cur.properties["ai-chat"] ?? latest;
-    const afterAssistant = latest.messages.filter((m) => m.role === "assistant").length;
+    const afterAssistant = latest.messages.filter(
+      (m) => m.role === "assistant",
+    ).length;
     if (latest.status === "idle" && afterAssistant > beforeAssistant) break;
   }
   if (latest.status !== "idle") {
@@ -169,7 +208,9 @@ async function cmdSend(id: string, message: string): Promise<void> {
 
   if (logSize > 0) reportTurnLog(logSize);
 
-  const reply = [...latest.messages].reverse().find((m) => m.role === "assistant");
+  const reply = [...latest.messages]
+    .reverse()
+    .find((m) => m.role === "assistant");
   console.log(`assistant> ${reply?.content ?? "(no assistant reply)"}`);
 }
 
@@ -189,7 +230,8 @@ async function main() {
       break;
     case "send": {
       const [id, ...msg] = rest;
-      if (!id || msg.length === 0) throw new Error("usage: send <id> <message>");
+      if (!id || msg.length === 0)
+        throw new Error("usage: send <id> <message>");
       await cmdSend(id, msg.join(" "));
       break;
     }
@@ -207,7 +249,9 @@ async function main() {
       break;
     }
     default:
-      console.error("usage: aichat.ts {new | send <id> <msg> | ask <msg> | show <id>}");
+      console.error(
+        "usage: aichat.ts {new | send <id> <msg> | ask <msg> | show <id>}",
+      );
       process.exit(1);
   }
 }

--- a/scripts/eval/fixtures/agent-matrix.test.ts
+++ b/scripts/eval/fixtures/agent-matrix.test.ts
@@ -176,4 +176,104 @@ describe("assertExpectation", () => {
       expect(result.passed).toBe(true);
     });
   });
+
+  /**
+   * A create_schema call can be counted once and still leave the user with
+   * nothing usable. Both cases below scored as PASSES before the outcome of the
+   * call was carried alongside its name.
+   */
+  describe("create_schema outcome", () => {
+    const noExtra: Expectation = { kind: "noExtraTypes" };
+    const once: Expectation = { kind: "toolOnce", tool: "create_schema" };
+
+    // The observed scenario-3 false pass: a title_template referencing fields
+    // that were never defined, rejected by title-template validation.
+    test("fails when the single create_schema call was rejected", () => {
+      const result = assertExpectation(
+        noExtra,
+        ["create_schema"],
+        [{ name: "create_schema", isError: true }],
+      );
+      expect(result.passed).toBe(false);
+      expect(result.failure).toContain("REJECTED");
+    });
+
+    // Distinct from rejection: this call SUCCEEDS. A create_schema carrying
+    // neither fields nor description persists a type with no properties.
+    test("fails when create_schema succeeded with zero fields", () => {
+      const result = assertExpectation(
+        noExtra,
+        ["create_schema"],
+        [{ name: "create_schema", isError: false, fieldCount: 0 }],
+      );
+      expect(result.passed).toBe(false);
+      expect(result.failure).toContain("NO fields");
+    });
+
+    test("passes when create_schema persisted fields", () => {
+      const result = assertExpectation(
+        noExtra,
+        ["create_schema"],
+        [{ name: "create_schema", isError: false, fieldCount: 4 }],
+      );
+      expect(result.passed).toBe(true);
+    });
+
+    // Scenarios 8a/8b reach create_schema through toolOnce, so the same hole
+    // has to be closed on that branch and not just on noExtraTypes.
+    test("toolOnce fails on a rejected create_schema", () => {
+      const result = assertExpectation(
+        once,
+        ["create_schema"],
+        [{ name: "create_schema", isError: true }],
+      );
+      expect(result.passed).toBe(false);
+      expect(result.failure).toContain("REJECTED");
+    });
+
+    test("toolOnce fails on a fieldless create_schema", () => {
+      const result = assertExpectation(
+        once,
+        ["create_schema"],
+        [{ name: "create_schema", isError: false, fieldCount: 0 }],
+      );
+      expect(result.passed).toBe(false);
+      expect(result.failure).toContain("NO fields");
+    });
+
+    test("toolOnce still reports a wrong call count before outcome", () => {
+      const result = assertExpectation(once, [], []);
+      expect(result.passed).toBe(false);
+      expect(result.failure).toContain("got 0");
+    });
+
+    // A baseline recorded before fieldCount existed must not read as a fresh
+    // failure: absence is unknown, not zero.
+    test("passes when the outcome was never captured", () => {
+      expect(assertExpectation(noExtra, ["create_schema"], []).passed).toBe(
+        true,
+      );
+      expect(
+        assertExpectation(
+          noExtra,
+          ["create_schema"],
+          [{ name: "create_schema", isError: false }],
+        ).passed,
+      ).toBe(true);
+    });
+
+    // Only create_schema outcomes are judged here; an unrelated failing tool is
+    // some other assertion's business.
+    test("ignores non-create_schema calls", () => {
+      const result = assertExpectation(
+        once,
+        ["create_schema"],
+        [
+          { name: "search_nodes", isError: true },
+          { name: "create_schema", isError: false, fieldCount: 2 },
+        ],
+      );
+      expect(result.passed).toBe(true);
+    });
+  });
 });

--- a/scripts/eval/fixtures/agent-matrix.ts
+++ b/scripts/eval/fixtures/agent-matrix.ts
@@ -21,7 +21,13 @@
  * example, and prompt tuning then has a degenerate solution.
  */
 
-import type { EvalFixture, Scenario, TurnRecord, Verdict } from "../types.ts";
+import type {
+  EvalFixture,
+  Scenario,
+  ToolCallRecord,
+  TurnRecord,
+  Verdict,
+} from "../types.ts";
 
 // ---------------------------------------------------------------------------
 // Structured expectation model
@@ -55,6 +61,48 @@ export function actionTools(toolsCalled: string[]): string[] {
 }
 
 /**
+ * Check that a create_schema call actually produced a usable type.
+ *
+ * Counting the tool name is not enough, and the gap is not hypothetical: the
+ * model has called create_schema with a title_template and no fields, been
+ * rejected outright by title-template validation, and still scored a pass
+ * because the name appeared once.
+ *
+ * Two distinct ways to call create_schema and end up with nothing usable:
+ *   - the call is REJECTED (is_error) — nothing persisted at all;
+ *   - the call SUCCEEDS with an empty field list. A call carrying neither
+ *     `fields` nor `description` is valid by design and persists a type with no
+ *     properties, against which the user cannot record anything. This one is
+ *     invisible to any check that only looks at whether the call failed.
+ *
+ * `fieldCount` is absent (rather than 0) on results recorded before it was
+ * captured, so absence is treated as unknown and passes — a stale baseline must
+ * not read as a fresh failure.
+ */
+function schemaCallsAreSound(calls: ToolCallRecord[]): Verdict {
+  for (const c of calls) {
+    if (c.name !== "create_schema") continue;
+    if (c.isError) {
+      return {
+        passed: false,
+        failure:
+          "create_schema was called but REJECTED — no schema persisted (the call " +
+          "scores as a pass on tool name alone)",
+      };
+    }
+    if (c.fieldCount === 0) {
+      return {
+        passed: false,
+        failure:
+          "create_schema succeeded but persisted a type with NO fields — nothing " +
+          "can be recorded against it",
+      };
+    }
+  }
+  return { passed: true };
+}
+
+/**
  * Decide whether a turn met its expectation.
  *
  * Pure and daemon-free so it is unit-testable without a model — see
@@ -63,6 +111,7 @@ export function actionTools(toolsCalled: string[]): string[] {
 export function assertExpectation(
   expect: Expectation,
   toolsCalled: string[],
+  toolCalls: ToolCallRecord[] = [],
 ): Verdict {
   const actions = actionTools(toolsCalled);
 
@@ -85,7 +134,9 @@ export function assertExpectation(
           failure: `Expected '${expect.tool}' exactly once, got ${count} (tools: ${actions.join(",")})`,
         };
       }
-      return { passed: true };
+      // Scenarios 8a/8b target create_schema through this branch, so the
+      // count-only hole this closes for noExtraTypes exists here too.
+      return schemaCallsAreSound(toolCalls);
     }
 
     case "toolSequence": {
@@ -125,7 +176,7 @@ export function assertExpectation(
           failure: `Expected exactly one create_schema (no extra related types), got ${count} (tools: ${actions.join(",")})`,
         };
       }
-      return { passed: true };
+      return schemaCallsAreSound(toolCalls);
     }
   }
 }
@@ -238,13 +289,22 @@ const fixture: EvalFixture = {
   groups: GROUPS,
   score(scenario, turns) {
     const toolsCalled = turns.flatMap((t) => t.toolsCalled);
-    return assertExpectation((scenario as MatrixScenario).expect, toolsCalled);
+    const toolCalls = turns.flatMap((t) => t.toolCalls ?? []);
+    return assertExpectation(
+      (scenario as MatrixScenario).expect,
+      toolsCalled,
+      toolCalls,
+    );
   },
   extra(scenario, turns: TurnRecord[]) {
     return {
       expect: (scenario as MatrixScenario).expect,
       toolsOffered: turns[0]?.toolsOffered ?? "",
       toolsCalled: turns.flatMap((t) => t.toolsCalled),
+      // Recorded so a failure carries its evidence: which call errored, and how
+      // many fields it actually persisted. Reading a results file should not
+      // require re-running the eval to find out why a scenario failed.
+      toolCalls: turns.flatMap((t) => t.toolCalls ?? []),
       latencyMs: turns.reduce((sum, t) => sum + t.latencyMs, 0),
     };
   },

--- a/scripts/eval/runner.ts
+++ b/scripts/eval/runner.ts
@@ -26,6 +26,7 @@ import type {
   Provenance,
   Scenario,
   ScenarioResult,
+  ToolCallRecord,
   TurnRecord,
 } from "./types.ts";
 
@@ -89,9 +90,24 @@ function runTurn(env: EvalEnv, chatId: string, message: string): TurnRecord {
   }
 
   const out = r.stdout.toString();
+
+  // One pass over the [tool] lines feeds both shapes, so they cannot disagree
+  // about how many calls a turn made. aichat.ts emits:
+  //   [tool] <name>[ERROR][ [fields=N]] <args>
+  // The args are free-form and truncated, so every structured marker precedes
+  // them and nothing here parses them.
+  const toolCalls: ToolCallRecord[] = [
+    ...out.matchAll(/\[tool\] ([a-z_]+)( \[ERROR\])?( \[fields=(\d+)\])?/g),
+  ].map((m) => ({
+    name: m[1],
+    isError: m[2] !== undefined,
+    ...(m[4] === undefined ? {} : { fieldCount: Number(m[4]) }),
+  }));
+
   return {
     toolsOffered: out.match(/\[tools offered\] (.*)/)?.[1]?.trim() ?? "",
-    toolsCalled: [...out.matchAll(/\[tool\] ([a-z_]+)/g)].map((m) => m[1]),
+    toolsCalled: toolCalls.map((t) => t.name),
+    toolCalls,
     reply:
       out.match(/assistant> ([\s\S]*)$/)?.[1]?.trim() ?? "(no reply parsed)",
     latencyMs,

--- a/scripts/eval/types.ts
+++ b/scripts/eval/types.ts
@@ -7,10 +7,50 @@
  * scripts/eval/runner.ts and is not reimplemented per eval.
  */
 
+/**
+ * One tool call's outcome, beyond its name.
+ *
+ * Sourced from the executor's own report of what it did — `isError` is only
+ * false once the write returned Ok, and `fieldCount` is read from the tool
+ * RESULT rather than its arguments. Asserting on arguments would measure what
+ * the model asked for, which is a property of the model's output and so the
+ * same class of evidence as counting tool names; the result is what the system
+ * actually persisted.
+ */
+export interface ToolCallRecord {
+  name: string;
+  isError: boolean;
+  /**
+   * Length of the result's `fields` array, for tools that return one.
+   *
+   * Absent when the tool does not report fields at all; `0` when a schema
+   * persisted with no properties — a real failure that is indistinguishable
+   * from success by tool name alone, and which `create_schema` reaches by
+   * design (a call carrying neither `fields` nor `description` succeeds).
+   */
+  fieldCount?: number;
+}
+
 /** One turn's observable outcome, scraped from an aichat.ts run. */
 export interface TurnRecord {
   toolsOffered: string;
+  /**
+   * Tool names in call order.
+   *
+   * Kept as a plain string[] rather than folded into `toolCalls` below: this is
+   * the shape recorded in every baseline results file, and `compareToBaseline`
+   * joins recorded runs against new ones. Changing it would orphan the recorded
+   * baselines — a data-format concern, not the code-level backward compatibility
+   * the greenfield rule tells us to delete on sight.
+   */
   toolsCalled: string[];
+  /**
+   * Per-call outcomes, parallel to `toolsCalled`.
+   *
+   * Optional because results files recorded before this field existed do not
+   * carry it; a scoring function must treat absence as "unknown", not "failed".
+   */
+  toolCalls?: ToolCallRecord[];
   reply: string;
   latencyMs: number;
   /**

--- a/scripts/eval/types.ts
+++ b/scripts/eval/types.ts
@@ -37,11 +37,11 @@ export interface TurnRecord {
   /**
    * Tool names in call order.
    *
-   * Kept as a plain string[] rather than folded into `toolCalls` below: this is
-   * the shape recorded in every baseline results file, and `compareToBaseline`
-   * joins recorded runs against new ones. Changing it would orphan the recorded
-   * baselines — a data-format concern, not the code-level backward compatibility
-   * the greenfield rule tells us to delete on sight.
+   * Kept as a plain string[] rather than folded into `toolCalls` below because
+   * it has a live reader: the routing fixture scores turns off these names
+   * directly and never calls into the matrix fixture's assertions. This is a
+   * field in current use, not a compatibility shim the greenfield rule would
+   * tell us to delete.
    */
   toolsCalled: string[];
   /**


### PR DESCRIPTION
Closes #1799

## What this changes

The `noExtraTypes` assertion counted `create_schema` calls and never checked what was persisted, so a call that was rejected outright scored as a pass. Scenario 3 had been a recorded false pass in every prior run.

The evidence needed to catch it was already produced and already printed — `aichat.ts` emits an `[ERROR]` marker per tool call — but `runner.ts` kept only the tool name and discarded the rest of the line. This carries the outcome through.

- **`agent_loop.rs`** logs `result_field_count`, taken from the tool RESULT rather than its arguments. Args are the model's report of what it asked for; the result is what the executor persisted. A bare integer because both previews truncate at 300 chars and a realistic `create_schema` payload exceeds that — a parser reading them would fail on exactly the well-formed calls it should pass.
- **`types.ts`** gains `toolCalls` alongside `toolsCalled` rather than replacing it, so `routing.ts` needs no edits and recorded baselines still join in `compareToBaseline`.
- **`agent-matrix.ts`** checks schema soundness on **both** the `noExtraTypes` and `toolOnce` branches. Scenarios 8a/8b reach `create_schema` through `toolOnce` and had the identical count-only hole; fixing only `noExtraTypes` (what the issue named) would have left most of the measurement defect in place.

## Two failure modes, not one

A rejected call persists nothing. But a call carrying neither `fields` nor `description` **succeeds** and persists a type with no properties (`packages/core/src/schema/mod.rs:275-277`) — invisible to any check that only asks whether the call errored. The issue's framing would have missed this; 8a/8b are exactly this case.

Absent `fieldCount` is treated as unknown, so baselines recorded before this do not read as fresh failures.

## Verification

Both branches mutation-tested: reverting either one fails exactly its own two unit tests and no others.

Run against **unmodified** guidance — so the assertion is demonstrated failing on current code, per the issue's first acceptance criterion:

- **3** — `create_schema was called but REJECTED — no schema persisted`
- **8a** — `create_schema succeeded but persisted a type with NO fields`
- **8b** — same

`bun run test:all` passes (4,106 frontend / 20 browser / 29 scripts / 10 Rust suites), no new failures.

## Scope: assertion only

The issue's checklist items 3-5 (routing `create_schema` through `search_skills`) are **not** included. That change was implemented and measured, and it makes behavior worse: 6/12 → 3/12 under identical conditions, with the model calling `search_skills` and then stopping. Its premise also does not hold — `SCHEMA_CREATION_RULES` is resident every turn and already carries the rule the model broke. Detail in the issue comments; the underlying guidance defect is now the spike #1802.

**No baseline is recorded here.** `scripts/results-e4b.json` is deliberately untouched: every run it holds was measured through an architecture #1802 is questioning, and at n=12 with only 3 schema scenarios the matrix cannot clear its own ~2-scenario noise floor. The assertion fix stands on mutation testing, not on any eval score.

## Note on the branch name

Created via the worktree tool, which names branches `worktree-<name>`; the CLAUDE.md convention is `issue-<number>-brief-desc`. Cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2fwCrhS3Bfq4uDGM61iCr