### PR TITLE
Implement ADR-038 Stage-1 and Stage-2 gates; replace the rejected single-turn pull

### DIFF
--- a/packages/agent/src/agent_guidance.rs
+++ b/packages/agent/src/agent_guidance.rs
@@ -18,9 +18,9 @@
 /// `skill_pipeline.rs` (used only by the skill-based schema-creation path) and
 /// should be consolidated here when that path is unified.
 pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built-in types: task, text, date. Custom types need a schema first (create_schema). Once a schema exists, create instances with create_node(node_type=<schema_id>). Never call create_schema for a type already in RELEVANT ENTITY TYPES.\n\
-    \"DATABASE\" = SCHEMA: A request to start tracking a kind of thing — worded as a database, a tracker, a list, or \"track X\" — means call create_schema IMMEDIATELY: no confirmation, no search_skills, no planning text. Name the schema after the single entity being tracked, in singular form, stripped of the tracking wording itself.\n\
-    INSTANCE vs TYPE: A request that supplies the particulars of ONE record — a name, an amount, a title, a date — asks for an INSTANCE of a type that already exists, not a new type. Call search_skills, then create_node(node_type=<id from RELEVANT ENTITY TYPES>, ...) with those particulars as properties. Never ask for confirmation — just execute. Only a request to start tracking a KIND of thing calls for create_schema.\n\
-    NO CONFIRMATION FOR KNOWN TYPES: If a type appears in RELEVANT ENTITY TYPES, you have all the information you need. Do NOT say \"Could you confirm\" or \"I want to make sure\" or \"Would you like me to\" — just call search_skills then create_node immediately. Confirmation is NEVER required when the schema already exists.\n\
+    \"DATABASE\" = SCHEMA: A request to start tracking a kind of thing — worded as a database, a tracker, a list, or \"track X\" — means call create_schema IMMEDIATELY: no confirmation, no planning text. Name the schema after the single entity being tracked, in singular form, stripped of the tracking wording itself.\n\
+    INSTANCE vs TYPE: A request that supplies the particulars of ONE record — a name, an amount, a title, a date — asks for an INSTANCE of a type that already exists, not a new type. Call create_node(node_type=<id from RELEVANT ENTITY TYPES>, ...) with those particulars as properties. Never ask for confirmation — just execute. Only a request to start tracking a KIND of thing calls for create_schema.\n\
+    NO CONFIRMATION FOR KNOWN TYPES: If a type appears in RELEVANT ENTITY TYPES, you have all the information you need. Do NOT say \"Could you confirm\" or \"I want to make sure\" or \"Would you like me to\" — just call create_node immediately. Confirmation is NEVER required when the schema already exists.\n\
     SCHEMA SUCCESS/FAILURE: After create_schema returns a schema object, respond to the user and STOP — do NOT call create_schema again. If create_schema returns an \"already exists\" error, stop immediately and tell the user the type already exists.\n\
     TITLE TEMPLATE: Every {field_name} in title_template MUST appear in the fields array. If you want {invoice_number} in a template, you MUST add a field named invoice_number. Never reference a placeholder that is not in fields — this causes a validation error.\n\
     FIELD RULES: Every field object MUST have both \"name\" AND \"type\". Missing either causes a validation error that will never self-correct — stop retrying and fix the field. Valid: {\"name\":\"amount\",\"type\":\"number\",\"required\":true}.";
@@ -31,8 +31,8 @@ pub const SCHEMA_CREATION_RULES: &str = "NODE MODEL: Everything is a node. Built
 /// identity and policy, nothing else). Argument shape (node_type provenance)
 /// now lives on the relevant tool schemas' parameter descriptions; per-operation
 /// tool-call routing now lives in each operation's skill instructions
-/// (`skill_pipeline.rs`) or is redundant with the model's own choice to reach
-/// a skill via `search_skills`; tool-usage reference facts (how search_nodes
+/// (`skill_pipeline.rs`), delivered by the two-stage routing pipeline
+/// (`local_agent/routing.rs`); tool-usage reference facts (how search_nodes
 /// filters work, when to prefer search_semantic, etc.) now live on the tools'
 /// own descriptions in `local_agent/tools.rs`.
 pub const TOOL_STRATEGY_RULES: &str = "TOOL STRATEGY:\n\

--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -587,6 +587,18 @@ pub trait AgentToolExecutor: Send + Sync {
     /// Execute a tool by name with the given JSON arguments.
     async fn execute(&self, name: &str, args: serde_json::Value) -> Result<ToolResult, ToolError>;
 
+    /// Whether skill retrieval is wired up and worth spending a routing turn on.
+    ///
+    /// Stage 1 costs a full model generation, so the loop asks first: with no
+    /// retrieval behind it there are no candidates to judge and the query it
+    /// produces goes nowhere. Executors that do not implement
+    /// [`AgentToolExecutor::retrieve_skills`] inherit `false` here and keep the
+    /// single-turn behaviour, which is also what keeps routing out of the way
+    /// of test doubles that never opted into it.
+    async fn routing_available(&self) -> bool {
+        false
+    }
+
     /// Run semantic retrieval over the skill registry as a **deterministic
     /// system step**, returning at most `limit` candidates.
     ///

--- a/packages/agent/src/agent_types.rs
+++ b/packages/agent/src/agent_types.rs
@@ -543,6 +543,39 @@ pub trait ModelManager: Send + Sync {
     async fn recommended_model(&self) -> Result<String, ModelError>;
 }
 
+/// A skill candidate returned by the deterministic retrieval step.
+///
+/// Produced by [`AgentToolExecutor::retrieve_skills`], not by a model tool
+/// call. ADR-038 keeps retrieval out of the model's hands so the system can
+/// bound the candidate count and apply the trust filter; this struct is what
+/// crosses that boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillCandidate {
+    /// Node id of the matched skill.
+    pub id: String,
+    /// Skill name (the node's content).
+    pub name: String,
+    /// The skill's `description` property — the index key retrieval matched on.
+    pub description: String,
+    /// Raw retrieval score. The mechanical half of the Stage-2 gate; the
+    /// model's judgment is the other, independently-sourced half.
+    pub score: f32,
+    /// Tools this skill is permitted to fire. Also the source of the skill's
+    /// blast radius — see [`SkillCandidate::is_mutating`].
+    pub tools: Vec<String>,
+    /// The skill's full instruction subtree, rendered to markdown.
+    pub instructions: String,
+    /// Schema metadata scoped to this skill, as returned by retrieval.
+    pub schema_metadata: serde_json::Value,
+}
+
+/// Outcome of the deterministic retrieval step.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SkillRetrieval {
+    /// Candidates, highest score first, already truncated to the bounded K.
+    pub candidates: Vec<SkillCandidate>,
+}
+
 /// Executor for agent tools (function calling).
 ///
 /// Each tool is identified by name and accepts/returns JSON values.
@@ -553,4 +586,25 @@ pub trait AgentToolExecutor: Send + Sync {
 
     /// Execute a tool by name with the given JSON arguments.
     async fn execute(&self, name: &str, args: serde_json::Value) -> Result<ToolResult, ToolError>;
+
+    /// Run semantic retrieval over the skill registry as a **deterministic
+    /// system step**, returning at most `limit` candidates.
+    ///
+    /// This is deliberately not a model-facing tool. ADR-038 rejects the
+    /// single-turn pull (the model calling retrieval itself) because it
+    /// "removes the system's ability to bound K and enforce the trust
+    /// boundary" — both of which happen here instead.
+    ///
+    /// The default returns no candidates, which the agent loop treats as the
+    /// documented degraded path: with nothing retrieved there is nothing for
+    /// Stage-2 to judge, so the turn proceeds on the general tool surface
+    /// rather than failing. Test doubles that do not exercise routing inherit
+    /// this and need no implementation.
+    async fn retrieve_skills(
+        &self,
+        _query: &str,
+        _limit: usize,
+    ) -> Result<SkillRetrieval, ToolError> {
+        Ok(SkillRetrieval::default())
+    }
 }

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -521,6 +521,10 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         // every failure path inside returns "no candidates", which leaves the
         // turn running on the full tool surface rather than costing the user
         // their request.
+        // Stage 1 runs a generation, so the turn is already working from the
+        // caller's point of view — announce it before the routing turn rather
+        // than leaving the UI idle through it.
+        on_status(LocalAgentStatus::Thinking);
         let routed = self.route(session, user_message, &turn_cx, &cancel).await;
 
         if let Some(clarification) = routed.clarification {
@@ -5560,6 +5564,56 @@ mod tests {
         assert!(
             queries.lock().unwrap().is_empty(),
             "a clarification must not trigger retrieval"
+        );
+    }
+
+    #[tokio::test]
+    async fn clarification_still_reports_thinking_then_idle() {
+        // A clarification returns early, but the caller must still see the
+        // normal status arc — a reply with no preceding Thinking would leave a
+        // UI showing idle while the routing turn is generating.
+        let engine = MockEngine::new(vec![vec![
+            StreamingChunk::ToolCallStart {
+                id: "r1".into(),
+                name: routing::ROUTE_CLARIFY_TOOL.into(),
+            },
+            StreamingChunk::ToolCallArgs {
+                id: "r1".into(),
+                args_json: json!({"question": "Which one?", "options": ["A", "B"]}).to_string(),
+            },
+            StreamingChunk::Done {
+                usage: InferenceUsage {
+                    prompt_tokens: 8,
+                    completion_tokens: 4,
+                },
+            },
+        ]]);
+        let statuses = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = statuses.clone();
+        let loop_ = LocalAgentLoop::new(
+            Arc::new(engine),
+            Arc::new(RoutingToolExecutor::new(MockToolExecutor::new(), vec![])),
+        );
+        let mut session = new_session();
+        loop_
+            .run_turn(
+                &mut session,
+                "something ambiguous",
+                move |s| sink.lock().unwrap().push(format!("{s:?}")),
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let seen = statuses.lock().unwrap().clone();
+        assert!(
+            seen.iter().any(|s| s.contains("Thinking")),
+            "expected a Thinking status before the clarification: {seen:?}"
+        );
+        assert!(
+            seen.last().is_some_and(|s| s.contains("Idle")),
+            "turn must end Idle: {seen:?}"
         );
     }
 

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -632,10 +632,10 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         // model can burn every iteration without executing a single tool. Reset
         // on any successful parse, so only an unbroken run trips it.
         let mut consecutive_parse_failures = 0usize;
-        let mut total_usage = InferenceUsage {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-        };
+        // Seeded with the Stage-1 routing turn's usage: it is part of what this
+        // turn cost, and reporting only the Stage-2 tokens would hide the price
+        // of the extra turn from everything that reads this figure.
+        let mut total_usage = routed.usage;
 
         // ReAct loop: iterate up to effective_max_iterations (skill-specific or global fallback)
         for iteration in 0..effective_max_iterations {
@@ -5313,5 +5313,410 @@ mod tests {
             !calls.lock().unwrap().iter().any(|c| c == "create_node"),
             "an empty-args repeat must still be recognised as the same call"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Two-stage routing (ADR-038)
+    // -----------------------------------------------------------------------
+
+    use crate::agent_types::SkillCandidate;
+
+    /// A tool executor with skill retrieval wired up, so the loop takes the
+    /// two-stage path instead of the single-turn fallback.
+    struct RoutingToolExecutor {
+        inner: MockToolExecutor,
+        candidates: Vec<SkillCandidate>,
+        /// Queries retrieval was actually asked for, so a test can assert the
+        /// system — not the model — issued the retrieval.
+        queries: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl RoutingToolExecutor {
+        fn new(inner: MockToolExecutor, candidates: Vec<SkillCandidate>) -> Self {
+            Self {
+                inner,
+                candidates,
+                queries: Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn queries_handle(&self) -> Arc<std::sync::Mutex<Vec<String>>> {
+            self.queries.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AgentToolExecutor for RoutingToolExecutor {
+        async fn available_tools(&self) -> Result<Vec<ToolDefinition>, ToolError> {
+            self.inner.available_tools().await
+        }
+        async fn execute(
+            &self,
+            name: &str,
+            args: serde_json::Value,
+        ) -> Result<ToolResult, ToolError> {
+            self.inner.execute(name, args).await
+        }
+        async fn routing_available(&self) -> bool {
+            true
+        }
+        async fn retrieve_skills(
+            &self,
+            query: &str,
+            limit: usize,
+        ) -> Result<crate::agent_types::SkillRetrieval, ToolError> {
+            self.queries.lock().unwrap().push(query.to_string());
+            let mut c = self.candidates.clone();
+            c.truncate(limit);
+            Ok(crate::agent_types::SkillRetrieval { candidates: c })
+        }
+    }
+
+    fn skill_candidate(name: &str, score: f32, tools: &[&str]) -> SkillCandidate {
+        SkillCandidate {
+            id: format!("skill-{name}"),
+            name: name.to_string(),
+            description: format!("Use this to {name}"),
+            score,
+            tools: tools.iter().map(|t| t.to_string()).collect(),
+            instructions: format!("INSTRUCTIONS FOR {name}"),
+            schema_metadata: json!([]),
+        }
+    }
+
+    /// A model that calls `route_query` at Stage 1, then the given tool.
+    fn routed_engine(query: &str, tool_name: &str, tool_args: &str, final_text: &str) -> MockEngine {
+        MockEngine::new(vec![
+            // Stage 1: the structural choice, expressed as a tool call.
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "r1".into(),
+                    name: routing::ROUTE_QUERY_TOOL.into(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "r1".into(),
+                    args_json: json!({ "query": query }).to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 8,
+                        completion_tokens: 4,
+                    },
+                },
+            ],
+            // Stage 2: act on the judged candidate.
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "t1".into(),
+                    name: tool_name.into(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "t1".into(),
+                    args_json: tool_args.into(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 20,
+                        completion_tokens: 10,
+                    },
+                },
+            ],
+            vec![
+                StreamingChunk::Token {
+                    text: final_text.into(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 30,
+                        completion_tokens: 12,
+                    },
+                },
+            ],
+        ])
+    }
+
+    #[tokio::test]
+    async fn retrieval_runs_as_a_system_step_on_stage1s_query() {
+        // ADR-038: retrieval is a deterministic system step, not a model tool
+        // call. The model supplies the query; the system issues the retrieval.
+        let engine = routed_engine(
+            "create a schema",
+            "search_nodes",
+            r#"{"query":"x"}"#,
+            "Done.",
+        );
+        let exec = RoutingToolExecutor::new(
+            MockToolExecutor::new(),
+            vec![skill_candidate("research", 0.9, &["search_nodes"])],
+        );
+        let queries = exec.queries_handle();
+        let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
+        let mut session = new_session();
+        loop_
+            .run_turn(
+                &mut session,
+                "find my billing notes",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            queries.lock().unwrap().as_slice(),
+            &["create a schema".to_string()],
+            "the system must issue exactly one retrieval, on Stage 1's query"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage2_tool_surface_is_scoped_to_the_matched_skill() {
+        // The matched skill is read-only, so a destructive tool must not be in
+        // reach even though the executor registers one.
+        let engine = routed_engine("find notes", "search_nodes", r#"{"query":"x"}"#, "Done.");
+        let inner = MockToolExecutor::new().with_tool(
+            "delete_node",
+            json!({"type": "object", "properties": {"id": {"type": "string"}}}),
+            json!({"deleted": true}),
+        );
+        let exec = RoutingToolExecutor::new(
+            inner,
+            vec![skill_candidate("research", 0.9, &["search_nodes", "get_node"])],
+        );
+        let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
+        let mut session = new_session();
+        let result = loop_
+            .run_turn(
+                &mut session,
+                "find my billing notes",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
+    }
+
+    #[tokio::test]
+    async fn a_mutating_skill_below_its_bar_is_not_offered() {
+        // Identical score, different verdict: 0.2 clears the read bar but not
+        // the mutating one, so this candidate is never rendered or actioned.
+        let cands = vec![skill_candidate("deletion", 0.2, &["delete_node"])];
+        assert!(routing::render_candidates_for_prompt(&cands).is_none());
+    }
+
+    #[tokio::test]
+    async fn stage1_clarify_answers_the_user_without_running_stage2() {
+        let engine = MockEngine::new(vec![vec![
+            StreamingChunk::ToolCallStart {
+                id: "r1".into(),
+                name: routing::ROUTE_CLARIFY_TOOL.into(),
+            },
+            StreamingChunk::ToolCallArgs {
+                id: "r1".into(),
+                args_json: json!({
+                    "question": "Did you want to track debts or search notes?",
+                    "options": ["Track who owes me money", "Search existing notes"]
+                })
+                .to_string(),
+            },
+            StreamingChunk::Done {
+                usage: InferenceUsage {
+                    prompt_tokens: 8,
+                    completion_tokens: 4,
+                },
+            },
+        ]]);
+        let exec = RoutingToolExecutor::new(MockToolExecutor::new(), vec![]);
+        let queries = exec.queries_handle();
+        let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
+        let mut session = new_session();
+        let result = loop_
+            .run_turn(
+                &mut session,
+                "keep tabs on who owes me money",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.tool_calls_made.is_empty());
+        // Specific, with the concrete options — not a bare "what do you mean?".
+        assert!(result.response.contains("Track who owes me money"));
+        assert!(result.response.contains("Search existing notes"));
+        assert!(
+            queries.lock().unwrap().is_empty(),
+            "a clarification must not trigger retrieval"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_second_clarification_for_one_intent_falls_through_to_retrieval() {
+        // The contract: at most one clarification per intent. On the turn after
+        // the user answered one, Stage 1 asking again must be suppressed and
+        // the turn must retrieve on the raw message instead.
+        let engine = MockEngine::new(vec![
+            vec![
+                StreamingChunk::ToolCallStart {
+                    id: "r1".into(),
+                    name: routing::ROUTE_CLARIFY_TOOL.into(),
+                },
+                StreamingChunk::ToolCallArgs {
+                    id: "r1".into(),
+                    args_json: json!({"question": "Which one?", "options": ["A", "B"]})
+                        .to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 8,
+                        completion_tokens: 4,
+                    },
+                },
+            ],
+            vec![
+                StreamingChunk::Token {
+                    text: "Here is what I found.".to_string(),
+                },
+                StreamingChunk::Done {
+                    usage: InferenceUsage {
+                        prompt_tokens: 20,
+                        completion_tokens: 8,
+                    },
+                },
+            ],
+        ]);
+        let exec = RoutingToolExecutor::new(
+            MockToolExecutor::new(),
+            vec![skill_candidate("research", 0.9, &["search_nodes"])],
+        );
+        let queries = exec.queries_handle();
+        let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
+
+        let mut session = new_session();
+        // A prior clarification the user has already answered.
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            format!("{CLARIFICATION_OPENER}. Which one?"),
+        ));
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "the first one".to_string()));
+
+        let result = loop_
+            .run_turn(
+                &mut session,
+                "the first one",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !result.response.starts_with(CLARIFICATION_OPENER),
+            "never clarify twice for one intent: {:?}",
+            result.response
+        );
+        assert_eq!(
+            queries.lock().unwrap().len(),
+            1,
+            "the suppressed clarification must fall through to retrieval"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unanswered_clarification_is_not_treated_as_already_clarified() {
+        // The clarification we just asked and are still waiting on is not a
+        // prior one — otherwise a single clarification would disable the
+        // mechanism for the rest of the conversation.
+        let mut session = new_session();
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            format!("{CLARIFICATION_OPENER}. Which one?"),
+        ));
+        assert!(!session_already_clarified(&session));
+
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "the first".to_string()));
+        assert!(session_already_clarified(&session));
+    }
+
+    #[tokio::test]
+    async fn routing_failure_leaves_the_turn_on_the_full_tool_surface() {
+        // Retrieval is best-effort: losing it must not cost the user the turn.
+        struct FailingRetrieval(MockToolExecutor);
+        #[async_trait::async_trait]
+        impl AgentToolExecutor for FailingRetrieval {
+            async fn available_tools(&self) -> Result<Vec<ToolDefinition>, ToolError> {
+                self.0.available_tools().await
+            }
+            async fn execute(
+                &self,
+                name: &str,
+                args: serde_json::Value,
+            ) -> Result<ToolResult, ToolError> {
+                self.0.execute(name, args).await
+            }
+            async fn routing_available(&self) -> bool {
+                true
+            }
+            async fn retrieve_skills(
+                &self,
+                _q: &str,
+                _l: usize,
+            ) -> Result<crate::agent_types::SkillRetrieval, ToolError> {
+                Err(ToolError::ExecutionFailed("embedding down".into()))
+            }
+        }
+
+        let engine = routed_engine("find notes", "search_nodes", r#"{"query":"x"}"#, "Done.");
+        let loop_ = LocalAgentLoop::new(
+            Arc::new(engine),
+            Arc::new(FailingRetrieval(MockToolExecutor::new())),
+        );
+        let mut session = new_session();
+        let result = loop_
+            .run_turn(
+                &mut session,
+                "find my notes",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
+        assert_eq!(result.response, "Done.");
+    }
+
+    #[tokio::test]
+    async fn stage1_usage_is_included_in_the_turns_reported_total() {
+        // The routing turn spends tokens; under-reporting them would hide the
+        // cost of the extra turn from every consumer of the usage figure.
+        let engine = routed_engine("find notes", "search_nodes", r#"{"query":"x"}"#, "Done.");
+        let exec = RoutingToolExecutor::new(
+            MockToolExecutor::new(),
+            vec![skill_candidate("research", 0.9, &["search_nodes"])],
+        );
+        let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
+        let mut session = new_session();
+        let result = loop_
+            .run_turn(
+                &mut session,
+                "find my notes",
+                |_| {},
+                |_| {},
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        // 8 (stage 1) + 20 + 30 from the scripted responses.
+        assert_eq!(result.usage.prompt_tokens, 58);
     }
 }

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -2002,8 +2002,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     // Compile-time coupling check: `multi_skill_turn_invokes_skill_tools_between_searches`
-    // feeds exactly 5 inference rounds (search_skills → search_semantic →
-    // search_skills → create_node → final text) and expects the loop to make
+    // feeds exactly 5 inference rounds (search_nodes → search_semantic →
+    // search_nodes → create_node → final text) and expects the loop to make
     // it through all of them without hitting the iteration-cap fallback.
     // If `MAX_TOOL_ITERATIONS` is ever reduced below 5, that test would
     // silently start asserting on the fallback path instead of the multi-skill
@@ -3599,22 +3599,22 @@ mod tests {
         assert_eq!(sessions.len(), 1);
     }
 
-    // -- search_skills as a regular tool ---------------------------------
+    // -- multi-round tool dispatch ---------------------------------------
 
-    /// The model decides when to search for skills by calling
-    /// the `search_skills` tool, then invokes a matching skill (if any) like
-    /// any other tool. There's no pre-LLM dispatch — the loop always runs the
-    /// full tool set against the model.
+    /// A read followed by a write in one turn dispatches both correctly and
+    /// preserves their order. Uses `search_nodes` as the leading read; the
+    /// property under test is the loop's round-to-round dispatch, independent
+    /// of which tool leads.
     #[tokio::test]
-    async fn model_calls_search_skills_then_invokes_matched_skill() {
-        // Round 1: model calls search_skills
-        // Round 2: model invokes create_node (a "skill" tool) after seeing the match
+    async fn model_chains_a_read_then_a_write_in_one_turn() {
+        // Round 1: model calls search_nodes
+        // Round 2: model invokes create_node after seeing the result
         // Round 3: model produces a text summary
         let engine = Arc::new(MockEngine::new(vec![
             vec![
                 StreamingChunk::ToolCallStart {
                     id: "tc_1".to_string(),
-                    name: "search_skills".to_string(),
+                    name: "search_nodes".to_string(),
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "tc_1".to_string(),
@@ -3658,7 +3658,7 @@ mod tests {
 
         let executor = MockToolExecutor::new()
             .with_tool(
-                "search_skills",
+                "search_nodes",
                 json!({"type": "object"}),
                 json!({
                     "query": "create a new task",
@@ -3689,14 +3689,14 @@ mod tests {
 
         assert_eq!(result.response, "Created the task.");
         assert_eq!(result.tool_calls_made.len(), 2);
-        assert_eq!(result.tool_calls_made[0].name, "search_skills");
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
         assert_eq!(result.tool_calls_made[1].name, "create_node");
     }
 
-    /// Regression coverage: `update_node` must remain reachable through
-    /// `search_skills` -> Graph Editing's own routing (`search_nodes` then
-    /// `update_node`) now that `TOOL_STRATEGY_RULES` no longer hardcodes
-    /// "ALWAYS search_nodes first before update_node" in resident prose.
+    /// Regression coverage: `update_node` must remain reachable through a
+    /// find-then-act chain (`search_nodes` then `update_node`) now that
+    /// `TOOL_STRATEGY_RULES` no longer hardcodes "ALWAYS search_nodes first
+    /// before update_node" in resident prose.
     ///
     /// This scripts the full chain a real model is expected to follow and
     /// asserts the loop dispatches every step correctly against a scripted
@@ -3709,12 +3709,12 @@ mod tests {
     /// (`scripts/eval/fixtures/agent-matrix.ts`), which is not run as part
     /// of `test:all`.
     #[tokio::test]
-    async fn search_skills_then_search_nodes_then_update_node_chain_dispatches_correctly() {
+    async fn find_then_act_chain_dispatches_correctly() {
         let engine = Arc::new(MockEngine::new(vec![
             vec![
                 StreamingChunk::ToolCallStart {
                     id: "tc_1".to_string(),
-                    name: "search_skills".to_string(),
+                    name: "search_nodes".to_string(),
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "tc_1".to_string(),
@@ -3774,7 +3774,7 @@ mod tests {
 
         let executor = MockToolExecutor::new()
             .with_tool(
-                "search_skills",
+                "search_nodes",
                 json!({"type": "object"}),
                 json!({
                     "query": "mark an invoice as paid",
@@ -3811,7 +3811,7 @@ mod tests {
 
         assert_eq!(result.response, "Marked the invoice as paid.");
         assert_eq!(result.tool_calls_made.len(), 3);
-        assert_eq!(result.tool_calls_made[0].name, "search_skills");
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
         assert_eq!(result.tool_calls_made[1].name, "search_nodes");
         assert_eq!(result.tool_calls_made[2].name, "update_node");
     }
@@ -3819,7 +3819,7 @@ mod tests {
     /// When the model decides no skill is needed, it responds directly —
     /// no clarification short-circuit, no canned string.
     #[tokio::test]
-    async fn model_can_respond_without_calling_search_skills() {
+    async fn model_can_respond_without_calling_any_tool() {
         let engine = Arc::new(MockEngine::single_text("Hi there — how can I help?"));
         let executor = Arc::new(MockToolExecutor::new());
         let agent_loop = LocalAgentLoop::new(engine, executor);
@@ -3836,20 +3836,20 @@ mod tests {
         assert!(result.usage.prompt_tokens > 0);
     }
 
-    /// Multi-skill turn: the model calls `search_skills`
+    /// Multi-skill turn: the model calls a read tool
     /// for each sub-task, then invokes the matched skill's tool. This test
-    /// exercises a full chain — search_skills (notes) → search_semantic →
-    /// search_skills (task) → create_node — not just two back-to-back
+    /// exercises a full chain — search_nodes (notes) → search_semantic →
+    /// search_nodes (task) → create_node — not just two back-to-back
     /// searches, so a regression that breaks tool dispatch after a second
-    /// `search_skills` call is caught here.
+    /// tool call is caught here.
     #[tokio::test]
     async fn multi_skill_turn_invokes_skill_tools_between_searches() {
         let engine = Arc::new(MockEngine::new(vec![
-            // Round 1: search_skills for "find notes"
+            // Round 1: search_nodes for "find notes"
             vec![
                 StreamingChunk::ToolCallStart {
                     id: "tc_1".to_string(),
-                    name: "search_skills".to_string(),
+                    name: "search_nodes".to_string(),
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "tc_1".to_string(),
@@ -3879,11 +3879,11 @@ mod tests {
                     },
                 },
             ],
-            // Round 3: search_skills for "create task"
+            // Round 3: search_nodes for "create task"
             vec![
                 StreamingChunk::ToolCallStart {
                     id: "tc_3".to_string(),
-                    name: "search_skills".to_string(),
+                    name: "search_nodes".to_string(),
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "tc_3".to_string(),
@@ -3929,7 +3929,7 @@ mod tests {
 
         let executor = MockToolExecutor::new()
             .with_tool(
-                "search_skills",
+                "search_nodes",
                 json!({"type": "object"}),
                 // Same canned response works for both calls; in production
                 // the embeddings would distinguish them, but the agent loop
@@ -3979,9 +3979,9 @@ mod tests {
             "{:?}",
             result.tool_calls_made
         );
-        assert_eq!(result.tool_calls_made[0].name, "search_skills");
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
         assert_eq!(result.tool_calls_made[1].name, "search_semantic");
-        assert_eq!(result.tool_calls_made[2].name, "search_skills");
+        assert_eq!(result.tool_calls_made[2].name, "search_nodes");
         assert_eq!(result.tool_calls_made[3].name, "create_node");
         assert_eq!(
             result.response,
@@ -3989,18 +3989,18 @@ mod tests {
         );
     }
 
-    /// Empty `search_skills` matches → model judges and produces a contextual
+    /// An empty tool result → model judges and produces a contextual
     /// clarification (referencing what it searched), rather than the prior
     /// hardcoded `CLARIFYING_QUESTION` string. This is the "no relevant skill"
     /// path.
     #[tokio::test]
-    async fn empty_search_skills_matches_let_model_clarify_with_context() {
+    async fn empty_tool_result_lets_the_model_clarify_with_context() {
         let engine = Arc::new(MockEngine::new(vec![
-            // Round 1: model calls search_skills
+            // Round 1: model calls a read tool
             vec![
                 StreamingChunk::ToolCallStart {
                     id: "tc_1".to_string(),
-                    name: "search_skills".to_string(),
+                    name: "search_nodes".to_string(),
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "tc_1".to_string(),
@@ -4030,7 +4030,7 @@ mod tests {
         ]));
 
         let executor = MockToolExecutor::new().with_tool(
-            "search_skills",
+            "search_nodes",
             json!({"type": "object"}),
             // Empty matches array — the meaningful "no skill applies" signal.
             json!({"query": "send carrier pigeons", "matches": []}),
@@ -4050,7 +4050,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.tool_calls_made.len(), 1);
-        assert_eq!(result.tool_calls_made[0].name, "search_skills");
+        assert_eq!(result.tool_calls_made[0].name, "search_nodes");
         // Crucially: the response is the model's contextual text, not a
         // canned constant. Just check it's non-empty and acknowledges the
         // search — exact wording belongs to the model.

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -22,6 +22,7 @@ use crate::agent_types::{
 use crate::local_agent::otlp_tracer::TRACER_NAME;
 use crate::local_agent::prompt_templates;
 use crate::local_agent::response_processing::{normalize_response, normalize_response_traced};
+use crate::local_agent::routing::{self, RouteDecision};
 use crate::local_agent::tools::is_cross_turn_guarded_tool;
 use crate::prompt_assembler::{PromptAssembler, TemplateContext, EMERGENCY_FALLBACK_PROMPT};
 
@@ -39,6 +40,37 @@ const MAX_TOOL_ITERATIONS: usize = 5;
 /// recovery and observed in practice, so tripping on the first would abort turns
 /// that were about to succeed.
 const MAX_CONSECUTIVE_PARSE_FAILURES: usize = 2;
+
+/// Token ceiling for the Stage-1 routing turn.
+///
+/// Stage 1 emits one short tool call — a search query, or a question with a
+/// couple of options — and nothing else. A tight ceiling bounds the latency
+/// the extra turn adds and gives a runaway generation nowhere to go.
+const STAGE1_MAX_TOKENS: u32 = 256;
+
+/// The Stage-1 system prompt.
+///
+/// Deliberately small. Stage 1 makes one structural choice and the two tool
+/// schemas carry the shape of that choice, so prose here would duplicate the
+/// channel that already decides it — the failure ADR-064 rule 5 names. It says
+/// who to be, what the single decision is, and that clarifying is the
+/// exception.
+const STAGE1_SYSTEM_PROMPT: &str = "You are routing a user's request to the right capability.\n\
+    Call route_query with a short description of the capability the request needs.\n\
+    Call route_clarify ONLY if the request is too ambiguous to describe at all.\n\
+    Prefer route_query: most requests can be described even when phrased indirectly.\n\
+    Call exactly one tool. Do not answer the user.";
+
+/// Opening phrase of a routing clarification.
+///
+/// The session is rebuilt from persisted messages every turn, so the
+/// clarification contract ("at most one per intent") cannot rely on in-memory
+/// state — whether we already clarified has to be answerable from the history
+/// alone. Clarifications are composed here and always open with this phrase,
+/// so their own text is the record. Matching on text is imprecise in general,
+/// but it is exact for strings this module wrote itself, and it avoids
+/// widening the persisted session shape for one boolean.
+const CLARIFICATION_OPENER: &str = "I can take that a couple of ways";
 
 /// Longest canonical-args string stored verbatim as a completed write's identity.
 ///
@@ -205,6 +237,70 @@ const CONFIRMATION_REQUEST: &str =
 
 fn session_prompt_override(session: &AgentSession) -> Option<&str> {
     session.system_prompt_override.as_deref()
+}
+
+/// What Stage 1 and the retrieval step produced for Stage 2 to work with.
+#[derive(Default)]
+struct RoutingOutcome {
+    /// Candidates for Stage 2 to judge. Empty means routing produced nothing —
+    /// whether because retrieval was unavailable, matched nothing, or failed —
+    /// and the turn runs on the full tool surface.
+    candidates: Vec<crate::agent_types::SkillCandidate>,
+    /// A composed clarification to return instead of running Stage 2. `Some`
+    /// only when Stage 1 asked to clarify *and* the contract allowed it.
+    clarification: Option<String>,
+    /// Tokens spent on the Stage-1 turn, so the turn's reported usage covers
+    /// the whole two-stage flow rather than under-reporting it.
+    usage: InferenceUsage,
+}
+
+/// Whether this conversation already asked the user to clarify.
+///
+/// Enforces ADR-038's "at most one clarification per intent": if the user
+/// answered a clarification and the request still cannot be routed, asking
+/// again is the loop the contract exists to prevent — the turn falls through
+/// to retrieval instead.
+///
+/// Scoped to the current intent by looking only at messages after the last
+/// *unclarified* user turn, so a clarification early in a long conversation
+/// does not permanently disable clarifying for every later request.
+fn session_already_clarified(session: &AgentSession) -> bool {
+    // The current intent starts at the clarification we last asked, if any:
+    // everything after it is the user answering that question. So the intent
+    // is "already clarified" exactly when a clarification exists and the user
+    // has since replied — which is the case the contract forbids repeating.
+    //
+    // A clarification with no user message after it is the one we just asked
+    // and are still waiting on, not a second attempt.
+    let last_clarification = session.messages.iter().rposition(|m| {
+        matches!(m.role, Role::Assistant) && m.content.starts_with(CLARIFICATION_OPENER)
+    });
+    match last_clarification {
+        Some(idx) => session.messages[idx + 1..]
+            .iter()
+            .any(|m| matches!(m.role, Role::User)),
+        None => false,
+    }
+}
+
+/// Compose a clarification from Stage 1's question and options.
+///
+/// ADR-038 requires clarification be *specific*: it surfaces the concrete
+/// candidates the model already produced, turning a dead end into a one-tap
+/// disambiguation. A bare "what do you mean?" is the failure mode to avoid,
+/// so the options are rendered as an explicit list when the model supplied
+/// them.
+fn format_clarification(question: &str, options: &[String]) -> String {
+    let usable: Vec<&String> = options.iter().filter(|o| !o.trim().is_empty()).collect();
+    if usable.is_empty() {
+        return format!("{CLARIFICATION_OPENER}. {question}");
+    }
+    let listed = usable
+        .iter()
+        .map(|o| format!("- {o}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{CLARIFICATION_OPENER}. {question}\n\n{listed}")
 }
 
 // ---------------------------------------------------------------------------
@@ -410,16 +506,48 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             .messages
             .push(ChatMessage::text(Role::User, user_message.to_string()));
 
-        // Full tool list including search_skills — the model calls search_skills
-        // itself to discover capabilities (ADR-036 pull model). No pre-filtering:
-        // the model receives all tools and judges which skill applies after retrieval.
-        // Degraded path: if embedding service is unavailable, search_skills returns
-        // an error result and the model falls through to general tools — acceptable.
-        let tools = self
+        // The model-facing tool surface. `search_skills` is deliberately absent:
+        // ADR-038 makes retrieval a deterministic system step (see `route`
+        // below) rather than a model tool call, because a model-issued
+        // retrieval lets the model set K and bypasses the trust filter.
+        let all_tools = self
             .tool_executor
             .available_tools()
             .await
             .unwrap_or_default();
+
+        // Stage 1 + deterministic retrieval. Yields the candidates Stage 2 will
+        // judge, or a clarification to put to the user. Routing is best-effort:
+        // every failure path inside returns "no candidates", which leaves the
+        // turn running on the full tool surface rather than costing the user
+        // their request.
+        let routed = self
+            .route(session, user_message, &turn_cx, &cancel)
+            .await;
+
+        if let Some(clarification) = routed.clarification {
+            // Stage 1 chose to clarify and the contract permits it. Answer with
+            // the question directly — no retrieval, no tool surface, no second
+            // model turn to paraphrase what the model already composed.
+            session.messages.push(ChatMessage::text(
+                Role::Assistant,
+                clarification.clone(),
+            ));
+            on_status(LocalAgentStatus::Idle);
+            return Ok(AgentTurnResult {
+                response: clarification,
+                reasoning: None,
+                tool_calls_made: Vec::new(),
+                usage: routed.usage,
+            });
+        }
+
+        // Stage 2's surface: scoped to what the eligible candidates permit, so
+        // the model judges among what retrieval surfaced and can only fire what
+        // the matched skills allow. Falls back to the full list when nothing
+        // was retrieved.
+        let tools = routing::stage2_tools(&routed.candidates, &all_tools);
+        let candidate_block = routing::render_candidates_for_prompt(&routed.candidates);
 
         let dynamic_ctx = session.dynamic_context.as_deref().unwrap_or("");
         let model_name = session.model_id.as_deref().unwrap_or("unknown");
@@ -434,7 +562,7 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         // the `testing` feature on the agent crate). Production inference always
         // wires a `PromptAssembler`; the emergency arm only fires for the
         // daemon's no-op/idle service, which never reaches live inference.
-        let system_content = if let Some(override_prompt) = session_prompt_override(session) {
+        let base_system_content = if let Some(override_prompt) = session_prompt_override(session) {
             override_prompt.to_string()
         } else if let Some(ref assembler) = self.prompt_assembler {
             assembler
@@ -443,6 +571,19 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
                 .system_prompt
         } else {
             EMERGENCY_FALLBACK_PROMPT.to_string()
+        };
+
+        // Stage 2 receives its candidates **in the prompt**, not as a tool
+        // result. ADR-064 rule 4 reserves tool results for resolved facts
+        // rather than procedures, and the measurement supporting skill
+        // instructions was taken on prompt-rendered text; the same payload
+        // returned as a tool result was observed to suppress tool-calling.
+        //
+        // This is the injection point where the KV-cache prefix diverges from
+        // Stage 1 — the cost ADR-038 accepts and requires be measured.
+        let system_content = match &candidate_block {
+            Some(block) => format!("{base_system_content}\n\n{block}"),
+            None => base_system_content,
         };
 
         // prompt_assembly child span: records full assembled system prompt and tools offered.
@@ -1287,6 +1428,155 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
     /// Reasoning chunks (the model's chain-of-thought, already separated from the
     /// answer at the nlp-engine parse layer) are accumulated independently of the
     /// answer text so the answer bubble stays clean.
+    /// Run Stage 1 and the deterministic retrieval step (ADR-038).
+    ///
+    /// Stage 1 asks the model for a *structural* choice — form a search query,
+    /// or ask to clarify — expressed as which of two typed tools it calls. A
+    /// tool schema is the strongest measured channel for structured output,
+    /// and using the tool-call path means there is no free text to parse and
+    /// so no parser failure to confuse with a model failure. ADR-038 rejects
+    /// gating on a self-reported confidence number, which a small model is not
+    /// calibrated to produce.
+    ///
+    /// Retrieval then runs here, in the system, rather than as a model tool
+    /// call — that is where K is bounded and the trust filter applies.
+    ///
+    /// Every failure path yields no candidates rather than an error: routing
+    /// is an optimisation over the general tool surface, and losing it must
+    /// not cost the user their turn.
+    async fn route(
+        &self,
+        session: &AgentSession,
+        user_message: &str,
+        turn_cx: &opentelemetry::Context,
+        cancel: &CancellationToken,
+    ) -> RoutingOutcome {
+        let tracer = opentelemetry::global::tracer(TRACER_NAME);
+        let mut span = tracer.start_with_context("stage1_routing", turn_cx);
+        let started = Instant::now();
+        let mut outcome = RoutingOutcome::default();
+
+        if cancel.is_cancelled() {
+            return outcome;
+        }
+
+        let stage1_tools = routing::stage1_tool_definitions();
+        let messages = vec![
+            ChatMessage::text(Role::System, STAGE1_SYSTEM_PROMPT.to_string()),
+            ChatMessage::text(Role::User, user_message.to_string()),
+        ];
+        let request = InferenceRequest {
+            messages,
+            tools: Some(stage1_tools),
+            temperature: Some(0.1),
+            max_tokens: Some(STAGE1_MAX_TOKENS),
+        };
+
+        let chunks: Arc<std::sync::Mutex<Vec<StreamingChunk>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = chunks.clone();
+        // Stage 1 is internal routing, not user-facing content: its chunks are
+        // collected here and deliberately not forwarded to `on_chunk`, so the
+        // user never sees the routing turn stream past.
+        let usage = match self
+            .engine
+            .generate(
+                request,
+                Box::new(move |c| {
+                    if let Ok(mut g) = sink.lock() {
+                        g.push(c);
+                    }
+                }),
+            )
+            .await
+        {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::warn!(error = %e, "stage-1 routing failed; continuing unrouted");
+                span.set_attribute(KeyValue::new("routing.failed", true));
+                return outcome;
+            }
+        };
+        outcome.usage = usage;
+
+        let collected = chunks.lock().map(|g| g.clone()).unwrap_or_default();
+        let (_, _, tool_calls) = Self::parse_chunks(&collected);
+        let decision = tool_calls
+            .iter()
+            .find_map(|tc| routing::parse_route_decision(&tc.function_name, &tc.arguments_json));
+
+        let query = match decision {
+            Some(RouteDecision::Query(q)) => {
+                span.set_attribute(KeyValue::new("routing.decision", "query"));
+                span.set_attribute(KeyValue::new("routing.query", q.clone()));
+                q
+            }
+            Some(RouteDecision::Clarify { question, options }) => {
+                // The clarification contract: at most one per intent. If the
+                // conversation already contains a clarification, asking again
+                // is the annoying-loop failure ADR-038 specifies against — fall
+                // through to retrieval on the raw message instead, so the turn
+                // resolves with whatever the general skill can offer.
+                if session_already_clarified(session) {
+                    span.set_attribute(KeyValue::new("routing.decision", "clarify_suppressed"));
+                    tracing::debug!(
+                        "stage-1 asked to clarify twice in one intent; falling through to retrieval"
+                    );
+                    user_message.to_string()
+                } else {
+                    span.set_attribute(KeyValue::new("routing.decision", "clarify"));
+                    outcome.clarification = Some(format_clarification(&question, &options));
+                    span.set_attribute(KeyValue::new(
+                        "routing.latency_ms",
+                        started.elapsed().as_millis() as i64,
+                    ));
+                    return outcome;
+                }
+            }
+            None => {
+                // The model called neither routing tool, or emitted arguments
+                // that would not parse. Retrieve on the raw message rather than
+                // abandoning routing: a weak query still beats none.
+                span.set_attribute(KeyValue::new("routing.decision", "none"));
+                user_message.to_string()
+            }
+        };
+
+        if cancel.is_cancelled() {
+            return outcome;
+        }
+
+        match self
+            .tool_executor
+            .retrieve_skills(&query, routing::RETRIEVAL_TOP_K)
+            .await
+        {
+            Ok(r) => {
+                span.set_attribute(KeyValue::new("routing.candidates", r.candidates.len() as i64));
+                span.set_attribute(KeyValue::new(
+                    "routing.top_score",
+                    r.candidates.first().map(|c| c.score).unwrap_or(0.0) as f64,
+                ));
+                outcome.candidates = r.candidates;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "skill retrieval failed; continuing unrouted");
+            }
+        }
+
+        // The latency ADR-038 requires be measured rather than assumed. Covers
+        // the Stage-1 generation plus the retrieval step — i.e. everything the
+        // two-stage flow adds ahead of the turn that previously ran alone.
+        let elapsed_ms = started.elapsed().as_millis() as i64;
+        span.set_attribute(KeyValue::new("routing.latency_ms", elapsed_ms));
+        tracing::info!(
+            routing_latency_ms = elapsed_ms,
+            candidates = outcome.candidates.len(),
+            "two-stage routing overhead"
+        );
+        outcome
+    }
+
     fn parse_chunks(chunks: &[StreamingChunk]) -> (String, String, Vec<ToolCallRaw>) {
         let mut text = String::new();
         let mut reasoning = String::new();

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -1451,14 +1451,24 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         turn_cx: &opentelemetry::Context,
         cancel: &CancellationToken,
     ) -> RoutingOutcome {
-        let tracer = opentelemetry::global::tracer(TRACER_NAME);
-        let mut span = tracer.start_with_context("stage1_routing", turn_cx);
-        let started = Instant::now();
         let mut outcome = RoutingOutcome::default();
 
         if cancel.is_cancelled() {
             return outcome;
         }
+
+        // Routing costs a model turn, so it only runs where it can pay for
+        // itself: when retrieval is actually wired up. Without it there are no
+        // candidates to judge, and Stage 1 would spend a full generation to
+        // produce a query nothing consumes. This also keeps every test double
+        // that does not opt into routing on the single-turn path.
+        if !self.tool_executor.routing_available().await {
+            return outcome;
+        }
+
+        let tracer = opentelemetry::global::tracer(TRACER_NAME);
+        let mut span = tracer.start_with_context("stage1_routing", turn_cx);
+        let started = Instant::now();
 
         let stage1_tools = routing::stage1_tool_definitions();
         let messages = vec![

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -254,6 +254,30 @@ struct RoutingOutcome {
     usage: InferenceUsage,
 }
 
+/// Build the message Stage 1 routes on: prior turns blended with the current one.
+///
+/// `run_turn` pushes the current user message into `session.messages` before
+/// routing, so the trailing entry is excluded here and supplied separately —
+/// blending it twice would double-weight it against the history it is meant to
+/// be read in light of.
+///
+/// Only user/assistant turns are blended, matching `schema_retrieval_query`:
+/// tool results are machine payloads whose vocabulary would dilute the query
+/// rather than sharpen it.
+fn stage1_query(session: &AgentSession, user_message: &str) -> String {
+    let prior = session
+        .messages
+        .split_last()
+        .map(|(_, rest)| rest)
+        .unwrap_or(&[]);
+    let prior_turns: Vec<&str> = prior
+        .iter()
+        .filter(|m| matches!(m.role, Role::User | Role::Assistant))
+        .map(|m| m.content.as_str())
+        .collect();
+    nodespace_core::ops::context_ops::build_retrieval_query(&prior_turns, user_message)
+}
+
 /// Whether this conversation already asked the user to clarify.
 ///
 /// Enforces ADR-038's "at most one clarification per intent": if the user
@@ -261,26 +285,42 @@ struct RoutingOutcome {
 /// again is the loop the contract exists to prevent — the turn falls through
 /// to retrieval instead.
 ///
-/// Scoped to the current intent by looking only at messages after the last
-/// *unclarified* user turn, so a clarification early in a long conversation
-/// does not permanently disable clarifying for every later request.
+/// Scoped to the **current intent**, not the whole conversation. ADR-038 says
+/// "at most one clarification per intent", and a conversation is many intents:
+/// a clarification answered twenty turns ago must not stop a genuinely new
+/// ambiguous request from being clarified today.
+///
+/// The intent boundary is an assistant turn that *answered* rather than asked:
+/// once the agent has resolved something and replied normally, whatever the
+/// user says next starts a fresh intent and the mechanism re-arms.
 fn session_already_clarified(session: &AgentSession) -> bool {
-    // The current intent starts at the clarification we last asked, if any:
-    // everything after it is the user answering that question. So the intent
-    // is "already clarified" exactly when a clarification exists and the user
-    // has since replied — which is the case the contract forbids repeating.
-    //
-    // A clarification with no user message after it is the one we just asked
-    // and are still waiting on, not a second attempt.
-    let last_clarification = session.messages.iter().rposition(|m| {
-        matches!(m.role, Role::Assistant) && m.content.starts_with(CLARIFICATION_OPENER)
-    });
-    match last_clarification {
-        Some(idx) => session.messages[idx + 1..]
-            .iter()
-            .any(|m| matches!(m.role, Role::User)),
-        None => false,
-    }
+    // Everything from the last resolved turn onward is the current intent.
+    // A clarification is not a resolution, so it does not close an intent —
+    // that is what lets the "already clarified" state survive the user's reply
+    // to it, while still clearing once the turn actually completes.
+    let intent_start = session
+        .messages
+        .iter()
+        .rposition(|m| {
+            matches!(m.role, Role::Assistant) && !m.content.starts_with(CLARIFICATION_OPENER)
+        })
+        .map_or(0, |idx| idx + 1);
+
+    let current_intent = &session.messages[intent_start..];
+
+    // Within this intent: did we ask, and has the user since replied? A
+    // clarification with no user message after it is the one we just asked and
+    // are still waiting on, not a second attempt.
+    current_intent
+        .iter()
+        .position(|m| {
+            matches!(m.role, Role::Assistant) && m.content.starts_with(CLARIFICATION_OPENER)
+        })
+        .is_some_and(|idx| {
+            current_intent[idx + 1..]
+                .iter()
+                .any(|m| matches!(m.role, Role::User))
+        })
 }
 
 /// Compose a clarification from Stage 1's question and options.
@@ -1468,23 +1508,47 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             return outcome;
         }
 
+        let tracer = opentelemetry::global::tracer(TRACER_NAME);
+
         // Routing costs a model turn, so it only runs where it can pay for
         // itself: when retrieval is actually wired up. Without it there are no
         // candidates to judge, and Stage 1 would spend a full generation to
         // produce a query nothing consumes. This also keeps every test double
         // that does not opt into routing on the single-turn path.
         if !self.tool_executor.routing_available().await {
+            // Say so in the trace. Routing availability is a live per-turn
+            // property — the embedding service loads in the background — so two
+            // identical messages in one session can take structurally different
+            // paths, and without this nothing distinguishes "routing off, model
+            // still warming" from "this executor never routes". An eval run
+            // started before the embedding service is ready would otherwise
+            // measure the unrouted path and blame routing quality for it.
+            let mut span = tracer.start_with_context("stage1_routing_skipped", turn_cx);
+            span.set_attribute(KeyValue::new("routing.available", false));
+            tracing::debug!("routing unavailable for this turn; running unrouted");
             return outcome;
         }
 
-        let tracer = opentelemetry::global::tracer(TRACER_NAME);
         let mut span = tracer.start_with_context("stage1_routing", turn_cx);
         let started = Instant::now();
 
         let stage1_tools = routing::stage1_tool_definitions();
+        // Blend the preceding turns into Stage 1's view, the same way schema
+        // retrieval does. A follow-up naming its subject only by pronoun or
+        // ellipsis ("mark it paid", "add another one") gives the model nothing
+        // to describe on its own, so it emits a weak query or asks to clarify
+        // a request the conversation had already disambiguated — and both fail
+        // silently, as worse routing rather than an error.
+        //
+        // This bites hardest right after a clarification: the answer to one is
+        // a short reply, i.e. the message with the least standalone routing
+        // signal, arriving on the turn that must succeed without clarifying
+        // again. Shares `build_retrieval_query` with schema retrieval so the
+        // two context constructions cannot drift apart.
+        let routing_query = stage1_query(session, user_message);
         let messages = vec![
             ChatMessage::text(Role::System, STAGE1_SYSTEM_PROMPT.to_string()),
-            ChatMessage::text(Role::User, user_message.to_string()),
+            ChatMessage::text(Role::User, routing_query),
         ];
         let request = InferenceRequest {
             messages,
@@ -5721,6 +5785,103 @@ mod tests {
             1,
             "the suppressed clarification must fall through to retrieval"
         );
+    }
+
+    #[tokio::test]
+    async fn the_clarification_contract_re_arms_on_a_new_intent() {
+        // ADR-038 scopes the contract "per intent", and a conversation is many
+        // intents. A clarification answered earlier must not stop a genuinely
+        // new ambiguous request from being clarified later.
+        let mut session = new_session();
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            format!("{CLARIFICATION_OPENER}. Which one?"),
+        ));
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "the first".to_string()));
+        assert!(
+            session_already_clarified(&session),
+            "still inside the clarified intent"
+        );
+
+        // The turn completes: the agent answers rather than asking again.
+        // That closes the intent.
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            "Done — I created it.".to_string(),
+        ));
+        session.messages.push(ChatMessage::text(
+            Role::User,
+            "now do the other thing".to_string(),
+        ));
+        assert!(
+            !session_already_clarified(&session),
+            "a resolved turn starts a new intent; clarifying must be possible again"
+        );
+    }
+
+    #[test]
+    fn a_composed_clarification_is_recognised_as_one() {
+        // Round-trip: the contract is carried in user-visible message text, so
+        // a rewording of `format_clarification` that broke the read would
+        // silently stop the contract enforcing. Tests that hand-build the
+        // marker from the constant would still pass; this one would not.
+        let mut session = new_session();
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            format_clarification("Which did you mean?", &["Track debts".to_string()]),
+        ));
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "the first".to_string()));
+        assert!(
+            session_already_clarified(&session),
+            "format_clarification output must be recognised by session_already_clarified"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage1_blends_prior_turns_into_its_query() {
+        // A follow-up naming its subject by pronoun gives the model nothing to
+        // describe on its own. The prior turns must reach Stage 1.
+        let mut session = new_session();
+        session.messages.push(ChatMessage::text(
+            Role::User,
+            "create an invoice for Acme".to_string(),
+        ));
+        session.messages.push(ChatMessage::text(
+            Role::Assistant,
+            "Created invoice INV-1 for Acme.".to_string(),
+        ));
+        // run_turn pushes the current message before routing; mirror that.
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "mark it paid".to_string()));
+
+        let q = stage1_query(&session, "mark it paid");
+        assert!(
+            q.contains("mark it paid"),
+            "current message must be present"
+        );
+        assert!(
+            q.contains("invoice"),
+            "prior turns must be blended so a pronoun-only follow-up still routes: {q:?}"
+        );
+        assert_eq!(
+            q.matches("mark it paid").count(),
+            1,
+            "the current message must not be blended twice: {q:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage1_query_on_a_first_turn_is_just_the_message() {
+        let mut session = new_session();
+        session
+            .messages
+            .push(ChatMessage::text(Role::User, "find my notes".to_string()));
+        assert_eq!(stage1_query(&session, "find my notes"), "find my notes");
     }
 
     #[tokio::test]

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -521,18 +521,15 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
         // every failure path inside returns "no candidates", which leaves the
         // turn running on the full tool surface rather than costing the user
         // their request.
-        let routed = self
-            .route(session, user_message, &turn_cx, &cancel)
-            .await;
+        let routed = self.route(session, user_message, &turn_cx, &cancel).await;
 
         if let Some(clarification) = routed.clarification {
             // Stage 1 chose to clarify and the contract permits it. Answer with
             // the question directly — no retrieval, no tool surface, no second
             // model turn to paraphrase what the model already composed.
-            session.messages.push(ChatMessage::text(
-                Role::Assistant,
-                clarification.clone(),
-            ));
+            session
+                .messages
+                .push(ChatMessage::text(Role::Assistant, clarification.clone()));
             on_status(LocalAgentStatus::Idle);
             return Ok(AgentTurnResult {
                 response: clarification,
@@ -1562,7 +1559,10 @@ impl<E: ChatInferenceEngine + ?Sized, T: AgentToolExecutor + ?Sized> LocalAgentL
             .await
         {
             Ok(r) => {
-                span.set_attribute(KeyValue::new("routing.candidates", r.candidates.len() as i64));
+                span.set_attribute(KeyValue::new(
+                    "routing.candidates",
+                    r.candidates.len() as i64,
+                ));
                 span.set_attribute(KeyValue::new(
                     "routing.top_score",
                     r.candidates.first().map(|c| c.score).unwrap_or(0.0) as f64,
@@ -5385,7 +5385,12 @@ mod tests {
     }
 
     /// A model that calls `route_query` at Stage 1, then the given tool.
-    fn routed_engine(query: &str, tool_name: &str, tool_args: &str, final_text: &str) -> MockEngine {
+    fn routed_engine(
+        query: &str,
+        tool_name: &str,
+        tool_args: &str,
+        final_text: &str,
+    ) -> MockEngine {
         MockEngine::new(vec![
             // Stage 1: the structural choice, expressed as a tool call.
             vec![
@@ -5482,7 +5487,11 @@ mod tests {
         );
         let exec = RoutingToolExecutor::new(
             inner,
-            vec![skill_candidate("research", 0.9, &["search_nodes", "get_node"])],
+            vec![skill_candidate(
+                "research",
+                0.9,
+                &["search_nodes", "get_node"],
+            )],
         );
         let loop_ = LocalAgentLoop::new(Arc::new(engine), Arc::new(exec));
         let mut session = new_session();
@@ -5567,8 +5576,7 @@ mod tests {
                 },
                 StreamingChunk::ToolCallArgs {
                     id: "r1".into(),
-                    args_json: json!({"question": "Which one?", "options": ["A", "B"]})
-                        .to_string(),
+                    args_json: json!({"question": "Which one?", "options": ["A", "B"]}).to_string(),
                 },
                 StreamingChunk::Done {
                     usage: InferenceUsage {

--- a/packages/agent/src/local_agent/agent_loop.rs
+++ b/packages/agent/src/local_agent/agent_loop.rs
@@ -424,11 +424,21 @@ fn looks_like_narrated_tool_call(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     crate::local_agent::tools::Tool::ALL.iter().any(|tool| {
         let name = tool.name();
-        // Find each occurrence of the tool name and check the next
-        // non-whitespace character is an opening paren.
         lower.match_indices(name).any(|(idx, _)| {
-            let after = &lower[idx + name.len()..];
-            after.trim_start().starts_with('(')
+            let after = &lower[idx + name.len()..].trim_start();
+            // `create_node(...)` — the tool named as a function.
+            if after.starts_with('(') {
+                return true;
+            }
+            // `{"name": "create_node", "arguments": {...}}` — the tool named as
+            // the value of a JSON `name` key. Observed in practice: a model
+            // emits a well-formed tool call as *text*, so the loop sees no tool
+            // call at all and the turn silently does nothing. The quote before
+            // the name distinguishes this from prose that merely mentions the
+            // tool.
+            let before = &lower[..idx];
+            let quoted = before.trim_end().ends_with('"') || before.trim_end().ends_with('\'');
+            quoted && after.starts_with(['"', '\''])
         })
     })
 }
@@ -4118,6 +4128,28 @@ mod tests {
         // Embedded in surrounding prose.
         assert!(looks_like_narrated_tool_call(
             "Let me run search_nodes(query='invoice') to find it."
+        ));
+    }
+
+    #[test]
+    fn narrated_tool_call_detects_a_json_tool_call_emitted_as_text() {
+        // A model emitting a well-formed tool call as *text* leaves the loop
+        // with no tool call to execute, so the turn silently does nothing.
+        assert!(looks_like_narrated_tool_call(
+            r#"[{"name":"create_node","arguments":{"content":"Review billing docs"}}]"#
+        ));
+        assert!(looks_like_narrated_tool_call(
+            r#"{"name": "search_nodes", "arguments": {"query": "billing"}}"#
+        ));
+    }
+
+    #[test]
+    fn narrated_tool_call_ignores_a_tool_merely_mentioned_in_prose() {
+        assert!(!looks_like_narrated_tool_call(
+            "I used create_node to add that for you."
+        ));
+        assert!(!looks_like_narrated_tool_call(
+            "The search_nodes results were empty."
         ));
     }
 

--- a/packages/agent/src/local_agent/mod.rs
+++ b/packages/agent/src/local_agent/mod.rs
@@ -8,4 +8,5 @@ pub mod otlp_tracer;
 pub mod prompt_dump;
 pub mod prompt_templates;
 pub mod response_processing;
+pub mod routing;
 pub mod tools;

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -416,11 +416,11 @@ mod tests {
 
     #[test]
     fn mutating_skills_carry_a_strictly_higher_bar() {
-        assert!(
-            MUTATING_SKILL_SCORE_BAR > READ_SKILL_SCORE_BAR,
-            "ADR-038 requires the expensive error — firing the wrong mutating \
-             tool — to be gated harder than a wrong read"
-        );
+        // Compile-time: ADR-038 requires the expensive error — firing the
+        // wrong *mutating* tool — to be gated harder than a wrong read. Tuning
+        // the values is expected; inverting the ordering is not, so it fails
+        // the build rather than a test run.
+        const _: () = assert!(MUTATING_SKILL_SCORE_BAR > READ_SKILL_SCORE_BAR);
         let read = candidate("research", 0.2, &["search_nodes"]);
         let write = candidate("schema", 0.2, &["create_schema"]);
         // Identical score, different verdict — the bar is a property of the

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -22,7 +22,7 @@
 use crate::agent_types::{SkillCandidate, ToolDefinition};
 use serde::Deserialize;
 
-use super::tools::is_write_tool;
+use super::tools::Tool;
 
 /// How many skill candidates retrieval may return.
 ///
@@ -192,8 +192,20 @@ pub fn parse_route_decision(tool_name: &str, arguments_json: &str) -> Option<Rou
 /// it cannot drift from what the skill is actually able to do — adding a
 /// mutating tool to a whitelist raises that skill's bar automatically, with
 /// no second field to keep in sync.
+/// An unrecognised tool name counts as mutating. `is_write_tool` answers
+/// `false` for a name not in the registry — a typo, a renamed tool, or a
+/// future externally-registered one — which would put the *lower* bar on a
+/// skill whose blast radius is unknown. ADR-038 says to bias against the
+/// expensive error, so the unknown case belongs on the restrictive side.
+///
+/// This gates a safety bar, not availability. `stage2_tools` fails open in the
+/// other direction on purpose: there, an unknown name simply is not offered,
+/// and stranding the model with no tools would be the worse outcome.
 pub fn skill_is_mutating(candidate: &SkillCandidate) -> bool {
-    candidate.tools.iter().any(|t| is_write_tool(t))
+    candidate
+        .tools
+        .iter()
+        .any(|t| Tool::from_name(t).is_none_or(Tool::is_write))
 }
 
 /// The retrieval score a candidate must clear to be actionable.
@@ -426,6 +438,19 @@ mod tests {
             0.5,
             &["search_nodes", "delete_node"]
         )));
+    }
+
+    #[test]
+    fn an_unrecognised_whitelist_tool_is_treated_as_mutating() {
+        // Fail-safe: a typo, a renamed tool, or a future externally-registered
+        // one is of unknown blast radius, so it takes the higher bar rather
+        // than defaulting to read-only.
+        let ghost = candidate("ghost", 0.2, &["delete_everything_v2"]);
+        assert!(skill_is_mutating(&ghost));
+        assert!(
+            !clears_score_gate(&ghost),
+            "0.2 clears the read bar but must not clear the mutating one"
+        );
     }
 
     #[test]

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -264,7 +264,11 @@ fn render_schema_metadata(meta: &serde_json::Value) -> Option<String> {
     }
     let mut lines = Vec::new();
     for entry in arr {
-        let type_id = entry.get("type_id").and_then(|v| v.as_str())?;
+        // Skip a malformed entry rather than propagating out of the loop: `?`
+        // here would discard every remaining type because one lacked an id.
+        let Some(type_id) = entry.get("type_id").and_then(|v| v.as_str()) else {
+            continue;
+        };
         let fields: Vec<String> = entry
             .get("fields")
             .and_then(|f| f.as_array())
@@ -286,6 +290,9 @@ fn render_schema_metadata(meta: &serde_json::Value) -> Option<String> {
             })
             .unwrap_or_default();
         lines.push(format!("- {type_id}: {}", fields.join(", ")));
+    }
+    if lines.is_empty() {
+        return None;
     }
     Some(lines.join("\n"))
 }
@@ -500,6 +507,28 @@ mod tests {
             1,
             "stranding the model with zero tools is worse than a wide surface"
         );
+    }
+
+    #[test]
+    fn a_malformed_metadata_entry_does_not_discard_the_others() {
+        let mut c = candidate("Node Creation", 0.9, &["create_node"]);
+        c.schema_metadata = json!([
+            {"fields": [{"name": "orphan", "type": "text"}]},
+            {"type_id": "task", "fields": [{"name": "title", "type": "text"}]}
+        ]);
+        let rendered = render_candidates_for_prompt(&[c]).unwrap();
+        assert!(
+            rendered.contains("- task: title (text)"),
+            "an entry missing type_id must not take the valid ones with it: {rendered}"
+        );
+    }
+
+    #[test]
+    fn metadata_with_no_usable_entries_renders_no_section() {
+        let mut c = candidate("Node Creation", 0.9, &["create_node"]);
+        c.schema_metadata = json!([{"fields": []}]);
+        let rendered = render_candidates_for_prompt(&[c]).unwrap();
+        assert!(!rendered.contains("RELEVANT ENTITY TYPES"));
     }
 
     #[test]

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -192,11 +192,13 @@ pub fn parse_route_decision(tool_name: &str, arguments_json: &str) -> Option<Rou
 /// it cannot drift from what the skill is actually able to do — adding a
 /// mutating tool to a whitelist raises that skill's bar automatically, with
 /// no second field to keep in sync.
-/// An unrecognised tool name counts as mutating. `is_write_tool` answers
-/// `false` for a name not in the registry — a typo, a renamed tool, or a
-/// future externally-registered one — which would put the *lower* bar on a
-/// skill whose blast radius is unknown. ADR-038 says to bias against the
-/// expensive error, so the unknown case belongs on the restrictive side.
+///
+/// An unrecognised tool name counts as mutating. Resolving a name that is not
+/// in the registry — a typo, a renamed tool, or a future externally-registered
+/// one — yields no write classification at all, and treating that absence as
+/// read-only would put the *lower* bar on a skill whose blast radius is
+/// unknown. ADR-038 says to bias against the expensive error, so the unknown
+/// case belongs on the restrictive side.
 ///
 /// This gates a safety bar, not availability. `stage2_tools` fails open in the
 /// other direction on purpose: there, an unknown name simply is not offered,

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -235,10 +235,17 @@ pub fn render_candidates_for_prompt(candidates: &[SkillCandidate]) -> Option<Str
         return None;
     }
 
+    // Phrased as a direct instruction to act, not to deliberate. An earlier
+    // wording ("Pick the ONE that fits and carry out its instructions") framed
+    // the turn as a selection exercise, and the model answered it in kind:
+    // it narrated which tool it would use — in one case emitting the tool-call
+    // JSON inside a code block — instead of calling it. Measured on
+    // mistral:7b, that wording produced zero tool calls where the unrouted
+    // control produced one.
     let mut out = String::from(
-        "CANDIDATE SKILLS (retrieved for this request). Pick the ONE that fits and carry out its \
-         instructions by calling the appropriate tool. If none fits, say so plainly instead of \
-         forcing a match.\n",
+        "REFERENCE — procedures relevant to this request. Use whichever applies and IGNORE the \
+         rest. Do not describe, quote, or summarise any of it. Your reply must be the tool call \
+         itself. If none applies, answer the user normally.\n",
     );
     for (i, c) in eligible.iter().enumerate() {
         out.push_str(&format!("\n--- Candidate {}: {}\n", i + 1, c.name));

--- a/packages/agent/src/local_agent/routing.rs
+++ b/packages/agent/src/local_agent/routing.rs
@@ -1,0 +1,518 @@
+//! Two-stage skill-mediated routing (ADR-038).
+//!
+//! The model reaches capabilities through skills discovered by semantic
+//! retrieval, with the LLM judging at two gates and an explicit clarification
+//! fallback. Retrieval itself is a deterministic system step the model does
+//! not perform, which is where the candidate count is bounded and the trust
+//! filter applies.
+//!
+//! ```text
+//! Stage 1 (model):  emit EITHER a search query OR a clarification request
+//!                   — a structural choice, not a confidence number
+//! [system step]:    semantic retrieval over the skill registry → top-K,
+//!                   score-gated. NOT a model tool call.
+//! Stage 2 (model):  judge the candidates against the intent → pick one and
+//!                   act, or clarify with the candidates as concrete options
+//! ```
+//!
+//! ADR-038 rejects the single-turn pull (handing the model a `search_skills`
+//! tool and letting it call retrieval itself), because that removes the
+//! system's ability to bound K and enforce the trust boundary.
+
+use crate::agent_types::{SkillCandidate, ToolDefinition};
+use serde::Deserialize;
+
+use super::tools::is_write_tool;
+
+/// How many skill candidates retrieval may return.
+///
+/// This is the bound ADR-038 requires the system — not the model — to own.
+/// Three is enough to offer a real choice at Stage 2 (and to name concrete
+/// options in a clarification) while keeping the injected instruction payload
+/// small, since each candidate carries its full instruction subtree.
+pub const RETRIEVAL_TOP_K: usize = 3;
+
+/// Minimum retrieval score for a **read-only** skill to be actionable.
+///
+/// The mechanical half of the Stage-2 gate. The model's yes/no on the
+/// candidate is the other, independently-sourced half; both must pass.
+///
+/// **Deliberately permissive, and not yet tuned.** Tuning requires an eval
+/// that can distinguish a model failure from a harness failure, which the
+/// agent matrix currently cannot do. Until that lands, a stricter value would
+/// be tightening against an untested target: it would silently hide the long
+/// tail, and no measurement would show the loss. Raise this only alongside a
+/// measurement that demonstrates the tail being hidden is genuinely noise.
+///
+/// Note this is a different constant from `skill_ops::SKILL_SEARCH_THRESHOLD`,
+/// which stays at `0.0` on purpose: retrieval still *returns* the long tail so
+/// the judged gate can see it, and this bar decides what is *actionable*.
+/// One gate filters, the other judges.
+pub const READ_SKILL_SCORE_BAR: f32 = 0.15;
+
+/// Minimum retrieval score for a **mutating** skill to be actionable.
+///
+/// ADR-038: "the Stage-2 bar is a property of the matched skill, not a single
+/// global constant. Mutating skills warrant a higher bar than read-only ones,
+/// because the expensive error — firing the wrong *mutating* tool — changes
+/// the graph." Bias the gate against that error.
+///
+/// **Deliberately permissive, and not yet tuned** — see
+/// [`READ_SKILL_SCORE_BAR`]. The ordering (mutating strictly above read-only)
+/// is the load-bearing property here; the absolute values are placeholders
+/// awaiting a diagnostic eval.
+pub const MUTATING_SKILL_SCORE_BAR: f32 = 0.30;
+
+/// Stage-1's structural choice, recovered from which tool the model called.
+///
+/// ADR-038 rejects gating on a self-reported confidence number: a numeric
+/// self-rating from a small model is not calibrated and invites anchoring.
+/// The choice is therefore *which of two typed tools* the model calls, which
+/// is also the channel measured strongest for structured output — a tool
+/// schema, rather than prose the model must be trusted to follow.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RouteDecision {
+    /// The model formed a search query; run retrieval on it.
+    Query(String),
+    /// The model could not form a query and asked to clarify.
+    Clarify {
+        /// The specific question to put to the user.
+        question: String,
+        /// Concrete options to offer. ADR-038: a bare "what do you mean?" is
+        /// the failure mode to avoid.
+        options: Vec<String>,
+    },
+}
+
+/// Wire name of the Stage-1 tool that emits a search query.
+pub const ROUTE_QUERY_TOOL: &str = "route_query";
+/// Wire name of the Stage-1 tool that requests clarification.
+pub const ROUTE_CLARIFY_TOOL: &str = "route_clarify";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RouteQueryParams {
+    query: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RouteClarifyParams {
+    question: String,
+    #[serde(default)]
+    options: Vec<String>,
+}
+
+/// The two tools offered at Stage 1, and only these two.
+///
+/// Offering exactly two makes the model's tool choice a discriminated output:
+/// there is no third thing it can call, and no free text to parse. The
+/// alternative — asking in prose for a `QUERY:`/`CLARIFY:` prefix — relies on
+/// the weakest measured channel and needs a parser whose failures are
+/// indistinguishable from model failures.
+pub fn stage1_tool_definitions() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: ROUTE_QUERY_TOOL.to_string(),
+            description: "Use when you understand what the user wants. Provide a short search \
+                 query describing the capability needed to fulfil it — describe the task, not \
+                 the user's exact words."
+                .to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "A short description of the capability needed, in plain language."
+                    }
+                },
+                "required": ["query"]
+            }),
+        },
+        ToolDefinition {
+            name: ROUTE_CLARIFY_TOOL.to_string(),
+            description: "Use ONLY when the request is too ambiguous to describe as a capability. \
+                 Ask one specific question and offer concrete alternatives — never a bare \
+                 'what do you mean?'."
+                .to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "One specific question that would resolve the ambiguity."
+                    },
+                    "options": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Two or more concrete interpretations the user can pick between."
+                    }
+                },
+                "required": ["question"]
+            }),
+        },
+    ]
+}
+
+/// Recover Stage-1's decision from the model's tool call.
+///
+/// Returns `None` when the model called neither routing tool or emitted
+/// unparseable arguments. The caller treats that as "no routing decision" and
+/// falls through to the general tool surface rather than failing the turn:
+/// a routing step that cannot decide must not cost the user their request.
+pub fn parse_route_decision(tool_name: &str, arguments_json: &str) -> Option<RouteDecision> {
+    match tool_name {
+        ROUTE_QUERY_TOOL => {
+            let p: RouteQueryParams = serde_json::from_str(arguments_json).ok()?;
+            let q = p.query.trim();
+            if q.is_empty() {
+                return None;
+            }
+            Some(RouteDecision::Query(q.to_string()))
+        }
+        ROUTE_CLARIFY_TOOL => {
+            let p: RouteClarifyParams = serde_json::from_str(arguments_json).ok()?;
+            let question = p.question.trim();
+            if question.is_empty() {
+                return None;
+            }
+            Some(RouteDecision::Clarify {
+                question: question.to_string(),
+                options: p.options,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Whether a skill can change graph state, derived from the tools it may fire.
+///
+/// Blast radius is not a stored property. It is computed from the skill's
+/// `tool_whitelist` through the tool registry's own write classification, so
+/// it cannot drift from what the skill is actually able to do — adding a
+/// mutating tool to a whitelist raises that skill's bar automatically, with
+/// no second field to keep in sync.
+pub fn skill_is_mutating(candidate: &SkillCandidate) -> bool {
+    candidate.tools.iter().any(|t| is_write_tool(t))
+}
+
+/// The retrieval score a candidate must clear to be actionable.
+///
+/// Scales with blast radius per ADR-038.
+pub fn score_bar_for(candidate: &SkillCandidate) -> f32 {
+    if skill_is_mutating(candidate) {
+        MUTATING_SKILL_SCORE_BAR
+    } else {
+        READ_SKILL_SCORE_BAR
+    }
+}
+
+/// Whether a candidate clears the **mechanical** half of the Stage-2 gate.
+///
+/// Passing this is necessary, not sufficient: ADR-038 requires two
+/// independently-sourced signals, and the model's judgment supplies the other.
+/// A candidate that clears this bar is offered to the model to judge; one that
+/// does not is never actionable regardless of what the model says.
+pub fn clears_score_gate(candidate: &SkillCandidate) -> bool {
+    candidate.score >= score_bar_for(candidate)
+}
+
+/// Render retrieved candidates for injection into the Stage-2 prompt.
+///
+/// Delivered **in the prompt** rather than as a tool result. ADR-064 rule 4
+/// reserves tool results for resolved facts rather than procedures, and the
+/// supporting measurement for skill instructions was taken on prompt-rendered
+/// text; the same payload returned as a tool result was observed to suppress
+/// tool-calling substantially.
+///
+/// Only candidates clearing the score gate are rendered — the mechanical gate
+/// runs before the judged one, so the model is never asked to judge a
+/// candidate the system has already ruled out.
+pub fn render_candidates_for_prompt(candidates: &[SkillCandidate]) -> Option<String> {
+    let eligible: Vec<&SkillCandidate> =
+        candidates.iter().filter(|c| clears_score_gate(c)).collect();
+    if eligible.is_empty() {
+        return None;
+    }
+
+    let mut out = String::from(
+        "CANDIDATE SKILLS (retrieved for this request). Pick the ONE that fits and carry out its \
+         instructions by calling the appropriate tool. If none fits, say so plainly instead of \
+         forcing a match.\n",
+    );
+    for (i, c) in eligible.iter().enumerate() {
+        out.push_str(&format!("\n--- Candidate {}: {}\n", i + 1, c.name));
+        if !c.description.is_empty() {
+            out.push_str(&format!("Purpose: {}\n", c.description));
+        }
+        if !c.instructions.is_empty() {
+            out.push_str(&format!("\n{}\n", c.instructions));
+        }
+        if let Some(meta) = render_schema_metadata(&c.schema_metadata) {
+            out.push_str(&format!("\nRELEVANT ENTITY TYPES:\n{meta}\n"));
+        }
+    }
+    Some(out)
+}
+
+/// Render a candidate's `schema_metadata` into the compact form the model
+/// already sees elsewhere, or `None` when there is nothing to show.
+fn render_schema_metadata(meta: &serde_json::Value) -> Option<String> {
+    let arr = meta.as_array()?;
+    if arr.is_empty() {
+        return None;
+    }
+    let mut lines = Vec::new();
+    for entry in arr {
+        let type_id = entry.get("type_id").and_then(|v| v.as_str())?;
+        let fields: Vec<String> = entry
+            .get("fields")
+            .and_then(|f| f.as_array())
+            .map(|fs| {
+                fs.iter()
+                    .filter_map(|f| {
+                        let name = f.get("name").and_then(|v| v.as_str())?;
+                        let ty = f.get("type").and_then(|v| v.as_str()).unwrap_or("text");
+                        match f.get("enum_values").and_then(|v| v.as_array()) {
+                            Some(vals) if !vals.is_empty() => {
+                                let vs: Vec<&str> =
+                                    vals.iter().filter_map(|v| v.as_str()).collect();
+                                Some(format!("{name} ({ty}: {})", vs.join(", ")))
+                            }
+                            _ => Some(format!("{name} ({ty})")),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        lines.push(format!("- {type_id}: {}", fields.join(", ")));
+    }
+    Some(lines.join("\n"))
+}
+
+/// The tools Stage 2 may offer, restricted to the union of the eligible
+/// candidates' whitelists.
+///
+/// This is the trust boundary ADR-038 places on the system side: the model
+/// judges *among* what retrieval surfaced, and can only fire what the matched
+/// skills permit. A skill's `tool_whitelist` was previously read only by
+/// external ACP agents; this gives it a local-agent consumer.
+///
+/// Falls back to the full surface when nothing was retrieved, so an
+/// unavailable embedding service degrades to today's behaviour rather than
+/// leaving the model with no tools at all.
+pub fn stage2_tools(candidates: &[SkillCandidate], all: &[ToolDefinition]) -> Vec<ToolDefinition> {
+    let permitted: std::collections::HashSet<&str> = candidates
+        .iter()
+        .filter(|c| clears_score_gate(c))
+        .flat_map(|c| c.tools.iter().map(|t| t.as_str()))
+        .collect();
+
+    if permitted.is_empty() {
+        return all.to_vec();
+    }
+    let scoped: Vec<ToolDefinition> = all
+        .iter()
+        .filter(|t| permitted.contains(t.name.as_str()))
+        .cloned()
+        .collect();
+
+    // A whitelist naming only tools this build does not register would strand
+    // the model with nothing to call. Fail open to the full surface.
+    if scoped.is_empty() {
+        return all.to_vec();
+    }
+    scoped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn candidate(name: &str, score: f32, tools: &[&str]) -> SkillCandidate {
+        SkillCandidate {
+            id: format!("skill-{name}"),
+            name: name.to_string(),
+            description: format!("{name} description"),
+            score,
+            tools: tools.iter().map(|t| t.to_string()).collect(),
+            instructions: format!("{name} instructions"),
+            schema_metadata: json!([]),
+        }
+    }
+
+    fn tool(name: &str) -> ToolDefinition {
+        ToolDefinition {
+            name: name.to_string(),
+            description: String::new(),
+            parameters_schema: json!({}),
+        }
+    }
+
+    #[test]
+    fn stage1_offers_exactly_the_two_routing_tools() {
+        let defs = stage1_tool_definitions();
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec![ROUTE_QUERY_TOOL, ROUTE_CLARIFY_TOOL]);
+    }
+
+    #[test]
+    fn route_query_parses_into_a_query_decision() {
+        let d = parse_route_decision(ROUTE_QUERY_TOOL, r#"{"query":"create a schema"}"#);
+        assert_eq!(d, Some(RouteDecision::Query("create a schema".into())));
+    }
+
+    #[test]
+    fn route_clarify_parses_question_and_options() {
+        let d = parse_route_decision(
+            ROUTE_CLARIFY_TOOL,
+            r#"{"question":"Which did you mean?","options":["Track debts","Search notes"]}"#,
+        );
+        assert_eq!(
+            d,
+            Some(RouteDecision::Clarify {
+                question: "Which did you mean?".into(),
+                options: vec!["Track debts".into(), "Search notes".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn clarify_without_options_still_parses() {
+        // `options` is optional on the wire so a model omitting it does not
+        // cost the turn; the contract's "be specific" requirement is enforced
+        // by the tool description, not by rejecting the call.
+        let d = parse_route_decision(ROUTE_CLARIFY_TOOL, r#"{"question":"Which one?"}"#);
+        assert!(matches!(d, Some(RouteDecision::Clarify { .. })));
+    }
+
+    #[test]
+    fn unknown_tool_or_blank_query_yields_no_decision() {
+        assert!(parse_route_decision("search_nodes", r#"{"query":"x"}"#).is_none());
+        assert!(parse_route_decision(ROUTE_QUERY_TOOL, r#"{"query":"   "}"#).is_none());
+        assert!(parse_route_decision(ROUTE_QUERY_TOOL, "not json").is_none());
+    }
+
+    #[test]
+    fn blast_radius_derives_from_the_tool_whitelist() {
+        assert!(!skill_is_mutating(&candidate(
+            "research",
+            0.5,
+            &["search_nodes", "get_node"]
+        )));
+        assert!(skill_is_mutating(&candidate(
+            "schema",
+            0.5,
+            &["create_schema", "get_node"]
+        )));
+        // A single write tool among reads is enough to raise the bar.
+        assert!(skill_is_mutating(&candidate(
+            "deletion",
+            0.5,
+            &["search_nodes", "delete_node"]
+        )));
+    }
+
+    #[test]
+    fn mutating_skills_carry_a_strictly_higher_bar() {
+        assert!(
+            MUTATING_SKILL_SCORE_BAR > READ_SKILL_SCORE_BAR,
+            "ADR-038 requires the expensive error — firing the wrong mutating \
+             tool — to be gated harder than a wrong read"
+        );
+        let read = candidate("research", 0.2, &["search_nodes"]);
+        let write = candidate("schema", 0.2, &["create_schema"]);
+        // Identical score, different verdict — the bar is a property of the
+        // matched skill, not a single global constant.
+        assert!(clears_score_gate(&read));
+        assert!(!clears_score_gate(&write));
+    }
+
+    #[test]
+    fn candidates_below_their_bar_are_never_rendered() {
+        let cands = vec![
+            candidate("weak", 0.01, &["search_nodes"]),
+            candidate("strong", 0.9, &["search_nodes"]),
+        ];
+        let rendered = render_candidates_for_prompt(&cands).expect("one candidate is eligible");
+        assert!(rendered.contains("strong"));
+        assert!(!rendered.contains("weak instructions"));
+    }
+
+    #[test]
+    fn no_eligible_candidates_renders_nothing() {
+        let cands = vec![candidate("weak", 0.001, &["create_schema"])];
+        assert!(render_candidates_for_prompt(&cands).is_none());
+    }
+
+    #[test]
+    fn rendered_candidates_carry_their_instruction_subtree() {
+        let cands = vec![candidate("Schema Creation", 0.9, &["create_schema"])];
+        let rendered = render_candidates_for_prompt(&cands).unwrap();
+        assert!(rendered.contains("Schema Creation instructions"));
+        assert!(rendered.contains("Purpose: Schema Creation description"));
+    }
+
+    #[test]
+    fn stage2_tools_are_scoped_to_eligible_candidate_whitelists() {
+        let all = vec![
+            tool("search_nodes"),
+            tool("get_node"),
+            tool("create_schema"),
+            tool("delete_node"),
+        ];
+        let cands = vec![candidate("research", 0.9, &["search_nodes", "get_node"])];
+        let scoped = stage2_tools(&cands, &all);
+        let names: Vec<&str> = scoped.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["search_nodes", "get_node"]);
+        assert!(
+            !names.contains(&"delete_node"),
+            "a read-only skill must not put a destructive tool in reach"
+        );
+    }
+
+    #[test]
+    fn an_ineligible_candidate_does_not_widen_the_tool_surface() {
+        let all = vec![tool("search_nodes"), tool("delete_node")];
+        // Deletion is mutating, so 0.2 is below its bar though above the read bar.
+        let cands = vec![
+            candidate("research", 0.9, &["search_nodes"]),
+            candidate("deletion", 0.2, &["delete_node"]),
+        ];
+        let scoped = stage2_tools(&cands, &all);
+        let names: Vec<&str> = scoped.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["search_nodes"]);
+    }
+
+    #[test]
+    fn empty_retrieval_falls_back_to_the_full_tool_surface() {
+        let all = vec![tool("search_nodes"), tool("create_schema")];
+        assert_eq!(stage2_tools(&[], &all).len(), 2);
+    }
+
+    #[test]
+    fn whitelist_naming_only_unregistered_tools_fails_open() {
+        let all = vec![tool("search_nodes")];
+        let cands = vec![candidate("ghost", 0.9, &["tool_that_does_not_exist"])];
+        assert_eq!(
+            stage2_tools(&cands, &all).len(),
+            1,
+            "stranding the model with zero tools is worse than a wide surface"
+        );
+    }
+
+    #[test]
+    fn schema_metadata_renders_enum_values() {
+        let mut c = candidate("Node Creation", 0.9, &["create_node"]);
+        c.schema_metadata = json!([{
+            "type_id": "task",
+            "fields": [
+                {"name": "title", "type": "text"},
+                {"name": "status", "type": "enum", "enum_values": ["todo", "done"]}
+            ]
+        }]);
+        let rendered = render_candidates_for_prompt(&[c]).unwrap();
+        assert!(rendered.contains("- task: title (text), status (enum: todo, done)"));
+    }
+}

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -2172,7 +2172,7 @@ impl AgentToolExecutor for GraphToolExecutor {
     async fn available_tools(&self) -> Result<Vec<ToolDefinition>, ToolError> {
         let ns = match &self.node_service {
             Some(svc) => svc,
-            None => return Ok(all_tool_definitions()),
+            None => return Ok(model_facing_tool_definitions()),
         };
 
         let query_result = node_ops::query_nodes(
@@ -2319,6 +2319,15 @@ impl AgentToolExecutor for GraphToolExecutor {
                     .await
             }
         }
+    }
+
+    /// Routing is available once both services backing retrieval are loaded.
+    ///
+    /// The embedding service loads asynchronously after startup, so this is
+    /// read per-call rather than cached: early turns run unrouted and later
+    /// ones route, without the executor being rebuilt.
+    async fn routing_available(&self) -> bool {
+        self.node_service.is_some() && self.embedding_service.read().await.is_some()
     }
 
     /// Run skill retrieval as a deterministic system step (ADR-038).
@@ -3579,10 +3588,9 @@ mod tests {
     // -- Available tools --
 
     #[tokio::test]
-    async fn available_tools_returns_all() {
+    async fn available_tools_returns_every_model_facing_tool() {
         let executor = test_executor();
         let tools = executor.available_tools().await.unwrap();
-        assert_eq!(tools.len(), 14);
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(names.contains(&"search_nodes"));
         assert!(names.contains(&"resolve_query"));
@@ -3592,12 +3600,45 @@ mod tests {
         assert!(names.contains(&"update_node"));
         assert!(names.contains(&"create_relationship"));
         assert!(names.contains(&"get_related_nodes"));
-        assert!(names.contains(&"search_skills"));
         assert!(names.contains(&"create_schema"));
         assert!(names.contains(&"update_schema"));
         assert!(names.contains(&"update_task_status"));
         assert!(names.contains(&"delete_node"));
         assert!(names.contains(&"create_nodes_from_markdown"));
+        // Every registered tool except the ones the system reserves.
+        assert_eq!(tools.len(), Tool::ALL.len() - 1);
+    }
+
+    #[tokio::test]
+    async fn search_skills_is_withheld_from_the_model_facing_surface() {
+        // ADR-038 makes retrieval a deterministic system step. Offering
+        // `search_skills` back to the model is the single-turn pull that ADR
+        // rejects: it lets the model set K and bypasses the trust filter.
+        let executor = test_executor();
+        let names: Vec<String> = executor
+            .available_tools()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+        assert!(
+            !names.iter().any(|n| n == "search_skills"),
+            "search_skills must not reach the model: {names:?}"
+        );
+    }
+
+    #[test]
+    fn search_skills_stays_in_the_registry_for_external_agents() {
+        // Withheld from the local model, but still a real tool: the MCP
+        // `find_skills` handler shares its implementation, and the seeded tool
+        // node backing that surface is generated from `Tool::ALL`.
+        assert!(Tool::ALL.contains(&Tool::SearchSkills));
+        assert!(all_tool_definitions()
+            .iter()
+            .any(|t| t.name == "search_skills"));
+        assert!(is_system_only_tool("search_skills"));
+        assert!(!is_system_only_tool("search_nodes"));
     }
 
     // -- Embedding handle is read live (race fix) --

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -2385,10 +2385,7 @@ impl AgentToolExecutor for GraphToolExecutor {
                     .and_then(|v| v.as_str())
                     .unwrap_or_default()
                     .to_string(),
-                score: s
-                    .get("confidence")
-                    .and_then(|v| v.as_f64())
-                    .unwrap_or(0.0) as f32,
+                score: s.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32,
                 tools: s
                     .get("tools")
                     .and_then(|v| v.as_array())

--- a/packages/agent/src/local_agent/tools.rs
+++ b/packages/agent/src/local_agent/tools.rs
@@ -6,8 +6,8 @@
 //! returns a compact, token-efficient result suitable for an 8k-context local model.
 
 use crate::agent_types::{
-    AgentToolExecutor, ChatInferenceEngine, ChatMessage, InferenceRequest, Role, StreamingChunk,
-    ToolDefinition, ToolError, ToolResult,
+    AgentToolExecutor, ChatInferenceEngine, ChatMessage, InferenceRequest, Role, SkillCandidate,
+    SkillRetrieval, StreamingChunk, ToolDefinition, ToolError, ToolResult,
 };
 use async_trait::async_trait;
 use nodespace_core::agent_params::{SearchNodesParams, SearchSemanticParams};
@@ -1151,6 +1151,27 @@ pub fn all_tool_definitions() -> Vec<ToolDefinition> {
     Tool::ALL.iter().map(|t| t.definition()).collect()
 }
 
+/// Whether a tool is withheld from the local agent's model-facing surface.
+///
+/// `search_skills` is retrieval, and ADR-038 makes retrieval a deterministic
+/// system step rather than a model tool call — offering it back to the model
+/// is the single-turn pull that ADR rejects, because it lets the model set K
+/// and bypasses the trust filter. The tool stays in [`Tool::ALL`] because it
+/// remains a legitimate surface for external agents (the MCP `find_skills`
+/// handler shares its implementation); only the local loop withholds it.
+pub fn is_system_only_tool(tool: &str) -> bool {
+    matches!(Tool::from_name(tool), Some(Tool::SearchSkills))
+}
+
+/// Tool definitions offered to the local agent's model, excluding those the
+/// system reserves for itself. See [`is_system_only_tool`].
+pub fn model_facing_tool_definitions() -> Vec<ToolDefinition> {
+    all_tool_definitions()
+        .into_iter()
+        .filter(|t| !is_system_only_tool(&t.name))
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // GraphToolExecutor
 // ---------------------------------------------------------------------------
@@ -2173,11 +2194,11 @@ impl AgentToolExecutor for GraphToolExecutor {
             Ok(output) if !output.nodes.is_empty() => output.nodes,
             Ok(_) => {
                 tracing::debug!("available_tools: no tool nodes in DB, using hardcoded list");
-                return Ok(all_tool_definitions());
+                return Ok(model_facing_tool_definitions());
             }
             Err(e) => {
                 tracing::warn!(error = %e, "available_tools: node query failed, using hardcoded list");
-                return Ok(all_tool_definitions());
+                return Ok(model_facing_tool_definitions());
             }
         };
 
@@ -2236,7 +2257,7 @@ impl AgentToolExecutor for GraphToolExecutor {
 
         if node_defs.is_empty() {
             tracing::debug!("available_tools: no valid tool nodes found, using hardcoded list");
-            return Ok(all_tool_definitions());
+            return Ok(model_facing_tool_definitions());
         }
 
         // Emit ToolDefinitions in canonical registry order so the model always
@@ -2245,6 +2266,14 @@ impl AgentToolExecutor for GraphToolExecutor {
         // are appended after the registered tools.
         let mut result: Vec<ToolDefinition> = Vec::with_capacity(node_defs.len());
         for &tool in Tool::ALL {
+            // Tools the system reserves for itself are dropped even when a
+            // node for them exists: the seeded tool node is what backs the
+            // external (MCP) surface, so it must stay in the DB while staying
+            // out of the local model's reach. See `is_system_only_tool`.
+            if is_system_only_tool(tool.name()) {
+                node_defs.remove(tool.name());
+                continue;
+            }
             if let Some(def) = node_defs.remove(tool.name()) {
                 result.push(def);
             }
@@ -2290,6 +2319,89 @@ impl AgentToolExecutor for GraphToolExecutor {
                     .await
             }
         }
+    }
+
+    /// Run skill retrieval as a deterministic system step (ADR-038).
+    ///
+    /// Shares `skill_ops::find_skills` with the `search_skills` handler — the
+    /// retrieval itself is identical. What differs is who initiates it: here
+    /// the system does, so `limit` is a bound the model cannot widen and the
+    /// results pass through the score gate before the model sees them.
+    ///
+    /// An unavailable embedding service yields no candidates rather than an
+    /// error, matching the documented degraded path: routing is best-effort,
+    /// and losing it must not cost the user their turn.
+    async fn retrieve_skills(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<SkillRetrieval, ToolError> {
+        use nodespace_core::ops::skill_ops;
+
+        let (Some(ns), Some(emb)) = (
+            self.node_service.as_ref(),
+            self.embedding_service.read().await.clone(),
+        ) else {
+            tracing::debug!("retrieve_skills: services unavailable, no candidates");
+            return Ok(SkillRetrieval::default());
+        };
+
+        let output = skill_ops::find_skills(
+            &emb,
+            ns,
+            skill_ops::FindSkillsInput {
+                query: query.to_string(),
+                limit: Some(limit),
+            },
+        )
+        .await
+        .map_err(|e| ToolError::ExecutionFailed(format!("skill retrieval failed: {}", e)))?;
+
+        let candidates = output
+            .skills
+            .iter()
+            .map(|s| SkillCandidate {
+                id: s
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                name: s
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                description: s
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                score: s
+                    .get("confidence")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0) as f32,
+                tools: s
+                    .get("tools")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|t| t.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                instructions: s
+                    .get("instructions")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                schema_metadata: s
+                    .get("schema_metadata")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!([])),
+            })
+            .collect();
+
+        Ok(SkillRetrieval { candidates })
     }
 }
 

--- a/packages/agent/src/prompt_assembler.rs
+++ b/packages/agent/src/prompt_assembler.rs
@@ -454,9 +454,9 @@ mod tests {
     /// then assembles the system prompt through the real graph path. Before the
     /// fix, `fetch_prompt_body` flattened only the prompt node's direct children,
     /// so the `TOOL STRATEGY:` bullets (nested one level under the header line)
-    /// were dropped and the assembled prompt was missing the search_skills
-    /// mandate, CLARIFICATION CONTRACT, and BLAST-RADIUS GATE. The fix walks the
-    /// full subtree, so all of that text must now reach the assembled prompt.
+    /// were dropped and the assembled prompt was missing the CLARIFICATION
+    /// CONTRACT and BLAST-RADIUS GATE. The fix walks the full subtree, so all
+    /// of that text must now reach the assembled prompt.
     #[tokio::test]
     async fn assembled_prompt_contains_full_tool_strategy_body() {
         use nodespace_core::db::SqliteStore;
@@ -489,7 +489,6 @@ mod tests {
         // The full TOOL_STRATEGY_RULES body must be present in the assembled prompt.
         for needle in [
             "TOOL STRATEGY:",
-            "search_skills",
             "CLARIFICATION CONTRACT",
             "BLAST-RADIUS GATE",
             "NEVER CLAIM ACTION WITHOUT TOOL RESULT",

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -299,9 +299,9 @@ STRUCTURED PROPERTY QUERIES: To filter by property values (status, due_date, etc
 
 ⚡ IMMEDIATE ACTION REQUIRED: Call create_node NOW with all values from the user message. Do NOT output any text — your response to receiving these instructions must be the create_node tool call.
 
-CALL create_node NOW: You received this instruction because search_skills was called. Your NEXT action MUST be create_node — do not output any planning text. Gather all needed values from the user message and call create_node immediately.
+CALL create_node NOW: You received this instruction because this skill was matched to the request. Your NEXT action MUST be create_node — do not output any planning text. Gather all needed values from the user message and call create_node immediately.
 
-TYPE MAPPING FROM schema_metadata: When search_skills returned schema_metadata for this skill, set node_type to the type_id from that metadata, copied exactly as written — never the user's noun for it, and never a shortened or paraphrased form. For generic text notes use node_type="text". For tasks use node_type="task".
+TYPE MAPPING FROM RELEVANT ENTITY TYPES: When entity types are listed with this skill, set node_type to the type_id shown there, copied exactly as written — never the user's noun for it, and never a shortened or paraphrased form. For generic text notes use node_type="text". For tasks use node_type="task".
 
 REQUIRED FIELDS: Read the fields array from schema_metadata. Required fields (required=true) MUST be included in the properties map. Optional fields should be included if the user provided a value for them.
 
@@ -322,7 +322,7 @@ EXAMPLE — the shape of the call, NOT the values. Copy the structure; take ever
 }
 Never reuse "widget" or these field names — they are placeholders. Your node_type is the type_id from schema_metadata, and your property keys are that metadata's field names.
 
-SUCCESS: After create_node returns a node ID, confirm to the user what was created and STOP. Do NOT call search_skills, get_node, or any other tool — the create response is sufficient. The task is complete."#.to_string(),
+SUCCESS: After create_node returns a node ID, confirm to the user what was created and STOP. Do NOT call get_node or any other tool — the create response is sufficient. The task is complete."#.to_string(),
         },
         NodeTemplate {
             title: "Schema Creation".to_string(),

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -596,6 +596,40 @@ mod tests {
         }
     }
 
+    /// Blast radius is derived from each seeded skill's `tool_whitelist`
+    /// (ADR-038), so the derivation must agree with what the seeds actually
+    /// declare. This pins the classification against the real seed data rather
+    /// than a stub, and fails if a seed's whitelist gains or loses a write tool
+    /// without that being an intentional change to its Stage-2 bar.
+    #[test]
+    fn seeded_skills_classify_by_blast_radius_as_expected() {
+        let expected_mutating = [
+            ("Node Creation", true),
+            ("Schema Creation", true),
+            ("Graph Editing", true),
+            ("Relationship Management", true),
+            ("Node Deletion", true),
+            ("Bulk Import", true),
+            ("Organization", true),
+            ("Research & Search", false),
+        ];
+
+        for (title, should_mutate) in expected_mutating {
+            let seed = seed_skill_nodes()
+                .into_iter()
+                .find(|t| t.title == title)
+                .unwrap_or_else(|| panic!("seed skill '{title}' must exist"));
+            let tools = tmpl_tool_whitelist(&seed);
+            let mutates = tools
+                .iter()
+                .any(|t| crate::local_agent::tools::is_write_tool(t));
+            assert_eq!(
+                mutates, should_mutate,
+                "skill '{title}' blast radius changed; whitelist is {tools:?}"
+            );
+        }
+    }
+
     #[test]
     fn update_schema_is_reachable_via_search_skills() {
         let seeds = seed_skill_nodes();

--- a/packages/agent/src/skill_pipeline.rs
+++ b/packages/agent/src/skill_pipeline.rs
@@ -620,9 +620,20 @@ mod tests {
                 .find(|t| t.title == title)
                 .unwrap_or_else(|| panic!("seed skill '{title}' must exist"));
             let tools = tmpl_tool_whitelist(&seed);
-            let mutates = tools
-                .iter()
-                .any(|t| crate::local_agent::tools::is_write_tool(t));
+            // Exercise the production classifier rather than restating its
+            // rule: a reimplementation here would keep passing while
+            // `skill_is_mutating` regressed, which is the opposite of what
+            // this test is for.
+            let candidate = crate::agent_types::SkillCandidate {
+                id: format!("seed-{title}"),
+                name: title.to_string(),
+                description: String::new(),
+                score: 1.0,
+                tools: tools.clone(),
+                instructions: String::new(),
+                schema_metadata: serde_json::json!([]),
+            };
+            let mutates = crate::local_agent::routing::skill_is_mutating(&candidate);
             assert_eq!(
                 mutates, should_mutate,
                 "skill '{title}' blast radius changed; whitelist is {tools:?}"

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -14,7 +14,7 @@
 //! Run with:
 //!   cargo test -p nodespace-agent --test routing_latency -- --nocapture
 //!
-//! Skips gracefully when no inference backend is reachable.
+//! Skips gracefully when the locked model is not downloaded.
 
 use async_trait::async_trait;
 use nodespace_agent::agent_types::{
@@ -24,14 +24,14 @@ use nodespace_agent::agent_types::{
 use nodespace_agent::local_agent::agent_loop::LocalAgentService;
 use nodespace_agent::local_agent::inference::LlamaChatInferenceEngine;
 use nodespace_agent::local_agent::model_manager::GgufModelManager;
-use nodespace_agent::local_agent::openai_compat_discovery::discover_models;
-use nodespace_agent::local_agent::openai_compat_inference::OpenAiCompatInferenceEngine;
 use nodespace_nlp_engine::ChatConfig;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Instant;
 
-const LOCAL_OPENAI_COMPAT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
+/// The locked native agent model (ADR-056). This benchmark measures only this
+/// model — a routing result on anything else does not describe what ships.
+const LOCKED_NATIVE_MODEL: &str = "gemma-4-e4b-q4km";
 
 /// Repetitions per arm. Small — this is a wall-clock cost estimate to inform
 /// the workstream, not a variance study.
@@ -44,60 +44,32 @@ const PROMPTS: &[&str] = &[
     "start tracking the invoices my clients owe me",
 ];
 
+/// Load the locked native model in-process, the way NodeSpace runs it.
+///
+/// There is deliberately no OpenAI-compatible/HTTP path here. NodeSpace's
+/// native agent is Gemma 4 E4B loaded in-process via llama.cpp (ADR-056);
+/// measuring through a local HTTP server measures a different stack, on
+/// whatever model that server happens to have loaded. Both of those went
+/// wrong on this issue — an incidental model produced a suppression result
+/// that does not apply to what ships, and a 4096-token server context against
+/// the engine's `N_CTX_MINIMUM` produced a full table of error timings.
 async fn resolve_backend() -> Option<(Arc<dyn ChatInferenceEngine>, String)> {
-    // NODESPACE_BENCH_GGUF forces the in-process llama.cpp path, bypassing a
-    // local OpenAI-compatible endpoint. Useful when that endpoint is
-    // misconfigured (e.g. serving a context window below N_CTX_MINIMUM, which
-    // makes every turn return empty) or otherwise unhealthy.
-    let force_gguf = std::env::var("NODESPACE_BENCH_GGUF").is_ok();
-    if !force_gguf {
-        if let Ok(models) = discover_models(LOCAL_OPENAI_COMPAT_BASE_URL, "").await {
-            // Prefer the locked production model when the endpoint serves it, so a
-            // result describes the model NodeSpace actually ships (ADR-056).
-            // NODESPACE_BENCH_MODEL overrides for cross-model comparison.
-            let preferred = std::env::var("NODESPACE_BENCH_MODEL").ok();
-            let pick = preferred
-                .as_deref()
-                .and_then(|want| models.iter().find(|m| m.as_str() == want).cloned())
-                .or_else(|| models.iter().find(|m| m.contains("gemma")).cloned())
-                .or_else(|| models.first().cloned());
-            if let Some(model) = pick {
-                let engine = OpenAiCompatInferenceEngine::new(
-                    LOCAL_OPENAI_COMPAT_BASE_URL.to_string(),
-                    String::new(),
-                    model.clone(),
-                );
-                return Some((Arc::new(engine) as Arc<dyn ChatInferenceEngine>, model));
-            }
-        }
-    }
-
     let gguf = GgufModelManager::new().ok()?;
-    for id in ["gemma-4-e4b-q4km", "ministral-3b-q4km"] {
-        let Ok(path) = gguf.model_path(id) else {
-            continue;
-        };
-        if !path.exists() {
-            continue;
-        }
-        let family = if id.starts_with("gemma") {
-            ModelFamily::Gemma4
-        } else {
-            ModelFamily::Ministral
-        };
-        let path_str = path.to_string_lossy().to_string();
-        let engine = tokio::task::spawn_blocking(move || {
-            LlamaChatInferenceEngine::load(&path_str, family, ChatConfig::default())
-        })
-        .await
-        .ok()?
-        .ok()?;
-        return Some((
-            Arc::new(engine) as Arc<dyn ChatInferenceEngine>,
-            id.to_string(),
-        ));
+    let path = gguf.model_path(LOCKED_NATIVE_MODEL).ok()?;
+    if !path.exists() {
+        return None;
     }
-    None
+    let path_str = path.to_string_lossy().to_string();
+    let engine = tokio::task::spawn_blocking(move || {
+        LlamaChatInferenceEngine::load(&path_str, ModelFamily::Gemma4, ChatConfig::default())
+    })
+    .await
+    .ok()?
+    .ok()?;
+    Some((
+        Arc::new(engine) as Arc<dyn ChatInferenceEngine>,
+        LOCKED_NATIVE_MODEL.to_string(),
+    ))
 }
 
 /// Executor whose only variable is whether routing is on. Retrieval is served

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -46,7 +46,16 @@ const PROMPTS: &[&str] = &[
 
 async fn resolve_backend() -> Option<(Arc<dyn ChatInferenceEngine>, String)> {
     if let Ok(models) = discover_models(LOCAL_OPENAI_COMPAT_BASE_URL, "").await {
-        if let Some(model) = models.into_iter().next() {
+        // Prefer the locked production model when the endpoint serves it, so a
+        // result describes the model NodeSpace actually ships (ADR-056).
+        // NODESPACE_BENCH_MODEL overrides for cross-model comparison.
+        let preferred = std::env::var("NODESPACE_BENCH_MODEL").ok();
+        let pick = preferred
+            .as_deref()
+            .and_then(|want| models.iter().find(|m| m.as_str() == want).cloned())
+            .or_else(|| models.iter().find(|m| m.contains("gemma")).cloned())
+            .or_else(|| models.first().cloned());
+        if let Some(model) = pick {
             let engine = OpenAiCompatInferenceEngine::new(
                 LOCAL_OPENAI_COMPAT_BASE_URL.to_string(),
                 String::new(),

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -45,23 +45,30 @@ const PROMPTS: &[&str] = &[
 ];
 
 async fn resolve_backend() -> Option<(Arc<dyn ChatInferenceEngine>, String)> {
-    if let Ok(models) = discover_models(LOCAL_OPENAI_COMPAT_BASE_URL, "").await {
-        // Prefer the locked production model when the endpoint serves it, so a
-        // result describes the model NodeSpace actually ships (ADR-056).
-        // NODESPACE_BENCH_MODEL overrides for cross-model comparison.
-        let preferred = std::env::var("NODESPACE_BENCH_MODEL").ok();
-        let pick = preferred
-            .as_deref()
-            .and_then(|want| models.iter().find(|m| m.as_str() == want).cloned())
-            .or_else(|| models.iter().find(|m| m.contains("gemma")).cloned())
-            .or_else(|| models.first().cloned());
-        if let Some(model) = pick {
-            let engine = OpenAiCompatInferenceEngine::new(
-                LOCAL_OPENAI_COMPAT_BASE_URL.to_string(),
-                String::new(),
-                model.clone(),
-            );
-            return Some((Arc::new(engine) as Arc<dyn ChatInferenceEngine>, model));
+    // NODESPACE_BENCH_GGUF forces the in-process llama.cpp path, bypassing a
+    // local OpenAI-compatible endpoint. Useful when that endpoint is
+    // misconfigured (e.g. serving a context window below N_CTX_MINIMUM, which
+    // makes every turn return empty) or otherwise unhealthy.
+    let force_gguf = std::env::var("NODESPACE_BENCH_GGUF").is_ok();
+    if !force_gguf {
+        if let Ok(models) = discover_models(LOCAL_OPENAI_COMPAT_BASE_URL, "").await {
+            // Prefer the locked production model when the endpoint serves it, so a
+            // result describes the model NodeSpace actually ships (ADR-056).
+            // NODESPACE_BENCH_MODEL overrides for cross-model comparison.
+            let preferred = std::env::var("NODESPACE_BENCH_MODEL").ok();
+            let pick = preferred
+                .as_deref()
+                .and_then(|want| models.iter().find(|m| m.as_str() == want).cloned())
+                .or_else(|| models.iter().find(|m| m.contains("gemma")).cloned())
+                .or_else(|| models.first().cloned());
+            if let Some(model) = pick {
+                let engine = OpenAiCompatInferenceEngine::new(
+                    LOCAL_OPENAI_COMPAT_BASE_URL.to_string(),
+                    String::new(),
+                    model.clone(),
+                );
+                return Some((Arc::new(engine) as Arc<dyn ChatInferenceEngine>, model));
+            }
         }
     }
 

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -1,0 +1,244 @@
+//! Latency cost of ADR-038's two-stage routing, measured on a real model.
+//!
+//! ADR-038 accepts an extra model turn as the price of bounded retrieval and a
+//! judged gate, and requires that price be **measured, not assumed**: KV-cache
+//! reuse "reduces but does not eliminate the multi-turn cost: Turn 2 injects
+//! retrieved skills not present in Turn 1, so the cached prefix diverges at the
+//! injection point."
+//!
+//! Both arms run the same production `LocalAgentLoop` against the same engine
+//! and the same request. They differ in exactly one thing — whether the
+//! executor reports `routing_available()` — so the delta is the routing
+//! overhead and nothing else.
+//!
+//! Run with:
+//!   cargo test -p nodespace-agent --test routing_latency -- --nocapture
+//!
+//! Skips gracefully when no inference backend is reachable.
+
+use async_trait::async_trait;
+use nodespace_agent::agent_types::{
+    AgentToolExecutor, ChatInferenceEngine, ModelFamily, SkillCandidate, SkillRetrieval,
+    ToolDefinition, ToolError, ToolResult,
+};
+use nodespace_agent::local_agent::agent_loop::LocalAgentService;
+use nodespace_agent::local_agent::inference::LlamaChatInferenceEngine;
+use nodespace_agent::local_agent::model_manager::GgufModelManager;
+use nodespace_agent::local_agent::openai_compat_discovery::discover_models;
+use nodespace_agent::local_agent::openai_compat_inference::OpenAiCompatInferenceEngine;
+use nodespace_nlp_engine::ChatConfig;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Instant;
+
+const LOCAL_OPENAI_COMPAT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
+
+/// Repetitions per arm. Small — this is a wall-clock cost estimate to inform
+/// the workstream, not a variance study.
+const RUNS: usize = 3;
+
+/// Requests that should route to a skill, phrased as a user would.
+const PROMPTS: &[&str] = &[
+    "add a task to review the billing docs tomorrow",
+    "find my notes about payment processing",
+    "start tracking the invoices my clients owe me",
+];
+
+async fn resolve_backend() -> Option<(Arc<dyn ChatInferenceEngine>, String)> {
+    if let Ok(models) = discover_models(LOCAL_OPENAI_COMPAT_BASE_URL, "").await {
+        if let Some(model) = models.into_iter().next() {
+            let engine = OpenAiCompatInferenceEngine::new(
+                LOCAL_OPENAI_COMPAT_BASE_URL.to_string(),
+                String::new(),
+                model.clone(),
+            );
+            return Some((Arc::new(engine) as Arc<dyn ChatInferenceEngine>, model));
+        }
+    }
+
+    let gguf = GgufModelManager::new().ok()?;
+    for id in ["gemma-4-e4b-q4km", "ministral-3b-q4km"] {
+        let Ok(path) = gguf.model_path(id) else {
+            continue;
+        };
+        if !path.exists() {
+            continue;
+        }
+        let family = if id.starts_with("gemma") {
+            ModelFamily::Gemma4
+        } else {
+            ModelFamily::Ministral
+        };
+        let path_str = path.to_string_lossy().to_string();
+        let engine = tokio::task::spawn_blocking(move || {
+            LlamaChatInferenceEngine::load(&path_str, family, ChatConfig::default())
+        })
+        .await
+        .ok()?
+        .ok()?;
+        return Some((
+            Arc::new(engine) as Arc<dyn ChatInferenceEngine>,
+            id.to_string(),
+        ));
+    }
+    None
+}
+
+/// Executor whose only variable is whether routing is on. Retrieval is served
+/// from fixed candidates so the measurement isolates the extra model turn and
+/// the prompt-injection divergence, not embedding-search time (which is
+/// unchanged by this work — the same `find_skills` ran before, as a tool).
+struct BenchExecutor {
+    routing: bool,
+}
+
+fn stub_tools() -> Vec<ToolDefinition> {
+    ["create_node", "search_nodes", "get_node", "create_schema"]
+        .iter()
+        .map(|n| ToolDefinition {
+            name: (*n).to_string(),
+            description: format!("{n} operation"),
+            parameters_schema: json!({
+                "type": "object",
+                "properties": {
+                    "node_type": {"type": "string"},
+                    "query": {"type": "string"},
+                    "content": {"type": "string"}
+                }
+            }),
+        })
+        .collect()
+}
+
+#[async_trait]
+impl AgentToolExecutor for BenchExecutor {
+    async fn available_tools(&self) -> Result<Vec<ToolDefinition>, ToolError> {
+        Ok(stub_tools())
+    }
+
+    async fn execute(&self, name: &str, _args: serde_json::Value) -> Result<ToolResult, ToolError> {
+        Ok(ToolResult {
+            tool_call_id: format!("call_{name}"),
+            name: name.to_string(),
+            result: json!({"id": "node-1", "title": "Done"}),
+            is_error: false,
+        })
+    }
+
+    async fn routing_available(&self) -> bool {
+        self.routing
+    }
+
+    async fn retrieve_skills(
+        &self,
+        _query: &str,
+        limit: usize,
+    ) -> Result<SkillRetrieval, ToolError> {
+        let mut candidates = vec![
+            SkillCandidate {
+                id: "skill-node-creation".into(),
+                name: "Node Creation".into(),
+                description: "Create new records, entries, or instances of a type".into(),
+                score: 0.72,
+                tools: vec!["create_node".into(), "search_nodes".into()],
+                instructions: "Call create_node with the values from the user message. \
+                     Set node_type to the type id, copied exactly. Do not ask for \
+                     confirmation when the type already exists."
+                    .into(),
+                schema_metadata: json!([{
+                    "type_id": "task",
+                    "fields": [
+                        {"name": "title", "type": "text"},
+                        {"name": "due_date", "type": "date"}
+                    ]
+                }]),
+            },
+            SkillCandidate {
+                id: "skill-research".into(),
+                name: "Research & Search".into(),
+                description: "Search and explore the knowledge graph".into(),
+                score: 0.55,
+                tools: vec!["search_nodes".into(), "get_node".into()],
+                instructions: "Call search_nodes with a query drawn from the request.".into(),
+                schema_metadata: json!([]),
+            },
+        ];
+        candidates.truncate(limit);
+        Ok(SkillRetrieval { candidates })
+    }
+}
+
+async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> Vec<u128> {
+    let mut samples = Vec::new();
+    for prompt in PROMPTS {
+        for _ in 0..RUNS {
+            let service = LocalAgentService::new(
+                engine.clone(),
+                Arc::new(BenchExecutor { routing }) as Arc<dyn AgentToolExecutor>,
+            );
+            let session = service.create_session(None, Vec::new()).await;
+            let started = Instant::now();
+            let _ = service.send_message(&session, prompt, |_| {}, |_| {}).await;
+            samples.push(started.elapsed().as_millis());
+        }
+    }
+    samples
+}
+
+fn mean(v: &[u128]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.iter().sum::<u128>() as f64 / v.len() as f64
+}
+
+fn median(v: &[u128]) -> u128 {
+    if v.is_empty() {
+        return 0;
+    }
+    let mut s = v.to_vec();
+    s.sort_unstable();
+    s[s.len() / 2]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a local inference backend; run explicitly for a latency number"]
+async fn two_stage_routing_latency_vs_single_turn() {
+    let Some((engine, model)) = resolve_backend().await else {
+        eprintln!("no inference backend available — skipping routing latency benchmark");
+        return;
+    };
+
+    // Warm the engine so the first arm does not absorb load/compile cost.
+    let _ = time_arm(engine.clone(), false).await;
+
+    let baseline = time_arm(engine.clone(), false).await;
+    let routed = time_arm(engine.clone(), true).await;
+
+    let (b_mean, r_mean) = (mean(&baseline), mean(&routed));
+    let overhead = r_mean - b_mean;
+
+    println!("\n=== ADR-038 two-stage routing latency ===");
+    println!("model: {model}");
+    println!("prompts: {}  runs each: {RUNS}", PROMPTS.len());
+    println!(
+        "single-turn (baseline): mean {:.0} ms   median {} ms",
+        b_mean,
+        median(&baseline)
+    );
+    println!(
+        "two-stage (routed):     mean {:.0} ms   median {} ms",
+        r_mean,
+        median(&routed)
+    );
+    println!(
+        "routing overhead:       {:+.0} ms  ({:+.1}%)",
+        overhead,
+        if b_mean > 0.0 {
+            overhead / b_mean * 100.0
+        } else {
+            0.0
+        }
+    );
+    println!("=========================================\n");
+}

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -204,6 +204,9 @@ impl AgentToolExecutor for BenchExecutor {
 
 struct ArmStats {
     latencies: Vec<u128>,
+    /// Turns that never reached the model. A run with any of these cannot be
+    /// reported as a latency result.
+    errors: usize,
     tool_rounds: Vec<usize>,
     prompt_tokens: Vec<u32>,
     completion_tokens: Vec<u32>,
@@ -212,6 +215,7 @@ struct ArmStats {
 async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmStats {
     let mut stats = ArmStats {
         latencies: Vec::new(),
+        errors: 0,
         tool_rounds: Vec::new(),
         prompt_tokens: Vec::new(),
         completion_tokens: Vec::new(),
@@ -230,12 +234,14 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmSta
             let session = service.create_session(None, Vec::new()).await;
             let started = Instant::now();
             let result = service.send_message(&session, prompt, |_| {}, |_| {}).await;
-            stats.latencies.push(started.elapsed().as_millis());
+            let elapsed = started.elapsed().as_millis();
             // Rounds and tokens explain the wall-clock delta. Without them a
             // surprising number is unattributable — and an unattributable
             // benchmark number is how false conclusions get recorded.
             match result {
                 Ok(r) => {
+                    // Only a turn that actually reached the model is a sample.
+                    stats.latencies.push(elapsed);
                     if r.tool_calls_made.is_empty() {
                         println!(
                             "[{}] NO TOOL CALL for {prompt:?} -> {:?}",
@@ -247,10 +253,15 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmSta
                     stats.prompt_tokens.push(r.usage.prompt_tokens);
                     stats.completion_tokens.push(r.usage.completion_tokens);
                 }
-                Err(e) => println!(
-                    "[{}] ERROR for {prompt:?}: {e}",
-                    if routing { "routed" } else { "baseline" }
-                ),
+                Err(e) => {
+                    // A failed turn returns in error-path time, not turn time.
+                    // Timing it would report a fast mean for a broken run.
+                    stats.errors += 1;
+                    println!(
+                        "[{}] ERROR for {prompt:?}: {e}",
+                        if routing { "routed" } else { "baseline" }
+                    );
+                }
             }
         }
     }
@@ -300,6 +311,24 @@ async fn two_stage_routing_latency_vs_single_turn() {
 
     let baseline = time_arm(engine.clone(), false).await;
     let routed = time_arm(engine.clone(), true).await;
+
+    // A benchmark that silently reports error-path timings is worse than no
+    // benchmark: it produces a confident number for a run that never reached
+    // the model. Refuse rather than print one.
+    let total_errors = baseline.errors + routed.errors;
+    if total_errors > 0 || baseline.latencies.is_empty() || routed.latencies.is_empty() {
+        panic!(
+            "routing latency benchmark did not produce a usable result: \
+             {total_errors} turn(s) failed to reach the model \
+             (baseline {} ok / {} failed, routed {} ok / {} failed). \
+             The locked model is likely unloaded or the endpoint is cold — \
+             warm it and re-run.",
+            baseline.latencies.len(),
+            baseline.errors,
+            routed.latencies.len(),
+            routed.errors,
+        );
+    }
 
     let (b_mean, r_mean) = (mean(&baseline.latencies), mean(&routed.latencies));
     let overhead = r_mean - b_mean;

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -93,6 +93,11 @@ struct BenchExecutor {
     /// When false, candidates carry no instruction text — isolating "tool
     /// surface was scoped" from "procedural instructions were injected".
     with_instructions: bool,
+    /// When true, retrieval returns nothing, so only the Stage-1 turn is added.
+    empty_retrieval: bool,
+    /// When true, candidates keep only their names — isolates "a block was
+    /// injected at all" from "the block carried procedures".
+    minimal_block: bool,
 }
 
 fn stub_tools() -> Vec<ToolDefinition> {
@@ -174,6 +179,15 @@ impl AgentToolExecutor for BenchExecutor {
                 schema_metadata: json!([]),
             },
         ];
+        if !self.with_instructions && self.empty_retrieval {
+            return Ok(SkillRetrieval::default());
+        }
+        if self.minimal_block {
+            for c in &mut candidates {
+                c.instructions.clear();
+                c.schema_metadata = json!([]);
+            }
+        }
         candidates.truncate(limit);
         Ok(SkillRetrieval { candidates })
     }
@@ -200,6 +214,8 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmSta
                 Arc::new(BenchExecutor {
                     routing,
                     with_instructions: true,
+                    empty_retrieval: false,
+                    minimal_block: false,
                 }) as Arc<dyn AgentToolExecutor>,
             );
             let session = service.create_session(None, Vec::new()).await;
@@ -326,14 +342,21 @@ async fn dump_one_routed_turn() {
 
     for (label, routing, with_instructions) in [
         ("baseline (no routing)", false, false),
-        ("routed, scoped tools only", true, false),
+        // Stage 1 runs, but retrieval returns nothing — isolates the cost of
+        // the extra routing turn from the cost of the injected block.
+        ("stage-1 only, no candidates", true, false),
         ("routed + injected instructions", true, true),
-    ] {
+    ]
+    .into_iter()
+    .chain(std::iter::once(("routed, minimal block", true, false)))
+    {
         let service = LocalAgentService::new(
             engine.clone(),
             Arc::new(BenchExecutor {
                 routing,
                 with_instructions,
+                empty_retrieval: label.contains("no candidates"),
+                minimal_block: label.contains("minimal block"),
             }) as Arc<dyn AgentToolExecutor>,
         );
         let session = service.create_session(None, Vec::new()).await;

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -90,6 +90,9 @@ async fn resolve_backend() -> Option<(Arc<dyn ChatInferenceEngine>, String)> {
 /// unchanged by this work — the same `find_skills` ran before, as a tool).
 struct BenchExecutor {
     routing: bool,
+    /// When false, candidates carry no instruction text — isolating "tool
+    /// surface was scoped" from "procedural instructions were injected".
+    with_instructions: bool,
 }
 
 fn stub_tools() -> Vec<ToolDefinition> {
@@ -141,10 +144,14 @@ impl AgentToolExecutor for BenchExecutor {
                 description: "Create new records, entries, or instances of a type".into(),
                 score: 0.72,
                 tools: vec!["create_node".into(), "search_nodes".into()],
-                instructions: "Call create_node with the values from the user message. \
+                instructions: if self.with_instructions {
+                    "Call create_node with the values from the user message. \
                      Set node_type to the type id, copied exactly. Do not ask for \
                      confirmation when the type already exists."
-                    .into(),
+                        .into()
+                } else {
+                    String::new()
+                },
                 schema_metadata: json!([{
                     "type_id": "task",
                     "fields": [
@@ -159,7 +166,11 @@ impl AgentToolExecutor for BenchExecutor {
                 description: "Search and explore the knowledge graph".into(),
                 score: 0.55,
                 tools: vec!["search_nodes".into(), "get_node".into()],
-                instructions: "Call search_nodes with a query drawn from the request.".into(),
+                instructions: if self.with_instructions {
+                    "Call search_nodes with a query drawn from the request.".into()
+                } else {
+                    String::new()
+                },
                 schema_metadata: json!([]),
             },
         ];
@@ -186,7 +197,10 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmSta
         for _ in 0..RUNS {
             let service = LocalAgentService::new(
                 engine.clone(),
-                Arc::new(BenchExecutor { routing }) as Arc<dyn AgentToolExecutor>,
+                Arc::new(BenchExecutor {
+                    routing,
+                    with_instructions: true,
+                }) as Arc<dyn AgentToolExecutor>,
             );
             let session = service.create_session(None, Vec::new()).await;
             let started = Instant::now();
@@ -195,10 +209,23 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmSta
             // Rounds and tokens explain the wall-clock delta. Without them a
             // surprising number is unattributable — and an unattributable
             // benchmark number is how false conclusions get recorded.
-            if let Ok(r) = result {
-                stats.tool_rounds.push(r.tool_calls_made.len());
-                stats.prompt_tokens.push(r.usage.prompt_tokens);
-                stats.completion_tokens.push(r.usage.completion_tokens);
+            match result {
+                Ok(r) => {
+                    if r.tool_calls_made.is_empty() {
+                        println!(
+                            "[{}] NO TOOL CALL for {prompt:?} -> {:?}",
+                            if routing { "routed" } else { "baseline" },
+                            r.response.chars().take(220).collect::<String>()
+                        );
+                    }
+                    stats.tool_rounds.push(r.tool_calls_made.len());
+                    stats.prompt_tokens.push(r.usage.prompt_tokens);
+                    stats.completion_tokens.push(r.usage.completion_tokens);
+                }
+                Err(e) => println!(
+                    "[{}] ERROR for {prompt:?}: {e}",
+                    if routing { "routed" } else { "baseline" }
+                ),
             }
         }
     }
@@ -283,4 +310,51 @@ async fn two_stage_routing_latency_vs_single_turn() {
         }
     );
     println!("=========================================\n");
+}
+
+/// One routed turn, with the assembled Stage-2 prompt and the model's raw
+/// reply printed. Diagnostic for "the routed arm makes no tool calls" — the
+/// aggregate benchmark can show that it happened but not why.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "diagnostic; requires a local inference backend"]
+async fn dump_one_routed_turn() {
+    let Some((engine, model)) = resolve_backend().await else {
+        eprintln!("no backend");
+        return;
+    };
+    println!("model: {model}");
+
+    for (label, routing, with_instructions) in [
+        ("baseline (no routing)", false, false),
+        ("routed, scoped tools only", true, false),
+        ("routed + injected instructions", true, true),
+    ] {
+        let service = LocalAgentService::new(
+            engine.clone(),
+            Arc::new(BenchExecutor {
+                routing,
+                with_instructions,
+            }) as Arc<dyn AgentToolExecutor>,
+        );
+        let session = service.create_session(None, Vec::new()).await;
+        let r = service
+            .send_message(
+                &session,
+                "add a task to review the billing docs tomorrow",
+                |_| {},
+                |_| {},
+            )
+            .await;
+        match r {
+            Ok(res) => println!(
+                "\n--- {label}: tools_called={:?} ---\nreply: {}\n",
+                res.tool_calls_made
+                    .iter()
+                    .map(|t| t.name.clone())
+                    .collect::<Vec<_>>(),
+                res.response.chars().take(400).collect::<String>()
+            ),
+            Err(e) => println!("\n--- {label} ERROR: {e} ---\n"),
+        }
+    }
 }

--- a/packages/agent/tests/routing_latency.rs
+++ b/packages/agent/tests/routing_latency.rs
@@ -168,8 +168,20 @@ impl AgentToolExecutor for BenchExecutor {
     }
 }
 
-async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> Vec<u128> {
-    let mut samples = Vec::new();
+struct ArmStats {
+    latencies: Vec<u128>,
+    tool_rounds: Vec<usize>,
+    prompt_tokens: Vec<u32>,
+    completion_tokens: Vec<u32>,
+}
+
+async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> ArmStats {
+    let mut stats = ArmStats {
+        latencies: Vec::new(),
+        tool_rounds: Vec::new(),
+        prompt_tokens: Vec::new(),
+        completion_tokens: Vec::new(),
+    };
     for prompt in PROMPTS {
         for _ in 0..RUNS {
             let service = LocalAgentService::new(
@@ -178,11 +190,33 @@ async fn time_arm(engine: Arc<dyn ChatInferenceEngine>, routing: bool) -> Vec<u1
             );
             let session = service.create_session(None, Vec::new()).await;
             let started = Instant::now();
-            let _ = service.send_message(&session, prompt, |_| {}, |_| {}).await;
-            samples.push(started.elapsed().as_millis());
+            let result = service.send_message(&session, prompt, |_| {}, |_| {}).await;
+            stats.latencies.push(started.elapsed().as_millis());
+            // Rounds and tokens explain the wall-clock delta. Without them a
+            // surprising number is unattributable — and an unattributable
+            // benchmark number is how false conclusions get recorded.
+            if let Ok(r) = result {
+                stats.tool_rounds.push(r.tool_calls_made.len());
+                stats.prompt_tokens.push(r.usage.prompt_tokens);
+                stats.completion_tokens.push(r.usage.completion_tokens);
+            }
         }
     }
-    samples
+    stats
+}
+
+fn mean_u32(v: &[u32]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.iter().map(|x| *x as f64).sum::<f64>() / v.len() as f64
+}
+
+fn mean_usize(v: &[usize]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.iter().map(|x| *x as f64).sum::<f64>() / v.len() as f64
 }
 
 fn mean(v: &[u128]) -> f64 {
@@ -215,21 +249,29 @@ async fn two_stage_routing_latency_vs_single_turn() {
     let baseline = time_arm(engine.clone(), false).await;
     let routed = time_arm(engine.clone(), true).await;
 
-    let (b_mean, r_mean) = (mean(&baseline), mean(&routed));
+    let (b_mean, r_mean) = (mean(&baseline.latencies), mean(&routed.latencies));
     let overhead = r_mean - b_mean;
 
     println!("\n=== ADR-038 two-stage routing latency ===");
     println!("model: {model}");
     println!("prompts: {}  runs each: {RUNS}", PROMPTS.len());
     println!(
-        "single-turn (baseline): mean {:.0} ms   median {} ms",
+        "single-turn (baseline): mean {:.0} ms   median {} ms   \
+         tool rounds {:.2}   tokens {:.0} in / {:.0} out",
         b_mean,
-        median(&baseline)
+        median(&baseline.latencies),
+        mean_usize(&baseline.tool_rounds),
+        mean_u32(&baseline.prompt_tokens),
+        mean_u32(&baseline.completion_tokens),
     );
     println!(
-        "two-stage (routed):     mean {:.0} ms   median {} ms",
+        "two-stage (routed):     mean {:.0} ms   median {} ms   \
+         tool rounds {:.2}   tokens {:.0} in / {:.0} out",
         r_mean,
-        median(&routed)
+        median(&routed.latencies),
+        mean_usize(&routed.tool_rounds),
+        mean_u32(&routed.prompt_tokens),
+        mean_u32(&routed.completion_tokens),
     );
     println!(
         "routing overhead:       {:+.0} ms  ({:+.1}%)",

--- a/packages/daemon/src/services/local_agent_service.rs
+++ b/packages/daemon/src/services/local_agent_service.rs
@@ -186,7 +186,7 @@ impl LocalAgentServiceImpl {
     async fn replace_engine(&self, engine: Arc<dyn ChatInferenceEngine>) {
         // Hand the executor the *shared* embedding handle, not a snapshot. The
         // executor reads the current value per call, so search_semantic and
-        // search_skills work as soon as the embedding model finishes loading
+        // skill retrieval work as soon as the embedding model finishes loading
         // in the background — no engine swap required, and no construction
         // site can wire a stale or `None` service.
         //

--- a/scripts/eval/fixtures/agent-matrix.ts
+++ b/scripts/eval/fixtures/agent-matrix.ts
@@ -11,8 +11,9 @@
  *   - this                          — END-TO-END behavior (right tool, right
  *                                     count, right effect)
  *
- * Under ADR-038 the model calls search_skills before acting, so assertions
- * check for the TARGET tool tolerating search_skills, never raw tool count.
+ * Under ADR-038 routing happens in a separate stage before the acting turn, so
+ * assertions check for the TARGET tool tolerating routing calls, never raw
+ * tool count.
  *
  * Scenario wording must stay independent of packages/agent/src/agent_guidance.rs.
  * `guidance_is_not_contaminated_by_eval_prompts` enforces it by parsing the
@@ -54,7 +55,13 @@ export type Expectation =
  * Cross-referenced against Tool::ALL in
  * packages/agent/src/local_agent/tools.rs — update here if the registry changes.
  */
-const ROUTING_TOOLS = ["search_skills"];
+// Stage-1 routing calls (ADR-038). These are not actions the scenario is
+// asserting on, so they are filtered out before the action-tool check.
+// `search_skills` remains listed because the tool still exists for external
+// agents; the local model is no longer offered it, so it should not appear in
+// a local trace — tolerating it costs nothing and avoids a false failure if it
+// ever does.
+const ROUTING_TOOLS = ["route_query", "route_clarify", "search_skills"];
 
 export function actionTools(toolsCalled: string[]): string[] {
   return toolsCalled.filter((t) => !ROUTING_TOOLS.includes(t));

--- a/scripts/eval/fixtures/routing.ts
+++ b/scripts/eval/fixtures/routing.ts
@@ -148,9 +148,8 @@ const FIXTURES: RoutingScenario[] = [
     prompt: "What's the weather like in Tokyo today?",
     // The ADR requires: out-of-scope queries should not silently fire a mutating tool.
     // The correct guard is "no mutating tool called" — enforced via adversarial:true on
-    // a clarify fixture (see assertFixture clarify branch). The routing pipeline may or
-    // may not be entered (search_skills may still fire to confirm no skill matches),
-    // so !calledSearchSkills is not asserted here — the key invariant is no mutation.
+    // a clarify fixture (see assertFixture clarify branch). Retrieval may still run and
+    // match nothing, which is a normal outcome, so the key invariant is no mutation.
     expected: { kind: "clarify" },
     adversarial: true, // enforces calledMutatingTool check in assertFixture clarify branch
   },
@@ -213,8 +212,8 @@ function isClarification(reply: string): boolean {
 }
 
 function skillNameFromTurns(turns: TurnRecord[]): string | null {
-  // search_skills is always called before using a skill; the matched skill name
-  // appears in the reply or is implicit from subsequent tool calls.
+  // The matched skill name appears in the reply or is implicit from subsequent
+  // tool calls.
   // We parse from the reply text as a heuristic — the name appears in the model's
   // "I'll use the Schema Creation skill..." style phrasing.
   for (const t of turns) {
@@ -236,9 +235,10 @@ function skillNameFromTurns(turns: TurnRecord[]): string | null {
   return null;
 }
 
-function calledSearchSkills(turns: TurnRecord[]): boolean {
-  return turns.some((t) => t.toolsCalled.includes("search_skills"));
-}
+// Under ADR-038's two-stage routing there is no model-visible retrieval call:
+// Stage 1 emits route_query/route_clarify and the system performs retrieval
+// itself. Skill routing is therefore observed through its effect — the action
+// tool the matched skill permits — not through a retrieval call in the trace.
 
 function calledMutatingTool(turns: TurnRecord[]): boolean {
   // All tools that write or mutate graph state — cross-referenced against Tool::ALL
@@ -263,19 +263,12 @@ function calledSchemaCreate(turns: TurnRecord[]): boolean {
 function assertFixture(fixture: RoutingScenario, turns: TurnRecord[]): Verdict {
   const allReplies = turns.map((t) => t.reply).join("\n");
   const clarified = isClarification(allReplies);
-  const searched = calledSearchSkills(turns);
 
   switch (fixture.expected.kind) {
     case "skill": {
       const expectedSkill = fixture.expected.skill.toLowerCase();
       const replyLower = allReplies.toLowerCase();
-      // Model should have called search_skills and referenced or used the expected skill
-      if (!searched) {
-        return {
-          passed: false,
-          failure: `Expected search_skills to be called for skill routing, but it was not`,
-        };
-      }
+      // Model should have referenced or used the expected skill.
       if (!replyLower.includes(expectedSkill)) {
         // Also check if the right tools were called (e.g. create_schema for Schema Creation)
         const toolCheck =
@@ -353,7 +346,6 @@ const fixture: EvalFixture = {
       loadBearing: s.loadBearing ?? false,
       mutating: s.mutating ?? false,
       adversarial: s.adversarial ?? false,
-      skillsSearched: calledSearchSkills(turns),
       matchedSkill: skillNameFromTurns(turns),
       clarified: isClarification(turns.map((t) => t.reply).join("\n")),
       toolsCalled: turns.flatMap((t) => t.toolsCalled),


### PR DESCRIPTION
Implements the routing flow [ADR-038](../nodespace-docs/decisions/038-skill-mediated-tool-routing.md) decided, replacing the *single-turn pull* that ADR explicitly rejects under *Alternatives Considered*.

Closes #1815.

## What changed

```
Stage 1 (model):  route_query(query) | route_clarify(question, options)
                  — a structural choice, not a confidence number
[system step]:    semantic retrieval → top-K, score-gated, trust-filtered
                  — NOT a model tool call
Stage 2 (model):  judge the candidates → act with the matched skill's tools,
                  or clarify with the candidates as concrete options
```

- **Stage 1** emits its discriminated choice as one of exactly two typed tools. Which tool the model calls *is* the output — no confidence scalar, no free text to parse.
- **Retrieval** moved into `AgentToolExecutor::retrieve_skills`, a deterministic system step. K is bounded by the system (`RETRIEVAL_TOP_K`), not the model.
- **Stage 2** combines the mechanical retrieval score with the model's judgment. Only candidates clearing the score gate are rendered, so the model never judges something the system already ruled out.
- **Blast radius** is derived from the matched skill's existing `tool_whitelist` via `Tool::write_semantics()`: any write tool in the whitelist raises that skill's bar. Mutating > read-only is a **compile-time** invariant.
- **Stage-2 tool surface** is scoped to the union of eligible candidates' whitelists — a read-only skill cannot put `delete_node` in reach.
- **`search_skills`** is withheld from the model-facing surface but stays in `Tool::ALL`, because the MCP `find_skills` handler shares its implementation and the seeded tool node backs that external surface.
- **Clarification contract**: at most one per intent, then fall through to retrieval. Derived from message history, since the session is rebuilt from persisted messages each turn.

## One channel decision, applied twice

Q1 (Stage-2 candidate delivery) and Q2 (Stage-1 output) were settled independently but land on the same principle: **prefer the tool-schema channel over prose and parsing.** That is the channel [ADR-064](../nodespace-docs/decisions/064-instruction-channel-doctrine.md)'s evidence favors throughout — tool schema 100% compliance vs prose 87.5%, and instructions rendered *into the prompt* (Finding 2) rather than returned as a tool result (measured to drop continuation 100% → 44%).

Concretely: Stage 1 uses two typed tools instead of a `QUERY:`/`CLARIFY:` prose convention, and Stage 2 receives candidates in the prompt instead of as a tool result. These are the same decision seen from two directions, not two coincidentally-aligned choices.

This resolves the ADR-064 *Provisional* question for the Stage-2 path specifically. It is a reasoned choice on existing evidence, not a new measurement.

## Threshold values

`SKILL_SEARCH_THRESHOLD` stays at `0.0` — deliberately. Retrieval still *returns* the long tail so the judged gate can see it; the new bars decide what is *actionable*. One gate filters, the other judges.

The two bars are **deliberately permissive and not yet tuned**, and their doc comments say why: tuning needs an eval that can distinguish a model failure from a harness failure (#1764). Tightening them before that would hide the long tail against an untested target, with no measurement showing the loss.

## Latency

ADR-038 requires the extra turn's cost be measured, not assumed. `packages/agent/tests/routing_latency.rs` runs both arms through the same production loop against the same engine, differing only in whether `routing_available()` reports true.

On **gemma-4-e4b-q4km** (ADR-056's locked model), in-process, 3 prompts x 3 runs:

| Arm | Mean | Median | Tool rounds | Tokens |
|---|---|---|---|---|
| single-turn (baseline) | 3231 ms | 3044 ms | 1.00 | 606 in / 88 out |
| two-stage (routed) | 3650 ms | 3534 ms | 1.00 | 1121 in / 65 out |

**Routing overhead: +419 ms (+13.0%).**

`tool rounds 1.00` in both arms is what makes this comparable — same work, done two ways. The prompt-token rise (606 -> 1121) is the injected candidate block, i.e. the KV-cache prefix divergence ADR-038 predicted.

Three earlier attempts were rejected rather than reported, and the harness now refuses error-dominated runs instead of printing a confident number from error paths.

## A model-specific failure worth knowing about

A four-arm diagnostic (`dump_one_routed_turn` in the same file) isolates which part of routing affects tool-calling:

| Arm | Block injected at Stage 2 | gemma-4-e4b (locked) | mistral:7b via HTTP |
|---|---|---|---|
| baseline | none | ✅ | ✅ |
| Stage-1 only, no candidates | none | ✅ | ✅ |
| routed + full instructions | yes | ✅ | ❌ |
| routed + names only | yes | ✅ | ❌ |

On the locked model every arm fires. On mistral over the OpenAI-compatible endpoint, **any** injected block suppresses the tool call — even one containing only skill names, no instructions and no metadata. Stage 1 alone is harmless in both.

That does not block this change, since the failure is confined to a model we do not ship. It is worth keeping as a regression guard when the locked model changes, and it is a data point against ADR-064's prediction that the operative variable is how *procedural* the payload is: here, payload content did not matter, only the block's presence.

## Two bugs the tests caught

- **Routed turns could silently do no work.** `looks_like_narrated_tool_call` only detected `tool_name(...)` syntax; a model emitting the JSON form `[{"name":"create_node",...}]` as *text* slipped past it, so the loop saw no tool call and the turn produced nothing. Pre-existing gap, surfaced by the latency measurement; now detects both forms.
- **Stage-1 usage was dropped** from the turn's reported total, hiding the cost of the extra turn from every consumer of that figure.
- **`?` inside a loop** in schema-metadata rendering discarded every remaining type when one entry lacked a `type_id`.

Also fixed: Stage 1 originally ran on *every* turn, taxing conversational turns that need no capability. It is now gated on retrieval actually being wired up.

## Not in scope

The three blockers #1815 names remain open — the resident-prompt reduction (#1813) and the diagnostic eval (#1764). This was built at Michael's direction with verification explicitly deferred to #1764; the acceptance criteria that depend on a trustworthy eval cannot be closed until it lands.

## Testing

- 365 agent unit tests, 1,067 core, full workspace green
- Frontend 4,112 tests — matches baseline exactly
- `quality:fix` clean (ESLint, svelte-check, tsc, fmt, clippy)
- The ADR-036 → ADR-038 miscitation at the old `agent_loop.rs:415` is corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)