### PR TITLE
create_schema enum fields silently discarded: prose teaches core_values, serde expects coreValues

### DIFF
--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -23,8 +23,7 @@ pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built
     NO CONFIRMATION FOR KNOWN TYPES: If a type appears in RELEVANT ENTITY TYPES, you have all the information you need. Do NOT say \"Could you confirm\" or \"I want to make sure\" or \"Would you like me to\" — just call search_skills then create_node immediately. Confirmation is NEVER required when the schema already exists.\n\
     SCHEMA SUCCESS/FAILURE: After create_schema returns a schema object, respond to the user and STOP — do NOT call create_schema again. If create_schema returns an \"already exists\" error, stop immediately and tell the user the type already exists.\n\
     TITLE TEMPLATE: Every {field_name} in title_template MUST appear in the fields array. If you want {invoice_number} in a template, you MUST add a field named invoice_number. Never reference a placeholder that is not in fields — this causes a validation error.\n\
-    FIELD RULES: Every field object MUST have both \"name\" AND \"type\". Missing either causes a validation error that will never self-correct — stop retrying and fix the field. Valid: {\"name\":\"amount\",\"type\":\"number\",\"required\":true}.\n\
-    ENUM FIELDS: type=\"enum\" requires a non-empty \"core_values\" array: [{\"value\":\"pending\",\"label\":\"Pending\"},{\"value\":\"paid\",\"label\":\"Paid\"}]. An enum with empty core_values always fails. If you don't have predefined values ready, use type=\"text\" instead — you can always add enum values later with update_schema.";
+    FIELD RULES: Every field object MUST have both \"name\" AND \"type\". Missing either causes a validation error that will never self-correct — stop retrying and fix the field. Valid: {\"name\":\"amount\",\"type\":\"number\",\"required\":true}.";
 
 /// Tool strategy guidance.
 ///

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -3076,6 +3076,60 @@ mod tests {
         }
     }
 
+    // -- create_schema enum field end-to-end (acceptance criterion) --
+
+    /// Exercises `create_schema` through the real `GraphToolExecutor` dispatch
+    /// path — not just `handle_create_schema` directly — with an enum field
+    /// using the tool-schema-correct "coreValues" key. Confirms the wire-format
+    /// contract the tool schema advertises actually round-trips end to end.
+    #[tokio::test]
+    async fn create_schema_enum_field_succeeds_end_to_end() {
+        use nodespace_core::db::SqliteStore;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let mut store: Arc<SqliteStore> = Arc::new(SqliteStore::new(db_path).await.unwrap());
+        let svc = Arc::new(NodeService::new(&mut store).await.unwrap());
+
+        let executor = GraphToolExecutor {
+            node_service: Some(svc),
+            embedding_service: Arc::new(RwLock::new(None)),
+            inference_engine: None,
+        };
+
+        let result = executor
+            .execute(
+                "create_schema",
+                json!({
+                    "name": "Invoice",
+                    "fields": [
+                        {
+                            "name": "status",
+                            "type": "enum",
+                            "coreValues": [
+                                { "value": "pending", "label": "Pending" },
+                                { "value": "paid", "label": "Paid" }
+                            ]
+                        }
+                    ]
+                }),
+            )
+            .await
+            .expect("execute should not return a ToolError");
+
+        assert!(
+            !result.is_error,
+            "create_schema with a coreValues enum field must succeed, got: {}",
+            result.result
+        );
+        assert_eq!(result.result["schemaId"], "invoice");
+        let core_values = result.result["fields"][0]["coreValues"]
+            .as_array()
+            .expect("coreValues array present on the created field");
+        assert_eq!(core_values.len(), 2);
+    }
+
     // -- Scope passthrough test (acceptance criterion) --
 
     /// Verifies that scope="conversations" is correctly parsed from JSON params

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -629,7 +629,7 @@ fn def_create_schema() -> ToolDefinition {
                             "description": { "type": "string", "description": "Field description" },
                             "coreValues": {
                                 "type": "array",
-                                "description": "For enum fields: array of {value, label} pairs. Use lowercase values (e.g., 'active' not 'Active').",
+                                "description": "REQUIRED and must be non-empty when type=\"enum\" — an enum field with no values always fails validation. Array of {value, label} pairs. Use lowercase values (e.g., 'active' not 'Active'). If predefined values aren't known yet, use type=\"text\" instead; values can be added later with update_schema.",
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -697,7 +697,7 @@ fn def_update_schema() -> ToolDefinition {
                             "description": { "type": "string" },
                             "coreValues": {
                                 "type": "array",
-                                "description": "For enum fields: array of {value, label} pairs",
+                                "description": "REQUIRED and must be non-empty when type=\"enum\" — an enum field with no values always fails validation. Array of {value, label} pairs.",
                                 "items": { "type": "object", "properties": { "value": { "type": "string" }, "label": { "type": "string" } } }
                             }
                         },

--- a/packages/core/src/schema/mod.rs
+++ b/packages/core/src/schema/mod.rs
@@ -136,6 +136,7 @@ fn json_type_name(v: &Value) -> &'static str {
 
 /// Input parameters for create_schema
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateSchemaParams {
     /// Schema name (e.g., "Invoice", "Customer")
     pub name: String,

--- a/packages/core/src/schema/schema_test.rs
+++ b/packages/core/src/schema/schema_test.rs
@@ -868,6 +868,74 @@ async fn test_create_schema_reports_non_object_field_entry() {
 }
 
 #[tokio::test]
+async fn test_create_schema_snake_case_core_values_rejected() {
+    let (svc, _tmp) = create_test_service().await;
+
+    // The tool schema declares "coreValues" (camelCase). A caller that sends
+    // the snake_case Rust field name instead must be rejected with an error
+    // naming the unknown key, not silently produce an enum with no values.
+    let result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "Invoice",
+            "fields": [
+                {
+                    "name": "status",
+                    "type": "enum",
+                    "core_values": [
+                        { "value": "pending", "label": "Pending" },
+                        { "value": "paid", "label": "Paid" }
+                    ]
+                }
+            ]
+        }),
+    )
+    .await;
+
+    let msg = result
+        .expect_err("core_values is not a recognized key on a schema field")
+        .to_string();
+    assert!(
+        msg.contains("core_values"),
+        "error must name the unknown field so the caller can correct it: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_create_schema_enum_field_with_core_values_succeeds() {
+    let (svc, _tmp) = create_test_service().await;
+
+    let result = handle_create_schema(
+        &svc,
+        json!({
+            "name": "Invoice",
+            "fields": [
+                {
+                    "name": "status",
+                    "type": "enum",
+                    "coreValues": [
+                        { "value": "pending", "label": "Pending" },
+                        { "value": "paid", "label": "Paid" }
+                    ]
+                }
+            ]
+        }),
+    )
+    .await;
+
+    let val = result.expect("enum field with coreValues should succeed end to end");
+    assert_eq!(val["schemaId"], "invoice");
+    let fields = val["fields"].as_array().expect("fields array");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0]["name"], "status");
+    let core_values = fields[0]["coreValues"]
+        .as_array()
+        .expect("coreValues array");
+    assert_eq!(core_values.len(), 2);
+    assert_eq!(core_values[0]["value"], "pending");
+}
+
+#[tokio::test]
 async fn test_create_schema_with_well_formed_fields_is_unaffected() {
     let (svc, _tmp) = create_test_service().await;
 

--- a/packages/nodespace-types/src/schema.rs
+++ b/packages/nodespace-types/src/schema.rs
@@ -27,7 +27,7 @@ pub enum SchemaProtectionLevel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SchemaField {
     pub name: String,
     #[serde(rename = "type")]
@@ -290,6 +290,28 @@ mod tests {
         assert_eq!(core_values.len(), 2);
         assert_eq!(core_values[0].value, "open");
         assert_eq!(core_values[0].label, "Open");
+    }
+
+    #[test]
+    fn test_schema_field_rejects_snake_case_core_values() {
+        // core_values is the Rust field name; the wire key is coreValues
+        // (rename_all = "camelCase"). A payload using the snake_case name must
+        // be rejected outright, not silently dropped as an unknown field.
+        let json = json!({
+            "name": "status",
+            "type": "enum",
+            "core_values": [
+                { "value": "open", "label": "Open" },
+                { "value": "done", "label": "Done" }
+            ]
+        });
+
+        let err = serde_json::from_value::<SchemaField>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("core_values"),
+            "expected error naming the unknown field `core_values`, got: {}",
+            err
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1809