### PR TITLE
TOOL_STRATEGY_RULES conflates safety policy with tool routing; split it and delete routing in favor of skill/schema-carried routing

### DIFF
--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -27,34 +27,24 @@ pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built
 
 /// Tool strategy guidance.
 ///
-/// Compressed "TOOL STRATEGY:" bulleted list. Covers the search-first mandate
-/// (never invent placeholder IDs), tool selection hints for search_nodes vs.
-/// search_semantic, and canonical create/update/connect patterns. Parameter-level
-/// detail is intentionally deferred to tool schemas to avoid duplication.
+/// Safety-invariant policy only, per ADR-064 rule 5 (resident prose owns
+/// identity and policy, nothing else). Argument shape (node_type provenance)
+/// now lives on the relevant tool schemas' parameter descriptions; per-operation
+/// tool-call routing now lives in each operation's skill instructions
+/// (`skill_pipeline.rs`) or is redundant with the model's own choice to reach
+/// a skill via `search_skills`; tool-usage reference facts (how search_nodes
+/// filters work, when to prefer search_semantic, etc.) now live on the tools'
+/// own descriptions in `local_agent/tools.rs`. See issue #1820 and its audit
+/// trail for the per-line disposition.
 pub const TOOL_STRATEGY_RULES: &str = "TOOL STRATEGY:\n\
-    - NODE_TYPE COMES FROM RELEVANT ENTITY TYPES: Every node_type argument (search_nodes, create_node, update_node, resolve_query) MUST be an id copied exactly from the RELEVANT ENTITY TYPES block in this prompt — character for character, including any underscores. Never shorten, singularize, paraphrase, or guess it from the user's wording: the user's noun is usually NOT the id, because the id was derived from whatever the type was named when its schema was created. If the type you need is not listed in RELEVANT ENTITY TYPES, it does not exist yet — do not invent an id for it.\n\
     - CONVERSATIONAL TURNS USE NO TOOLS. Greetings, thanks, small talk, questions about your own capabilities or limits, and other meta questions about yourself — answer directly in text. Do NOT call any tool: nothing in the user's graph needs to be read to answer them.\n\
     - META QUESTIONS (\"how did you check?\", \"what tool did you use?\", \"did you look up X?\"): answer ONLY from what is visible in this conversation's tool call history. Do NOT fabricate tool names, arguments, or results. If you cannot see a tool call in the history that matches the claim, say so honestly — \"I did not make that search\" or \"I don't see a record of that in this conversation.\"\n\
     - SCHEMA CLAIMS WITHOUT VERIFICATION: Never state that a node type has or lacks a specific property (e.g. \"task has no due_date field\") without first calling a tool to verify. If you have not called get_node or search_nodes on the schema in this turn, you do not know its fields — say so.\n\
     - IDENTICAL TOOL CALLS: Never call the same tool with the exact same arguments twice in one turn. If a tool returned a result and you are about to call it again identically, you already have the answer — produce your response using the result you have.\n\
-    - For create_node (adding an instance): call search_skills(query) THEN immediately call create_node in the SAME turn — no text between them. After search_skills returns, your next step MUST be create_node, not a planning message.\n\
-    - For create_schema (new entity type): call create_schema DIRECTLY — no search_skills needed. See DATABASE=SCHEMA rule above.\n\
-    - SKILL COMPLETION: Once create_node, update_node, create_schema, or delete_node returns successfully, respond to the user immediately. Do NOT call search_skills again or call create_schema again — the task is done.\n\
     - NEVER CLAIM ACTION WITHOUT TOOL RESULT: Never tell the user a node was created, updated, or deleted without a successful tool result in this turn. If no tool was called, no action happened — call the tool.\n\
     - CLARIFICATION CONTRACT: at most one clarification per intent. If the user clarifies and the request is still ambiguous, fall through to semantic_search and answer with what's available. Never clarify twice.\n\
     - AMBIGUITY: If a search returns 0 results or multiple results that don't clearly match, ask the user one specific clarifying question (e.g. \"Are you looking for the invoice with amount $500?\") rather than retrying the search.\n\
-    - BLAST-RADIUS GATE: deletion is irreversible — only call delete_node or delete_schema when the user explicitly and unambiguously asks to delete. Never clarify before create_schema, create_node, or update operations. \"Could you confirm?\" and \"I want to make sure\" are FORBIDDEN before any non-delete operation.\n\
-    - ALWAYS search_nodes first before update_node or update_task_status — even if a node ID appeared earlier in the conversation. Never skip the search step.\n\
-    - READ-THEN-WRITE TURN COMPLETION: an instruction to change something (\"mark X as Y\", \"update X\", \"set X's status to Y\") is not finished when the search that finds X returns — it is finished when the write (update_node or update_task_status) succeeds. Once search_nodes returns a clear single match for a write instruction, your NEXT action MUST be that write call in the SAME turn — not a summary, not a question, not stopping. Searching and then stopping is a FAILED turn, not a completed one.\n\
-    - search_nodes is the ONE tool for finding, listing, and filtering nodes. By keyword/title: search_nodes(query, node_type). To LIST EVERY NODE OF A TYPE — any request naming a type with no narrowing condition — call search_nodes(query=\"\", node_type=<type>); the empty query is what makes it return the whole type, so do NOT invent a keyword to put there. To FILTER BY A TYPED PROPERTY (status, due_date, amount, operators like gt/lt): add filters, e.g. search_nodes(node_type=<type>, filters=[{\"type\":\"property\",\"operator\":\"equals\",\"property\":\"status\",\"value\":\"open\"}]). search_nodes returns each node's properties. Use search_semantic(query, node_types, scope, threshold, graph_boost) ONLY for meaning-based / fuzzy questions.\n\
-    - search_nodes filter \"type\" values: use \"property\" for schema/node fields (e.g. status, due_date, priority — anything defined on the node type). Use \"metadata\" ONLY for created_at, modified_at, node_type, or content. Using \"metadata\" for a property field (e.g. status) always fails with \"Invalid metadata field\".\n\
-    - search_semantic result: if 'markdown' is non-empty, summarize from it directly — skip get_node.\n\
-    - To get full content: get_node(id, format=markdown). To get connections: get_related_nodes(id).\n\
-    - To update a CUSTOM schema node's property: if the request identifies the target indirectly — by a paraphrased description, an implicit property reference (a bare value such as an amount or code, without naming which field it belongs to), or a relative date/status word (a weekday, \"overdue\", \"recent\") — call resolve_query(request=<the user's request verbatim>, node_type=<id from RELEVANT ENTITY TYPES>) FIRST, then pass its returned \"query\" and \"filters\" directly into search_nodes, then update_node(id=<found_id>, properties={...}). Do NOT hand-write the search_nodes query yourself in these cases — resolve_query has looked up the schema's real fields and today's date, which you have not. Skip resolve_query only when the target is already named directly and unambiguously (a proper name or exact title you can pass straight to search_nodes as query). Use update_task_status ONLY for built-in task nodes — for every custom schema type, use update_node.\n\
-    - To create a node: call search_skills first to get schema_metadata, then call create_node(content, node_type=<type_id>, properties=<fields from schema_metadata>). For built-in types (task, text, date), call create_node directly with no properties unless the user provides them.\n\
-    - To add/modify an entity type: create_schema or update_schema(schema_id).\n\
-    - To connect nodes: create_relationship with names from schemas above.\n\
-    - Tool arguments must be valid JSON. No comments (#) in JSON.";
+    - BLAST-RADIUS GATE: deletion is irreversible — only call delete_node or delete_schema when the user explicitly and unambiguously asks to delete. Never clarify before create_schema, create_node, or update operations. \"Could you confirm?\" and \"I want to make sure\" are FORBIDDEN before any non-delete operation.";
 
 /// Node reference formatting rule.
 ///
@@ -78,8 +68,29 @@ mod tests {
     #[test]
     fn tool_strategy_rules_non_empty() {
         assert!(TOOL_STRATEGY_RULES.contains("TOOL STRATEGY:"));
-        assert!(TOOL_STRATEGY_RULES.contains("ALWAYS search_nodes first"));
-        assert!(TOOL_STRATEGY_RULES.contains("Never skip the search step"));
+        assert!(TOOL_STRATEGY_RULES.contains("BLAST-RADIUS GATE"));
+    }
+
+    /// Per-operation routing (which tool to call in what order for a given
+    /// request shape) is now owned by skill instructions (`skill_pipeline.rs`)
+    /// and tool descriptions (`local_agent/tools.rs`), not resident prose — see
+    /// ADR-064 rules 2 and 5, and issue #1820. Nothing that names a specific
+    /// tool-call sequence for an operation may reappear here.
+    #[test]
+    fn tool_strategy_rules_contain_no_per_operation_routing() {
+        for forbidden in [
+            "ALWAYS search_nodes first",
+            "READ-THEN-WRITE TURN COMPLETION",
+            "SKILL COMPLETION",
+            "NODE_TYPE COMES FROM RELEVANT ENTITY TYPES",
+            "resolve_query",
+            "schema_metadata",
+        ] {
+            assert!(
+                !TOOL_STRATEGY_RULES.contains(forbidden),
+                "TOOL_STRATEGY_RULES must not contain per-operation routing text {forbidden:?} — it belongs in a skill's instructions or a tool's description"
+            );
+        }
     }
 
     #[test]
@@ -102,57 +113,6 @@ mod tests {
         assert!(
             TOOL_STRATEGY_RULES.contains("IDENTICAL TOOL CALLS"),
             "must prohibit identical repeated tool calls"
-        );
-    }
-
-    #[test]
-    fn tool_strategy_rules_cover_read_then_write_completion() {
-        assert!(
-            TOOL_STRATEGY_RULES.contains("READ-THEN-WRITE TURN COMPLETION"),
-            "must instruct the model to continue to the write call after a successful search, not stop"
-        );
-        assert!(
-            TOOL_STRATEGY_RULES.contains("FAILED turn"),
-            "must frame search-then-stop as a failed turn"
-        );
-    }
-
-    #[test]
-    fn tool_strategy_rules_reference_resolve_query_for_ambiguous_updates() {
-        assert!(
-            TOOL_STRATEGY_RULES.contains("resolve_query"),
-            "must instruct the model to call resolve_query for ambiguous update targets"
-        );
-        assert!(
-            !TOOL_STRATEGY_RULES.contains("ONE WORD ONLY"),
-            "the ineffective ONE-WORD-ONLY prompt workaround must be removed, not layered under resolve_query"
-        );
-    }
-
-    /// `node_type` must be taught as a lookup into the injected RELEVANT ENTITY
-    /// TYPES block, never as a literal. A hardcoded type id is wrong for
-    /// essentially every real workspace, because the id is derived from whatever
-    /// the schema happened to be named at creation time.
-    #[test]
-    fn tool_strategy_rules_bind_node_type_to_relevant_entity_types() {
-        assert!(
-            TOOL_STRATEGY_RULES.contains("NODE_TYPE COMES FROM RELEVANT ENTITY TYPES"),
-            "must state where node_type values come from"
-        );
-        for tool in [
-            "search_nodes",
-            "create_node",
-            "update_node",
-            "resolve_query",
-        ] {
-            assert!(
-                TOOL_STRATEGY_RULES.contains(tool),
-                "node_type guidance must cover {tool}"
-            );
-        }
-        assert!(
-            !TOOL_STRATEGY_RULES.contains("node_type=\"invoice\""),
-            "node_type must never be taught as a hardcoded literal"
         );
     }
 

--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -34,8 +34,7 @@ pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built
 /// (`skill_pipeline.rs`) or is redundant with the model's own choice to reach
 /// a skill via `search_skills`; tool-usage reference facts (how search_nodes
 /// filters work, when to prefer search_semantic, etc.) now live on the tools'
-/// own descriptions in `local_agent/tools.rs`. See issue #1820 and its audit
-/// trail for the per-line disposition.
+/// own descriptions in `local_agent/tools.rs`.
 pub const TOOL_STRATEGY_RULES: &str = "TOOL STRATEGY:\n\
     - CONVERSATIONAL TURNS USE NO TOOLS. Greetings, thanks, small talk, questions about your own capabilities or limits, and other meta questions about yourself — answer directly in text. Do NOT call any tool: nothing in the user's graph needs to be read to answer them.\n\
     - META QUESTIONS (\"how did you check?\", \"what tool did you use?\", \"did you look up X?\"): answer ONLY from what is visible in this conversation's tool call history. Do NOT fabricate tool names, arguments, or results. If you cannot see a tool call in the history that matches the claim, say so honestly — \"I did not make that search\" or \"I don't see a record of that in this conversation.\"\n\
@@ -73,9 +72,9 @@ mod tests {
 
     /// Per-operation routing (which tool to call in what order for a given
     /// request shape) is now owned by skill instructions (`skill_pipeline.rs`)
-    /// and tool descriptions (`local_agent/tools.rs`), not resident prose — see
-    /// ADR-064 rules 2 and 5, and issue #1820. Nothing that names a specific
-    /// tool-call sequence for an operation may reappear here.
+    /// and tool descriptions (`local_agent/tools.rs`), not resident prose —
+    /// see ADR-064 rules 2 and 5. Nothing that names a specific tool-call
+    /// sequence for an operation may reappear here.
     #[test]
     fn tool_strategy_rules_contain_no_per_operation_routing() {
         for forbidden in [

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -3393,6 +3393,122 @@ mod tests {
         assert_eq!(result.tool_calls_made[1].name, "create_node");
     }
 
+    /// Regression coverage for issue #1820: `update_node` must remain
+    /// reachable through `search_skills` -> Graph Editing's own routing
+    /// (`search_nodes` then `update_node`) now that `TOOL_STRATEGY_RULES`
+    /// no longer hardcodes "ALWAYS search_nodes first before update_node" in
+    /// resident prose. This scripts the full chain a real model is expected
+    /// to follow and asserts the loop dispatches every step correctly — it
+    /// proves the plumbing supports the routed path; live-model adherence to
+    /// it is a separate concern covered by the agent-matrix eval.
+    #[tokio::test]
+    async fn search_skills_then_search_nodes_then_update_node_chain_dispatches_correctly() {
+        let engine = Arc::new(MockEngine::new(vec![
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "tc_1".to_string(),
+                    name: "search_skills".to_string(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "tc_1".to_string(),
+                    args_json: r#"{"query":"mark an invoice as paid"}"#.to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 10,
+                        completion_tokens: 5,
+                    },
+                },
+            ],
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "tc_2".to_string(),
+                    name: "search_nodes".to_string(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "tc_2".to_string(),
+                    args_json: r#"{"query":"","node_type":"invoice","filters":[{"type":"property","operator":"equals","property":"amount","value":500}]}"#.to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 20,
+                        completion_tokens: 8,
+                    },
+                },
+            ],
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "tc_3".to_string(),
+                    name: "update_node".to_string(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "tc_3".to_string(),
+                    args_json: r#"{"id":"nodespace://invoice-1","properties":{"status":"paid"}}"#.to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 30,
+                        completion_tokens: 8,
+                    },
+                },
+            ],
+            vec![
+                StreamingChunk::Token {
+                    text: "Marked the invoice as paid.".to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 40,
+                        completion_tokens: 6,
+                    },
+                },
+            ],
+        ]));
+
+        let executor = MockToolExecutor::new()
+            .with_tool(
+                "search_skills",
+                json!({"type": "object"}),
+                json!({
+                    "query": "mark an invoice as paid",
+                    "matches": [
+                        {"id": "skill-graph-editing", "name": "Graph Editing", "confidence": 0.9,
+                         "description": "Modify existing nodes in the knowledge graph",
+                         "tools": ["update_node", "search_nodes", "resolve_query"]}
+                    ]
+                }),
+            )
+            .with_tool(
+                "search_nodes",
+                json!({"type": "object"}),
+                json!({"results": [{"id": "nodespace://invoice-1", "title": "Invoice #001", "properties": {"amount": 500, "status": "open"}}]}),
+            )
+            .with_tool(
+                "update_node",
+                json!({"type": "object"}),
+                json!({"id": "nodespace://invoice-1", "properties": {"status": "paid"}}),
+            );
+
+        let agent_loop = LocalAgentLoop::new(engine, Arc::new(executor));
+        let mut session = new_session();
+        let result = agent_loop
+            .run_turn(
+                &mut session,
+                "Mark the $500 invoice as paid",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.response, "Marked the invoice as paid.");
+        assert_eq!(result.tool_calls_made.len(), 3);
+        assert_eq!(result.tool_calls_made[0].name, "search_skills");
+        assert_eq!(result.tool_calls_made[1].name, "search_nodes");
+        assert_eq!(result.tool_calls_made[2].name, "update_node");
+    }
+
     /// When the model decides no skill is needed, it responds directly —
     /// no clarification short-circuit, no canned string.
     #[tokio::test]

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -3393,14 +3393,21 @@ mod tests {
         assert_eq!(result.tool_calls_made[1].name, "create_node");
     }
 
-    /// Regression coverage for issue #1820: `update_node` must remain
-    /// reachable through `search_skills` -> Graph Editing's own routing
-    /// (`search_nodes` then `update_node`) now that `TOOL_STRATEGY_RULES`
-    /// no longer hardcodes "ALWAYS search_nodes first before update_node" in
-    /// resident prose. This scripts the full chain a real model is expected
-    /// to follow and asserts the loop dispatches every step correctly — it
-    /// proves the plumbing supports the routed path; live-model adherence to
-    /// it is a separate concern covered by the agent-matrix eval.
+    /// Regression coverage: `update_node` must remain reachable through
+    /// `search_skills` -> Graph Editing's own routing (`search_nodes` then
+    /// `update_node`) now that `TOOL_STRATEGY_RULES` no longer hardcodes
+    /// "ALWAYS search_nodes first before update_node" in resident prose.
+    ///
+    /// This scripts the full chain a real model is expected to follow and
+    /// asserts the loop dispatches every step correctly against a scripted
+    /// `MockEngine` — it proves the DISPATCH PLUMBING supports the routed
+    /// path (tool execution order, argument passing, session state), not
+    /// that a real model will choose this sequence. `MockEngine` returns a
+    /// fixed queue of responses regardless of prompt content, so it cannot
+    /// exercise routing choice. Live-model adherence to this routing is a
+    /// separate, not-yet-closed concern for the agent-matrix eval
+    /// (`scripts/eval/fixtures/agent-matrix.ts`), which is not run as part
+    /// of `test:all`.
     #[tokio::test]
     async fn search_skills_then_search_nodes_then_update_node_chain_dispatches_correctly() {
         let engine = Arc::new(MockEngine::new(vec![

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -278,7 +278,7 @@ fn def_search_nodes() -> ToolDefinition {
                 },
                 "node_type": {
                     "type": "string",
-                    "description": "Filter by node type (e.g. 'task', 'text', or a custom schema ID). Omit to search all types."
+                    "description": "Filter by node type (e.g. 'task', 'text', or a custom schema ID). For a custom schema ID, copy the id exactly from the RELEVANT ENTITY TYPES block — character for character, including underscores — never shorten, singularize, paraphrase, or guess it from the user's wording. Omit to search all types."
                 },
                 "filters": {
                     "type": "array",
@@ -370,7 +370,7 @@ fn def_resolve_query() -> ToolDefinition {
                 },
                 "node_type": {
                     "type": "string",
-                    "description": "The target node type to resolve against (e.g. 'invoice')."
+                    "description": "The target node type to resolve against (e.g. 'invoice'). Copy the id exactly from the RELEVANT ENTITY TYPES block — character for character, including underscores — never shorten, singularize, paraphrase, or guess it from the user's wording."
                 }
             },
             "required": ["request", "node_type"]
@@ -381,7 +381,7 @@ fn def_resolve_query() -> ToolDefinition {
 fn def_search_semantic() -> ToolDefinition {
     ToolDefinition {
         name: "search_semantic".into(),
-        description: "Find nodes semantically related to a natural-language query. By default returns full content for the top result (include_markdown=1). Increase include_markdown to get full content for more results, or set to 0 for IDs and snippets only.".into(),
+        description: "Find nodes semantically related to a natural-language query. By default returns full content for the top result (include_markdown=1). Increase include_markdown to get full content for more results, or set to 0 for IDs and snippets only. If a result's 'markdown' field is non-empty, that is the complete document — summarize or answer from it directly, do not call get_node or search_nodes again for that result.".into(),
         parameters_schema: json!({
             "type": "object",
             "properties": {
@@ -478,7 +478,7 @@ fn def_create_node() -> ToolDefinition {
                 },
                 "node_type": {
                     "type": "string",
-                    "description": "Node type: 'text', 'task', or a custom schema ID (e.g. 'project', 'customer')"
+                    "description": "Node type: 'text', 'task', or a custom schema ID (e.g. 'project', 'customer'). For a custom schema ID, copy the id exactly from the RELEVANT ENTITY TYPES block — character for character, including underscores — never shorten, singularize, paraphrase, or guess it from the user's wording. If the type is not listed there, it does not exist yet — do not invent an id for it."
                 },
                 "properties": {
                     "type": "object",
@@ -536,7 +536,7 @@ fn def_create_relationship() -> ToolDefinition {
                 },
                 "relationship_type": {
                     "type": "string",
-                    "description": "Type of relationship (member_of, mentions, etc.)"
+                    "description": "Type of relationship. Use a relationship name defined on the relevant schema(s) (e.g. 'has_task', 'billed_to') if one applies, otherwise a generic label (member_of, mentions, related_to, etc.)."
                 }
             },
             "required": ["from_id", "to_id", "relationship_type"]
@@ -2274,6 +2274,54 @@ mod tests {
         // Derived from the registry: one definition per `Tool::ALL` entry.
         assert_eq!(all_tool_definitions().len(), Tool::ALL.len());
         assert_eq!(all_tool_definitions().len(), 14);
+    }
+
+    /// `node_type` argument-shape guidance (copy the id exactly from RELEVANT
+    /// ENTITY TYPES, never paraphrase/guess) moved here from resident prose
+    /// per ADR-064 rule 1 (tool schemas own argument shape) and issue #1820.
+    /// `update_node` has no `node_type` parameter — it addresses by `id` — so
+    /// it is intentionally excluded.
+    #[test]
+    fn node_type_params_bind_to_relevant_entity_types() {
+        for tool in [Tool::SearchNodes, Tool::CreateNode, Tool::ResolveQuery] {
+            let def = tool.definition();
+            let node_type_desc = def.parameters_schema["properties"]["node_type"]["description"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{} must have a node_type parameter", tool.name()));
+            assert!(
+                node_type_desc.contains("RELEVANT ENTITY TYPES")
+                    && node_type_desc.to_lowercase().contains("copy"),
+                "{}'s node_type description must instruct copying the id exactly from RELEVANT ENTITY TYPES, got: {node_type_desc:?}",
+                tool.name()
+            );
+        }
+    }
+
+    /// The markdown-shortcut rule (non-empty `markdown` field is the complete
+    /// document — skip get_node/search_nodes) moved here from resident prose;
+    /// see issue #1820.
+    #[test]
+    fn search_semantic_description_covers_markdown_shortcut() {
+        let desc = Tool::SearchSemantic.definition().description;
+        assert!(
+            desc.contains("markdown") && desc.contains("summarize"),
+            "search_semantic description must instruct summarizing directly from a non-empty markdown field, got: {desc:?}"
+        );
+    }
+
+    /// `relationship_type` should steer the model toward schema-defined
+    /// relationship names before generic labels; see issue #1820.
+    #[test]
+    fn create_relationship_type_prefers_schema_defined_names() {
+        let def = Tool::CreateRelationship.definition();
+        let desc = def.parameters_schema["properties"]["relationship_type"]["description"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            desc.contains("relevant schema"),
+            "relationship_type description must point at schema-defined relationship names, got: {desc:?}"
+        );
     }
 
     // -- Tool registry invariants --

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -2277,10 +2277,10 @@ mod tests {
     }
 
     /// `node_type` argument-shape guidance (copy the id exactly from RELEVANT
-    /// ENTITY TYPES, never paraphrase/guess) moved here from resident prose
-    /// per ADR-064 rule 1 (tool schemas own argument shape) and issue #1820.
-    /// `update_node` has no `node_type` parameter — it addresses by `id` — so
-    /// it is intentionally excluded.
+    /// ENTITY TYPES, never paraphrase/guess) moved here from resident prose per
+    /// ADR-064 rule 1 (tool schemas own argument shape). `update_node` has no
+    /// `node_type` parameter — it addresses by `id` — so it is intentionally
+    /// excluded.
     #[test]
     fn node_type_params_bind_to_relevant_entity_types() {
         for tool in [Tool::SearchNodes, Tool::CreateNode, Tool::ResolveQuery] {
@@ -2298,8 +2298,7 @@ mod tests {
     }
 
     /// The markdown-shortcut rule (non-empty `markdown` field is the complete
-    /// document — skip get_node/search_nodes) moved here from resident prose;
-    /// see issue #1820.
+    /// document — skip get_node/search_nodes) moved here from resident prose.
     #[test]
     fn search_semantic_description_covers_markdown_shortcut() {
         let desc = Tool::SearchSemantic.definition().description;
@@ -2310,7 +2309,7 @@ mod tests {
     }
 
     /// `relationship_type` should steer the model toward schema-defined
-    /// relationship names before generic labels; see issue #1820.
+    /// relationship names before generic labels.
     #[test]
     fn create_relationship_type_prefers_schema_defined_names() {
         let def = Tool::CreateRelationship.definition();

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -489,7 +489,6 @@ mod tests {
             "search_skills",
             "CLARIFICATION CONTRACT",
             "BLAST-RADIUS GATE",
-            "ALWAYS search_nodes first",
             "NEVER CLAIM ACTION WITHOUT TOOL RESULT",
             // SCHEMA_CREATION_RULES, sharing the same prompt node, must also survive.
             "NODE MODEL:",

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -124,6 +124,8 @@ When updating an existing node:
 
 FIND THEN UPDATE: {find_then_act} Then call update_node with the ID and only the fields that need changing.
 
+INDIRECT TARGET: If the request identifies the target indirectly — a bare value without naming its field (an amount, a code), a relative date or status word (a weekday, "overdue", "recent"), or a paraphrased description — call resolve_query(request=<the request verbatim>, node_type) FIRST instead of hand-writing a search_nodes query yourself, then pass its returned query and filters directly into search_nodes.
+
 AMBIGUITY: {ambiguity_clarify} Examples:
 - 0 results: "I couldn't find an invoice matching that description. Are you looking for the invoice with amount $500?"
 - Multiple results: "I found 3 invoices — which one did you mean: Invoice #001 ($500), Invoice #002 ($750), or Invoice #003 ($500 overdue)?"
@@ -341,7 +343,7 @@ SUCCESS: After create_node returns a node ID, confirm to the user what was creat
             root_node_type: "skill".to_string(),
             root_properties: serde_json::json!({
                 "description": "Modify existing nodes in the knowledge graph - update content, properties, titles, and metadata. For tasks, use update_task_status to change status.",
-                "tool_whitelist": ["update_node", "update_task_status", "get_node", "search_nodes", "search_semantic"],
+                "tool_whitelist": ["update_node", "update_task_status", "get_node", "search_nodes", "search_semantic", "resolve_query"],
                 "max_iterations": 3,
             }),
             child_node_type: Some("prompt".to_string()),

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -122,7 +122,7 @@ fn graph_editing_guidance() -> String {
 
 When updating an existing node:
 
-FIND THEN UPDATE: {find_then_act} Then call update_node with the ID and only the fields that need changing.
+FIND THEN UPDATE: {find_then_act} Then call update_node with the ID and only the fields that need changing. Exception: see INDIRECT TARGET below when the target is not named directly.
 
 INDIRECT TARGET: If the request identifies the target indirectly — a bare value without naming its field (an amount, a code), a relative date or status word (a weekday, "overdue", "recent"), or a paraphrased description — call resolve_query(request=<the request verbatim>, node_type) FIRST instead of hand-writing a search_nodes query yourself, then pass its returned query and filters directly into search_nodes.
 


### PR DESCRIPTION
Closes #1820