### PR TITLE
Seeded content never reaches an existing install: replace type-level skip with per-node versioned re-seed

### DIFF
--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use nodespace_core::markdown::NodeTemplate;
+use nodespace_core::markdown::{NodeTemplate, SeedTier};
 use nodespace_core::models::Node;
 use nodespace_core::services::{flatten_subtree_content, NodeService};
 
@@ -266,6 +266,7 @@ impl PromptAssembler {
                 root_properties: serde_json::json!({}),
                 child_node_type: Some("text".to_string()),
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: "You are NodeSpace's built-in assistant. You help users work with their \
                     knowledge graph — creating, finding, updating, and connecting nodes."
                         .to_string(),
@@ -277,6 +278,7 @@ impl PromptAssembler {
                 root_properties: serde_json::json!({}),
                 child_node_type: Some("text".to_string()),
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: "Current date: {{ current_date }}\nActive model: {{ model_name }}\n\n{{ workspace_context }}"
                     .to_string(),
             },
@@ -287,6 +289,7 @@ impl PromptAssembler {
                 root_properties: serde_json::json!({}),
                 child_node_type: Some("text".to_string()),
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: format!("{}\n\n{}", SCHEMA_CREATION_RULES, TOOL_STRATEGY_RULES),
             },
             NodeTemplate {
@@ -296,6 +299,7 @@ impl PromptAssembler {
                 root_properties: serde_json::json!({}),
                 child_node_type: Some("text".to_string()),
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: format!(
                     "RESPONSE RULES:\n\
                     - Call tools immediately when intent is clear. Do NOT output text before the tool call — your first response token must be the tool call.\n\
@@ -315,6 +319,7 @@ impl PromptAssembler {
                 root_properties: serde_json::json!({}),
                 child_node_type: Some("text".to_string()),
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: "TOOL CALL FORMAT: Pass arguments flat (not nested under \"properties\"/\"arguments\"). Use exact field names from the schema."
                         .to_string(),
             },

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -24,7 +24,7 @@ use crate::skill_rules::{
     SINGLE_ITEM_PER_CALL, SUCCESS_NO_REVERIFY, TARGET_TYPE_MUST_EXIST, TASK_STATUS_DEDICATED_VERB,
     TITLE_TEMPLATE_PLACEHOLDERS,
 };
-use nodespace_core::markdown::NodeTemplate;
+use nodespace_core::markdown::{NodeTemplate, SeedTier};
 
 /// Builds the Schema Creation skill's markdown_content, interpolating the
 /// shared rules from [`crate::skill_rules`] (imperative form) so this text
@@ -237,6 +237,7 @@ pub fn seed_skill_nodes() -> Vec<NodeTemplate> {
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: r#"# Research & Search Guidance
 
 When answering questions about stored knowledge:
@@ -290,6 +291,7 @@ STRUCTURED PROPERTY QUERIES: To filter by property values (status, due_date, etc
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: r#"# Node Creation Guidance
 
 ⚡ IMMEDIATE ACTION REQUIRED: Call create_node NOW with all values from the user message. Do NOT output any text — your response to receiving these instructions must be the create_node tool call.
@@ -330,6 +332,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: schema_creation_guidance(),
         },
         NodeTemplate {
@@ -343,6 +346,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: graph_editing_guidance(),
         },
         NodeTemplate {
@@ -356,6 +360,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: relationship_management_guidance(),
         },
         NodeTemplate {
@@ -369,6 +374,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: node_deletion_guidance(),
         },
         NodeTemplate {
@@ -382,6 +388,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: bulk_import_guidance(),
         },
         NodeTemplate {
@@ -395,6 +402,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             }),
             child_node_type: Some("prompt".to_string()),
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: organization_guidance(),
         },
     ]
@@ -436,6 +444,7 @@ pub fn seed_tool_nodes() -> Vec<NodeTemplate> {
                 }),
                 child_node_type: None,
                 child_properties: None,
+                tier: SeedTier::System,
                 markdown_content: String::new(),
             }
         })

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -711,6 +711,32 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Set a boolean value at a JSON path within a node's properties in-place
+    /// using `json_set`. `json_path` must start with `$.` (e.g. `$._seed.user_modified`).
+    ///
+    /// Bypasses OCC (no version check, no version bump) — used to stamp
+    /// bookkeeping metadata (e.g. `_seed.user_modified`) alongside a caller's
+    /// own version-checked update without racing it or requiring the caller
+    /// to round-trip the flag through its own `NodeUpdate`.
+    pub async fn set_property_bool(
+        &self,
+        node_id: &str,
+        json_path: &str,
+        value: bool,
+    ) -> Result<()> {
+        // json_set's value argument must be JSON, not SQLite's 0/1 integer
+        // affinity, or the stored value round-trips as an int instead of a bool.
+        let json_value = if value { "true" } else { "false" };
+        self.db
+            .execute(
+                "UPDATE node SET properties = json_set(properties, ?1, json(?2)) WHERE id = ?3",
+                libsql::params![json_path.to_string(), json_value, node_id.to_string()],
+            )
+            .await
+            .context("Failed to set property key")?;
+        Ok(())
+    }
+
     pub async fn delete_with_version_check(
         &self,
         id: &str,

--- a/packages/core/src/db/sqlite_store/nodes.rs
+++ b/packages/core/src/db/sqlite_store/nodes.rs
@@ -714,10 +714,14 @@ impl SqliteStore {
     /// Set a boolean value at a JSON path within a node's properties in-place
     /// using `json_set`. `json_path` must start with `$.` (e.g. `$._seed.user_modified`).
     ///
-    /// Bypasses OCC (no version check, no version bump) — used to stamp
-    /// bookkeeping metadata (e.g. `_seed.user_modified`) alongside a caller's
-    /// own version-checked update without racing it or requiring the caller
-    /// to round-trip the flag through its own `NodeUpdate`.
+    /// Best-effort and OCC-bypassing: no version check, no version bump. Used
+    /// to stamp bookkeeping metadata (e.g. `_seed.user_modified`) alongside a
+    /// caller's own version-checked update without racing it or requiring the
+    /// caller to round-trip the flag through its own `NodeUpdate`. Only safe
+    /// for values where a lost or doubled write is harmless — e.g. an
+    /// idempotent boolean flag, where setting it to the same value twice has
+    /// no observable effect beyond an undercounted `version`. Do not use for
+    /// values a concurrent writer could legitimately race to change.
     pub async fn set_property_bool(
         &self,
         node_id: &str,

--- a/packages/core/src/markdown/markdown_test.rs
+++ b/packages/core/src/markdown/markdown_test.rs
@@ -3020,7 +3020,7 @@ Some text here.
 
 #[cfg(test)]
 mod template_tests {
-    use crate::markdown::{prepare_nodes_from_template, NodeTemplate};
+    use crate::markdown::{prepare_nodes_from_template, NodeTemplate, SeedTier};
 
     fn skill_template(name: &str, guidance: &str) -> NodeTemplate {
         NodeTemplate {
@@ -3037,6 +3037,7 @@ mod template_tests {
                 "priority": 1,
                 "source": "built-in",
             })),
+            tier: SeedTier::System,
             markdown_content: guidance.to_string(),
         }
     }
@@ -3052,6 +3053,7 @@ mod template_tests {
             }),
             child_node_type: None,
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: String::new(),
         }
     }
@@ -3136,6 +3138,7 @@ mod template_tests {
             root_properties: serde_json::json!({}),
             child_node_type: None,
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: String::new(),
         };
         let nodes = prepare_nodes_from_template(&tmpl).unwrap();
@@ -3153,6 +3156,7 @@ mod template_tests {
             root_properties: serde_json::json!({}),
             child_node_type: Some("prompt".to_string()),
             child_properties: Some(serde_json::json!("plain-string")), // not an object
+            tier: SeedTier::System,
             markdown_content: "- A guidance item".to_string(),
         };
         let nodes = prepare_nodes_from_template(&tmpl).unwrap();
@@ -3175,6 +3179,7 @@ mod template_tests {
             }),
             child_node_type: None,
             child_properties: None,
+            tier: SeedTier::System,
             markdown_content: String::new(),
         };
         let nodes = prepare_nodes_from_template(&tmpl).unwrap();

--- a/packages/core/src/markdown/mod.rs
+++ b/packages/core/src/markdown/mod.rs
@@ -1298,6 +1298,32 @@ pub async fn handle_create_nodes_from_markdown(
 ///     child_properties: None,
 /// };
 /// ```
+/// Seeding tier for a [`NodeTemplate`], controlling reconciliation behavior
+/// when the template content changes after the node already exists.
+///
+/// - `System`: an engineering artifact stored as a node (skill descriptions,
+///   tool definitions, prompt sections). Not user-editable — always replaced
+///   when the template's content hash changes, same as updating a compiled-in
+///   constant.
+/// - `Starter`: example/workspace content genuinely owned by the user once
+///   they touch it. Replaced on hash mismatch only until the user edits it;
+///   after that, reconciliation skips it and logs once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SeedTier {
+    #[default]
+    System,
+    Starter,
+}
+
+impl SeedTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SeedTier::System => "system",
+            SeedTier::Starter => "starter",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NodeTemplate {
     /// Human-readable name / label for the root node (stored as the node's `title`).
@@ -1321,6 +1347,9 @@ pub struct NodeTemplate {
     pub child_node_type: Option<String>,
     /// Optional properties to merge into every child node (override parsed defaults).
     pub child_properties: Option<serde_json::Value>,
+    /// Reconciliation tier. Defaults to `System` — every existing seed source
+    /// (skills, prompts, tools) is an engineering artifact, not user content.
+    pub tier: SeedTier,
 }
 
 /// Parse a [`NodeTemplate`] into a flat list of [`PreparedNode`]s.
@@ -1380,7 +1409,62 @@ pub fn prepare_nodes_from_template(
     let mut nodes = Vec::with_capacity(1 + children.len());
     nodes.push(root);
     nodes.extend(children);
+
+    // Stamp reconciliation metadata onto the root's properties *after* the
+    // content hash is computed, so the hash reflects only authored content —
+    // not the metadata describing it. `seed_key` is the template's `title`,
+    // a stable slug used to match this group to an existing DB node across
+    // runs (the root's `content`/`properties` are expected to drift; the
+    // title is the one thing seed_nodes_from_templates can rely on to find
+    // "the same template" again).
+    //
+    // Nested under a single `_seed` object key rather than flat top-level
+    // keys: `normalize_flat_properties_to_namespace` (crud.rs) moves flat
+    // properties into a `{node_type: {...}}` namespace on create, which
+    // would otherwise bury these under `properties[root_node_type]` — a
+    // different path depending on the template's type. An object-valued key
+    // is preserved as its own namespace, so `_seed` lands at a fixed,
+    // type-independent path every time.
+    let seed_version = compute_seed_version(&nodes);
+    if let Some(root_props) = nodes[0].properties.as_object_mut() {
+        root_props.insert(
+            "_seed".to_string(),
+            serde_json::json!({
+                "key": tmpl.title,
+                "version": seed_version,
+                "tier": tmpl.tier.as_str(),
+            }),
+        );
+    }
+
     Ok(nodes)
+}
+
+/// Compute a stable content hash for a template's expanded node group.
+///
+/// Hashes `node_type` + `content` + `properties` for the root and every
+/// child, in order. Ignores `id`, `parent_id`, and `order`, which are
+/// per-insertion, not part of the template's authored content — including
+/// them would make every reconciliation see a "changed" hash even when
+/// nothing about the template itself changed.
+///
+/// `serde_json::Value` objects serialize with sorted keys (no `preserve_order`
+/// feature enabled), so this is stable across process runs regardless of the
+/// order properties were inserted in Rust source.
+pub fn compute_seed_version(nodes: &[PreparedNode]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    for node in nodes {
+        hasher.update(node.node_type.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(node.content.as_bytes());
+        hasher.update(b"\0");
+        // `Value`'s Serialize impl sorts object keys, so this is deterministic.
+        hasher.update(node.properties.to_string().as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("{:x}", hasher.finalize())
 }
 
 /// Check if a string matches the date format YYYY-MM-DD

--- a/packages/core/src/services/node_service/crud.rs
+++ b/packages/core/src/services/node_service/crud.rs
@@ -939,6 +939,30 @@ impl NodeService {
             ));
         }
 
+        // A starter-tier seeded node becomes user-owned the moment its content
+        // or properties are edited through the normal update path — reseed's
+        // replace path goes through delete_node + create_node_with_parent, not
+        // here, so it never trips this. Checked before the update so a
+        // version-conflict below doesn't leave a partial flag write behind.
+        let touches_content = update.content.is_some() || update.properties.is_some();
+        let mark_user_modified = if touches_content {
+            match self.store.get_node(node_id).await {
+                Ok(Some(existing)) => {
+                    let seed = existing.properties.get("_seed");
+                    let is_starter = seed.and_then(|s| s.get("tier")).and_then(|v| v.as_str())
+                        == Some("starter");
+                    let already_modified = seed
+                        .and_then(|s| s.get("user_modified"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    is_starter && !already_modified
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+
         // NOTE: Removed redundant get_node() call here - update_with_version_check_returning_node
         // already fetches the node and handles not-found case
 
@@ -947,7 +971,22 @@ impl NodeService {
             .update_with_version_check_returning_node(node_id, expected_version, update)
             .await?
         {
-            Some(updated_node) => Ok(updated_node),
+            Some(updated_node) => {
+                if mark_user_modified {
+                    if let Err(e) = self
+                        .store
+                        .set_property_bool(node_id, "$._seed.user_modified", true)
+                        .await
+                    {
+                        tracing::warn!(
+                            node_id,
+                            error = %e,
+                            "Failed to stamp seed_user_modified after edit"
+                        );
+                    }
+                }
+                Ok(updated_node)
+            }
             None => {
                 // The version-gated UPDATE matched no row for one of two
                 // reasons — the node was concurrently DELETED, or its version

--- a/packages/core/src/services/node_service/crud.rs
+++ b/packages/core/src/services/node_service/crud.rs
@@ -973,6 +973,14 @@ impl NodeService {
         {
             Some(updated_node) => {
                 if mark_user_modified {
+                    // Best-effort, OCC-bypassing second write (see set_property_bool's
+                    // doc comment). A concurrent writer landing between the update
+                    // above and this stamp could have its own version bump masked
+                    // by this call's WHERE-less json_set — the node's `version`
+                    // column would then undercount real mutations by one. Blast
+                    // radius is limited to that bookkeeping counter: `_seed.user_modified`
+                    // itself is idempotent (setting it to `true` twice is a no-op),
+                    // so no seeded content or user edit can be lost this way.
                     if let Err(e) = self
                         .store
                         .set_property_bool(node_id, "$._seed.user_modified", true)

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1298,12 +1298,29 @@ impl NodeService {
     /// Seed node hierarchies from pre-expanded template node lists.
     ///
     /// Each element of `template_groups` is a flat `Vec<PreparedNode>` produced
-    /// by [`crate::markdown::prepare_nodes_from_template`].
-    /// The first element of each group is the root node; subsequent elements are
-    /// its children.
+    /// by [`crate::markdown::prepare_nodes_from_template`], which stamps the
+    /// root node's properties with a `_seed` object containing `key` (the
+    /// template's stable title), `version` (a content hash), and `tier`
+    /// (`"system"` or `"starter"`). Nested under one object key (rather than
+    /// flat top-level keys) so [`Self::normalize_flat_properties_to_namespace`]
+    /// preserves it as a dormant namespace instead of hoisting its contents
+    /// into `properties[node_type]` on write — the same pattern the `tool`
+    /// seed template comment (`skill_pipeline.rs`) uses for the same reason.
     ///
-    /// Idempotency rule: if any node of a given `node_type` already exists in the
-    /// database, the entire type is skipped.
+    /// Reconciliation is per node, keyed by `_seed.key` within each `node_type`:
+    ///
+    /// | state                                          | action              |
+    /// |-------------------------------------------------|---------------------|
+    /// | absent                                           | create              |
+    /// | present, hash matches                            | skip (up to date)   |
+    /// | present, `system`, hash differs                  | replace             |
+    /// | present, `starter`, not user-modified, hash differs | replace          |
+    /// | present, `starter`, user-modified                | skip, log once      |
+    ///
+    /// A "replace" deletes the existing subtree and recreates it fresh — the
+    /// same insert path used for a first-time create — rather than diffing
+    /// individual children, since template content (including which children
+    /// exist) can change between versions.
     pub async fn seed_nodes_from_templates(
         &self,
         template_groups: Vec<Vec<crate::markdown::PreparedNode>>,
@@ -1312,37 +1329,93 @@ impl NodeService {
             return Ok(());
         }
 
-        // Collect the root node_types we need to check for existence.
+        // One query per distinct node_type covers every existing seeded node of
+        // that type in a single round trip — bounded by the number of seeded
+        // types (currently 3: prompt, skill, tool), not the number of nodes.
         let root_types: std::collections::HashSet<String> = template_groups
             .iter()
             .filter_map(|g| g.first())
             .map(|n| n.node_type.clone())
             .collect();
 
-        let mut seeded_types: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut existing_by_key: HashMap<String, HashMap<String, Node>> = HashMap::new();
         for node_type in &root_types {
             let filter = crate::models::NodeFilter {
                 node_type: Some(node_type.clone()),
                 ..Default::default()
             };
-            if !self.query_nodes(filter).await?.is_empty() {
-                seeded_types.insert(node_type.clone());
+            let mut by_key = HashMap::new();
+            for node in self.query_nodes(filter).await? {
+                if let Some(key) = node
+                    .properties
+                    .get("_seed")
+                    .and_then(|s| s.get("key"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                {
+                    by_key.insert(key, node);
+                }
             }
+            existing_by_key.insert(node_type.clone(), by_key);
         }
 
         let mut created_roots = 0u32;
         let mut created_children = 0u32;
-        let mut skipped = 0u32;
+        let mut replaced = 0u32;
+        let mut skipped_current = 0u32;
+        let mut skipped_user_modified = 0u32;
 
         for group in template_groups {
             let root = match group.first() {
                 Some(r) => r,
                 None => continue,
             };
+            let seed_meta = root.properties.get("_seed");
+            let seed_key = seed_meta
+                .and_then(|s| s.get("key"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let seed_version = seed_meta
+                .and_then(|s| s.get("version"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
 
-            if seeded_types.contains(&root.node_type) {
-                skipped += 1;
-                continue;
+            let existing = existing_by_key
+                .get(&root.node_type)
+                .and_then(|by_key| by_key.get(seed_key));
+
+            if let Some(existing_node) = existing {
+                let existing_seed = existing_node.properties.get("_seed");
+                let existing_version = existing_seed
+                    .and_then(|s| s.get("version"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+
+                if existing_version == seed_version {
+                    skipped_current += 1;
+                    continue;
+                }
+
+                let user_modified = existing_seed
+                    .and_then(|s| s.get("user_modified"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                if user_modified {
+                    tracing::info!(
+                        seed_key,
+                        node_type = %root.node_type,
+                        "Seed content changed but node was user-modified; skipping"
+                    );
+                    skipped_user_modified += 1;
+                    continue;
+                }
+
+                // Replace: delete the existing subtree, then fall through to the
+                // same create path used for a brand-new node.
+                self.delete_node(&existing_node.id, existing_node.version)
+                    .await?;
+                replaced += 1;
             }
 
             // Insert root node (no parent).
@@ -1385,12 +1458,14 @@ impl NodeService {
             }
         }
 
-        if created_roots > 0 {
+        if created_roots > 0 || replaced > 0 {
             tracing::info!(
                 created_roots,
                 created_children,
-                skipped,
-                "Agent nodes seeded from templates"
+                replaced,
+                skipped_current,
+                skipped_user_modified,
+                "Agent nodes reconciled from templates"
             );
         }
 
@@ -4067,6 +4142,158 @@ mod tests {
             edges.len(),
             1,
             "owner edge must not be duplicated on reopen"
+        );
+    }
+
+    fn seed_template(
+        title: &str,
+        markdown: &str,
+        tier: crate::markdown::SeedTier,
+    ) -> crate::markdown::NodeTemplate {
+        crate::markdown::NodeTemplate {
+            title: title.to_string(),
+            content: None,
+            root_node_type: "prompt".to_string(),
+            root_properties: json!({}),
+            child_node_type: Some("text".to_string()),
+            child_properties: None,
+            tier,
+            markdown_content: markdown.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reseed_replaces_system_tier_node_on_content_change() {
+        use crate::markdown::{prepare_nodes_from_template, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let v1 = seed_template("Core Identity", "You are v1.", SeedTier::System);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v1).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].content, "Core Identity");
+
+        // Re-seed with changed content under the same seed_key ("Core Identity").
+        let v2 = seed_template("Core Identity", "You are v2, rewritten.", SeedTier::System);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v2).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "replace must not leave the stale node behind"
+        );
+        let children = service.get_children(&nodes[0].id).await.unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].content, "You are v2, rewritten.");
+    }
+
+    #[tokio::test]
+    async fn reseed_updates_unmodified_starter_tier_node() {
+        use crate::markdown::{prepare_nodes_from_template, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let v1 = seed_template("Welcome Note", "Starter v1.", SeedTier::Starter);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v1).unwrap()])
+            .await
+            .unwrap();
+
+        let v2 = seed_template("Welcome Note", "Starter v2.", SeedTier::Starter);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v2).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        let children = service.get_children(&nodes[0].id).await.unwrap();
+        assert_eq!(
+            children[0].content, "Starter v2.",
+            "unedited starter-tier node must be updated on reseed"
+        );
+    }
+
+    #[tokio::test]
+    async fn reseed_skips_user_modified_starter_tier_node() {
+        use crate::markdown::{prepare_nodes_from_template, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let v1 = seed_template("Welcome Note", "Starter v1.", SeedTier::Starter);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v1).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        let root = &nodes[0];
+
+        // Simulate the user editing the seeded node through the normal update path.
+        service
+            .update_node(
+                &root.id,
+                root.version,
+                NodeUpdate::new().with_content("User's own title".to_string()),
+            )
+            .await
+            .unwrap();
+
+        // Re-seed with changed content under the same seed_key.
+        let v2 = seed_template("Welcome Note", "Starter v2.", SeedTier::Starter);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&v2).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "user-modified starter node must survive reseed, not be duplicated"
+        );
+        assert_eq!(
+            nodes[0].content, "User's own title",
+            "user-modified starter node must not be overwritten by reseed"
+        );
+    }
+
+    #[tokio::test]
+    async fn reseed_is_noop_when_hash_unchanged() {
+        use crate::markdown::{prepare_nodes_from_template, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let tmpl = seed_template("Core Identity", "Stable content.", SeedTier::System);
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&tmpl).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        let version_before = nodes[0].version;
+
+        // Re-seed with the exact same template (same content hash) — must be a no-op,
+        // not a delete+recreate, so the node's identity/version is untouched.
+        service
+            .seed_nodes_from_templates(vec![prepare_nodes_from_template(&tmpl).unwrap()])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("prompt", None).await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0].version, version_before,
+            "unchanged seed content must not touch the existing node"
         );
     }
 }

--- a/packages/core/src/services/node_service/mod.rs
+++ b/packages/core/src/services/node_service/mod.rs
@@ -1412,7 +1412,15 @@ impl NodeService {
                 }
 
                 // Replace: delete the existing subtree, then fall through to the
-                // same create path used for a brand-new node.
+                // same create path used for a brand-new node. The recreated root
+                // gets `root.id` — a fresh UUID assigned by
+                // `prepare_nodes_from_template` on every call — not the deleted
+                // node's ID. Nothing references seeded prompt/skill/tool nodes by
+                // stable ID today, so this is safe, but any future feature that
+                // does (e.g. a `mentions` edge into a skill node) would need
+                // either a stable ID carried across replace, or an explicit
+                // decision that seeded-content IDs are not a stable reference
+                // surface.
                 self.delete_node(&existing_node.id, existing_node.version)
                     .await?;
                 replaced += 1;
@@ -4294,6 +4302,212 @@ mod tests {
         assert_eq!(
             nodes[0].version, version_before,
             "unchanged seed content must not touch the existing node"
+        );
+    }
+
+    /// `prompt` (the type every other reseed test uses) is a core schema with
+    /// zero fields, so its properties never round-trip through
+    /// `normalize_flat_properties_to_namespace`'s flat-property-hoisting branch
+    /// with anything worth namespacing. `skill` has real required fields
+    /// (`description`, `tool_whitelist`) and hits that hoisting path on every
+    /// create. This proves `_seed` still survives — landing at
+    /// `properties._seed`, not buried under `properties.skill._seed` — for a
+    /// type that actually exercises the mechanism the whole fix depends on.
+    #[tokio::test]
+    async fn reseed_replaces_skill_tier_node_with_real_schema_fields() {
+        use crate::markdown::{prepare_nodes_from_template, NodeTemplate, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let skill_tmpl = |description: &str| NodeTemplate {
+            title: "Research & Search".to_string(),
+            content: None,
+            root_node_type: "skill".to_string(),
+            root_properties: json!({
+                "description": description,
+                "tool_whitelist": ["search_semantic"],
+            }),
+            child_node_type: Some("prompt".to_string()),
+            child_properties: None,
+            tier: SeedTier::System,
+            markdown_content: "Guidance v1.".to_string(),
+        };
+
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&skill_tmpl("Search v1")).unwrap()
+            ])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("skill", None).await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        // Real schema fields land namespaced under properties.skill.* — confirms
+        // this node actually went through the hoisting path this test targets.
+        assert_eq!(
+            nodes[0].properties["skill"]["description"], "Search v1",
+            "schema field must be namespaced under properties.skill"
+        );
+        // _seed must NOT be nested under properties.skill — it must survive at
+        // the top level, or the by-key lookup on reseed would never find it.
+        assert!(
+            nodes[0].properties.get("_seed").is_some(),
+            "_seed must land at the top level even when the node_type has real schema fields"
+        );
+
+        // Re-seed with changed description under the same seed_key — must replace,
+        // not duplicate, exactly like the empty-schema `prompt` case.
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&skill_tmpl("Search v2")).unwrap()
+            ])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("skill", None).await.unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "replace must not leave the stale skill node behind"
+        );
+        assert_eq!(nodes[0].properties["skill"]["description"], "Search v2");
+    }
+
+    /// `tool` seed templates pre-namespace their own properties under a `"tool"`
+    /// key (see `skill_pipeline.rs::seed_tool_nodes`) for an unrelated reason —
+    /// `tool` isn't a core schema, so `normalize_flat_properties_to_namespace`
+    /// wouldn't hoist it on its own; the pre-namespacing exists to protect the
+    /// nested `parameter_schema` object from being misclassified. This proves
+    /// `_seed` (stamped alongside that pre-existing `"tool"` namespace) doesn't
+    /// collide with it and both survive independently.
+    #[tokio::test]
+    async fn reseed_replaces_tool_tier_node_with_pre_namespaced_properties() {
+        use crate::markdown::{prepare_nodes_from_template, NodeTemplate, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let tool_tmpl = |description: &str| NodeTemplate {
+            title: "search_nodes".to_string(),
+            content: None,
+            root_node_type: "tool".to_string(),
+            root_properties: json!({
+                "tool": {
+                    "handler": "search_nodes",
+                    "description": description,
+                    "parameter_schema": {"type": "object"},
+                    "source": "internal",
+                    "enabled": true,
+                }
+            }),
+            child_node_type: None,
+            child_properties: None,
+            tier: SeedTier::System,
+            markdown_content: String::new(),
+        };
+
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&tool_tmpl("Search v1")).unwrap()
+            ])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("tool", None).await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].properties["tool"]["description"], "Search v1");
+        assert!(
+            nodes[0].properties.get("_seed").is_some(),
+            "_seed must coexist with the pre-namespaced 'tool' key, not be swallowed by it"
+        );
+
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&tool_tmpl("Search v2")).unwrap()
+            ])
+            .await
+            .unwrap();
+
+        let nodes = service.query_nodes_by_type("tool", None).await.unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "replace must not leave the stale tool node behind"
+        );
+        assert_eq!(nodes[0].properties["tool"]["description"], "Search v2");
+    }
+
+    /// A single `seed_nodes_from_templates` call, as the daemon issues it, mixes
+    /// `prompt` + `skill` + `tool` template groups together. Reconciliation
+    /// looks up existing nodes per-`node_type`, keyed by `_seed.key` — this
+    /// proves that grouping doesn't cross-contaminate: changing one type's
+    /// content doesn't touch, skip, or duplicate a sibling type's unrelated node
+    /// sharing the same batch.
+    #[tokio::test]
+    async fn reseed_handles_mixed_node_types_in_one_batch_independently() {
+        use crate::markdown::{prepare_nodes_from_template, NodeTemplate, SeedTier};
+
+        let (service, _temp) = create_test_service().await;
+
+        let prompt_tmpl = seed_template("Core Identity", "Prompt v1.", SeedTier::System);
+        let skill_tmpl = NodeTemplate {
+            title: "Research & Search".to_string(),
+            content: None,
+            root_node_type: "skill".to_string(),
+            root_properties: json!({
+                "description": "Skill v1",
+                "tool_whitelist": ["search_semantic"],
+            }),
+            child_node_type: Some("prompt".to_string()),
+            child_properties: None,
+            tier: SeedTier::System,
+            markdown_content: "Guidance v1.".to_string(),
+        };
+
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&prompt_tmpl).unwrap(),
+                prepare_nodes_from_template(&skill_tmpl).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            service
+                .query_nodes_by_type("prompt", None)
+                .await
+                .unwrap()
+                .len(),
+            2, // the skill's own "prompt"-typed child counts here too
+            "expected the Core Identity root plus the skill's prompt child"
+        );
+        assert_eq!(
+            service
+                .query_nodes_by_type("skill", None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Only the prompt template changes this round.
+        let prompt_v2 = seed_template("Core Identity", "Prompt v2.", SeedTier::System);
+        service
+            .seed_nodes_from_templates(vec![
+                prepare_nodes_from_template(&prompt_v2).unwrap(),
+                prepare_nodes_from_template(&skill_tmpl).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let skills = service.query_nodes_by_type("skill", None).await.unwrap();
+        assert_eq!(
+            skills.len(),
+            1,
+            "unchanged skill template must not be duplicated by the prompt's replace"
+        );
+        assert_eq!(
+            skills[0].properties["skill"]["description"], "Skill v1",
+            "unchanged skill content must be untouched"
         );
     }
 }


### PR DESCRIPTION
Closes #1812